### PR TITLE
Spelling doc fixes, new README listing test servers, format fixes for test server docs

### DIFF
--- a/docs/design/auth-phase-1.md
+++ b/docs/design/auth-phase-1.md
@@ -78,7 +78,7 @@ example response:
 
 ```
 
-- ```resource:``` this property will be calcuated based on the host and path of the MCP gateway.
+- ```resource:``` this property will be calculated based on the host and path of the MCP gateway.
 
 - ```authorization_servers:``` this property is expected to an IDP that is support OAuth and is used by each of the MCP servers using OAuth.
 
@@ -87,7 +87,7 @@ example response:
 
 - ```scopes_supported:``` This is an aggregated list of scopes for the MCP servers.
 
-> As we are using an aggregated set of scopes, the client and token will be highly privelleged. This is something we will look to address in phase 2 via token exchange.
+> As we are using an aggregated set of scopes, the client and token will be highly privileged. This is something we will look to address in phase 2 via token exchange.
 
 > As we will pass on this token in phase 1 it is expected that the audiences of the token include audiences required by all MCPs or they have a shared audience.
 
@@ -95,20 +95,20 @@ example response:
 
 ### Authenticated MCP Gateway Calls
 
-Once a client has obtained a token, it can then make requests to the MCP Gateway. When a request comes to the gateway, the Kuadrant WASM plugin intercepts this request and based on configuration, will decide whether or not to call to the Authorino component. With the [Example AuthPolicy](./../../config/mcp-system/authpolicy.yaml), Authorino will recieve the request and then validate the token with the configured auth server before allowing the request to continue. 
+Once a client has obtained a token, it can then make requests to the MCP Gateway. When a request comes to the gateway, the Kuadrant WASM plugin intercepts this request and based on configuration, will decide whether or not to call to the Authorino component. With the [Example AuthPolicy](./../../config/mcp-system/authpolicy.yaml), Authorino will receive the request and then validate the token with the configured auth server before allowing the request to continue.
 
 ### Token Exchange for Legacy API Keys
 
-Some MCP Servers may use legacy API Keys. As part of defining the AuthPolicy that protects access to the MCP servers, just as we fetched an ACL from a HTTP endpoint, you can also have it fetch an API Key from a provider that exposes a HTTP interface such as Vault. An example of doing this and setting the value into the request header for the targetted MCP Server will also be provided as an example AuthPolicy. It is possible to define an indiviudal AuthPolicy per MCP Server backend as each MCP Server registered has a corrosponding HTTPRoute attached to the Gateway. See the [routing doc](../design/routing.md).
+Some MCP Servers may use legacy API Keys. As part of defining the AuthPolicy that protects access to the MCP servers, just as we fetched an ACL from a HTTP endpoint, you can also have it fetch an API Key from a provider that exposes a HTTP interface such as Vault. An example of doing this and setting the value into the request header for the targeted MCP Server will also be provided as an example AuthPolicy. It is possible to define an individual AuthPolicy per MCP Server backend as each MCP Server registered has a corresponding HTTPRoute attached to the Gateway. See the [routing doc](../design/routing.md).
 
-### Authorization of specfic MCP tools/calls
+### Authorization of specific MCP tools/calls
 
-When the router recieves a tools/call. It sets some headers for use by other component.
+When the router receives a tools/call, it sets some headers for use by other components.
 
 `x-mcp-toolname:` used to indicate what tool (including prefix) is being accessed
 `x-mcp-method:` used to indicate the json RPC method being called
 
-There is an [example second AuthPolicy](../../config/mcp-system/tool-call-auth.yaml) that targets a second listener in the Gatway that is dedicated to routing MCP server requests. This AuthPolicy, via Authorino, fetches metadata that defines an ACL. This is a simplistic example to illustrate how data can be fetched dynamically to make these decisions. It then uses this data in the authorization phase to allow or deny access.
+There is an [example second AuthPolicy](../../config/mcp-system/tool-call-auth.yaml) that targets a second listener in the Gateway that is dedicated to routing MCP server requests. This AuthPolicy, via Authorino, fetches metadata that defines an ACL. This is a simplistic example to illustrate how data can be fetched dynamically to make these decisions. It then uses this data in the authorization phase to allow or deny access.
 In addition to this simplistic ACL, we will also provide an example that uses the Keycloak resource roles feature to define access to tools.
 
 AuthPolicy here uses 3 key phases

--- a/tests/servers/README.md
+++ b/tests/servers/README.md
@@ -1,0 +1,13 @@
+
+# Test MCP servers
+
+This folder contains MCP server implementations that are used for testing the MCP Gateway.
+
+| Name               | Library | Features |
+|--------------------|-----------------------|----------|
+| api-key-server     | github.com/modelcontextprotocol/go-sdk       | Auth middleware for Authorization header |
+| broken-server      | github.com/modelcontextprotocol/go-sdk       | Simulates tool conflicts, no tools, and wrong MCP protocol version |
+| custom-path-server | github.com/modelcontextprotocol/go-sdk       | HTTP endpoint /v1/special/mcp |
+| server1            | github.com/modelcontextprotocol/go-sdk       | |
+| server2            | github.com/mark3labs/mcp-go                  | |
+| server3            | [fastmcp](https://pypi.org/project/fastmcp/) | |

--- a/tests/servers/server1/README.md
+++ b/tests/servers/server1/README.md
@@ -5,14 +5,18 @@ with tools for time, HTTP header testing, and slow response testing.
 
 ## Test Go binary
 
+```bash
 go run main.go --http localhost:9090
 MCP=http://localhost:9090/mcp
+```
 
 ## Build and run Dockerfile
 
+```bash
 docker build --load --tag mcp-test1 . 
 docker run --publish 9091:9090 mcp-test1 /mcp-test-server --http 0.0.0.0:9090
 MCP=http://localhost:9091/mcp
+```
 
 ## Testing the MCP server with the @modelcontextprotocol/inspector
 

--- a/tests/servers/server2/README.md
+++ b/tests/servers/server2/README.md
@@ -5,14 +5,18 @@ with tools for time, HTTP header testing, and slow response testing.
 
 ## Test Go binary
 
+```bash
 MCP_TRANSPORT=http PORT=9091 go run main.go
 MCP=http://localhost:9091/mcp
+```
 
 ## Build and run Dockerfile
 
+```bash
 docker build --load --tag mcp-test2 .
 docker run --publish 9091:9090 --env MCP_TRANSPORT=http --env PORT=9090 mcp-test2
 MCP=http://localhost:9091/mcp
+```
 
 ## Testing the MCP server with the @modelcontextprotocol/inspector
 
@@ -22,7 +26,7 @@ Run `DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector`
 
 First, initialize the server:
 
-```
+```bash
 curl --include -X POST -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" ${MCP} --data '
 {
   "jsonrpc": "2.0",
@@ -47,7 +51,7 @@ curl --include -X POST -H "Content-Type: application/json" -H "Accept: applicati
 
 Next, complete the initialization:
 
-```
+```bash
 SESSION_ID=$(cat /tmp/init-response.txt | grep -i mcp-session-id: | sed 's/mcp-session-id: //I' | sed 's/\r//g')
 echo SESSION_ID is ${SESSION_ID}
 curl -v -X POST -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" ${MCP} --data '
@@ -60,7 +64,7 @@ curl -v -X POST -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application
 
 (Optional) List tools:
 
-```
+```bash
 curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" --silent --data '
 {
   "jsonrpc": "2.0",
@@ -72,7 +76,7 @@ curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/
 
 Inspect HTTP headers sent to server:
 
-```
+```bash
 curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" --silent --data '
 {
   "jsonrpc": "2.0",
@@ -87,7 +91,7 @@ curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/
 
 Make a slow call with progress updates:
 
-```
+```bash
 curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" --data '
 {
   "jsonrpc": "2.0",

--- a/tests/servers/server3/README.md
+++ b/tests/servers/server3/README.md
@@ -5,12 +5,16 @@ with tools for time and slow response testing.
 
 ## Test Python
 
+```bash
 fastmcp run server.py --transport http
+```
 
 ## Build and run Dockerfile
 
+```bash
 docker build --load --tag mcp-test3 .
 docker run --publish 9093:9090 mcp-test3
+```
 
 ## Testing the MCP server with the @modelcontextprotocol/inspector
 


### PR DESCRIPTION
No related issue.

This fixes spelling and formatting.  This also provides a table of test servers, to help developers find the test server they need.