### PR TITLE
:fire: Remove goarch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o mcp_gateway cmd/mcp-broker-router/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o mcp_gateway cmd/mcp-broker-router/main.go
 
 FROM alpine:latest
 


### PR DESCRIPTION
It appears that there is an attempt to build images for multi-architecture here: https://github.com/kagenti/mcp-gateway/blob/main/.github/workflows/images.yaml#L72

However, the `GOARCH` in the Dockerfile is hardcoded to `GOARCH=amd64` - removing this should allow for default building on the architecture available (an alternative being the workflow architecture is taken in)