### PR TITLE
Skip token exchange if scoped down already

### DIFF
--- a/config/samples/oauth-token-exchange/tools-call-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-call-auth.yaml
@@ -16,6 +16,8 @@ spec:
           issuerUrl: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp
     metadata:
       token-exchange:
+        when:
+          - predicate: type(auth.identity.aud) != string || auth.identity.aud != request.host
         http:
           url: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp/protocol/openid-connect/token
           method: POST
@@ -34,22 +36,34 @@ spec:
             scope:
               value: openid
     authorization:
-      'allow-tool-access':
+      'token':
+        opa:
+          rego: |
+            scoped_jwt := object.get(object.get(object.get(input.auth, "metadata", {}), "token-exchange", {}), "access_token", "")
+            jwt := j { scoped_jwt != ""; j := scoped_jwt }
+            jwt := j { scoped_jwt == ""; j := split(input.request.headers["authorization"], "Bearer ")[1] }
+            claims := c { [_, c, _] := io.jwt.decode(jwt) }
+            allow = true
+          allValues: true
+        priority: 0
+      'scoped-audience-check':
+        patternMatching:
+          patterns:
+            - predicate: has(auth.authorization.token.claims.aud) && type(auth.authorization.token.claims.aud) == string && auth.authorization.token.claims.aud == request.host
+        priority: 1
+      'tool-access-check':
         patternMatching:
           patterns:
             - predicate: |
-                request.headers['x-mcp-toolname'] in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.host) ? auth.identity.resource_access[request.host].roles : [])
-      'token-exchange-success':
-        patternMatching:
-          patterns:
-            - predicate: auth.metadata.exists(m, m == "token-exchange") && auth.metadata["token-exchange"].exists(k, k == "access_token")
+                request.headers['x-mcp-toolname'] in (has(auth.authorization.token.claims.resource_access) && auth.authorization.token.claims.resource_access.exists(p, p == request.host) ? auth.authorization.token.claims.resource_access[request.host].roles : [])
+        priority: 1
     response:
       success:
         headers:
           authorization:
             plain:
               expression: |
-                "Bearer " + auth.metadata["token-exchange"]["access_token"]
+                "Bearer " + auth.authorization.token.jwt
       unauthenticated:
         code: 401
         headers:


### PR DESCRIPTION
Makes the tools/call request to skip token exchange if the bearer token is scoped down to the target audience already.

### Steps to reproduce

Setup the env for the token exchange use case:

```sh
make local-env-setup
kubectl set env deployment/kuadrant-operator-controller-manager -n kuadrant-system RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-shim:replace-headers-default
make oauth-token-exchange-example-setup
make inspect-gateway
```

Then:

In the Keycloak UI: add `server2.mcp.local`'s `headers` role to the `accounting` group of the `mcp` realm.

#### Case 1: With token exchange handled by the MCP gateway

1. In the MCP inspector: connect with credentials `mcp` / `mcp`, list the tools, and run the `test2_headers` tool.

The response from the `headers` tool should echo back in the `Authorization:` header the scoped token instead of the "full fat" bearer token obtained in the MCP inspector and used to tools/list and tools/call.

Notice the response to the tools/list includes all tools the user has access to. This means the bearer token can be reused to call tools at other authorised servers and a corresponding token exchange will be always handled automatically by the MCP gateway to avoid leaking permissions across servers.

#### Case 2: With a bearer token obtained by the client and scoped down to the target server from start

1. In the Keycloak UI: enable _Direct access grant_ for the `server2.mcp.local` OAuth client and add the _Audience_ token mapper to `server2.mcp.local`'s dedicated scopes, with _Included client audience_ set to 'server2.mcp.local'

2. Obtain a token scoped for the `server2.mcp.local` server

```sh
ACCESS_TOKEN=$(curl http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp/protocol/openid-connect/token -s -d 'grant_type=password' -d 'client_id=server2.mcp.local' -d 'username=mcp' -d 'password=mcp' -d 'scope=openid' | jq -r .access_token)
```

3. Initialize a session, tools/list and tools/call, all using the scoped token to authenticate

```sh
MCP_SESSION_ID=$(curl -s -o /dev/null -w '%header{mcp-session-id}\n' \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  -H 'Content-Type: application/json' \
  -H 'mcp-protocol-version: 2025-06-18' \
  --data-raw '{"method":"initialize","params":{"_meta":{"progressToken":1}},"jsonrpc":"2.0","id":1}' \
  http://mcp.127-0-0-1.sslip.io:8888/mcp)

curl -s \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  -H 'Content-Type: application/json' \
  -H 'mcp-protocol-version: 2025-06-18' \
  -H "mcp-session-id: $MCP_SESSION_ID" \
  --data-raw '{"method":"tools/list","params":{"_meta":{"progressToken":1}},"jsonrpc":"2.0","id":1}' \
  http://mcp.127-0-0-1.sslip.io:8888/mcp

curl -s \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -H 'mcp-protocol-version: 2025-06-18' \
  -H "mcp-session-id: $MCP_SESSION_ID" \
  --data-raw '{"method":"tools/call","params":{"name":"test2_headers","_meta":{"progressToken":3}},"jsonrpc":"2.0","id":1}' \
  http://server1.127-0-0-1.sslip.io:8888/mcp
```

The response from the `headers` tool should echo back in the `Authorization:` header the scoped token, which is the same as the bearer token obtained at step 2 and used to tools/list and tools/call.

Notice the tools/list response is filtered only to the tools included in the scoped token, as opposed to all tools the user has access to. This means the token cannot be used to call tools at other servers even if the tool is authorised for the user. Each tools/call to a different server will require another scoped token obtained by the client directly.