### PR TITLE
Fix keycloak port fowarding & env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ make local-env-setup
 
 # Or with custom ports (defaults: 8080/8443 for Kind, 8888/8889 for Gateway)
 KIND_HOST_PORT_HTTP=8090 KIND_HOST_PORT_HTTPS=8453 make local-env-setup
-GATEWAY_LOCAL_PORT_HTTP=9000 GATEWAY_LOCAL_PORT_HTTPS=9001 make dev-gateway-forward
+GATEWAY_LOCAL_PORT_HTTP_MCP=9000 GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK=9001 make dev-gateway-forward
 ```
 
 Run the MCP Inspector and connect to the gateway (This also port forwards to the gateway)

--- a/build/dev.mk
+++ b/build/dev.mk
@@ -37,11 +37,12 @@ dev-reset: # Reset to in-cluster service configuration
 
 # Port forward to access the gateway locally
 .PHONY: dev-gateway-forward
-dev-gateway-forward: ## Port forward the gateway to localhost:$(GATEWAY_LOCAL_PORT_HTTP)
-	@echo "Forwarding gateway to localhost:$(GATEWAY_LOCAL_PORT_HTTP)..."
-	@echo "You can now access the gateway at http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)"
-	@echo "Try: curl http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)"
-	kubectl -n gateway-system port-forward svc/mcp-gateway-istio $(GATEWAY_LOCAL_PORT_HTTP):8080
+dev-gateway-forward: ## Port forward the gateway to localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)
+	@echo "Forwarding gateway to localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)..."
+	@echo "You can now access the gateway at http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
+	@echo "You can also access keycloak via the gateway at http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)"
+	@echo "Try: curl http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
+	kubectl -n gateway-system port-forward svc/mcp-gateway-istio $(GATEWAY_LOCAL_PORT_HTTP_MCP):8080 $(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK):8081
 
 # Watch logs from the gateway
 .PHONY: dev-logs-gateway
@@ -55,7 +56,7 @@ dev-test: # Test MCP request through the gateway
 	curl -X POST \
 		-H "Content-Type: application/json" \
 		-d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}' \
-		http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)/mcp
+		http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/mcp
 
 # Clean up port forwards
 .PHONY: dev-stop-forward

--- a/build/info.mk
+++ b/build/info.mk
@@ -10,7 +10,7 @@ info-impl:
 	@echo "      Requires: Go 1.20+ for some tool installations."
 	@echo ""
 	@echo "Service URLs:"
-	@echo "  Gateway:     http://localhost:$(GATEWAY_LOCAL_PORT_HTTP) (run: make dev-gateway-forward)"
+	@echo "  Gateway:     http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP) (run: make dev-gateway-forward)"
 	@echo "  Broker:      http://localhost:8080 (run: make run-broker)"
 	@echo "  Router:      grpc://localhost:9002 (run: make run-router)"
 	@echo "  Mock MCP:    http://localhost:8081/mcp (run: kubectl port-forward -n mcp-server svc/mcp-test 8081:8081)"

--- a/build/inspect.mk
+++ b/build/inspect.mk
@@ -5,7 +5,7 @@ urls-impl:
 	@echo "=== MCP Gateway URLs ==="
 	@echo ""
 	@echo "Gateway (via port-forward):"
-	@echo "  http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)"
+	@echo "  http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
 	@echo ""
 	@echo "Local Services:"
 	@echo "  Broker: http://localhost:8080"
@@ -15,7 +15,7 @@ urls-impl:
 	@echo "  http://localhost:8081/mcp"
 	@echo ""
 	@echo "Test commands:"
-	@echo "  curl http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)/"
+	@echo "  curl http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/"
 	@echo "  curl http://localhost:8080/"
 
 # Deprecated - use inspect-gateway instead
@@ -83,16 +83,16 @@ inspect-mock-impl: inspect-server1
 inspect-gateway: ## Open MCP Inspector for the gateway
 	@echo "Setting up port-forward to gateway..."
 	@-pkill -f "kubectl.*port-forward.*mcp-gateway-istio" || true
-	@kubectl -n gateway-system port-forward svc/mcp-gateway-istio $(GATEWAY_LOCAL_PORT_HTTP):8080 > /dev/null 2>&1 & \
+	@kubectl -n gateway-system port-forward svc/mcp-gateway-istio $(GATEWAY_LOCAL_PORT_HTTP_MCP):8080 $(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK):8081 > /dev/null 2>&1 & \
 		PF_PID=$$!; \
 		trap "echo '\nCleaning up...'; kill $$PF_PID 2>/dev/null || true; exit" INT TERM; \
 		sleep 2; \
 		echo "Opening MCP Inspector for gateway"; \
-		echo "URL: http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)/mcp"; \
+		echo "URL: http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/mcp"; \
 		echo ""; \
 		MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
 		sleep 2; \
-		open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP)/mcp"; \
+		open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/mcp"; \
 		echo "Press Ctrl+C to stop and cleanup"; \
 		wait; \
 		kill $$PF_PID 2>/dev/null || true

--- a/build/keycloak.mk
+++ b/build/keycloak.mk
@@ -50,8 +50,8 @@ keycloak-status-impl:
 		echo ""; \
 		echo "Test Client Configuration:"; \
 		echo "  Client ID: mcp-gateway"; \
-		echo "  Root URL: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP)"; \
-		echo "  Valid Redirect URIs: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP)/*"; \
+		echo "  Root URL: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"; \
+		echo "  Valid Redirect URIs: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/*"; \
 		echo "  Web Origins: +"; \
 		echo ""; \
 		echo "Note: Create the test client manually in the Keycloak admin console"; \
@@ -76,8 +76,8 @@ keycloak-create-client: # Create a test OIDC client for MCP
 	@echo "Then create a client with:"
 	@echo "  - Client ID: mcp-gateway"
 	@echo "  - Client Protocol: openid-connect"
-	@echo "  - Root URL: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP)"
-	@echo "  - Valid Redirect URIs: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP)/*"
+	@echo "  - Root URL: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
+	@echo "  - Valid Redirect URIs: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/*"
 	@echo "  - Web Origins: +"
 
 .PHONY: keycloak-setup-mcp-realm
@@ -85,11 +85,11 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	@echo "========================================="
 	@echo "Setting up MCP Realm"
 	@echo "========================================="
-	@echo "Assuming Keycloak is available at http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)"
+	@echo "Assuming Keycloak is available at http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)"
 	@echo "(Run 'make inspect-gateway' or 'make dev-gateway-forward' to enable port forwarding)"
 	@echo ""
 	@echo "Getting admin access token..."
-	@TOKEN=$$(curl -s -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/realms/master/protocol/openid-connect/token" \
+	@TOKEN=$$(curl -s -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/realms/master/protocol/openid-connect/token" \
 		-H "Content-Type: application/x-www-form-urlencoded" \
 		-d "username=$(KEYCLOAK_ADMIN_USER)" \
 		-d "password=$(KEYCLOAK_ADMIN_PASSWORD)" \
@@ -106,7 +106,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	echo "✅ Successfully obtained access token"; \
 	echo ""; \
 	echo "Creating MCP realm..."; \
-	REALM_RESPONSE=$$(curl -s -w "%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms" \
+	REALM_RESPONSE=$$(curl -s -w "%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"realm":"mcp","enabled":true}'); \
@@ -120,7 +120,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Updating MCP realm token settings..."; \
-	REALM_UPDATE_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X PUT "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp" \
+	REALM_UPDATE_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X PUT "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"realm":"mcp","enabled":true,"ssoSessionIdleTimeout":1800,"accessTokenLifespan":1800}'); \
@@ -135,7 +135,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Creating MCP user..."; \
-	USER_RESPONSE=$$(curl -s -w "%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/users" \
+	USER_RESPONSE=$$(curl -s -w "%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/users" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"username":"mcp","email":"mcp@example.com","firstName":"mcp","lastName":"mcp","enabled":true,"emailVerified":true,"credentials":[{"type":"password","value":"mcp","temporary":false}]}'); \
@@ -149,7 +149,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Creating accounting group..."; \
-	GROUP_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/groups" \
+	GROUP_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/groups" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"name":"accounting"}'); \
@@ -165,7 +165,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Adding mcp user to accounting group..."; \
-	USERS_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/users?username=mcp" \
+	USERS_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/users?username=mcp" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Accept: application/json"); \
 	USER_ID=$$(echo "$$USERS_LIST" | jq -r '.[0].id // empty' 2>/dev/null); \
@@ -173,7 +173,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 		echo "❌ Failed to find mcp user"; \
 		exit 1; \
 	fi; \
-	GROUPS_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/groups" \
+	GROUPS_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/groups" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Accept: application/json"); \
 	GROUP_ID=$$(echo "$$GROUPS_LIST" | jq -r '.[] | select(.name == "accounting") | .id // empty' 2>/dev/null); \
@@ -181,7 +181,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 		echo "❌ Failed to find accounting group"; \
 		exit 1; \
 	fi; \
-	ADD_USER_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X PUT "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/users/$$USER_ID/groups/$$GROUP_ID" \
+	ADD_USER_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X PUT "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/users/$$USER_ID/groups/$$GROUP_ID" \
 		-H "Authorization: Bearer $$TOKEN"); \
 	ADD_USER_CODE=$$(echo "$$ADD_USER_RESPONSE" | grep -o "HTTPCODE:[0-9]*" | cut -d: -f2); \
 	if [ "$$ADD_USER_CODE" = "204" ]; then \
@@ -193,7 +193,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	echo ""; \
 	echo "Creating groups client scope..."; \
 	echo "Request payload: {\"name\":\"groups\",\"protocol\":\"openid-connect\",\"attributes\":{\"display.on.consent.screen\":\"false\",\"include.in.token.scope\":\"true\"}}"; \
-	SCOPE_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/client-scopes" \
+	SCOPE_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/client-scopes" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"name":"groups","protocol":"openid-connect","attributes":{"display.on.consent.screen":"false","include.in.token.scope":"true"}}'); \
@@ -211,7 +211,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Reading back groups client scope for debugging..."; \
-	SCOPES_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/client-scopes" \
+	SCOPES_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/client-scopes" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Accept: application/json"); \
 	SCOPE_DETAILS=$$(echo "$$SCOPES_LIST" | jq '.[] | select(.name == "groups")' 2>/dev/null); \
@@ -219,7 +219,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	echo "$$SCOPE_DETAILS"; \
 	echo ""; \
 	echo "Adding groups mapper to client scope..."; \
-	SCOPES_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/client-scopes" \
+	SCOPES_LIST=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/client-scopes" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Accept: application/json"); \
 	SCOPE_ID=$$(echo "$$SCOPES_LIST" | jq -r '.[] | select(.name == "groups") | .id // empty' 2>/dev/null); \
@@ -227,7 +227,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 		echo "❌ Failed to find groups client scope"; \
 		exit 1; \
 	fi; \
-	MAPPER_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/client-scopes/$$SCOPE_ID/protocol-mappers/models" \
+	MAPPER_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X POST "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/client-scopes/$$SCOPE_ID/protocol-mappers/models" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"name":"groups","protocol":"openid-connect","protocolMapper":"oidc-group-membership-mapper","config":{"claim.name":"groups","full.path":"false","id.token.claim":"true","access.token.claim":"true","userinfo.token.claim":"true"}}'); \
@@ -243,7 +243,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Adding groups client scope to realm's optional client scopes..."; \
-	ADD_OPTIONAL_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X PUT "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/default-optional-client-scopes/$$SCOPE_ID" \
+	ADD_OPTIONAL_RESPONSE=$$(curl -s -w "HTTPCODE:%{http_code}" -X PUT "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/default-optional-client-scopes/$$SCOPE_ID" \
 		-H "Authorization: Bearer $$TOKEN"); \
 	ADD_OPTIONAL_CODE=$$(echo "$$ADD_OPTIONAL_RESPONSE" | grep -o "HTTPCODE:[0-9]*" | cut -d: -f2); \
 	ADD_OPTIONAL_BODY=$$(echo "$$ADD_OPTIONAL_RESPONSE" | sed 's/HTTPCODE:[0-9]*$$//'); \
@@ -257,7 +257,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 	fi; \
 	echo ""; \
 	echo "Removing trusted hosts policy for anonymous client registration..."; \
-	COMPONENTS=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/components?name=Trusted%20Hosts" \
+	COMPONENTS=$$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/components?name=Trusted%20Hosts" \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Accept: application/json"); \
 	COMPONENT_ID=$$(echo "$$COMPONENTS" | jq -r '.[0].id // empty' 2>/dev/null); \
@@ -265,7 +265,7 @@ keycloak-setup-mcp-realm: ## Create MCP realm with user and configure client reg
 		echo "✅ Trusted hosts policy was not present"; \
 	else \
 		echo "Found trusted hosts component: $$COMPONENT_ID"; \
-		DELETE_RESPONSE=$$(curl -s -w "%{http_code}" -X DELETE "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTPS)/admin/realms/mcp/components/$$COMPONENT_ID" \
+		DELETE_RESPONSE=$$(curl -s -w "%{http_code}" -X DELETE "http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)/admin/realms/mcp/components/$$COMPONENT_ID" \
 			-H "Authorization: Bearer $$TOKEN"); \
 		DELETE_CODE=$$(echo "$$DELETE_RESPONSE" | tail -c 4); \
 		if [ "$$DELETE_CODE" = "204" ]; then \

--- a/build/ports.mk
+++ b/build/ports.mk
@@ -7,11 +7,11 @@ KIND_HOST_PORT_HTTPS ?= 8443
 
 # Local port forwarding ports (for accessing services via kubectl port-forward)
 # Gateway ports
-GATEWAY_LOCAL_PORT_HTTP ?= 8888
-GATEWAY_LOCAL_PORT_HTTPS ?= 8889
+GATEWAY_LOCAL_PORT_HTTP_MCP ?= 8888
+GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK ?= 8889
 
 # Export for use in shell commands
 export KIND_HOST_PORT_HTTP
 export KIND_HOST_PORT_HTTPS
-export GATEWAY_LOCAL_PORT_HTTP
-export GATEWAY_LOCAL_PORT_HTTPS
+export GATEWAY_LOCAL_PORT_HTTP_MCP
+export GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK


### PR DESCRIPTION
Fixes a regression from https://github.com/kagenti/mcp-gateway/pull/225 where the keycloak port forwarding args were removed from a couple of targets.
I hit this when trying to run `make inspect-gateway` followed by `make oauth-example-setup`, which expected to be able to reach keycloak then.

Also renames the 2 newly introduced variables from that PR to something more appropriate as both ports are http listeners, not http & https.