### PR TITLE
wildcard hostname for the `mcps` listener

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -61,6 +61,7 @@ spec:
         namespaces:
           from: All
     - name: mcps
+      hostname: '*.mcp.local'
       port: 8080
       protocol: HTTP
       allowedRoutes:


### PR DESCRIPTION
fix #334