### PR TITLE
add back the hostname to the listener and routes

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -15,6 +15,13 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: mcps
+      port: 8080
+      protocol: HTTP
+      hostname: '*.mcp.local' # this hostname can be any wildcard. It is here to simplify routing, ensure the MCP Server routes attach to this listener only, can be protected by the AuthPolicy and routed to via envoy and the MCPRouter.
+      allowedRoutes:
+        namespaces:
+          from: All #any namespace can register an MCP server route
     - name: keycloak
       hostname: 'keycloak.127-0-0-1.sslip.io'
       port: 8889
@@ -60,9 +67,3 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: mcps
-      port: 8080
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: All #any namespace can register an MCP server route

--- a/config/keycloak/httproute.yaml
+++ b/config/keycloak/httproute.yaml
@@ -39,13 +39,13 @@ spec:
               - Access-Control-Allow-Methods
             set:
               - name: Access-Control-Allow-Origin
-                value: "http://localhost:6274"
+                value: 'http://localhost:6274'
               - name: Access-Control-Allow-Credentials
-                value: "true"
+                value: 'true'
               - name: Access-Control-Allow-Headers
-                value: "Content-Type, Authorization"
+                value: 'Content-Type, Authorization'
               - name: Access-Control-Allow-Methods
-                value: "POST, OPTIONS"
+                value: 'POST, OPTIONS'
       backendRefs:
         - name: keycloak
           port: 80

--- a/config/mcp-system/httproute.yaml
+++ b/config/mcp-system/httproute.yaml
@@ -18,15 +18,15 @@ spec:
           responseHeaderModifier:
             add:
               - name: Access-Control-Allow-Origin
-                value: "*"
+                value: '*'
               - name: Access-Control-Allow-Methods
-                value: "GET, POST, PUT, DELETE, OPTIONS, HEAD"
+                value: 'GET, POST, PUT, DELETE, OPTIONS, HEAD'
               - name: Access-Control-Allow-Headers
-                value: "Content-Type, Authorization, Accept, Origin, X-Requested-With"
+                value: 'Content-Type, Authorization, Accept, Origin, X-Requested-With'
               - name: Access-Control-Max-Age
-                value: "3600"
+                value: '3600'
               - name: Access-Control-Allow-Credentials
-                value: "true"
+                value: 'true'
       backendRefs:
         - name: mcp-broker
           port: 8080

--- a/config/test-servers/server1-httproute.yaml
+++ b/config/test-servers/server1-httproute.yaml
@@ -9,7 +9,7 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'mcp-server-1' #note This is purely for internal routing by Envoy
+    - 'server1.mcp.local' #note This is purely for internal routing by Envoy
   rules:
     - matches:
         - path:

--- a/config/test-servers/server2-httproute.yaml
+++ b/config/test-servers/server2-httproute.yaml
@@ -9,7 +9,7 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'mcp-server-2' #note this is purely for internal routing by Envoy
+    - 'server2.mcp.local' #note this is purely for internal routing by Envoy
   rules:
     - matches:
         - path:

--- a/config/test-servers/server3-httproute.yaml
+++ b/config/test-servers/server3-httproute.yaml
@@ -9,7 +9,7 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'mcp-server-3' #note this is purely for internal routing by Envoy
+    - 'server3.mcp.local' #note this is purely for internal routing by Envoy
   rules:
     - matches:
         - path:

--- a/docs/design/routing.md
+++ b/docs/design/routing.md
@@ -38,6 +38,7 @@ listeners:
     - name: mcp-servers # no host name required as the host is set by the HTTRoute
       port: 8080
       protocol: HTTP
+      hostname: '*.mcp.local' # this hostname can be any wildcard hostname. It is here to ensure the MCP Server routes attach only to this listener and can be protected by the correct AuthPolicy. 
       allowedRoutes:
         namespaces:
           from: All #any namespace can register an MCP server route
@@ -66,4 +67,4 @@ To configure the MCP Gateway we have two different routes with distinct routing 
 
 - **The MCP Gateway Route:** This route is how agents interact with the Gateway and is intended to be the route exposed for use (for example via a DNS resolvable hostname). The default backend for this route must be the MCP Broker component. From a client perspective this endpoint acts as an MCP Server.[Example](../../config/mcp-system/httproute.yaml). Although this route will also receive tools/calls it does not actually send tools/calls to the broker backend. These are intercepted and re-routed.
 
-- **Individual MCP Server Routes:** These are intended to route to individual MCP Servers that can handle distinct tools/calls from a client. There can be many of these routes but there is expected to be a 1:1 relationship between a route and a MCP Backend. Each MCP Server route should have some form of hostname set. The hostname used, is not hugely important as it is not expected to be DNS resolvable. In our examples we use `server1.mcp.local` etc. Each route should have a single rule that points at the MCP backend. [Example](../../config/test-servers/server1-httproute.yaml).
+- **Individual MCP Server Routes:** These are intended to route to individual MCP Servers that can handle distinct tools/calls from a client. There can be many of these routes but there is expected to be a 1:1 relationship between a route and a MCP Backend. Each MCP Server route should have some form of hostname set and it should match the gateway listener (in the above example `*.mcp.local`). The hostname used, is not hugely important as it is not expected to be DNS resolvable. In our examples we use `{ServerName}.mcp.local` in the HTTPRoute. Each route should have a single rule that points at the MCP backend. [Example](../../config/test-servers/server1-httproute.yaml).


### PR DESCRIPTION
When adding the routing updates in https://github.com/kagenti/mcp-gateway/pull/318 I removed the hostnames from the listener and changed the hostnames in the httproute. This had the unintended side effect of breaking the Auth example.

This PR fixes that issue

replaces #336 