### PR TITLE
Change MCP server namespace from mcp-system to mcp-test

### DIFF
--- a/docs/guides/configure-mcp-servers.md
+++ b/docs/guides/configure-mcp-servers.md
@@ -54,7 +54,7 @@ apiVersion: mcp.kagenti.com/v1alpha1
 kind: MCPServer
 metadata:
   name: my-mcp-server
-  namespace: mcp-system
+  namespace: mcp-test
 spec:
   toolPrefix: "myserver_"
   targetRef:


### PR DESCRIPTION
Fix #302 
Use correct namespace for MCPServer resource in docs.