### PR TITLE
handle zero mcpserver resource at startup time

### DIFF
--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -355,7 +355,9 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	// Perform startup reconciliation to ensure config exists even with zero MCPServers
-	mgr.Add(&startupReconciler{reconciler: r})
+	if err := mgr.Add(&startupReconciler{reconciler: r}); err != nil {
+		return err
+	}
 
 	return controller.Complete(r)
 }


### PR DESCRIPTION
The current implementation seems to only handle the case where MCPServer resources are all deleted, and it would then write an empty Configmap. However, if there is zero MCPServer to start with, it doesn't write an empty Configmap. This PR fixes this use case.