### PR TITLE
docs: add issue process to CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ go.work.sum
 
 # Ignore Python bytecode cache
 **/__pycache__/
+
+# Ignore personal TODO lists
+TODO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,40 @@ To get started, kindly read through this document and familiarize yourself with 
 
 We can't wait to collaborate with you!
 
+## Issues
+
+Please feel free to report an issue for bugs, and any other problems you
+encounter with the MCP Gateway project.
+
+If you have something to propose (e.g. a big new feature) we recommend
+starting that out as a [discussion] first, to talk it through and build
+consensus ahead of time.
+
+[discussion]:https://github.com/kagenti/mcp-gateway/discussions
+
+### Process
+
+We have some light process around issue management that contributors should
+be aware of: We organize via [GitHub milestones], which are collected into
+a roadmap. We use [GitHub project boards] to track the milestones and issues.
+Milestones are sequential.
+
+We provide some labels to indicate individual issue priorities based on
+impact and time-sensitivity:
+
+* `priority/low` - Low-impact and little time-sensitivity. Can be worked on
+  after other issues have been accounted for.
+* `priority/normal` - Standard, default priority for issues. Can be worked on
+  after higher priority items are finished, and before any low priority items.
+* `priority/high` - High-impact, may affect many other issues, and may be very
+  time-sensitive. Should accounted for before non-critical issues.
+* `priority/critical` - Indicates an extremely time-sensitive and/or extremely
+  high impact critical issues. Interrupts other work until it is accounted for,
+  and should be used sparingly.
+
+[GitHub milestones]:https://github.com/kagenti/mcp-gateway/milestones
+[GitHub project boards]:https://github.com/orgs/kagenti/projects/6
+
 ## Contributing Code
 
 Please follow the [Contribution guide](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md#contributing-to-this-project), as found in the Kagenti Repository, for instructions on how to contribute to our repositories. 


### PR DESCRIPTION
Some notes around issue process. We don't have a lot here yet, but this is at least intended to provide some hints on how issues are organized and managed, and important links like our milestones and project board.