### PR TITLE
Add ping conformance test scenario to CI

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -74,6 +74,10 @@ jobs:
 
           npx @modelcontextprotocol/conformance server \
             --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+            --scenario ping
+
+          npx @modelcontextprotocol/conformance server \
+            --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
             --scenario tools-call-simple-text
 
           npx @modelcontextprotocol/conformance server \


### PR DESCRIPTION
## Summary

Adds the `ping` conformance scenario to the CI workflow. It's a new scenario that has been added only recently, see https://github.com/modelcontextprotocol/conformance/pull/75

## Changes
 - Added `ping` scenario test run in `.github/workflows/conformance.yaml`

## Verification Steps
None, passing PR checks is sufficient for verification
