### PR TITLE
fix: tolerate 404 on label removal in triage CI

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -137,12 +137,20 @@ jobs:
 
             for (const label of labelsToRemove) {
               console.log(`Removing label: ${label}`);
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                name: label
-              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`Label ${label} not found (may have been already removed)`);
+                } else {
+                  throw error;
+                }
+              }
             }
 
             if (labelsToAdd.length === 0 && labelsToRemove.length === 0) {


### PR DESCRIPTION
Noticed an issue where multiple triage triggers would lead to a failure to remove a label that was already removed:

https://github.com/kagenti/mcp-gateway/actions/runs/19639281485/job/56238716724

This patch adds tolerance for failures to remove labels which are not present anyhow.