### PR TITLE
OpenShift deploy script gateway helm version bump

### DIFF
--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_HELM_VERSION="${MCP_GATEWAY_HELM_VERSION:-0.3.0}"
+MCP_GATEWAY_HELM_VERSION="${MCP_GATEWAY_HELM_VERSION:-0.4.0}"
 
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 


### PR DESCRIPTION
Bumping the helm version from 0.3.0 to 0.4.0.

Avoids the following error:

```
--mcp-gateway-public-host cannot be empty. The mcp gateway needs to be informed of what public host to expect requests from so it can ensure routing and session mgmt happens. Set --mcp-gateway-public-host
```