### PR TITLE
Fix nodeport and mappings for helm quickstart

### DIFF
--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -29,11 +29,11 @@ nodes:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
   extraPortMappings:
-  - containerPort: 80
-    hostPort: 8080
+  - containerPort: 30080
+    hostPort: 7001
     protocol: TCP
-  - containerPort: 443
-    hostPort: 8443
+  - containerPort: 30089
+    hostPort: 7002
     protocol: TCP
 EOF
 
@@ -46,6 +46,7 @@ helm install istiod istio/istiod -n istio-system --wait
 
 kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/istio/gateway/namespace.yaml
 kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/istio/gateway/gateway.yaml -n gateway-system
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/istio/gateway/nodeport.yaml -n gateway-system
 kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/namespace.yaml
 kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server1-deployment.yaml -n mcp-test
 kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server1-service.yaml -n mcp-test
@@ -126,7 +127,7 @@ echo "================================================================"
 echo "Setup complete! 🎉"
 echo "================================================================"
 echo "MCP Inspector: http://localhost:6274"
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
 echo ""
 echo "Check status:"
 echo "  kubectl get pods -n mcp-system"
@@ -136,7 +137,7 @@ echo ""
 echo "Press Ctrl+C to stop and cleanup."
 echo "================================================================"
 
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp"
 
 # Cleanup function
 cleanup() {

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -59,7 +59,7 @@ Once the script completes, you'll have:
 
 ### MCP Inspector Access
 - **URL**: http://localhost:6274
-- **Gateway URL**: http://mcp.127-0-0-1.sslip.io:8001/mcp
+- **Gateway URL**: http://mcp.127-0-0-1.sslip.io:7001/mcp
 - **Pre-configured**: The inspector opens with the correct gateway URL
 
 ### Available Test Tools


### PR DESCRIPTION
To verify, run:

```
./charts/sample_local_helm_setup.sh
```

The MCP Inspector should open in your browser.
Try some test server tools. They should work as expected.
Note the different port, 7001 instead of 8001, for this quickstart script to avoid potential collision with a local dev environment.