### PR TITLE
don't reject notification requests without an id

### DIFF
--- a/internal/mcp-router/request.go
+++ b/internal/mcp-router/request.go
@@ -35,11 +35,15 @@ func (mr *MCPRequest) Validate() (bool, error) {
 	if mr.Method == "" {
 		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("no method set in json rpc payload"))
 	}
-	if mr.ID == nil {
-		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("no id set in json rpc payload"))
+	if mr.ID == nil && !mr.isNotificationRequest() {
+		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("no id set in json rpc payload for none notification method: %s ", mr.Method))
 	}
 
 	return true, nil
+}
+
+func (mr *MCPRequest) isNotificationRequest() bool {
+	return strings.HasPrefix(mr.Method, "notifications")
 }
 
 // isToolCall will check if the request is a tool call request
@@ -69,7 +73,7 @@ func (mr *MCPRequest) ReWriteToolName(actualTool string) {
 	mr.Params["name"] = actualTool
 }
 
-// ToBytes mashels the data ready to send on
+// ToBytes marshals the data ready to send on
 func (mr *MCPRequest) ToBytes() ([]byte, error) {
 	return json.Marshal(mr)
 }

--- a/internal/mcp-router/request_test.go
+++ b/internal/mcp-router/request_test.go
@@ -35,6 +35,15 @@ func TestMCPRequestValid(t *testing.T) {
 			ExpectErr: nil,
 		},
 		{
+			Name: "test with valid notification request",
+			Input: &MCPRequest{
+				JSONRPC: "2.0",
+				Method:  "notifications/initialize",
+				Params:  map[string]any{},
+			},
+			ExpectErr: nil,
+		},
+		{
 			Name: "test with invalid version",
 			Input: &MCPRequest{
 				JSONRPC: "1.0",
@@ -55,7 +64,7 @@ func TestMCPRequestValid(t *testing.T) {
 			ExpectErr: ErrInvalidRequest,
 		},
 		{
-			Name: "test with missing id ",
+			Name: "test with missing id  for none notification call",
 			Input: &MCPRequest{
 				JSONRPC: "2.0",
 				Method:  "tools/call",


### PR DESCRIPTION
partial fix for https://github.com/kagenti/mcp-gateway/issues/284

Not all json rpc messages need an ID just those that expect an response. As per the MCP and Json RPC spec. This pr checks if the method is prefixed with notifications 