### PR TITLE
Fix backend mcp server tool rediscovery via notification

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -433,13 +433,6 @@ func (m *mcpBrokerImpl) discoverTools(ctx context.Context, upstream *upstreamMCP
 		return nil, fmt.Errorf("failed to create streamable client: %w", err)
 	}
 
-	// Let transport listen for updates
-	// TODO Note that currently this pollutes the log, see https://github.com/mark3labs/mcp-go/issues/552
-	err = upstream.mpcClient.Start(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to start streamable client: %w", err)
-	}
-
 	upstream.initializeResult = resInit
 
 	resTools, err := upstream.mpcClient.ListTools(ctx, mcp.ListToolsRequest{})
@@ -742,6 +735,12 @@ func (m *mcpBrokerImpl) createMCPClient(ctx context.Context, mcpURL, name string
 	httpClient, err := client.NewStreamableHttpClient(mcpURL, options...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	// Start the client before initialize to listen for notifications
+	err = httpClient.Start(context.Background())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to start streamable client: %w", err)
 	}
 
 	// Configure capabilities and client info based on type


### PR DESCRIPTION
In #164 functionality was added to re-list tools whenever a 'notification/tools/list_changed' message is received.
This was inadvertently broken in https://github.com/kagenti/mcp-gateway/pull/184/files#diff-859c24a32d9f6d5ac854ed430c6990859a50de9f9c4bbec83a552d431e1d1f1dL340-L373.
I don't see any obvious reason for that specific change happening, and looks more like a small refactor with unintended consequences in a larger PR.
This change moves the call to `.Start()` before the `.Initialize()` which is important for the notifications channel to be established.


To verify, the exact same steps in #164 can be executed again, and log entries seen like this:

```
time=2025-11-10T22:39:26.411Z level=INFO msg="Broker OnNotification" notification.Method=notifications/tools/list_changed notification.Params="{Meta:map[] AdditionalFields:map[]}"
time=2025-11-10T22:39:26.413Z level=INFO msg="Re-Discovered tools" mcpURL=http://mcp-test-server2.mcp-test.svc.cluster.local:9090/mcp #tools=3
time=2025-11-10T22:39:26.413Z level=INFO msg="Removing tools" mcpURL=http://mcp-test-server2.mcp-test.svc.cluster.local:9090/mcp newlyRemovedToolNames=[test2_time]
```