### PR TITLE
Don't make changes to HTTPRoute status that trigger infinite reconcile looping

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -219,6 +219,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	discoveredTools := []mcp.Tool{}
 	for _, mcpServer := range conf.Servers {
 		m.logger.Info("Registering Server ", "mcpID", mcpServer.ID())
+
 		tools, err := m.RegisterServerWithConfig(ctx, mcpServer)
 		if err != nil {
 			slog.Warn("Could not register upstream MCP", "upstream", mcpServer.URL, "name", mcpServer.Name, "error", err)
@@ -258,7 +259,7 @@ func (m *mcpBrokerImpl) RegisterServerWithConfig(ctx context.Context, mcpServer 
 		}
 		configChanged := mcpServer.ConfigChanged(existingUpstream.MCPServer)
 		if !configChanged && !credentialValueChanged {
-			m.logger.Debug("mcp server is already registered and upto date", "server ", mcpServer.ID())
+			m.logger.Debug("mcp server is already registered and up to date", "server ", mcpServer.ID())
 			return nil, nil
 		}
 		// config or credentials changed, unregister and re-register
@@ -365,7 +366,7 @@ func (m *mcpBrokerImpl) discoverTools(ctx context.Context, mcpID upstreamMCPID, 
 	}
 
 	if upstream.mcpClient == nil {
-		// TODO (craig) most of the function require an upstremMCP object
+		// TODO (craig) most of the function require an upstreamMCP object
 		// Connection mgmt shouldn't be a part of this function
 		// prob functions should just become methods of that object
 		//upstreamMCP.Connect()
@@ -719,7 +720,7 @@ func toolsToServerTools(newTools []mcp.Tool) []server.ServerTool {
 // validateMCPServer validates a single MCP server using existing session data
 func (m *mcpBrokerImpl) validateMCPServer(_ context.Context, mcpID, name, toolPrefix string) ServerValidationStatus {
 	// Use already-discovered data for registered servers
-	m.logger.Debug("validateMCPServer: validating MCPServer ", "servername", name)
+	m.logger.Debug("validateMCPServer: validating MCPServer", "servername", name)
 	upstream, exists := m.mcpServers[upstreamMCPID(mcpID)]
 	if !exists {
 		m.logger.Warn("Server validation failed: server not registered", "id", mcpID, "name", name)
@@ -733,7 +734,7 @@ func (m *mcpBrokerImpl) validateMCPServer(_ context.Context, mcpID, name, toolPr
 			},
 		}
 	}
-	m.logger.Debug("validateMCPServer: checking MCPServer connection status ", "servername", name)
+	m.logger.Debug("validateMCPServer: checking MCPServer connection status", "servername", name)
 	connectionStatus := m.checkSessionHealth(upstream)
 
 	var protocolValidation ProtocolValidation

--- a/internal/config/mcpservers.go
+++ b/internal/config/mcpservers.go
@@ -93,7 +93,8 @@ func (mcpServer *MCPServer) ID() string {
 	return fmt.Sprintf("%s:%s:%s", mcpServer.Name, mcpServer.ToolPrefix, mcpServer.URL)
 }
 
-// ConfigChanged checks if a servers config has changed
+// ConfigChanged checks if a server's config has changed in a way that will affect the gateway.
+// This means having a different name, prefix, hostname, or credential variable.
 func (mcpServer *MCPServer) ConfigChanged(existingConfig MCPServer) bool {
 	return existingConfig.Name != mcpServer.Name ||
 		existingConfig.ToolPrefix != mcpServer.ToolPrefix ||

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -119,7 +119,8 @@ func (r *MCPReconciler) Reconcile(
 	}
 
 	// Neither resource found, regenerate config (handles deletions)
-	log.Info("MCP resource not found, regenerating aggregated config")
+	log.Info("MCP resource not found, regenerating aggregated config",
+		"req.NamespacedName", req.NamespacedName)
 	return r.regenerateAggregatedConfig(ctx)
 }
 
@@ -641,7 +642,8 @@ func (r *MCPReconciler) updateHTTPRouteStatus(
 	if affected {
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = "InUseByMCPServer"
-		condition.Message = fmt.Sprintf("HTTPRoute is referenced by MCPServer %s/%s", mcpServer.Namespace, mcpServer.Name)
+		// We don't include the MCP Server in the status because >1 MCPServer may reference the same HTTPRoute
+		condition.Message = "HTTPRoute is referenced by at least one MCPServer"
 	} else {
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = "NotInUse"


### PR DESCRIPTION
Resolves #304 

This eliminates an infinite reconcile loop.

The loop is caused by two MCPServers that both reference the same HTTPRoute each modifying that HTTPRoute's `.Status` to mention themselves, e.g.

- message: HTTPRoute is referenced by MCPServer mcp-test/test-server2
- message: HTTPRoute is referenced by MCPServer mcp-test/test-server22

I tested this by following the instructions in #304 and doing `oc -n mcp-test get httproute mcp-server2-route -o yaml` before and after making this change.  With this change, it says

- message: HTTPRoute is referenced by at least one MCPServer

This is a trivial fix but it might not be what is desired.  This fixes the problem because both MCPServers make the same change to the route, and Kubernetes knows to combine those changes.  If we want to reject >1 MCPServer pointing to the same HTTPRoute, a different PR is needed.  If we want the _.Status_ to explicitly name all of the MCPServers that refer to it a different PR is needed.  We can revise this PR, or we can create a new issue for the full desired behavior.

(It also isn't clear to me, as a novice in Controllers, if the kubebuilder Reconcile() is correct.  I would have expected the current code to not re-trigger a Reconcile if an HTTPRoute status changes.  We might improve efficiency if we didn't reconcile HTTPRoute statuses).

This fix also ads a bit of logging and fixes a few typos.