### PR TITLE
Temp fix for typescript build of everything server

### DIFF
--- a/tests/servers/everything-server/Dockerfile
+++ b/tests/servers/everything-server/Dockerfile
@@ -12,6 +12,7 @@ RUN git clone --depth 1 https://github.com/modelcontextprotocol/servers.git && \
 
 WORKDIR /app
 
+RUN --mount=type=cache,target=/root/.npm npm install @modelcontextprotocol/sdk@1.19.1 # Temp fix for "everything.ts:624:72 - error TS2339: Property 'text' does not exist on type" 
 RUN --mount=type=cache,target=/root/.npm npm install && npm run build
 
 FROM node:22-alpine AS release


### PR DESCRIPTION
Temp fix for this error.

```
everything.ts:624:72 - error TS2339: Property 'text' does not exist on type '{ type: "text"; text: string; _meta?: Record<string, unknown> | undefined; } | { type: "image"; data: string; mimeType: string; _meta?: Record<string, unknown> | undefined; } | { type: "audio"; data: string; mimeType: string; _meta?: Record<...> | undefined; }'.
  Property 'text' does not exist on type '{ type: "image"; data: string; mimeType: string; _meta?: Record<string, unknown> | undefined; }'.

624           { type: "text", text: `LLM sampling result: ${result.content.text}` },
                                                                           ~~~~

```

Pin the mcp sdk version pulled in.
I don't know why the package-lock.json version isn't being respected when installed in the build container.