### PR TITLE
test server API key auth

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -30,12 +30,23 @@ jobs:
           - server: server1
             context: tests/servers/server1
             dockerfile: Dockerfile
+            image-name: test-server1
           - server: server2
             context: tests/servers/server2
             dockerfile: Dockerfile
+            image-name: test-server2
           - server: server3
             context: tests/servers/server3
             dockerfile: Dockerfile
+            image-name: test-server3
+          - server: api-key-server
+            context: tests/servers/api-key-server
+            dockerfile: Dockerfile
+            image-name: test-api-key-server
+          - server: broken-server
+            context: tests/servers/broken-server
+            dockerfile: Dockerfile
+            image-name: test-broken-server
 
     steps:
       - name: Check out code
@@ -53,7 +64,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/test-${{ matrix.server }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image-name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ deploy-example: install-crd ## Deploy example MCPServer resource
 	@kubectl wait --for=condition=ready pod -n mcp-test -l app=mcp-test-server1 --timeout=60s
 	@kubectl wait --for=condition=ready pod -n mcp-test -l app=mcp-test-server2 --timeout=60s
 	@kubectl wait --for=condition=ready pod -n mcp-test -l app=mcp-test-server3 --timeout=90s
+	@kubectl wait --for=condition=ready pod -n mcp-test -l app=mcp-api-key-server --timeout=60s
 	@kubectl wait --for=condition=ready pod -n mcp-test -l app=mcp-test-broken-server --timeout=60s
 	@echo "All test servers ready, deploying MCPServer resources..."
 	kubectl apply -f config/samples/mcpserver-test-servers.yaml
@@ -96,6 +97,7 @@ build-test-servers: ## Build test server Docker images locally
 	cd tests/servers/server1 && docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway/test-server1:latest .
 	cd tests/servers/server2 && docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway/test-server2:latest .
 	cd tests/servers/server3 && docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway/test-server3:latest .
+	cd tests/servers/api-key-server && docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway/test-api-key-server:latest .
 	cd tests/servers/broken-server && docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway/test-broken-server:latest .
 
 # Load test server images into Kind cluster
@@ -104,6 +106,7 @@ kind-load-test-servers: build-test-servers ## Load test server images into Kind 
 	kind load docker-image ghcr.io/kagenti/mcp-gateway/test-server1:latest --name mcp-gateway
 	kind load docker-image ghcr.io/kagenti/mcp-gateway/test-server2:latest --name mcp-gateway
 	kind load docker-image ghcr.io/kagenti/mcp-gateway/test-server3:latest --name mcp-gateway
+	kind load docker-image ghcr.io/kagenti/mcp-gateway/test-api-key-server:latest --name mcp-gateway
 	kind load docker-image ghcr.io/kagenti/mcp-gateway/test-broken-server:latest --name mcp-gateway
 
 # Deploy test servers

--- a/build/inspect.mk
+++ b/build/inspect.mk
@@ -54,9 +54,9 @@ inspect-server2: ## Open MCP Inspector for test server 2
 inspect-server3: ## Open MCP Inspector for test server 3
 	$(call inspect-server-template,test server 3,mcp-test-server3,9092,time add dozen pi get_weather slow)
 
-.PHONY: inspect-server4
-inspect-server4: ## Open MCP Inspector for test server 4 (requires auth)
-	$(call inspect-server-template,test server 4,mcp-test-server4,9093,similar to server2 but requires authentication,NOTE: This server requires Bearer token authentication)
+.PHONY: inspect-api-key-server
+inspect-api-key-server: ## Open MCP Inspector for API key test server (requires auth)
+	$(call inspect-server-template,API key test server,mcp-api-key-server,9093,hello_world tool with authentication,NOTE: This server requires Bearer token authentication)
 
 # Legacy alias for compatibility
 inspect-mock-impl: inspect-server1

--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -46,8 +46,8 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: mcp-server4-route-ext
-      hostname: 'server4.127-0-0-1.sslip.io'
+    - name: mcp-api-key-server-route-ext
+      hostname: 'api-key-server.127-0-0-1.sslip.io'
       port: 8080
       protocol: HTTP
       allowedRoutes:

--- a/config/samples/mcpserver-test-servers.yaml
+++ b/config/samples/mcpserver-test-servers.yaml
@@ -48,19 +48,19 @@ spec:
 apiVersion: mcp.kagenti.com/v1alpha1
 kind: MCPServer
 metadata:
-  name: test-server4
+  name: api-key-server
   namespace: mcp-test
   labels:
     "kagenti/mcp": "true"
 spec:
-  toolPrefix: test4_
+  toolPrefix: apikey_
   targetRef:
-    # Server 4 - Go SDK based with authentication (same as server2 but requires auth)
+    # API key test server - validates Bearer token authentication
     group: gateway.networking.k8s.io
     kind: HTTPRoute
-    name: mcp-server4-route
+    name: mcp-api-key-server-route
   credentialRef:
-    name: server4-auth-credentials
+    name: api-key-server-credentials
     key: token
 ---
 apiVersion: mcp.kagenti.com/v1alpha1

--- a/config/test-servers/api-key-server-deployment.yaml
+++ b/config/test-servers/api-key-server-deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mcp-test-server4
+  name: mcp-api-key-server
   namespace: mcp-test
   labels:
-    app: mcp-test-server4
+    app: mcp-api-key-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mcp-test-server4
+      app: mcp-api-key-server
   template:
     metadata:
       labels:
-        app: mcp-test-server4
+        app: mcp-api-key-server
     spec:
       containers:
       - name: server
-        image: ghcr.io/kagenti/mcp-gateway/test-server2:latest
+        image: ghcr.io/kagenti/mcp-gateway/test-api-key-server:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090
@@ -27,4 +27,4 @@ spec:
         - name: PORT
           value: "9090"
         - name: EXPECTED_AUTH
-          value: "Bearer test-server4-secret-token"
+          value: "Bearer test-api-key-secret-token"

--- a/config/test-servers/api-key-server-httproute-ext.yaml
+++ b/config/test-servers/api-key-server-httproute-ext.yaml
@@ -1,8 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-server4-route
-  namespace: mcp-test
+  name: mcp-api-key-server-route-ext
   labels:
     mcp-server: 'true'
 spec:
@@ -10,12 +9,12 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server4.mcp.local' # note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'api-key-server.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: mcp-test-server4
+        - name: mcp-api-key-server
           port: 9090

--- a/config/test-servers/api-key-server-httproute.yaml
+++ b/config/test-servers/api-key-server-httproute.yaml
@@ -1,7 +1,8 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-server4-route-ext
+  name: mcp-api-key-server-route
+  namespace: mcp-test
   labels:
     mcp-server: 'true'
 spec:
@@ -9,12 +10,12 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server4.127-0-0-1.sslip.io'
+    - 'api-key-server.mcp.local' # note this is matching the gateway listener. It is purely for internal routing by Envoy
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: mcp-test-server4
+        - name: mcp-api-key-server
           port: 9090

--- a/config/test-servers/api-key-server-secret.yaml
+++ b/config/test-servers/api-key-server-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: server4-auth-credentials
+  name: api-key-server-credentials
   namespace: mcp-test
 type: Opaque
 stringData:
-  token: "Bearer test-server4-secret-token"
+  token: "Bearer test-api-key-secret-token"

--- a/config/test-servers/api-key-server-service.yaml
+++ b/config/test-servers/api-key-server-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mcp-test-server4
+  name: mcp-api-key-server
   namespace: mcp-test
   labels:
-    app: mcp-test-server4
+    app: mcp-api-key-server
 spec:
   selector:
-    app: mcp-test-server4
+    app: mcp-api-key-server
   ports:
   - port: 9090
     targetPort: 9090

--- a/config/test-servers/kustomization.yaml
+++ b/config/test-servers/kustomization.yaml
@@ -17,11 +17,11 @@ resources:
   - server3-service.yaml
   - server3-httproute.yaml
   - server3-httproute-ext.yaml
-  - server4-deployment.yaml
-  - server4-service.yaml
-  - server4-httproute.yaml
-  - server4-httproute-ext.yaml
-  - server4-secret.yaml
+  - api-key-server-deployment.yaml
+  - api-key-server-service.yaml
+  - api-key-server-httproute.yaml
+  - api-key-server-httproute-ext.yaml
+  - api-key-server-secret.yaml
   - broken-server-deployment.yaml
   - broken-server-service.yaml
   - broken-server-httproute.yaml

--- a/pkg/controller/config_pusher.go
+++ b/pkg/controller/config_pusher.go
@@ -61,7 +61,7 @@ func (p *ConfigPusher) PushConfig(ctx context.Context, servers []*config.MCPServ
 
 	// get endpoints for the config service
 	// using endpoints api (simpler than endpointslice for our needs)
-	endpoints := &corev1.Endpoints{} //nolint:staticcheck // endpoints api is simpler for our use case
+	endpoints := &corev1.Endpoints{} //nolint:staticcheck
 	err = p.k8sClient.Get(ctx, client.ObjectKey{
 		Namespace: p.namespace,
 		Name:      "mcp-config",

--- a/tests/servers/api-key-server/Dockerfile
+++ b/tests/servers/api-key-server/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+# Copy Go dependencies first to leverage Docker cache
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+# Copy the rest of the application source code
+COPY *.go ./
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /api-key-server
+
+CMD ["/api-key-server"]

--- a/tests/servers/api-key-server/README.md
+++ b/tests/servers/api-key-server/README.md
@@ -1,0 +1,15 @@
+# MCP API Key Test Server
+
+Minimal MCP server for testing API key authentication in MCP Gateway.
+
+## Features
+- Validates Authorization headers (Bearer tokens/API keys)
+- Returns 401 for invalid/missing credentials
+- Single `hello_world` tool for testing authenticated access
+
+## Configuration
+- `PORT`: Server port (default: 9090)
+- `EXPECTED_AUTH`: Expected Authorization header (e.g., "Bearer <api-key>")
+
+## Usage
+Deployed in Kubernetes with API key `Bearer test-api-key-secret-token`

--- a/tests/servers/api-key-server/go.mod
+++ b/tests/servers/api-key-server/go.mod
@@ -1,0 +1,7 @@
+module github.com/kagenti/mcp-gateway/tests/servers/api-key-server
+
+go 1.23.0
+
+require github.com/modelcontextprotocol/go-sdk v0.2.0
+
+require github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/tests/servers/api-key-server/go.sum
+++ b/tests/servers/api-key-server/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/modelcontextprotocol/go-sdk v0.2.0 h1:PESNYOmyM1c369tRkzXLY5hHrazj8x9CY1Xu0fLCryM=
+github.com/modelcontextprotocol/go-sdk v0.2.0/go.mod h1:0sL9zUKKs2FTTkeCCVnKqbLJTw5TScefPAzojjU459E=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/tests/servers/api-key-server/main.go
+++ b/tests/servers/api-key-server/main.go
@@ -1,0 +1,106 @@
+// api-key-test-server is an MCP test server that validates API key authentication
+// It validates Authorization headers for all requests when EXPECTED_AUTH is set
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// tool argument struct
+type helloArgs struct {
+	Name string `json:"name" jsonschema:"the name to greet"`
+}
+
+// tool implementation
+func helloWorldTool(
+	_ context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[helloArgs],
+) (*mcp.CallToolResultFor[struct{}], error) {
+	return &mcp.CallToolResultFor[struct{}]{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Hello, %s! (from authenticated server)", params.Arguments.Name)},
+		},
+	}, nil
+}
+
+// http middleware for auth validation
+type authMiddleware struct {
+	Handler      http.Handler
+	ExpectedAuth string
+}
+
+func (a authMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if a.ExpectedAuth != "" {
+		auth := req.Header.Get("Authorization")
+		if auth != a.ExpectedAuth {
+			log.Printf("Auth failed: expected %q, got %q", a.ExpectedAuth, auth)
+			http.Error(w,
+				fmt.Sprintf(`{"error": "Unauthorized: expected %q, got %q"}`, a.ExpectedAuth, auth),
+				http.StatusUnauthorized)
+			return
+		}
+	}
+	a.Handler.ServeHTTP(w, req)
+}
+
+func main() {
+	// get config from environment
+	expectedAuth := os.Getenv("EXPECTED_AUTH")
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "9090"
+	}
+
+	if expectedAuth != "" {
+		log.Printf("API key test server: Auth required - expecting: %q", expectedAuth)
+	} else {
+		log.Printf("API key test server: No auth required (EXPECTED_AUTH not set)")
+	}
+
+	// create MCP server
+	server := mcp.NewServer(&mcp.Implementation{Name: "mcp-api-key-test-server"}, nil)
+
+	// register tool
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "hello_world",
+		Description: "A simple hello world tool that requires authentication",
+	}, helloWorldTool)
+
+	// create handler
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, nil)
+
+	// wrap with auth middleware
+	authHandler := authMiddleware{
+		Handler:      handler,
+		ExpectedAuth: expectedAuth,
+	}
+
+	// setup http server
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", authHandler)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	log.Printf("API key test server listening on :%s", port)
+	httpServer := &http.Server{
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+
+	if err := httpServer.ListenAndServe(); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}


### PR DESCRIPTION
Adds a test-server back with bearer auth for demos.

server4->api-key-server


Easiest route to test:

```bash
make local-env-setup
make inspect-api-key-server
```


And set the `Authorization` bearer to:

`Bearer test-api-key-secret-token`