### PR TITLE
Add instructions on how to configure AuthPolicy to get external Github use case working again

### DIFF
--- a/config/samples/remote-github/authpolicy.yaml
+++ b/config/samples/remote-github/authpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: mcps-auth-policy
+  namespace: mcp-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: github-mcp-external
+  rules:
+    response:
+      success:
+        headers:
+          authorization:
+            plain:
+              expression: 'request.headers["authorization"]'
+          x-mcp-api-key:
+            plain:
+              expression: 'request.headers["authorization"].split(" ")[1]'

--- a/config/samples/remote-github/create_resources.sh
+++ b/config/samples/remote-github/create_resources.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -e
+
+# check for GITHUB_PAT environment variable
+if [ -z "$GITHUB_PAT" ]; then
+  echo "Error: GITHUB_PAT environment variable is not set"
+  echo ""
+  echo "Please set your GitHub Personal Access Token:"
+  echo "  export GITHUB_PAT=\"ghp_YOUR_GITHUB_TOKEN_HERE\""
+  echo ""
+  echo "Get a token at: https://github.com/settings/tokens/new"
+  echo "Required permissions: read:user"
+  exit 1
+fi
+
+# validate token format (should start with ghp_)
+if [[ ! "$GITHUB_PAT" =~ ^ghp_ ]]; then
+  echo "Warning: GITHUB_PAT should start with 'ghp_' (Personal Access Token)"
+  echo "Current value starts with: ${GITHUB_PAT:0:4}..."
+  echo ""
+  read -p "Continue anyway? (y/N) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Step 1: Patching Gateway to add GitHub external listener..."
+kubectl patch gateway mcp-gateway -n gateway-system --type json -p='[
+  {
+    "op": "add",
+    "path": "/spec/listeners/-",
+    "value": {
+      "name": "github-external",
+      "hostname": "api.githubcopilot.com",
+      "port": 8080,
+      "protocol": "HTTP",
+      "allowedRoutes": {
+        "namespaces": {
+          "from": "All"
+        }
+      }
+    }
+  }
+]' || echo "Note: Listener may already exist, continuing..."
+
+echo ""
+echo "==> Step 2: Creating HTTPRoute for External Service..."
+kubectl apply -f "$SCRIPT_DIR/httproute.yaml"
+
+echo ""
+echo "==> Step 3: Creating ExternalName Service..."
+kubectl apply -f "$SCRIPT_DIR/service.yaml"
+
+echo ""
+echo "==> Step 4: Creating ServiceEntry for GitHub MCP API..."
+kubectl apply -f "$SCRIPT_DIR/serviceentry.yaml"
+
+echo ""
+echo "==> Step 5: Creating DestinationRule..."
+kubectl apply -f "$SCRIPT_DIR/destinationrule.yaml"
+
+echo ""
+echo "==> Step 6: Creating Secret with Authentication..."
+envsubst < "$SCRIPT_DIR/secret.yaml" | kubectl apply -f -
+
+echo ""
+echo "==> Step 7: Creating MCPServer Resource..."
+kubectl apply -f "$SCRIPT_DIR/mcpserver.yaml"
+
+echo ""
+echo "==> Step 8: Applying AuthPolicy..."
+kubectl apply -f "$SCRIPT_DIR/authpolicy.yaml"
+
+echo ""
+echo "==> Done! Resources applied successfully."
+echo ""
+echo "To verify the setup:"
+echo "  kubectl get mcpservers -n mcp-test"
+echo "  kubectl logs -n mcp-system deployment/mcp-broker-router | grep github"
+echo ""
+echo "To wait for tool discovery:"
+echo "  until kubectl logs -n mcp-system deploy/mcp-broker-router | grep 'Discovered.*tools.*github'; do sleep 5; done"

--- a/config/samples/remote-github/destinationrule.yaml
+++ b/config/samples/remote-github/destinationrule.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: github-mcp-external
+  namespace: mcp-test
+spec:
+  host: api.githubcopilot.com
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 10
+      http:
+        http1MaxPendingRequests: 10
+        h2UpgradePolicy: UPGRADE
+    tls:
+      mode: SIMPLE
+      sni: api.githubcopilot.com

--- a/config/samples/remote-github/httproute.yaml
+++ b/config/samples/remote-github/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: github-mcp-external
+  namespace: mcp-test
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: mcp-gateway
+    namespace: gateway-system
+  hostnames:
+  - api.githubcopilot.com  # must match the Gateway listener hostname
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mcp
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: api-githubcopilot-com
+      namespace: mcp-test
+      port: 443

--- a/config/samples/remote-github/mcpserver.yaml
+++ b/config/samples/remote-github/mcpserver.yaml
@@ -1,0 +1,14 @@
+apiVersion: mcp.kagenti.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: github
+  namespace: mcp-test
+spec:
+  toolPrefix: github_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: github-mcp-external
+  credentialRef:
+    name: github-token
+    key: token

--- a/config/samples/remote-github/secret.yaml
+++ b/config/samples/remote-github/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+  namespace: mcp-test
+  labels:
+    mcp.kagenti.com/credential: "true"  # Required label for credential secrets
+type: Opaque
+stringData:
+  token: "Bearer $GITHUB_PAT"

--- a/config/samples/remote-github/service.yaml
+++ b/config/samples/remote-github/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-githubcopilot-com
+  namespace: mcp-test
+spec:
+  type: ExternalName
+  externalName: api.githubcopilot.com
+  ports:
+  - name: https
+    port: 443
+    targetPort: 443
+    protocol: TCP
+    appProtocol: https

--- a/config/samples/remote-github/serviceentry.yaml
+++ b/config/samples/remote-github/serviceentry.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: github-mcp-external
+  namespace: mcp-test
+spec:
+  hosts:
+  - api.githubcopilot.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS


### PR DESCRIPTION
Fixes https://github.com/kagenti/mcp-gateway/issues/390. After adding the headers, I'm able to get github tool successfully initialize and run with an appropriate Github PAT.

<img width="668" height="379" alt="image" src="https://github.com/user-attachments/assets/0a5f2797-81cb-4bcc-aebb-10a227815d97" />
