### PR TITLE
Disable writeTimeout to allow long running SSE connections for notifi…

### DIFF
--- a/charts/mcp-gateway/templates/deployment-broker.yaml
+++ b/charts/mcp-gateway/templates/deployment-broker.yaml
@@ -39,6 +39,7 @@ spec:
             - --mcp-broker-public-address=0.0.0.0:8080
             - --mcp-router-address=0.0.0.0:50051
             - --mcp-gateway-public-host={{ .Values.gateway.publicHost }}
+            - --mcp-broker-write-timeout={{ .Values.broker.writeTimeoutSeconds | default 0 }}
             - --log-level=-4
           env:
             - name: NAMESPACE

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -24,3 +24,10 @@ envoyFilter:
 gateway:
   # publicHost set the value for --mcp-gateway-public-host flag
   publicHost: mcp.127-0-0-1.sslip.io
+
+# Broker configuration
+broker:
+  # writeTimeoutSeconds sets the HTTP write timeout for the broker in seconds.
+  # Default 0 (disabled) is required for SSE notification support via GET /mcp.
+  # Set > 0 to enable a timeout (will break SSE notifications).
+  writeTimeoutSeconds: 0


### PR DESCRIPTION
…cations

Closes #348 

Sets the `writeTimeout` to 0 by default.
Adds a new optional arg to the broker (and a helm chart value) to allow overwriting it.

TODO:

- [ ] e2e test (will experiment with Claude for that)
- [ ] test coverage and fix for a duplicate session id issue (likely to hit this in a test where 2 clients establish a connection at the same time)

This also fixes the cause of these errors when using mcp-inspector:
```
Error from MCP server: Error: SSE stream disconnected: Error: Premature close
    at processStream (file:///Users/davidmartin/.npm/_npx/9eac9498388ae25e/node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js:240:88)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```
and periodic EOF errors like this in the broker and envoy proxy.

Prior to this change, the writeTimeout was 10 seconds.
This means that the server would wait a maximum of 10 seconds to write a response to the client.

My understanding of this is that if the writing of a chunk/block takes more than 10 seconds, the connection is closed, resulting in a `EOF / remote close / HPE_INVALID_EOF_STATE` from Envoys point of view.
The behaviour from the client side is that an SSE connection would establish OK, but then close immediately when a notification is sent over that connection if that notification is sent after 10 seconds.
Any notifications sent before 10 seconds arrive OK.
This can be clearly seen with curl.

Waiting for 10 seconds, no notifications:

```
curl -v -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/json, text/event-stream" -H "Accept: application/json, text/event-stream" http://mcp.127-0-0-1.sslip.io:8001/mcp
* Host mcp.127-0-0-1.sslip.io:8001 was resolved.
* IPv6: (none)
* IPv4: 127.0.0.1
*   Trying 127.0.0.1:8001...
* Connected to mcp.127-0-0-1.sslip.io (127.0.0.1) port 8001
> GET /mcp HTTP/1.1
> Host: mcp.127-0-0-1.sslip.io:8001
> User-Agent: curl/8.7.1
> Content-Type: application/json, text/event-stream
> Accept: application/json, text/event-stream
>
* Request completely sent off
< HTTP/1.1 200 OK
< cache-control: no-cache
< content-type: text/event-stream
< date: Fri, 05 Dec 2025 11:26:11 GMT
< x-envoy-upstream-service-time: 1
< access-control-allow-credentials: true
< access-control-allow-headers: Content-Type, Authorization, Accept, Origin, X-Requested-With
< access-control-allow-methods: GET, POST, PUT, DELETE, OPTIONS, HEAD
< access-control-allow-origin: *
< access-control-max-age: 3600
< server: istio-envoy
< transfer-encoding: chunked
<

* transfer closed with outstanding read data remaining
* Closing connection
curl: (18) transfer closed with outstanding read data remaining
```

Waiting for 10 seconds, with notifications happening every 1 second (only 4 notifications here as it took a few seconds for me to kick off my notifications triggering loop)

```
curl -k -LX POST https://$(oc get routes -n gateway-system -o jsonpath='{ .items[0].spec.host }')/mcp   -H "Content-Type: application/json"   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize"}'
davmarti-mac:mcp-gateway davidmartin$ curl -v -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/json, text/event-stream" -H "Accept: application/json, text/event-stream" http://mcp.127-0-0-1.sslip.io:8001/mcp
* Host mcp.127-0-0-1.sslip.io:8001 was resolved.
* IPv6: (none)
* IPv4: 127.0.0.1
*   Trying 127.0.0.1:8001...
* Connected to mcp.127-0-0-1.sslip.io (127.0.0.1) port 8001
> GET /mcp HTTP/1.1
> Host: mcp.127-0-0-1.sslip.io:8001
> User-Agent: curl/8.7.1
> Content-Type: application/json, text/event-stream
> Accept: application/json, text/event-stream
>
* Request completely sent off
< HTTP/1.1 200 OK
< cache-control: no-cache
< content-type: text/event-stream
< date: Fri, 05 Dec 2025 11:25:52 GMT
< x-envoy-upstream-service-time: 2
< access-control-allow-credentials: true
< access-control-allow-headers: Content-Type, Authorization, Accept, Origin, X-Requested-With
< access-control-allow-methods: GET, POST, PUT, DELETE, OPTIONS, HEAD
< access-control-allow-origin: *
< access-control-max-age: 3600
< server: istio-envoy
< transfer-encoding: chunked
<
event: message
data: {"jsonrpc":"2.0","method":"notifications/tools/list_changed","params":{}}

event: message
data: {"jsonrpc":"2.0","method":"notifications/tools/list_changed","params":{}}

event: message
data: {"jsonrpc":"2.0","method":"notifications/tools/list_changed","params":{}}

event: message
data: {"jsonrpc":"2.0","method":"notifications/tools/list_changed","params":{}}

* transfer closed with outstanding read data remaining
* Closing connection
curl: (18) transfer closed with outstanding read data remaining
```

In the MCP Inspector, the client reconnects automatically when the connection is closes,
which is why there are repeated `Error from MCP server: Error: SSE stream disconnected: Error: Premature close` errors in inspector logs.


With a writeTimeout of 0, the above errors and disconnections are no longer observed.
I ran a manual test for ~1hr with the addTool/removeTool endpoints of test server 2, and all notifications seem to get through without any closed connections:

```shell
kubectl -n mcp-test port-forward svc/mcp-test-server2 9090:9090
```

```shell
while true; do curl -v -X DELETE server2.127-0-0-1.sslip.io:9090/admin/deleteTool -d "time" && sleep 1 && curl -v -X POST server2.127-0-0-1.sslip.io:9090/admin/addTool -d "time" && sleep 1; done
```

<img width="496" height="299" alt="image" src="https://github.com/user-attachments/assets/34d8f2c6-af7e-41c0-b4bc-56aab862740c" />

