### PR TITLE
docs: Add design document for tool prefix matching

### DIFF
--- a/docs/design/tool-prefix-matching.md
+++ b/docs/design/tool-prefix-matching.md
@@ -17,15 +17,19 @@ MCPServer A: toolPrefix="" (empty)
 MCPServer B: toolPrefix="test_"
 
 Tool call: "test_tool_from_B"
-Current behavior: Routes to A (wrong)
-Expected behavior: Routes to B (correct)
+Current behavior: Routes to A if A is checked before B (wrong)
+Expected behavior: Always routes to B (correct)
 ```
 
 ### Solution
 
 Enforce single empty-prefix server and prioritize prefix matching:
 
-1. **Validation**: Only one MCPServer with an empty toolPrefix is allowed per namespace. Additional MCPServers with empty prefix fail validation with clear error message.
+1. **Validation**: Only one MCPServer with an empty toolPrefix is allowed. Additional MCPServers with empty prefix fail validation with clear error message.
+
+> Alternative approach: a stricter validation rule that prevents the creation of any MCPServer CRs with duplicate `toolPrefix` values. This would prevent both types of routing ambiguity.
+
+> Note: currently only one MCP Gateway instance per cluster is supported thus the MCPServer prefix needs to be unique cluster-wide for the routing to work reliably. Once multiple MCP Gateway instances are supported this can be relaxed so that the prefix is unique per namespace (MCP Gateway instance).
 
 2. **Router Ordering**: Router checks prefixed servers first, falling back to empty-prefix server only when no prefix matches.
 
@@ -34,13 +38,13 @@ Enforce single empty-prefix server and prioritize prefix matching:
 ### Implementation Details
 
 **Controller Changes:**
-- Validate at reconciliation time that only one MCPServer per namespace has empty `toolPrefix`
+- Validate at reconciliation time that only one MCPServer defines empty `toolPrefix`
 - Set appropriate status conditions on conflicting resources
 
 **Router Changes:**
 - Check prefixed servers first using longest-prefix-match algorithm
 - Use empty-prefix server as fallback when no prefix matches
-- Refactor current logic where the server info and prefix are already available (stored in [serverInfo](https://github.com/kagenti/mcp-gateway/blob/8665eaaa9ba666a961e0d9424c8549d1356ecf30/internal/mcp-router/request_handlers.go#L192) object) but it is not used, instead a complex [StripServerPrefix](https://github.com/kagenti/mcp-gateway/blob/8665eaaa9ba666a961e0d9424c8549d1356ecf30/internal/mcp-router/request_handlers.go#L226) method is called.
+- Refactor current logic where the information about the server including its prefix is already available (stored in [serverInfo](https://github.com/kagenti/mcp-gateway/blob/8665eaaa9ba666a961e0d9424c8549d1356ecf30/internal/mcp-router/request_handlers.go#L192) object) but it is not used, instead a complex [StripServerPrefix](https://github.com/kagenti/mcp-gateway/blob/8665eaaa9ba666a961e0d9424c8549d1356ecf30/internal/mcp-router/request_handlers.go#L226) method is called to retrieve the information again.
 
 ### Limitations
 


### PR DESCRIPTION
Documents validation approach for empty-prefix MCPServers and router changes to prioritize prefix matching over empty-prefix MCPServer fallback.