### PR TITLE
Update dco.yaml to skip dependabot dco.

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -9,6 +9,8 @@ jobs:
   check:
     name: DCO 
     runs-on: ubuntu-latest
+    # This 'if' condition will only run the job if the actor is not dependabot[bot]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python 3.x


### PR DESCRIPTION
There was an error being generated on build

Run pip3 install -U dco-check
Collecting dco-check
  Downloading dco_check-0.5.0-py3-none-any.whl.metadata (8.7 kB)
Downloading dco_check-0.5.0-py3-none-any.whl (19 kB)
Installing collected packages: dco-check
Successfully installed dco-check-0.5.0
Detected: GitHub CI

Checking commits: 8b917f1a7cf9ce4175b6f414be9966a0b3609df2..afafb854c41c4a5dd3c78c0d6ea03e10617718dd

Missing sign-off(s):

	2f01e42c3e3d515b306aeaa8a0ef706f5740487d
		sign-off not found for commit author: dependabot[bot] 49699333+dependabot[bot]@users.noreply.github.com; found: ['dependabot[bot] <support@github.com>']