### PR TITLE
Allow broker to recognize MCP protocol 2025-03-26

### DIFF
--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -180,7 +180,7 @@ curl http://localhost:8080/health
 # Test through Envoy proxy
 curl http://localhost:8888/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}'
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}'
 
 # List available tools
 curl -X POST http://localhost:8888/mcp \

--- a/docs/guides/configure-mcp-servers.md
+++ b/docs/guides/configure-mcp-servers.md
@@ -89,7 +89,7 @@ Verify that your MCP server tools are now available through the gateway:
 # Use -D to dump headers to a file, then read the session ID
 curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 
 # Extract the MCP session ID from response headers
 SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d '\r')

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -419,7 +419,7 @@ kubectl get mcpvirtualserver <name> -n <namespace> -o yaml | grep -A 20 tools
 # Test initialization with header dump
 curl -D - -X POST http://<mcp-hostname>/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}'
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}'
 ```
 
 **Solutions**:

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -91,7 +91,7 @@ Test your virtual servers using curl with the appropriate header:
 ```bash
 curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8888/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 
 # Extract the MCP session ID from response headers
 SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d '\r')

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -948,7 +948,7 @@ func (m *mcpBrokerImpl) validateServerConnectivity(upstream *upstreamMCP) Connec
 // validateProtocol validates the MCP protocol version
 func validateProtocol(initResp *mcp.InitializeResult) ProtocolValidation {
 	return ProtocolValidation{
-		IsValid:          initResp.ProtocolVersion == mcp.LATEST_PROTOCOL_VERSION,
+		IsValid:          slices.Contains(mcp.ValidProtocolVersions, initResp.ProtocolVersion),
 		SupportedVersion: initResp.ProtocolVersion,
 		ExpectedVersion:  mcp.LATEST_PROTOCOL_VERSION,
 	}

--- a/tests/servers/server1/README.md
+++ b/tests/servers/server1/README.md
@@ -33,7 +33,7 @@ curl --include -X POST -H "Content-Type: application/json" -H "Accept: applicati
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2025-03-26",
+    "protocolVersion": "2025-06-18",
     "capabilities": {
       "roots": {
         "listChanged": true

--- a/tests/servers/server2/README.md
+++ b/tests/servers/server2/README.md
@@ -33,7 +33,7 @@ curl --include -X POST -H "Content-Type: application/json" -H "Accept: applicati
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2025-03-26",
+    "protocolVersion": "2025-06-18",
     "capabilities": {
       "roots": {
         "listChanged": true


### PR DESCRIPTION
Resolves #281
Resolves #354

**ONLY MERGE IF YOU AGREE WITH THE BEHAVIOR CHANGE**

This PR cause the MCP-Gateway to forward any version of the MCP Protocol supported by the mark3labs API, rather than only the latest version.

This PR also changes the MCP protocol version we use in our documentation.