### PR TITLE
Remove port forwarding in favour of node port.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,6 @@ Client → Gateway (Envoy) → Router (ext_proc) → Broker → Upstream MCP Ser
 ### Quick Start
 ```bash
 make local-env-setup     # Create Kind cluster with everything
-make dev-gateway-forward # Access gateway at localhost:8888
 make reload              # Build, load to Kind, and restart controller and broker
 ```
 
@@ -85,7 +84,8 @@ This prevents resource waste during rapid development/force-pushing.
 - 8080: Broker HTTP (/mcp endpoint)
 - 50051: Router gRPC (ext_proc)
 - 8081: Controller health probes
-- 8888: Gateway forward for dev
+- 8001: Gateway port mapping
+- 8002: Keycloak port mapping
 
 ## Known Issues & Solutions
 

--- a/Makefile
+++ b/Makefile
@@ -395,10 +395,6 @@ keycloak-install: ## Install Keycloak IdP for development
 	@echo "Installing Keycloak - using official image with dev-file database"
 	@$(MAKE) -s -f build/keycloak.mk keycloak-install-impl
 
-.PHONY: keycloak-forward
-keycloak-forward: ## Port forward Keycloak to localhost:8090
-	@$(MAKE) -s -f build/keycloak.mk keycloak-forward-impl
-
 .PHONY: keycloak-status
 keycloak-status: ## Show Keycloak URLs, credentials, and OIDC endpoints
 	@$(MAKE) -s -f build/keycloak.mk keycloak-status-impl

--- a/README.md
+++ b/README.md
@@ -65,12 +65,15 @@ Also sets up an Istio Gateway API Gateway, and HTTPRoutes for test mcp servers, 
 ```bash
 make local-env-setup
 
-# Or with custom ports (defaults: 8080/8443 for Kind, 8888/8889 for Gateway)
-KIND_HOST_PORT_HTTP=8090 KIND_HOST_PORT_HTTPS=8453 make local-env-setup
-GATEWAY_LOCAL_PORT_HTTP_MCP=9000 GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK=9001 make dev-gateway-forward
+# Or with custom ports (defaults: 8001->30080->8080 for MCP Broker/Gateway, 8002->30089->8002 for Keycloak)
+KIND_HOST_PORT_MCP_GATEWAY=8090 KIND_HOST_PORT_KEYCLOAK=8453 make local-env-setup
 ```
 
-Run the MCP Inspector and connect to the gateway (This also port forwards to the gateway)
+> **Note**: If you change these ports, be mindful that some examples or YAML resources may need to be updated manually to use the updated port. You should check for anything that connects to `mcp.127-0-0-1.sslip.io` or `keycloak.127-0-0-1.sslip.io` and update the port numbers accordingly.
+>
+> **Keycloak Port Requirement**: The host port for Keycloak needs to match the internal listener port (8002 in the default configuration) because there is a `hostAlias` in Authorino in the local dev environment that ensures Authorino calls back to Keycloak at the correct IP/port to validate tokens. If you change the host port (e.g., to 9999), you must also change the listener in the gateway to 9999, otherwise Authorino cannot reach Keycloak over the internal Kubernetes network.
+
+Run the MCP Inspector and connect to the gateway
 
 ```bash
 make inspect-gateway
@@ -94,7 +97,7 @@ This will:
 
 The mcp-broker now serves OAuth discovery information at `/.well-known/oauth-protected-resource`.
 
-Finally, open MCP Inspector at http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp
+Finally, open MCP Inspector at http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp
 
 When you click connect with MCP Inspector, you should be redirected to Keycloak. There you will need to login as the MCP user with password mcp. You now should only be able to access tools based on the ACL configuration.
 

--- a/build/auth.mk
+++ b/build/auth.mk
@@ -10,8 +10,8 @@ oauth-acl-example-setup: ## Setup auth example based on OAuth2 - permissions man
 	@echo "Step 1/4: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-broker-router \
 		OAUTH_RESOURCE_NAME="MCP Server" \
-		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8888/mcp" \
-		OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp" \
+		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
+		OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp" \
 		OAUTH_BEARER_METHODS_SUPPORTED="header" \
 		OAUTH_SCOPES_SUPPORTED="basic,groups" \
 		-n mcp-system
@@ -49,8 +49,8 @@ oauth-token-exchange-example-setup: ## Setup auth example of enabling OAuth2 aut
 	@echo "Step 1/5: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-broker-router \
 		OAUTH_RESOURCE_NAME="MCP Server" \
-		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8888/mcp" \
-		OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp" \
+		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
+		OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp" \
 		OAUTH_BEARER_METHODS_SUPPORTED="header" \
 		OAUTH_SCOPES_SUPPORTED="basic,groups,roles,profile" \
 		-n mcp-system

--- a/build/dev.mk
+++ b/build/dev.mk
@@ -35,15 +35,6 @@ dev-reset: # Reset to in-cluster service configuration
 	kubectl apply -f config/istio/envoyfilter.yaml
 	@echo "Reset to in-cluster configuration"
 
-# Port forward to access the gateway locally
-.PHONY: dev-gateway-forward
-dev-gateway-forward: ## Port forward the gateway to localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)
-	@echo "Forwarding gateway to localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)..."
-	@echo "You can now access the gateway at http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
-	@echo "You can also access keycloak via the gateway at http://keycloak.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK)"
-	@echo "Try: curl http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
-	kubectl -n gateway-system port-forward svc/mcp-gateway-istio $(GATEWAY_LOCAL_PORT_HTTP_MCP):8080 $(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK):8889
-
 # Watch logs from the gateway
 .PHONY: dev-logs-gateway
 dev-logs-gateway: # Watch logs from the Istio gateway
@@ -56,7 +47,7 @@ dev-test: # Test MCP request through the gateway
 	curl -X POST \
 		-H "Content-Type: application/json" \
 		-d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}' \
-		http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/mcp
+		http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp
 
 # Clean up port forwards
 .PHONY: dev-stop-forward

--- a/build/info.mk
+++ b/build/info.mk
@@ -10,20 +10,13 @@ info-impl:
 	@echo "      Requires: Go 1.20+ for some tool installations."
 	@echo ""
 	@echo "Service URLs:"
-	@echo "  Gateway:     http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP) (run: make dev-gateway-forward)"
-	@echo "  Broker:      http://localhost:8080 (run: make run-broker)"
-	@echo "  Router:      grpc://localhost:9002 (run: make run-router)"
-	@echo "  Mock MCP:    http://localhost:8081/mcp (run: kubectl port-forward -n mcp-server svc/mcp-test 8081:8081)"
-	@if kubectl get svc -n keycloak keycloak >/dev/null 2>&1; then \
-		echo "  Keycloak:    http://localhost:8095 (run: make keycloak-forward)"; \
-		echo "               Admin: admin / admin"; \
-	fi
+	@echo "  Gateway:     http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
+	@echo "  Keycloak:    http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"
 	@echo ""
 	@echo "Quick Start Commands:"
 	@echo "  make dev                 # Configure for local development"
 	@echo "  make run-router          # Start router locally"
 	@echo "  make run-broker          # Start broker locally"
-	@echo "  make dev-gateway-forward # Access gateway"
 	@echo "  make logs                # Tail gateway logs"
 	@echo ""
 	@echo "Inspection:"

--- a/build/inspect.mk
+++ b/build/inspect.mk
@@ -5,44 +5,8 @@ open := $(shell { which xdg-open || which open; } 2>/dev/null)
 # URLs for services
 urls-impl:
 	@echo "=== MCP Gateway URLs ==="
-	@echo ""
-	@echo "Gateway (via port-forward):"
-	@echo "  http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"
-	@echo ""
-	@echo "Local Services:"
-	@echo "  Broker: http://localhost:8080"
-	@echo "  Router: grpc://localhost:9002"
-	@echo ""
-	@echo "Mock MCP Server (via port-forward):"
-	@echo "  http://localhost:8081/mcp"
-	@echo ""
-	@echo "Test commands:"
-	@echo "  curl http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/"
-	@echo "  curl http://localhost:8080/"
-
-# Deprecated - use inspect-gateway instead
-.PHONY: inspect-broker
-inspect-broker: inspect-gateway
-
-# Generic template for inspecting MCP servers
-# Args: $(1) = server name, $(2) = service name, $(3) = local port, $(4) = tools description, $(5) = extra notes
-define inspect-server-template
-	@echo "Setting up port-forward to $(1)..."
-	@kubectl -n mcp-test port-forward svc/$(2) $(3):9090 > /dev/null 2>&1 & \
-		PF_PID=$$$$!; \
-		trap "echo '\nCleaning up...'; kill $$$$PF_PID 2>/dev/null || true; exit" INT TERM; \
-		sleep 2; \
-		echo "Opening MCP Inspector for $(1) at http://localhost:$(3)/mcp"; \
-		echo "Available tools: $(4)"; \
-		$(if $(5),echo "$(5)";) \
-		echo ""; \
-		MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
-		sleep 2; \
-		$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:$(3)/mcp"; \
-		echo "Press Ctrl+C to stop and cleanup"; \
-		wait; \
-		kill $$$$PF_PID 2>/dev/null || true
-endef
+	@echo "Gateway: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
+	@echo "Keycloak: http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"
 
 .PHONY: inspect-server1
 inspect-server1: ## Open MCP Inspector for test server 1
@@ -91,21 +55,14 @@ inspect-mock-impl: inspect-server1
 # Open MCP Inspector for gateway (broker via gateway)
 .PHONY: inspect-gateway
 inspect-gateway: ## Open MCP Inspector for the gateway
-	@echo "Setting up port-forward to gateway..."
-	@-pkill -f "kubectl.*port-forward.*mcp-gateway-istio" || true
-	@kubectl -n gateway-system port-forward svc/mcp-gateway-istio $(GATEWAY_LOCAL_PORT_HTTP_MCP):8080 $(GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK):8889 > /dev/null 2>&1 & \
-		PF_PID=$$!; \
-		trap "echo '\nCleaning up...'; kill $$PF_PID 2>/dev/null || true; exit" INT TERM; \
-		sleep 2; \
-		echo "Opening MCP Inspector for gateway"; \
-		echo "URL: http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/mcp"; \
-		echo ""; \
-		MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
-		sleep 2; \
-		$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/mcp"; \
-		echo "Press Ctrl+C to stop and cleanup"; \
-		wait; \
-		kill $$PF_PID 2>/dev/null || true
+	echo "Opening MCP Inspector for gateway"; \
+	echo "URL: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
+	echo ""; \
+	MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
+	sleep 2; \
+	$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
+	echo "Press Ctrl+C to stop and cleanup"; \
+	wait; \
 
 # Show status of all MCP components implementation
 status-impl:

--- a/build/keycloak.mk
+++ b/build/keycloak.mk
@@ -37,11 +37,6 @@ keycloak-uninstall: # Uninstall Keycloak
 	@kubectl delete -f config/keycloak/realm-import.yaml 2>/dev/null || true
 	@kubectl delete namespace $(KEYCLOAK_NAMESPACE) 2>/dev/null || true
 
-keycloak-forward-impl:
-	@echo "Forwarding Keycloak to http://localhost:8095"
-	@echo "Login: $(KEYCLOAK_ADMIN_USER) / $(KEYCLOAK_ADMIN_PASSWORD)"
-	kubectl port-forward -n $(KEYCLOAK_NAMESPACE) svc/keycloak 8095:80
-
 keycloak-status-impl:
 	@if kubectl get svc -n $(KEYCLOAK_NAMESPACE) keycloak >/dev/null 2>&1; then \
 		echo "========================================"; \
@@ -51,21 +46,21 @@ keycloak-status-impl:
 		echo "Status: Installed"; \
 		echo ""; \
 		echo "Admin Console:"; \
-		echo "  URL: http://localhost:8095 (run: make keycloak-forward)"; \
+		echo "  URL: http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"; \
 		echo "  Username: $(KEYCLOAK_ADMIN_USER)"; \
 		echo "  Password: $(KEYCLOAK_ADMIN_PASSWORD)"; \
 		echo ""; \
 		echo "OIDC Endpoints:"; \
-		echo "  Discovery: http://localhost:8095/realms/master/.well-known/openid-configuration"; \
-		echo "  Token:     http://localhost:8095/realms/master/protocol/openid-connect/token"; \
-		echo "  Authorize: http://localhost:8095/realms/master/protocol/openid-connect/auth"; \
-		echo "  UserInfo:  http://localhost:8095/realms/master/protocol/openid-connect/userinfo"; \
-		echo "  JWKS:      http://localhost:8095/realms/master/protocol/openid-connect/certs"; \
+		echo "  Discovery: http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)/realms/master/.well-known/openid-configuration"; \
+		echo "  Token:     http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)/realms/master/protocol/openid-connect/token"; \
+		echo "  Authorize: http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)/realms/master/protocol/openid-connect/auth"; \
+		echo "  UserInfo:  http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)/realms/master/protocol/openid-connect/userinfo"; \
+		echo "  JWKS:      http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)/realms/master/protocol/openid-connect/certs"; \
 		echo ""; \
 		echo "Test Client Configuration:"; \
 		echo "  Client ID: mcp-gateway"; \
-		echo "  Root URL: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)"; \
-		echo "  Valid Redirect URIs: http://localhost:$(GATEWAY_LOCAL_PORT_HTTP_MCP)/*"; \
+		echo "  Root URL: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"; \
+		echo "  Valid Redirect URIs: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/*"; \
 		echo "  Web Origins: +"; \
 		echo ""; \
 		echo "========================================"; \
@@ -76,8 +71,7 @@ keycloak-status-impl:
 .PHONY: keycloak-url
 keycloak-url: # Get Keycloak URLs
 	@echo "=== Keycloak URLs ==="
-	@echo "Admin Console (via port-forward): http://localhost:8095"
-	@echo "OIDC Discovery: http://localhost:8095/realms/master/.well-known/openid-configuration"
+	@echo "Admin Console: http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"
+	@echo "OIDC Discovery: http://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)/realms/master/.well-known/openid-configuration"
 	@echo ""
-	@echo "To access: make keycloak-forward"
 	@echo "Credentials: $(KEYCLOAK_ADMIN_USER) / $(KEYCLOAK_ADMIN_PASSWORD)"

--- a/build/kind.mk
+++ b/build/kind.mk
@@ -11,10 +11,10 @@ kind-create-cluster: kind # Create the "mcp-gateway" kind cluster.
 	if $(KIND) get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
 		echo "Kind cluster '$(KIND_CLUSTER_NAME)' already exists, skipping creation"; \
 	else \
-		echo "Creating Kind cluster '$(KIND_CLUSTER_NAME)' with HTTP port $(KIND_HOST_PORT_HTTP) and HTTPS port $(KIND_HOST_PORT_HTTPS)..."; \
+		echo "Creating Kind cluster '$(KIND_CLUSTER_NAME)' with MCP_GATEWAY port $(KIND_HOST_PORT_MCP_GATEWAY) and KEYCLOAK port $(KIND_HOST_PORT_KEYCLOAK)..."; \
 		cat config/kind/cluster.yaml | sed \
-			-e 's/hostPort: 8080/hostPort: $(KIND_HOST_PORT_HTTP)/' \
-			-e 's/hostPort: 8443/hostPort: $(KIND_HOST_PORT_HTTPS)/' | \
+			-e 's/hostPort: 8001/hostPort: $(KIND_HOST_PORT_MCP_GATEWAY)/' \
+			-e 's/hostPort: 8002/hostPort: $(KIND_HOST_PORT_KEYCLOAK)/' | \
 		$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config -; \
 	fi
 

--- a/build/ports.mk
+++ b/build/ports.mk
@@ -2,16 +2,9 @@
 # These variables control both Kind cluster ports and local port forwarding
 
 # Kind cluster host ports (what gets exposed on your local machine from Kind)
-KIND_HOST_PORT_HTTP ?= 8080
-KIND_HOST_PORT_HTTPS ?= 8443
-
-# Local port forwarding ports (for accessing services via kubectl port-forward)
-# Gateway ports
-GATEWAY_LOCAL_PORT_HTTP_MCP ?= 8888
-GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK ?= 8889
+KIND_HOST_PORT_MCP_GATEWAY ?= 8001
+KIND_HOST_PORT_KEYCLOAK ?= 8002
 
 # Export for use in shell commands
-export KIND_HOST_PORT_HTTP
-export KIND_HOST_PORT_HTTPS
-export GATEWAY_LOCAL_PORT_HTTP_MCP
-export GATEWAY_LOCAL_PORT_HTTP_KEYCLOAK
+export KIND_HOST_PORT_MCP_GATEWAY
+export KIND_HOST_PORT_KEYCLOAK

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -116,10 +116,6 @@ kubectl wait --for=condition=available --timeout=300s deployment/mcp-gateway-con
 echo "Waiting for Istio gateway pod to be ready..."
 kubectl wait --for=condition=ready --timeout=300s pod -l istio=ingressgateway -n gateway-system
 
-echo "Starting port forwarding..."
-kubectl -n gateway-system port-forward svc/mcp-gateway-istio 8888:8080 8889:8889 &
-PORT_FORWARD_PID=$!
-
 echo "Starting MCP inspector..."
 MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest &
 INSPECTOR_PID=$!
@@ -129,24 +125,22 @@ sleep 3
 echo "================================================================"
 echo "Setup complete! 🎉"
 echo "================================================================"
-echo "Port forwarding: kubectl port-forward active (PID: $PORT_FORWARD_PID)"
 echo "MCP Inspector: http://localhost:6274"
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8888/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "Check status:"
 echo "  kubectl get pods -n mcp-system"
 echo "  kubectl get pods -n istio-system"
 echo "  kubectl get httproute -n mcp-system"
 echo ""
-echo "Press Ctrl+C to stop port forwarding and cleanup."
+echo "Press Ctrl+C to stop and cleanup."
 echo "================================================================"
 
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
 
 # Cleanup function
 cleanup() {
     echo "Cleaning up..."
-    kill $PORT_FORWARD_PID 2>/dev/null || true
     kill $INSPECTOR_PID 2>/dev/null || true
     exit 0
 }

--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -24,7 +24,7 @@ spec:
           from: All #any namespace can register an MCP server route
     - name: keycloak
       hostname: 'keycloak.127-0-0-1.sslip.io'
-      port: 8889
+      port: 8002
       protocol: HTTP
       allowedRoutes:
         namespaces:

--- a/config/istio/gateway/kustomization.yaml
+++ b/config/istio/gateway/kustomization.yaml
@@ -3,3 +3,4 @@ namespace: gateway-system
 resources:
 - namespace.yaml
 - gateway.yaml
+- nodeport.yaml

--- a/config/istio/gateway/nodeport.yaml
+++ b/config/istio/gateway/nodeport.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: mcp-gateway
+    istio.io/dataplane-mode: none
+  name: mcp-gateway-np
+  namespace: gateway-system
+spec:
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+  - appProtocol: http
+    name: mcp
+    nodePort: 30080
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - appProtocol: http
+    name: keycloak
+    nodePort: 30089
+    port: 8002
+    protocol: TCP
+    targetPort: 8002
+  selector:
+    gateway.networking.k8s.io/gateway-name: mcp-gateway
+  sessionAffinity: None
+  type: NodePort

--- a/config/keycloak/preflight_envoyfilter.yaml
+++ b/config/keycloak/preflight_envoyfilter.yaml
@@ -13,7 +13,7 @@ spec:
       context: GATEWAY
       routeConfiguration:
         vhost:
-          name: "keycloak.127-0-0-1.sslip.io:8889"
+          name: "keycloak.127-0-0-1.sslip.io:8002"
     patch:
       operation: INSERT_FIRST
       value:

--- a/config/kind/cluster.yaml
+++ b/config/kind/cluster.yaml
@@ -9,9 +9,9 @@ nodes:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
   extraPortMappings:
-  - containerPort: 80
-    hostPort: 8080
+  - containerPort: 30080 # MCP Gateway port
+    hostPort: 8001
     protocol: TCP
-  - containerPort: 443
-    hostPort: 8443
+  - containerPort: 30089 # keycloak port
+    hostPort: 8002
     protocol: TCP

--- a/config/samples/oauth-acl/tools-call-auth.yaml
+++ b/config/samples/oauth-acl/tools-call-auth.yaml
@@ -18,7 +18,7 @@ spec:
       authentication: #validates the token
         'keycloak':
           jwt:
-            issuerUrl: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp
+            issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
       authorization: #authorizes the tool call
         'allow-tool-call':
           patternMatching:
@@ -37,7 +37,7 @@ spec:
           code: 401
           headers:
             'WWW-Authenticate':
-              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
           body:
             value: |
               {

--- a/config/samples/oauth-acl/tools-list-auth.yaml
+++ b/config/samples/oauth-acl/tools-list-auth.yaml
@@ -16,7 +16,7 @@ spec:
       authentication:
         'keycloak':
           jwt:
-            issuerUrl: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp
+            issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
       authorization:
         'allow-tool-list':
           patternMatching:
@@ -28,7 +28,7 @@ spec:
           code: 401
           headers:
             'WWW-Authenticate':
-              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
           body:
             value: |
               {
@@ -39,7 +39,7 @@ spec:
           code: 401
           headers:
             'WWW-Authenticate':
-              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
           body:
             value: |
               {

--- a/config/samples/oauth-token-exchange/tools-call-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-call-auth.yaml
@@ -13,7 +13,7 @@ spec:
     authentication: #validates the token
       'keycloak':
         jwt:
-          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp
+          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
     metadata:
       vault:
         http:
@@ -32,7 +32,7 @@ spec:
           - predicate: "!has(auth.metadata.vault.data) || !has(auth.metadata.vault.data.data) || !has(auth.metadata.vault.data.data.token) || type(auth.metadata.vault.data.data.token) != string"
           - predicate: type(auth.identity.aud) != string || auth.identity.aud != request.host
         http:
-          url: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp/protocol/openid-connect/token
+          url: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token
           method: POST
           credentials:
             authorizationHeader:
@@ -87,7 +87,7 @@ spec:
         code: 401
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
         body:
           value: |
             {

--- a/config/samples/oauth-token-exchange/tools-list-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-list-auth.yaml
@@ -15,7 +15,7 @@ spec:
     authentication:
       'keycloak':
         jwt:
-          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp
+          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
     authorization:
       'allow-tool-list':
         patternMatching:
@@ -44,7 +44,7 @@ spec:
         code: 401
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
         body:
           value: |
             {
@@ -55,7 +55,7 @@ spec:
         code: 401
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
         body:
           value: |
             {

--- a/docs/design/auth-phase-1.md
+++ b/docs/design/auth-phase-1.md
@@ -70,8 +70,8 @@ example response:
 
 {
   "resource_name":"MCP Gateway",
-  "resource":"http://mcp.127-0-0-1.sslip.io:8888/mcp",
-  "authorization_servers":["http://keycloak.127-0-0-1.sslip.io:8888/realms/mcp"], 
+  "resource":"http://mcp.127-0-0-1.sslip.io:8001/mcp",
+  "authorization_servers":["http://keycloak.127-0-0-1.sslip.io:8001/realms/mcp"], 
   "bearer_methods_supported": ["header"],
   "scopes_supported":["email","role","user","groups"]
 }

--- a/docs/design/routing.md
+++ b/docs/design/routing.md
@@ -51,7 +51,7 @@ So here we have dedicated port 8080 to MCP requests.  It is strongly recommended
 ```yaml
     - name: keycloak
       hostname: 'keycloak.127-0-0-1.sslip.io'
-      port: 8889 #notice this is a different port to avoid the ext_proc router receiving these requests
+      port: 8002 #notice this is a different port to avoid the ext_proc router receiving these requests
       protocol: HTTP
       allowedRoutes:
         namespaces:

--- a/docs/dev/understanding-mcp-gateway-architecture.md
+++ b/docs/dev/understanding-mcp-gateway-architecture.md
@@ -139,7 +139,7 @@ The MCP Inspector provides a web interface for exploring the gateway:
 make inspect-gateway
 ```
 
-This opens `http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp`
+This opens `http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp`
 
 **What you can do:**
 1. **View all tools**: Navigate to **Tools** → **List Tools** to see all available tools with their prefixes
@@ -159,7 +159,6 @@ make status
 
 This shows:
 - Running components and their status
-- Active port forwards
 - Local processes (if any)
 
 ### Inspect Component Pods

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -42,7 +42,7 @@ Create the MCP realm and test user. This sets up a dedicated OAuth realm for MCP
 
 ```bash
 # Get admin access token from Keycloak
-TOKEN=$(curl -s -X POST "http://keycloak.127-0-0-1.sslip.io:8889/realms/master/protocol/openid-connect/token" \
+TOKEN=$(curl -s -X POST "http://keycloak.127-0-0-1.sslip.io:8002/realms/master/protocol/openid-connect/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "username=admin" \
   -d "password=admin" \
@@ -50,72 +50,72 @@ TOKEN=$(curl -s -X POST "http://keycloak.127-0-0-1.sslip.io:8889/realms/master/p
   -d "client_id=admin-cli" | jq -r '.access_token')
 
 # Create MCP realm
-curl -X POST "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms" \
+curl -X POST "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"realm":"mcp","enabled":true}'
 
 # Update MCP realm token settings
-curl -X PUT "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp" \
+curl -X PUT "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"realm":"mcp","enabled":true,"ssoSessionIdleTimeout":1800,"accessTokenLifespan":1800}'
 
 # Create test user 'mcp' with password 'mcp'
-curl -X POST "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/users" \
+curl -X POST "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/users" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"username":"mcp","email":"mcp@example.com","firstName":"mcp","lastName":"mcp","enabled":true,"emailVerified":true,"credentials":[{"type":"password","value":"mcp","temporary":false}]}'
 
 # Create accounting group
-curl -X POST "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/groups" \
+curl -X POST "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/groups" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name":"accounting"}'
 
 # Add mcp user to accounting group
 # First get the user ID
-USER_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/users?username=mcp" \
+USER_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/users?username=mcp" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Accept: application/json" | jq -r '.[0].id')
 
 # Get the group ID
-GROUP_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/groups" \
+GROUP_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/groups" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Accept: application/json" | jq -r '.[] | select(.name == "accounting") | .id')
 
 # Add user to group
-curl -X PUT "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/users/$USER_ID/groups/$GROUP_ID" \
+curl -X PUT "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/users/$USER_ID/groups/$GROUP_ID" \
   -H "Authorization: Bearer $TOKEN"
 
 # Create groups client scope
-curl -X POST "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/client-scopes" \
+curl -X POST "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/client-scopes" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name":"groups","protocol":"openid-connect","attributes":{"display.on.consent.screen":"false","include.in.token.scope":"true"}}'
 
 # Get the client scope ID
-SCOPE_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/client-scopes" \
+SCOPE_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/client-scopes" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Accept: application/json" | jq -r '.[] | select(.name == "groups") | .id')
 
 # Add groups mapper to client scope
-curl -X POST "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/client-scopes/$SCOPE_ID/protocol-mappers/models" \
+curl -X POST "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/client-scopes/$SCOPE_ID/protocol-mappers/models" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name":"groups","protocol":"openid-connect","protocolMapper":"oidc-group-membership-mapper","config":{"claim.name":"groups","full.path":"false","id.token.claim":"true","access.token.claim":"true","userinfo.token.claim":"true"}}'
 
 # Add groups client scope to realm's optional client scopes
-curl -X PUT "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/default-optional-client-scopes/$SCOPE_ID" \
+curl -X PUT "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/default-optional-client-scopes/$SCOPE_ID" \
   -H "Authorization: Bearer $TOKEN"
 
 # (FOR DEVELOPMENT ONLY) Remove trusted hosts policy for anonymous client registration
-COMPONENT_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/components?name=Trusted%20Hosts" \
+COMPONENT_ID=$(curl -s -X GET "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/components?name=Trusted%20Hosts" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Accept: application/json" | jq -r '.[0].id // empty' 2>/dev/null)
 
 if [ -n "$COMPONENT_ID" ] && [ "$COMPONENT_ID" != "null" ]; then
-  curl -X DELETE "http://keycloak.127-0-0-1.sslip.io:8889/admin/realms/mcp/components/$COMPONENT_ID" \
+  curl -X DELETE "http://keycloak.127-0-0-1.sslip.io:8002/admin/realms/mcp/components/$COMPONENT_ID" \
     -H "Authorization: Bearer $TOKEN"
   echo "Trusted hosts policy removed"
 else
@@ -144,8 +144,8 @@ Configure the MCP Gateway broker to respond with OAuth discovery information:
 ```bash
 kubectl set env deployment/mcp-gateway-broker-router \
   OAUTH_RESOURCE_NAME="MCP Server" \
-  OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8888/mcp" \
-  OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp" \
+  OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
+  OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp" \
   OAUTH_BEARER_METHODS_SUPPORTED="header" \
   OAUTH_SCOPES_SUPPORTED="basic,groups" \
   -n mcp-system
@@ -189,7 +189,7 @@ spec:
           code: 401
           headers:
             'WWW-Authenticate':
-              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
           body:
             value: |
               {
@@ -212,14 +212,14 @@ Test that the broker now serves OAuth discovery information:
 
 ```bash
 # Check the protected resource metadata endpoint
-curl http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource
+curl http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
 
 # Should return OAuth 2.0 Protected Resource Metadata like:
 # {
 #   "resource_name": "MCP Server",
-#   "resource": "http://mcp.127-0-0-1.sslip.io:8888/mcp",
+#   "resource": "http://mcp.127-0-0-1.sslip.io:8001/mcp",
 #   "authorization_servers": [
-#     "http://keycloak.127-0-0-1.sslip.io:8889/realms/mcp"
+#     "http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp"
 #   ],
 #   "bearer_methods_supported": [
 #     "header"
@@ -235,7 +235,7 @@ Test that protected endpoints now require authentication:
 
 ```bash
 # This should return 401 with WWW-Authenticate header
-curl -v http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -v http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
 ```
@@ -251,13 +251,9 @@ You should get a response like this:
 
 ## Step 5: Test Authentication Flow
 
-Use the MCP Inspector to test the complete OAuth flow. You'll need to set up port forwarding to access the gateway through your local browser:
+Use the MCP Inspector to test the complete OAuth flow.
 
 ```bash
-# Start port forwarding to the Istio gateway
-kubectl -n gateway-system port-forward svc/mcp-gateway-istio 8888:8080 &
-PORT_FORWARD_PID=$!
-
 # Start MCP Inspector (requires Node.js/npm)
 npx @modelcontextprotocol/inspector@latest &
 INSPECTOR_PID=$!
@@ -266,17 +262,16 @@ INSPECTOR_PID=$!
 sleep 3
 
 # Open MCP Inspector with the gateway URL
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
 ```
 
 **What this does:**
-- **Port Forwarding**: Makes the Istio gateway accessible on localhost:8888
 - **MCP Inspector**: Launches the official MCP debugging tool
 - **Auto-Configuration**: Pre-configures the inspector to connect to your gateway
 
 **To stop the services later:**
 ```bash
-kill $PORT_FORWARD_PID $INSPECTOR_PID
+kill $INSPECTOR_PID
 ```
 
 The MCP Inspector will:

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -69,7 +69,7 @@ data:
     # - "id" should match your MCP server hostnames
     # - "access" groups should match your Keycloak groups
     # - Tool names should match your actual MCP server tools
-    # Use 'curl http://mcp.127-0-0-1.sslip.io:8888/mcp' with tools/list to discover available tools
+    # Use 'curl http://mcp.127-0-0-1.sslip.io:8001/mcp' with tools/list to discover available tools
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -167,7 +167,7 @@ spec:
           code: 401
           headers:
             'WWW-Authenticate':
-              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
           body:
             value: |
               {
@@ -192,13 +192,9 @@ EOF
 
 **Note**: The authentication guide already created the `accounting` group, added the `mcp` user to it, and configured group claims in JWT tokens. No additional Keycloak configuration is needed.
 
-Test that authorization now controls tool access by setting up the MCP Inspector with port forwarding:
+Test that authorization now controls tool access by setting up the MCP Inspector:
 
 ```bash
-# Start port forwarding to the Istio gateway
-kubectl -n gateway-system port-forward svc/mcp-gateway-istio 8888:8080 &
-PORT_FORWARD_PID=$!
-
 # Start MCP Inspector (requires Node.js/npm)
 npx @modelcontextprotocol/inspector@latest &
 INSPECTOR_PID=$!
@@ -207,7 +203,7 @@ INSPECTOR_PID=$!
 sleep 3
 
 # Open MCP Inspector with the gateway URL
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
 ```
 
 **What this accomplishes:**

--- a/docs/guides/configure-mcp-servers.md
+++ b/docs/guides/configure-mcp-servers.md
@@ -87,7 +87,7 @@ Verify that your MCP server tools are now available through the gateway:
 ```bash
 # Step 1: Initialize MCP session and capture session ID
 # Use -D to dump headers to a file, then read the session ID
-curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 
@@ -97,7 +97,7 @@ SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d 
 echo "MCP Session ID: $SESSION_ID"
 
 # Step 2: List tools using the session ID
-curl -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -H "mcp-session-id: $SESSION_ID" \
   -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}'

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -51,7 +51,6 @@ The setup script automatically:
 5. **Installs MCP Gateway** using the Helm chart
 6. **Deploys test MCP servers** for demonstration
 7. **Configures routing** with HTTPRoute resources
-8. **Starts port forwarding** to make services accessible
 9. **Launches MCP Inspector** for testing and exploration
 
 ## Testing Your Setup
@@ -60,7 +59,7 @@ Once the script completes, you'll have:
 
 ### MCP Inspector Access
 - **URL**: http://localhost:6274
-- **Gateway URL**: http://mcp.127-0-0-1.sslip.io:8888/mcp
+- **Gateway URL**: http://mcp.127-0-0-1.sslip.io:8001/mcp
 - **Pre-configured**: The inspector opens with the correct gateway URL
 
 ### Available Test Tools
@@ -81,7 +80,6 @@ The setup includes example MCP servers with tools like:
 To stop the services and clean up:
 
 ```bash
-# Stop port forwarding (Ctrl+C in the terminal running the script)
 # Then delete the Kind cluster
 kind delete cluster
 ```

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -89,7 +89,7 @@ Test your virtual servers using curl with the appropriate header:
 ### Test Development Tools Virtual Server
 
 ```bash
-curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 
@@ -99,7 +99,7 @@ SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d 
 echo "MCP Session ID: $SESSION_ID"
 
 # Request tools from the dev-tools virtual server
-curl -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -H "mcp-session-id: $SESSION_ID" \
   -H "X-Mcp-Virtualserver: mcp-system/dev-tools" \
@@ -112,7 +112,7 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
 
 ```bash
 # Request tools from the data-tools virtual server
-curl -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -H "mcp-session-id: $SESSION_ID" \
   -H "X-Mcp-Virtualserver: mcp-system/data-tools" \
@@ -125,7 +125,7 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
 
 ```bash
 # Request all available tools (no filtering)
-curl -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "mcp-session-id: $SESSION_ID" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | jq '.result.tools[].name'


### PR DESCRIPTION
This is a large set of changes, but a small surface area affected.

* removes any port-forwarding required for accessing the mcp gateway or keycloak (was previously 8888 & 8889)
* replaces that access with extraPortMappings in kind, that leverages a nodeport service
    * MCP Broker/Gateway 8001 (host) ->30080 (nodeport) ->8080 (gateway mcp listener)
    * Keycloak: 8002 (host) ->30089 (nodeport) -> 8002 (gateway keycloak listener)
* removes any make targets, echo statements and readme content that referenced port forwarding for this
* updates existing references, including docs & yaml, to use the nodeport forwarded ports instead. These are 8001 for the mcp gateway, and 8002 for keycloak.
    * http://mcp.127-0-0-1.sslip.io:8001/mcp
    * http://keycloak.127-0-0-1.sslip.io:8002/admin/master/console/

(Also fixes #345 )

To verify:

```
make local-env-setup
make inspect-gateway
```
Tools listing and calling should work as before, without any port forwarding needed.


Additional verification with auth (Not working yet)

```
kubectl set env deployment/kuadrant-operator-controller-manager -n kuadrant-system RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-shim:replace-headers-default
make oauth-token-exchange-example-setup
```

* Connect via the inspector
* Login to keycloak as mcp/mcp
* List & use tools
