### PR TITLE
Add listener for everything server external route

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -67,3 +67,10 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: mcp-everything-server-route-ext
+      hostname: 'everything-server.127-0-0-1.sslip.io'
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
## Overview

Adds listener for everything server external route.
Closes https://github.com/kagenti/mcp-gateway/issues/355.

### Verification Steps

Install from this PR:
`make local-env-setup`

See that the HTTPRoute CR for everything server is valid:
`kubectl get httproute everything-server-route-ext -o yaml -n mcp-test`

To be honest I did not manage to use the external route to connect to the everything MCP server directly on my local machine but same was true for external routes to other MCP servers so it is unrelated to this fix. If I got it right the curl below should work:
```
curl -X POST http://everything-server.127-0-0-1.sslip.io:8080/mcp -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json"   -d '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "initialize",
    "params": {
      "protocolVersion": "2025-06-18",
      "capabilities": {},
      "clientInfo": {
        "name": "test-client",
        "version": "1.0.0"
      }
    }
  }'
  ```
