### PR TITLE
Fix keycloak listener allowedRoutes

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -21,7 +21,10 @@ spec:
       protocol: HTTP
       allowedRoutes:
         namespaces:
-          from: mcp-system #only the mcp-system namespace can define HTTPRoutes for this listener
+          from: Selector
+          selector:
+            matchLabels:
+              kubernetes.io/metadata.name: keycloak
     - name: mcps
       hostname: '*.mcp.local' # set to test.com on purpose to illustrate it doesn't matter what is in here but something has to be in here
       port: 8080


### PR DESCRIPTION
Fix for this error:

```
The Gateway "mcp-gateway" is invalid: 
* spec.listeners[1].allowedRoutes.namespaces.from: Unsupported value: "mcp-system": supported values: "All", "Selector", "Same"
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
make[1]: *** [deploy-gateway] Error 1
make: *** [local-env-setup] Error 2
```

Oversight on my part reviewing https://github.com/kagenti/mcp-gateway/pull/126