### PR TITLE
Fix for progress notifications. Don't buffer the response body.

### DIFF
--- a/charts/mcp-gateway/templates/envoyfilter.yaml
+++ b/charts/mcp-gateway/templates/envoyfilter.yaml
@@ -35,7 +35,7 @@ spec:
               request_header_mode: 'SEND'
               response_header_mode: 'SEND'
               request_body_mode: 'BUFFERED'
-              response_body_mode: 'BUFFERED'
+              response_body_mode: 'NONE'
               request_trailer_mode: 'SKIP'
               response_trailer_mode: 'SKIP'
             grpc_service:

--- a/config/dev/envoyfilter.yaml
+++ b/config/dev/envoyfilter.yaml
@@ -32,7 +32,7 @@ spec:
               request_header_mode: 'SEND'
               response_header_mode: 'SEND'
               request_body_mode: 'BUFFERED'
-              response_body_mode: 'BUFFERED'
+              response_body_mode: 'NONE'
               request_trailer_mode: 'SKIP'
               response_trailer_mode: 'SKIP'
             grpc_service:

--- a/config/istio/envoyfilter.yaml
+++ b/config/istio/envoyfilter.yaml
@@ -32,7 +32,7 @@ spec:
               request_header_mode: 'SEND'
               response_header_mode: 'SEND'
               request_body_mode: 'BUFFERED'
-              response_body_mode: 'BUFFERED'
+              response_body_mode: 'NONE'
               request_trailer_mode: 'SKIP'
               response_trailer_mode: 'SKIP'
             grpc_service:

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -132,7 +132,7 @@ static_resources:
                 request_header_mode: SEND
                 response_header_mode: SEND
                 request_body_mode: BUFFERED
-                response_body_mode: BUFFERED
+                response_body_mode: NONE
           - name: envoy.filters.http.router
 
   clusters:

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -133,7 +133,7 @@ spec:
               request_header_mode: SEND
               response_header_mode: SEND
               request_body_mode: BUFFERED
-              response_body_mode: BUFFERED
+              response_body_mode: NONE
               request_trailer_mode: SKIP
               response_trailer_mode: SKIP
             grpc_service:

--- a/internal/mcp-router/response.go
+++ b/internal/mcp-router/response.go
@@ -88,26 +88,6 @@ func (s *ExtProcServer) HandleResponseHeaders(
 	}, nil
 }
 
-// HandleResponseBody handles response bodies.
-func (s *ExtProcServer) HandleResponseBody(
-	body *eppb.HttpBody) ([]*eppb.ProcessingResponse, error) {
-	slog.Info(fmt.Sprintf("[EXT-PROC] Processing response body... (size: %d, end_of_stream: %t)",
-		len(body.GetBody()), body.GetEndOfStream()))
-
-	// slog the response body content if it's not too large
-	if len(body.GetBody()) > 0 && len(body.GetBody()) < 1000 {
-		slog.Info(fmt.Sprintf("[EXT-PROC] Response body content: %s", string(body.GetBody())))
-	}
-
-	return []*eppb.ProcessingResponse{
-		{
-			Response: &eppb.ProcessingResponse_ResponseBody{
-				ResponseBody: &eppb.BodyResponse{},
-			},
-		},
-	}, nil
-}
-
 // HandleResponseTrailers handles response trailers.
 func (s *ExtProcServer) HandleResponseTrailers(
 	_ *eppb.HttpTrailers,


### PR DESCRIPTION
Fixes #226 

Pulling out this change from the spike work in #315 
My understanding of client specific notifications was flawed when it came to tool call notifications.
There's a difference between solicited and unsolicited notifications.
For tool call notifications, which as solicited, the client sends a [progress token](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress) in the request, indicating they want to receive progress updates.
These progress updates *do not* seem to get sent over the /GET notifications channel.
They are sent as events in the /POST tool call response.
Here's an example curl request, showing events as the connection is kept alive until the tool call finishes.

```shell
curl -v -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' -H 'mcp-session-id: mcp-session-35d095c5-69d1-42a0-af3f-62712c76d25f' -X POST -d '{"jsonrpc": "2.0", "id": 1,"params":{"_meta": {"progressToken":"1"},"name":"test2_slow","arguments":{"seconds":3}},"method": "tools/call"}' http://mcp.127-0-0-1.sslip.io:8888/mcp
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host mcp.127-0-0-1.sslip.io:8888 was resolved.
* IPv6: (none)
* IPv4: 127.0.0.1
*   Trying 127.0.0.1:8888...
* Connected to mcp.127-0-0-1.sslip.io (127.0.0.1) port 8888
> POST /mcp HTTP/1.1
> Host: mcp.127-0-0-1.sslip.io:8888
> User-Agent: curl/8.7.1
> content-type: application/json
> accept: application/json, text/event-stream
> mcp-session-id: mcp-session-35d095c5-69d1-42a0-af3f-62712c76d25f
> Content-Length: 138
>
* upload completely sent off: 138 bytes
< HTTP/1.1 200 OK
< cache-control: no-cache
< content-type: text/event-stream
< date: Mon, 10 Nov 2025 20:38:46 GMT
< x-envoy-upstream-service-time: 1
< server: istio-envoy
< transfer-encoding: chunked
<
event: message
data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"message":"Waited 0 seconds...","progress":0,"progressToken":"1"}}

event: message
data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"message":"Waited 1 seconds...","progress":1,"progressToken":"1"}}

event: message
data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"message":"Waited 2 seconds...","progress":2,"progressToken":"1"}}

event: message
data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"done"}]}}

* Connection #0 to host mcp.127-0-0-1.sslip.io left intact
```

There may be other client specific notification events that are solicited, that *do* get sent over the /GET notifications channel , but tools/call behave different.
Let's support these first as they don't require the extra wiring up of the /GET notification channel to each backend mcp server.

Anyways, the fix here is disabling buffered response body parsing.
The buffering was leading to the 'bunched' progress updates seen in #226 when the tool call finished.
I've updated the response body ext-proc handler to output an error as this should not be executed. 
If it is, it indicates a misconfuration of the ext-proc filter.