### PR TITLE
Broker tests that really run

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -2,44 +2,67 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/kagenti/mcp-gateway/internal/tests/server2"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterServer(t *testing.T) {
-	// TODO introduce mocking, or stand up test servers in a test setup
-	if os.Getenv("RUN_TESTS") != "TRUE" {
-		t.Skip("Skipping testing")
+const (
+	MCPPort = "8088"
+	MCPAddr = "http://localhost:8088/mcp"
+)
+
+// TestMain starts an MCP server that we will run actual tests against
+func TestMain(m *testing.M) {
+	// Start an MCP server to test our broker client logic
+	startFunc, shutdownFunc, err := server2.RunServer("http", MCPPort)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Server setup error: %v\n", err)
+		os.Exit(1)
 	}
+
+	go func() {
+		// Start the server in a Goroutine
+		_ = startFunc()
+	}()
+
+	code := m.Run()
+
+	err = shutdownFunc()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Server shutdown error: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+func TestRegisterServer(t *testing.T) {
+	fmt.Fprintf(os.Stderr, "TestRegisterServer\n")
 
 	broker := NewBroker()
 
-	// err := broker.RegisterServer(context.Background(), "http://mcp-time:9090/mcp", "mcp_add_service_cluster")
 	err := broker.RegisterServer(
 		context.Background(),
-		"http://localhost:9090/mcp",
+		MCPAddr,
 		"testprefix-reg",
 		"mcp_add_service_cluster",
 	)
 	require.NoError(t, err)
-
-	// err = broker.RegisterServer(context.Background(), "http://mcp-time:8000/mcp", "mcp_time_service_cluster")
-	// require.NoError(t, err)
 }
 
 func TestUnregisterServer(t *testing.T) {
-	// TODO introduce mocking, or stand up test servers in a test setup
-	if os.Getenv("RUN_TESTS") != "TRUE" {
-		t.Skip("Skipping testing")
-	}
+	fmt.Fprintf(os.Stderr, "TestUnregisterServer\n")
 
 	broker := NewBroker()
 	err := broker.RegisterServer(
 		context.Background(),
-		"http://localhost:9090/mcp",
+		MCPAddr,
 		"testprefix-unreg",
 		"mcp_add_service_cluster",
 	)
@@ -51,26 +74,21 @@ func TestUnregisterServer(t *testing.T) {
 	require.Error(t, err)
 
 	// We should be able to unregister a known server
-	err = broker.UnregisterServer(context.Background(), "http://localhost:9090/mcp")
-	// err = broker.UnregisterServer(context.Background(), "http://mcp-add:8000/mcp")
+	err = broker.UnregisterServer(context.Background(), MCPAddr)
 	require.NoError(t, err)
 
 	// After the first unregister, the server should be unknown, and removing it again should fail
-	err = broker.UnregisterServer(context.Background(), "http://localhost:9090/mcp")
-	// err = broker.UnregisterServer(context.Background(), "http://mcp-add:8000/mcp")
+	err = broker.UnregisterServer(context.Background(), MCPAddr)
 	require.Error(t, err)
 }
 
 func TestToolCall(t *testing.T) {
-	// TODO introduce mocking, or stand up test servers in a test setup
-	if os.Getenv("RUN_TESTS") != "TRUE" {
-		t.Skip("Skipping testing")
-	}
+	fmt.Fprintf(os.Stderr, "TestToolCall\n")
 
 	broker := NewBroker()
 	err := broker.RegisterServer(
 		context.Background(),
-		"http://localhost:9090/mcp",
+		MCPAddr,
 		"testprefix-call",
 		"mcp_add_service_cluster",
 	)
@@ -78,9 +96,9 @@ func TestToolCall(t *testing.T) {
 
 	res, err := broker.CallTool(context.Background(), "test-session-id", mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name: "testprefix-call-greet", // Note that this is the gateway tool name, not the upstream tool name
+			Name: "testprefix-call-hello_world", // Note that this is the gateway tool name, not the upstream tool name
 			Arguments: map[string]any{
-				"Name": "Fred",
+				"name": "Fred",
 			},
 		},
 	})
@@ -88,7 +106,7 @@ func TestToolCall(t *testing.T) {
 	require.False(t, res.IsError)
 	require.Len(t, res.Content, 1)
 	require.IsType(t, mcp.TextContent{}, res.Content[0])
-	require.Equal(t, "Hi Fred", res.Content[0].(mcp.TextContent).Text)
+	require.Equal(t, "Hello, Fred!", res.Content[0].(mcp.TextContent).Text)
 
 	err = broker.Close(context.Background(), "test-session-id")
 	require.NoError(t, err)

--- a/internal/tests/server2/main/main.go
+++ b/internal/tests/server2/main/main.go
@@ -1,0 +1,44 @@
+// A simple MCP server that implements a few tools
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/kagenti/mcp-gateway/internal/tests/server2"
+)
+
+func main() {
+	// Choose transport based on environment
+	transport := os.Getenv("MCP_TRANSPORT")
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	startFunc, shutdownFunc, err := server2.RunServer(transport, port)
+	if err != nil {
+		fmt.Printf("Server error: %v\n", err)
+		return
+	}
+
+	go func() {
+		_ = startFunc()
+	}()
+
+	// Graceful shutdown
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	<-c
+	log.Println("Shutting down server...")
+	err = shutdownFunc()
+	if err != nil {
+		fmt.Printf("Shutdown error: %v\n", err)
+		return
+	}
+
+	fmt.Print("Server completed\n")
+}

--- a/internal/tests/server2/server2.go
+++ b/internal/tests/server2/server2.go
@@ -1,0 +1,225 @@
+// Based on sample https://github.com/mark3labs/mcp-go/blob/93935261086dda133e3e4b6447304e24deb56a21/www/docs/pages/servers/basics.mdx
+
+// Package server2 implements a simple MCP server that implements a few tools
+// - The "hello_world" tool from the library sample
+// - A "time" tool that returns the current time
+// - A "slow" tool that waits N seconds, notifying the client of progress
+// - A "headers" tool that returns all HTTP headers it received
+package server2
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// StartupFunc is used for functions that will start a server and block until it is finished
+type StartupFunc func() error
+
+// ShutdownFunc is used for functions that stop running servers
+type ShutdownFunc func() error
+
+// RunServer create a server that can be started and stopped
+func RunServer(transport, port string) (StartupFunc, ShutdownFunc, error) {
+
+	hooks := &server.Hooks{}
+
+	// Add session lifecycle hooks
+	hooks.AddOnRegisterSession(func(_ context.Context, session server.ClientSession) {
+		log.Printf("Client %s connected", session.SessionID())
+	})
+
+	hooks.AddOnUnregisterSession(func(_ context.Context, session server.ClientSession) {
+		log.Printf("Client %s disconnected", session.SessionID())
+	})
+
+	// Add request hooks
+	hooks.AddBeforeAny(func(_ context.Context, _ any, method mcp.MCPMethod, _ any) {
+		log.Printf("Processing %s request", method)
+	})
+
+	hooks.AddOnError(func(_ context.Context, _ any, method mcp.MCPMethod, _ any, err error) {
+		log.Printf("Error in %s: %v", method, err)
+	})
+
+	// Create a new MCP server
+	s := server.NewMCPServer(
+		"Demo rocket",
+		"1.0.0",
+		server.WithHooks(hooks),
+		server.WithToolCapabilities(true),
+	)
+
+	// Add tool
+	tool := mcp.NewTool("hello_world",
+		mcp.WithDescription("Say hello to someone"),
+		mcp.WithString("name",
+			mcp.Required(),
+			mcp.Description("Name of the person to greet"),
+		),
+	)
+
+	// Add tool handler
+	s.AddTool(tool, helloHandler)
+
+	// Add time handler
+	s.AddTool(mcp.NewTool("time",
+		mcp.WithDescription("Get the current time"),
+	), timeHandler)
+
+	// Add headers handler
+	s.AddTool(mcp.NewTool("headers",
+		mcp.WithDescription("get HTTP headers"),
+	), headersToolHandler)
+
+	// Add auth1234 handler
+	s.AddTool(mcp.NewTool("auth1234",
+		mcp.WithDescription("check authorization header"),
+	), auth1234ToolHandler)
+
+	// Add slow handler
+	s.AddTool(mcp.NewTool("slow",
+		mcp.WithDescription("Delay for N seconds"),
+		mcp.WithString("seconds",
+			mcp.Required(),
+			mcp.Description("number of seconds to wait"),
+		),
+	), slowHandler)
+
+	if port == "" {
+		port = "8080"
+	}
+
+	switch transport {
+	case "http":
+		// Define the HTTP server with interceptor to record HTTP headers
+		mux := http.NewServeMux()
+		httpServer := &http.Server{
+			Addr:              ":" + port,
+			Handler:           mux,
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+
+		streamableHTTPServer := server.NewStreamableHTTPServer(
+			s,
+			server.WithStreamableHTTPServer(httpServer),
+		)
+		mux.Handle("/mcp", streamableHTTPServer)
+
+		return func() error {
+				fmt.Printf("Serving HTTPStreamable on http://localhost:%s/mcp\n", port)
+
+				return streamableHTTPServer.Start(":" + port)
+			}, func() error {
+				// We use a timeout because the MCP inspector holds the port open
+				shutdownCtx, shutdownRelease := context.WithTimeout(
+					context.Background(),
+					1*time.Second,
+				)
+				defer shutdownRelease()
+				return streamableHTTPServer.Shutdown(shutdownCtx)
+			}, nil
+	case "sse":
+		fmt.Printf("Serving SSE on http://localhost:%s\n", port)
+		sseServer := server.NewSSEServer(s)
+
+		return func() error {
+				return sseServer.Start(":" + port)
+			}, func() error {
+				return sseServer.Shutdown(context.TODO())
+			}, nil
+	default:
+		fmt.Print("Serving on stdio")
+		return func() error {
+				return server.ServeStdio(s)
+			}, func() error {
+				return nil
+			}, nil
+	}
+}
+
+func helloHandler(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := request.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Hello, %s!", name)), nil
+}
+
+func timeHandler(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultText(time.Now().String()), nil
+}
+
+func headersToolHandler(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	content := make([]mcp.Content, 0)
+	for k, v := range req.Header {
+		content = append(content, &mcp.TextContent{
+			Type: "text",
+			Text: fmt.Sprintf("%s: %v", k, v),
+		})
+	}
+
+	return &mcp.CallToolResult{
+		Content: content}, nil
+}
+
+func auth1234ToolHandler(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+	auth := strings.ToLower(req.Header.Get("Authorization"))
+	if auth != "bearer 1234" {
+		return nil, fmt.Errorf("requires Authorization: bearer 1234, got %q", auth)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Text: "Success!",
+			},
+		},
+	}, nil
+}
+
+func slowHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	seconds, err := request.RequireInt("seconds")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	var progressToken mcp.ProgressToken
+	if request.Params.Meta != nil {
+		progressToken = request.Params.Meta.ProgressToken
+	}
+	server := server.ServerFromContext(ctx)
+
+	startTime := time.Now()
+	fmt.Printf("Slow tool will wait for %d seconds\n", seconds)
+	for {
+		waited := int(time.Since(startTime).Seconds())
+		if waited >= seconds {
+			break
+		}
+
+		if progressToken != nil {
+			fmt.Printf("Notify client that we have waited %d seconds\n", waited)
+			msg := fmt.Sprintf("Waited %d seconds...", waited)
+			err := server.SendNotificationToClient(ctx, "notifications/progress", map[string]any{
+				"progress":      waited,
+				"progressToken": progressToken,
+				"message":       msg,
+			})
+			if err != nil {
+				fmt.Printf("NotifyProgress error: %v\n", err)
+			}
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return mcp.NewToolResultText("done"), nil
+}

--- a/internal/tests/server2/server2_test.go
+++ b/internal/tests/server2/server2_test.go
@@ -1,0 +1,91 @@
+package server2
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHello(t *testing.T) {
+	res, err := helloHandler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+
+	res, err = helloHandler(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]any{
+				"name": "Fred",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.IsType(t, mcp.TextContent{}, res.Content[0])
+	require.Equal(t, "Hello, Fred!", res.Content[0].(mcp.TextContent).Text)
+}
+
+func TestTime(t *testing.T) {
+	res, err := timeHandler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.IsType(t, mcp.TextContent{}, res.Content[0])
+}
+
+func TestHeaders(t *testing.T) {
+	res, err := headersToolHandler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Len(t, res.Content, 0)
+
+	res, err = headersToolHandler(context.Background(), mcp.CallToolRequest{
+		Header: http.Header{
+			"Authorization": []string{"bearer 1234"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Len(t, res.Content, 1)
+	require.IsType(t, &mcp.TextContent{}, res.Content[0])
+	require.Equal(t, "Authorization: [bearer 1234]", res.Content[0].(*mcp.TextContent).Text)
+}
+
+func TestSlow(t *testing.T) {
+	res, err := slowHandler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+
+	res, err = slowHandler(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]any{
+				"seconds": "0",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.IsType(t, mcp.TextContent{}, res.Content[0])
+}
+
+func TestAuth1234(t *testing.T) {
+	_, err := auth1234ToolHandler(context.Background(), mcp.CallToolRequest{})
+	require.Error(t, err)
+
+	res, err := auth1234ToolHandler(context.Background(), mcp.CallToolRequest{
+		Header: http.Header{
+			"Authorization": []string{"bearer 1234"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.IsType(t, mcp.TextContent{}, res.Content[0])
+}
+
+func TestRunStreamableServer(t *testing.T) {
+	startFunc, shutdownFunc, err := RunServer("http", "8085")
+	require.NoError(t, err)
+	require.NotNil(t, startFunc)
+	require.NotNil(t, shutdownFunc)
+}


### PR DESCRIPTION
This PR causes the Broker tests to set up an MCP server in-process for testing.

(A follow-up will simplify the container-based server2.)
