### PR TITLE
Expose ability to deploy test server on other endpoints

### DIFF
--- a/internal/tests/server2/server2.go
+++ b/internal/tests/server2/server2.go
@@ -66,7 +66,7 @@ var (
 )
 
 // RunServer create a server that can be started and stopped
-func RunServer(transport, port string) (StartupFunc, ShutdownFunc, error) {
+func RunServer(transport, port string, streamOpts ...server.StreamableHTTPOption) (StartupFunc, ShutdownFunc, error) {
 
 	hooks := &server.Hooks{}
 
@@ -115,9 +115,10 @@ func RunServer(transport, port string) (StartupFunc, ShutdownFunc, error) {
 			ReadHeaderTimeout: 3 * time.Second,
 		}
 
+		streamOpts = append(streamOpts, server.WithStreamableHTTPServer(httpServer))
 		streamableHTTPServer := server.NewStreamableHTTPServer(
 			s,
-			server.WithStreamableHTTPServer(httpServer),
+			streamOpts...,
 		)
 		mux.Handle("/mcp", streamableHTTPServer)
 

--- a/internal/tests/server2/server2_test.go
+++ b/internal/tests/server2/server2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,6 +89,14 @@ func TestAuth1234(t *testing.T) {
 
 func TestRunStreamableServer(t *testing.T) {
 	startFunc, shutdownFunc, err := RunServer("http", "8085")
+	require.NoError(t, err)
+	require.NotNil(t, startFunc)
+	require.NotNil(t, shutdownFunc)
+}
+
+func TestCustomEndpointStreamableServer(t *testing.T) {
+	startFunc, shutdownFunc, err := RunServer("http", "8085",
+		server.WithEndpointPath("/emceepea"))
 	require.NoError(t, err)
 	require.NotNil(t, startFunc)
 	require.NotNil(t, shutdownFunc)


### PR DESCRIPTION
For #124

This exposes the ability to deploy the server2 test server library to endpoints other than `/mcp`.  There will be a follow-up for server2 itself.

This code does not fix any bugs, but will be used once there is a fix for #124 to avoid regressions.

Remember that [the spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) gives `https://example.com/mcp` as an example but the path could be anything: a don't-care, `/mcp`, `/mcp/`, or `/my-mcp-path/mcp`.