### PR TITLE
Add MCP conformance tests workflow

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,0 +1,108 @@
+name: MCP Conformance Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conformance-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Create Kind cluster
+        run: |
+          kind create cluster --name mcp-gateway --config - <<EOF
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+            kubeadmConfigPatches:
+              - |
+                apiVersion: kubelet.config.k8s.io/v1beta1
+                kind: KubeletConfiguration
+                syncFrequency: "10s"
+            extraPortMappings:
+            - containerPort: 30080
+              hostPort: 8001
+              protocol: TCP
+            - containerPort: 8443
+              hostPort: 8443
+              protocol: TCP
+          EOF
+
+      - name: Setup CI environment
+        run: make ci-setup
+
+      - name: Deploy conformance server
+        run: make deploy-conformance-server
+
+      - name: Wait for conformance server to get ready
+        run: sleep 10
+
+      - name: Run MCP conformance tests
+        run: |
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario server-initialize
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-list
+
+          sleep 10
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-simple-text
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-image
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-audio
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-embedded-resource
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-mixed-content
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-error
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario tools-call-with-progress
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          make ci-debug-logs
+          echo "=== Conformance server logs ==="
+          kubectl logs -n mcp-test deployment/conformance-server --tail=50

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,4 +54,6 @@ jobs:
 
       - name: Collect logs on failure
         if: failure()
-        run: make ci-debug-logs
+        run: |
+          make ci-debug-logs
+          make ci-debug-test-servers-logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,39 @@ ginkgo run -v --tags=e2e --focus="test description" tests/e2e/
 - Tests clean up existing resources before creating to avoid conflicts
 - Structured JSON responses provide better debugging when tests fail
 
+### Conformance Tests
+MCP conformance tests verify that the gateway correctly implements the Model Context Protocol specification. These tests are sourced from the official `@modelcontextprotocol/conformance` npm package maintained by Anthropic.
+
+**Test scenarios currently run in CI** (`.github/workflows/conformance.yaml`):
+- `server-initialize`: Server initialization handshake
+- `tools-list`: Tool listing and discovery
+- `tools-call-simple-text`: Simple text tool responses
+- `tools-call-image`: Image content in tool responses
+- `tools-call-audio`: Audio content in tool responses
+- `tools-call-embedded-resource`: Embedded resource handling
+- `tools-call-mixed-content`: Mixed content type responses
+- `tools-call-error`: Error handling and propagation
+- `tools-call-with-progress`: Progress notification support
+
+**Running conformance tests locally**:
+```bash
+make deploy-conformance-server  # Deploy test server to Kind cluster
+
+# Run specific scenario
+npx @modelcontextprotocol/conformance server \
+  --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  --scenario server-initialize
+
+# Run all active scenarios
+npx @modelcontextprotocol/conformance server \
+  --url http://mcp.127-0-0-1.sslip.io:8001/mcp
+```
+
+**Updating CI test scenarios**:
+1. Check available scenarios: `npx @modelcontextprotocol/conformance list`
+2. Add new scenario blocks to `.github/workflows/conformance.yaml` under the "Run MCP conformance tests" step
+3. Each scenario runs as a separate `npx @modelcontextprotocol/conformance server --url ... --scenario <name>` command
+
 ### CI/CD Optimizations
 All GitHub workflows have concurrency control to cancel stale runs:
 ```yaml

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -13,7 +13,7 @@ ci-setup: kind tools ## Setup environment for CI (creates Kind cluster if needed
 		echo "Kind cluster 'mcp-gateway' already exists"; \
 	fi
 	# Install Gateway API CRDs
-	$(KUBECTL) apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+	$(KUBECTL) apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
 	$(KUBECTL) wait --for condition=Established --timeout=60s crd/gateways.gateway.networking.k8s.io
 	# Build and load image
 	"$(MAKE)" docker-build
@@ -45,15 +45,18 @@ ci-debug-logs: ## Collect logs for debugging CI failures
 	-$(KUBECTL) logs -n mcp-system deployment/mcp-controller --tail=100
 	@echo "=== Broker logs ==="
 	-$(KUBECTL) logs -n mcp-system deployment/mcp-broker-router --tail=100
-	@echo "=== Test server logs ==="
-	-$(KUBECTL) logs -n mcp-test deployment/mcp-test-server1 --tail=50
-	-$(KUBECTL) logs -n mcp-test deployment/mcp-test-server2 --tail=50
-	-$(KUBECTL) logs -n mcp-test deployment/mcp-test-server3 --tail=50
 	@echo "=== MCPServers ==="
 	-$(KUBECTL) get mcpservers -A
 	@echo "=== HTTPRoutes ==="
 	-$(KUBECTL) get httproutes -A
-	@echo "=== ConfigMap ==="
-	-$(KUBECTL) get configmap -n mcp-system mcp-gateway-config -o yaml
+	@echo "=== Secret ==="
+	-$(KUBECTL) get secret -n mcp-system mcp-gateway-config -o jsonpath='{.data.config\.yaml}' | base64 --decode
 	@echo "=== Pods ==="
 	-$(KUBECTL) get pods -A
+
+.PHONY: ci-debug-test-servers-logs
+ci-debug-test-servers-logs: ## Collect test servers logs for debugging CI failures
+	@echo "=== Test server logs ==="
+	-$(KUBECTL) logs -n mcp-test deployment/mcp-test-server1 --tail=50
+	-$(KUBECTL) logs -n mcp-test deployment/mcp-test-server2 --tail=50
+	-$(KUBECTL) logs -n mcp-test deployment/mcp-test-server3 --tail=50


### PR DESCRIPTION
## Overview

 This PR introduces a new GitHub Actions workflow (`conformance.yaml`) to run MCP conformance tests. This workflow will help ensure that the gateway adheres to the Model Context Protocol specifications.

The source code of the testsuite itself: https://github.com/modelcontextprotocol/conformance
Note: in this PR only a few test scenarios that are known that they should be passing are executed. Other scenarios will be added in separate PRs as the MCP Gateway starts supporting additional features.

Key changes include:
-   A new `mcp-conformance.yaml` workflow that sets up a Kind cluster, deploys a conformance server, and executes conformance tests using `npx @modelcontextprotocol/conformance`.
-   Refactoring of `build/ci.mk` to extract the collection of test server logs into a dedicated and reusable `ci-debug-test-servers-logs` make target.
-   The `e2e.yaml` workflow has been updated to utilize this new, refactored log collection targets.

Separate workflow was created. Alternative would be to add the conformance tests into e2e.yaml workflow directly because these two have the same setup and it would be more efficient resource-wise (single KIND cluster used for both test suite). However, running both conformance tests and e2e test as part of single workflow would have certain disadvantages:
- no parallelization (both e2e and conformance tests might grow over the time and it can take too long running sequentially)
- no failure isolation (conformance test not get executed in case of e2e failures)
- not possible to re-run separately

### Verification Steps
None, successful workflow run is sufficient for verification.

## Update
I force pushed following changes:
- A short info on conformance tests added to CLAUDE.md (not sure if that's an ideal place)
- Gateway API upgraded from v1.2.0 to v1.4.1 (latest). I am not 100% sure here, it might be better to use whatever version latest Openshift provides by default (still I think using latest makes a bit more sense)
- Displaying `mcp-gateway-config` Secret for debugging purposes, it is no longer ConfigMap. However, not sure if it is wise to do it. It does not contain any sensitive information when running the conformance tests but it might potentially contain something sensitive in future or in some other context and we risk leakage.
- Ugly waits added to `conformance.yaml`, without them the tests were unstable. Not sure why was that, the `deploy-conformance-server` make target waits for both conformance server Pod and MCPServer CR to get ready which should suffice afaict.