### PR TITLE
fix: vault fallback

### DIFF
--- a/config/samples/oauth-token-exchange/tools-call-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-call-auth.yaml
@@ -29,7 +29,7 @@ spec:
         priority: 0
       oauth-token-exchange:
         when:
-          - predicate: "!has(auth.metadata.vault.data)"
+          - predicate: "!has(auth.metadata.vault.data) || !has(auth.metadata.vault.data.data) || !has(auth.metadata.vault.data.data.token) || type(auth.metadata.vault.data.data.token) != string"
           - predicate: type(auth.identity.aud) != string || auth.identity.aud != request.host
         http:
           url: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp/protocol/openid-connect/token
@@ -65,7 +65,7 @@ spec:
         priority: 0
       'scoped-audience-check':
         when:
-          - predicate: "!has(auth.metadata.vault.data)"
+          - predicate: "!has(auth.metadata.vault.data) || !has(auth.metadata.vault.data.data) || !has(auth.metadata.vault.data.data.token) || type(auth.metadata.vault.data.data.token) != string"
         patternMatching:
           patterns:
             - predicate: has(auth.authorization.token.claims.aud) && type(auth.authorization.token.claims.aud) == string && auth.authorization.token.claims.aud == request.host
@@ -82,7 +82,7 @@ spec:
           authorization:
             plain:
               expression: |
-                "Bearer " + (has(auth.metadata.vault.data) ? auth.metadata.vault.data.data.token : auth.authorization.token.jwt)
+                "Bearer " + ((has(auth.metadata.vault.data) && has(auth.metadata.vault.data.data) && has(auth.metadata.vault.data.data.token) && type(auth.metadata.vault.data.data.token) == string) ? auth.metadata.vault.data.data.token : auth.authorization.token.jwt)
       unauthenticated:
         code: 401
         headers:


### PR DESCRIPTION
bugfix: makea the OAuth2 Token Exchange example to not fallback to the full fat token when a vault entry once existed but was later deleted.

### Verification steps

❶ Setup the env

```sh
make local-env-setup
kubectl set env deployment/kuadrant-operator-controller-manager -n kuadrant-system RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-shim:replace-headers-default
make oauth-token-exchange-example-setup
make inspect-gateway
```

❷ Call a tool (before storing the secret in Vault)

Outcome: The scoped OAuth2 access token is propagated in the request to the MCP server.

❸ Store a secret in Vault

```sh
curl -s -H "X-Vault-Token: root" -H 'Content-Type: application/json' -X POST \
  --data '{"data":{"token":"s3cr3t"}}' \
  http://localhost:8200/v1/secret/data/mcp/server2.mcp.local
```

❹ Call a tool (after storing the secret in Vault)

Outcome: The secret stored in Vault is propagated in the request to the MCP server.

❹ Delete the secret stored in Vault

```sh
curl -s -H "X-Vault-Token: root" -H 'Content-Type: application/json' -X DELETE \
  http://localhost:8200/v1/secret/data/mcp/server2.mcp.local
```

❺ Call a tool (after deleting the secret from Vault)

**Without the fix:**

Outcome: The full fat OAuth2 access token is propagated in the request to the MCP server. ❌

**With the fix:**

Outcome: The scoped OAuth2 access token is propagated in the request to the MCP server. ✅