### PR TITLE
Remove namespace template from helm chart & use Release.Namespace

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -102,7 +102,7 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Installation Command" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "helm install mcp-gateway oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/mcp-gateway --version ${{ inputs.chart_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "helm install mcp-gateway oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/mcp-gateway --version ${{ inputs.chart_version }} --create-namespace --namespace mcp-system" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   create-git-tag:

--- a/charts/README.md
+++ b/charts/README.md
@@ -21,7 +21,7 @@ The MCP Gateway Helm chart deploys:
 ### Install from Chart
 
 ```bash
-helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --version 0.1.0
+helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --version 0.1.0 --create-namespace --namespace mcp-system
 ```
 
 > **Note**: The chart defaults to the `mcp-system` namespace to match the controller's expectations.
@@ -30,7 +30,7 @@ helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --version 0.1.
 
 ```bash
 # From the repository root
-helm install mcp-gateway ./charts/mcp-gateway
+helm install mcp-gateway ./charts/mcp-gateway --create-namespace --namespace mcp-system
 ```
 
 ## Post Install Setup
@@ -147,7 +147,7 @@ helm template test ./charts/mcp-gateway --debug
 
 # Install locally for testing
 helm install test-mcp-gateway ./charts/mcp-gateway \
-  --dry-run --debug
+  --create-namespace --namespace mcp-system --dry-run --debug
 ```
 
 ### Publishing New Versions

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Check the status of your deployment:
-  kubectl get pods -n {{ include "mcp-gateway.namespace" . }} -l "app.kubernetes.io/instance={{ .Release.Name }}"
+  kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }}"
 
 {{- if .Values.envoyFilter.create }}
 2. Verify EnvoyFilter is installed:
@@ -25,7 +25,7 @@
   kind: HTTPRoute
   metadata:
     name: mcp-route
-    namespace: {{ include "mcp-gateway.namespace" . }}
+    namespace: {{ .Release.Namespace }}
   spec:
     parentRefs:
       - name: mcp-gateway  # Your Gateway name
@@ -69,7 +69,7 @@
   kind: MCPServer
   metadata:
     name: my-mcp-server
-    namespace: {{ include "mcp-gateway.namespace" . }}
+    namespace: {{ .Release.Namespace }}
   spec:
     toolPrefix: "myserver_"
     targetRef:
@@ -83,9 +83,9 @@
 
 7. View logs for troubleshooting:
   # Broker/Router logs
-  kubectl logs -n {{ include "mcp-gateway.namespace" . }} deployment/{{ include "mcp-gateway.fullname" . }}-broker-router
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "mcp-gateway.fullname" . }}-broker-router
   
   # Controller logs  
-  kubectl logs -n {{ include "mcp-gateway.namespace" . }} deployment/{{ include "mcp-gateway.fullname" . }}-controller
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "mcp-gateway.fullname" . }}-controller
 
 For more information, visit: https://github.com/kagenti/mcp-gateway

--- a/charts/mcp-gateway/templates/_helpers.tpl
+++ b/charts/mcp-gateway/templates/_helpers.tpl
@@ -67,12 +67,6 @@ Create the name of the controller service account to use
 {{ include "mcp-gateway.fullname" . }}-controller
 {{- end }}
 
-{{/*
-Get the namespace
-*/}}
-{{- define "mcp-gateway.namespace" -}}
-mcp-system
-{{- end }}
 
 {{/*
 Docker image name

--- a/charts/mcp-gateway/templates/configmap.yaml
+++ b/charts/mcp-gateway/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mcp-gateway-config
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     app: mcp-gateway

--- a/charts/mcp-gateway/templates/deployment-broker.yaml
+++ b/charts/mcp-gateway/templates/deployment-broker.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-broker-router
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: broker-router

--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-controller
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: controller
@@ -34,7 +34,7 @@ spec:
                   name: {{ include "mcp-gateway.fullname" . }}-config-update-token
                   key: token
             - name: BROKER_CONFIG_URL
-              value: "http://{{ include "mcp-gateway.fullname" . }}-config.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8181/config"
+              value: "http://{{ include "mcp-gateway.fullname" . }}-config.{{ .Release.Namespace }}.svc.cluster.local:8181/config"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/mcp-gateway/templates/envoyfilter.yaml
+++ b/charts/mcp-gateway/templates/envoyfilter.yaml
@@ -40,5 +40,5 @@ spec:
               response_trailer_mode: 'SKIP'
             grpc_service:
               envoy_grpc:
-                cluster_name: outbound|50051||{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local
+                cluster_name: outbound|50051||{{ include "mcp-gateway.fullname" . }}-broker.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}

--- a/charts/mcp-gateway/templates/namespace.yaml
+++ b/charts/mcp-gateway/templates/namespace.yaml
@@ -1,8 +1,0 @@
-{{- if ne (include "mcp-gateway.namespace" .) "default" }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "mcp-gateway.namespace" . }}
-  labels:
-    {{- include "mcp-gateway.labels" . | nindent 4 }}
-{{- end }}

--- a/charts/mcp-gateway/templates/rbac.yaml
+++ b/charts/mcp-gateway/templates/rbac.yaml
@@ -55,13 +55,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "mcp-gateway.controllerServiceAccountName" . }}
-    namespace: {{ include "mcp-gateway.namespace" . }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-broker-router
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: broker-router
@@ -75,7 +75,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-broker-router
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: broker-router
@@ -86,4 +86,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "mcp-gateway.brokerServiceAccountName" . }}
-    namespace: {{ include "mcp-gateway.namespace" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/mcp-gateway/templates/secret.yaml
+++ b/charts/mcp-gateway/templates/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-config-update-token
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/mcp-gateway/templates/service.yaml
+++ b/charts/mcp-gateway/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-broker
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     app.kubernetes.io/component: mcp-broker
@@ -26,7 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-config
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     app.kubernetes.io/component: mcp-broker-config

--- a/charts/mcp-gateway/templates/serviceaccount.yaml
+++ b/charts/mcp-gateway/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "mcp-gateway.brokerServiceAccountName" . }}
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: broker-router
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "mcp-gateway.controllerServiceAccountName" . }}
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: controller

--- a/charts/mcp-gateway/templates/tests/test-connection.yaml
+++ b/charts/mcp-gateway/templates/tests/test-connection.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "mcp-gateway.fullname" . }}-test-connection"
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
   annotations:
@@ -22,6 +22,6 @@ spec:
         
         # Test broker health endpoint
         echo "Checking broker health endpoint..."
-        curl -f http://{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8080/healthz
+        curl -f http://{{ include "mcp-gateway.fullname" . }}-broker.{{ .Release.Namespace }}.svc.cluster.local:8080/healthz
         
         echo "All tests passed!"

--- a/charts/mcp-gateway/templates/tests/test-status.yaml
+++ b/charts/mcp-gateway/templates/tests/test-status.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "mcp-gateway.fullname" . }}-test-status"
-  namespace: {{ include "mcp-gateway.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
   annotations:
@@ -21,7 +21,7 @@ spec:
         echo "Testing MCP Gateway status endpoint..."
         
         # Test status endpoint returns valid JSON
-        response=$(curl -s http://{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8080/status)
+        response=$(curl -s http://{{ include "mcp-gateway.fullname" . }}-broker.{{ .Release.Namespace }}.svc.cluster.local:8080/status)
         echo "Status response: $response"
         
         # Check if response contains expected fields

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -59,10 +59,10 @@ kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRAN
 # Install MCP Gateway using either local chart or remote OCI chart
 if [ "$USE_LOCAL_CHART" = "true" ]; then
     echo "Installing from local chart: ./charts/mcp-gateway/"
-    helm install mcp-gateway ./charts/mcp-gateway/
+    helm install mcp-gateway ./charts/mcp-gateway/ --create-namespace --namespace mcp-system
 else
     echo "Installing from remote OCI chart: oci://ghcr.io/kagenti/charts/mcp-gateway"
-    helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway
+    helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --create-namespace --namespace mcp-system
 fi
 kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/samples/mcpserver-test-servers.yaml
 

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -41,7 +41,7 @@ You'll need at least one MCP server to route through the gateway. This can be:
 Install from GitHub Container Registry:
 
 ```bash
-helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway
+helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --create-namespace --namespace mcp-system
 ```
 
 This automatically installs:

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -26,8 +27,6 @@ import (
 )
 
 const (
-	// ConfigNamespace is the namespace for config
-	ConfigNamespace = "mcp-system"
 	// ConfigName is the name of the config
 	ConfigName = "mcp-gateway-config"
 
@@ -41,6 +40,15 @@ const (
 	// CredentialSecretValue is the required value for credential secrets
 	CredentialSecretValue = "true"
 )
+
+// getConfigNamespace returns the namespace for config, using NAMESPACE env var or defaulting to mcp-system
+func getConfigNamespace() string {
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		namespace = "mcp-system"
+	}
+	return namespace
+}
 
 // generates credential env var name: KAGENTAI_{MCP_NAME}_CRED
 func generateCredentialEnvVar(mcpServerName string) string {
@@ -360,7 +368,7 @@ func (r *MCPReconciler) writeAggregatedConfig(
 	brokerConfig *config.BrokerConfig,
 ) error {
 	writer := NewConfigMapWriter(r.Client, r.Scheme)
-	return writer.WriteAggregatedConfig(ctx, ConfigNamespace, ConfigName, brokerConfig)
+	return writer.WriteAggregatedConfig(ctx, getConfigNamespace(), ConfigName, brokerConfig)
 }
 
 func (r *MCPReconciler) discoverServersFromHTTPRoutes(
@@ -1073,7 +1081,7 @@ func (r *MCPReconciler) aggregateCredentials(ctx context.Context, mcpServers []m
 	aggregatedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mcp-aggregated-credentials",
-			Namespace: ConfigNamespace,
+			Namespace: getConfigNamespace(),
 			Labels: map[string]string{
 				"app":                        "mcp-gateway",
 				"mcp.kagenti.com/aggregated": "true",


### PR DESCRIPTION
Closes #290

There's a couple places where the namespcace was hardcoded as mcp-system in the mcp controller.

Most easily verified with something like `helm install my-mcp-gateway ./charts/mcp-gateway   --create-namespace --namespace my-mcp-gateway-ns --set envoyFilter.namespace=my-envoy-ns --dry-run --debug`.

To do a full verification, the `charts/sample_local_helm_setup.sh` could be used, but you'll need to modify it to install from local directory (an env var has been added in #292 to allow this in future), or copy and run the commands from that script, replacing the `helm install` with something like `helm install mcp-gateway ./charts/mcp-gateway  --create-namespace --namespace mcp-system`