### PR TITLE
Broker prompts, resources, and resource templates

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -291,7 +291,7 @@ func (m *mcpBrokerImpl) RegisterServerWithConfig(
 	// Add to map BEFORE discovering tools so createMCPClient can find it
 	m.mcpServers[upstreamMCPURL(mcpServer.URL)] = upstream
 
-	discovered, err := m.discoverTools(ctx, upstream)
+	discovered, err := m.discoverUpstream(ctx, upstream)
 	if err != nil {
 		slog.Info("Failed to discover tools, will retry with backoff", "mcpURL", mcpServer.URL, "error", err)
 		// start background retry with exponential backoff
@@ -428,7 +428,7 @@ func (m *mcpBrokerImpl) CallTool(
 	return res, err
 }
 
-func (m *mcpBrokerImpl) discoverTools(ctx context.Context, upstream *upstreamMCP, options ...transport.StreamableHTTPCOption) (*discoveryResult, error) {
+func (m *mcpBrokerImpl) discoverUpstream(ctx context.Context, upstream *upstreamMCP, options ...transport.StreamableHTTPCOption) (*discoveryResult, error) {
 
 	// Some MCP servers require a bearer token or other Authorization to init and list tools
 	serverAuthHeaderValue := getAuthorizationHeaderForUpstream(upstream)
@@ -577,7 +577,7 @@ func (m *mcpBrokerImpl) retryDiscovery(ctx context.Context, upstream *upstreamMC
 			"url", upstream.URL,
 			"attempt", attempt)
 
-		discovered, err := m.discoverTools(ctx, upstream)
+		discovered, err := m.discoverUpstream(ctx, upstream)
 		if err != nil {
 			m.logger.Warn("retry discovery failed",
 				"url", upstream.URL,


### PR DESCRIPTION
For #208

This adds resources, resource templates, and prompts to the broker.
(It does not add them to the router.  The gateway'ed resources and prompts appear in the MCP inspector, but cannot be invoked.)

To test this PR locally, first start the "everything MCP server" with

```bash
npm install -g @modelcontextprotocol/server-everything@latest
npm run start:streamableHttp
```

Next, run the MCP gateway against the everything server.

```bash
cat <<EOF > /tmp/mcp-gateway-config.yaml
servers:
  - name: test
    url: http://localhost:3001/mcp
    toolPrefix: everything_
    enabled: true
    hostname: t2.example.com
EOF

go run cmd/mcp-broker-router/main.go -mcp-broker-public-address localhost:8081 -mcp-gateway-config /tmp/mcp-gateway-config.yaml
```

At this point, run `DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector` and compare the difference between connecting to http://localhost:3001/mcp and http://localhost:8081/mcp in terms of prompts, resources, and resource templates.
