### PR TITLE
move away from bitnami helm chart, add simple KC deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,10 +318,7 @@ istioctl: ## Download and install istioctl
 
 .PHONY: keycloak-install
 keycloak-install: ## Install Keycloak IdP for development
-	docker pull docker.io/bitnami/keycloak:26.3.3-debian-12-r0
-	kind load -n mcp-gateway docker-image docker.io/bitnami/keycloak:26.3.3-debian-12-r0
-	docker pull docker.io/bitnami/postgresql:17.6.0-debian-12-r0
-	kind load -n mcp-gateway docker-image docker.io/bitnami/postgresql:17.6.0-debian-12-r0
+	@echo "Installing Keycloak - using official image with H2 database"
 	@$(MAKE) -s -f build/keycloak.mk keycloak-install-impl
 
 .PHONY: keycloak-forward

--- a/config/keycloak/deployment.yaml
+++ b/config/keycloak/deployment.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  namespace: keycloak
+  labels:
+    app: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+      - name: keycloak
+        image: quay.io/keycloak/keycloak:26.0
+        args: ["start-dev"]
+        env:
+        - name: KEYCLOAK_ADMIN
+          value: "admin"
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          value: "admin"
+        - name: KC_PROXY
+          value: "edge"
+        - name: KC_HOSTNAME_STRICT
+          value: "false"
+        - name: KC_HTTP_ENABLED
+          value: "true"
+        - name: KC_HEALTH_ENABLED
+          value: "true"
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 9000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 9000
+          initialDelaySeconds: 60
+          periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: keycloak
+  labels:
+    app: keycloak
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: keycloak
+  type: ClusterIP


### PR DESCRIPTION
re: https://github.com/kagenti/mcp-gateway/issues/195


Shifts to a regular deployment with the H2 built-in DB in dev mode.