### PR TITLE
fix: skip PRs for issue-triage CI wf

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -15,6 +15,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            if (context.payload.issue.pull_request) {
+              console.log('Skipping pull request');
+              return;
+            }
+
             // ------------------------------------------------------
             // Vars
             // ------------------------------------------------------


### PR DESCRIPTION
Was technically triggering (and [failing](https://github.com/kagenti/mcp-gateway/actions/runs/19670413283)) on PRs when a PR is added to a milestone (for review, etc). Could use it later if we wanted, but for now limiting it to issues only.