### PR TITLE
Add user docs TOC with placeholders for missing content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,39 +1,10 @@
 # MCP Gateway Documentation
 
-## Get Started
+## User Documentation
 
-**Want to try MCP Gateway?** Start here: **[Installation Guide](./guides/how-to-install-and-configure.md)**
+The [`./guides`](./guides/README.md) folder contains step-by-step instructions for installing, configuring, and using MCP Gateway.
 
-This guide walks you through setting up MCP Gateway on Kubernetes and connecting your first MCP servers.
+## Developer Documentation
 
-## Guides and Tutorials
+The [`./design/`](./design/) folder explains the architecture, design principles, and component responsibilities.
 
-The [`./guides/`](./guides/) folder contains step-by-step instructions for installing, configuring, and using MCP Gateway:
-
-**Essential Setup:**
-- [Installation and Configuration](./guides/how-to-install-and-configure.md) - Get MCP Gateway running
-- [Configure Gateway Routing](./guides/configure-mcp-gateway-listener-and-router.md) - Set up traffic routing
-- [Configure MCP Servers](./guides/configure-mcp-servers.md) - Connect internal servers
-- [External MCP Servers](./guides/external-mcp-server.md) - Connect to external APIs
-
-**Advanced Features:**
-- [Authentication](./guides/authentication.md) - OAuth-based security
-- [Authorization](./guides/authorization.md) - Fine-grained access control
-- [Virtual MCP Servers](./guides/virtual-mcp-servers.md) - Focused tool collections
-- [Standalone Installation](./guides/binary-install.md) - Non-Kubernetes deployment
-- [Troubleshooting](./guides/troubleshooting.md) - Common issues and solutions
-
-## Architecture and Design
-
-The [`./design/`](./design/) folder explains the architecture, design principles, and component responsibilities:
-
-- [Architecture Overview](./design/overview.md) - High-level system design
-- [Authentication Design](./design/auth-phase-1.md) - Security architecture
-- [Routing Design](./design/routing.md) - Traffic routing concepts
-- [Request Flows](./design/flows.md) - How requests are processed
-
-## Development and Internals
-
-The [`./dev/`](./dev/) folder covers code architecture and development workflows:
-
-- [Understanding Architecture](./dev/understanding-mcp-gateway-architecture.md) - Explore running system components

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,16 @@
+# MCP Gateway User Documentation
+
+- About the MCP Gateway
+    - [Overview](./overview.md)
+    - [Architecture](../design/overview.md)
+- [Getting Started](./getting-started.md)
+- Installing the MCP Gateway
+    - [Helm Install](./how-to-install-and-configure.md)
+- [Configure MCP Gateway Listener and Router](./configure-mcp-gateway-listener-and-router.md)
+- Configuring MCP Servers
+    - [MCP Server Configuration](./configure-mcp-servers.md)
+    - [Virtual MCP Servers](./virtual-mcp-servers.md)
+    - [External MCP Servers](./external-mcp-server.md)
+- [Authentication](./authentication.md)
+- [Authorization](./authorization.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+PLACEHOLDER https://github.com/Kuadrant/mcp-gateway/issues/493

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -1,0 +1,3 @@
+# MCP Gateway Overview
+
+PLACEHOLDER https://github.com/Kuadrant/mcp-gateway/issues/485

--- a/docs/guides/understanding-mcp-gateway-architecture.md
+++ b/docs/guides/understanding-mcp-gateway-architecture.md
@@ -4,13 +4,13 @@ This guide demonstrates how to explore and understand MCP Gateway's architecture
 
 ## About MCP Gateway Components
 
-You should read the [architecture overview](../design/overview.md) first to understand the high-level components and design.
+You should read the [overview](./overview.md) first to understand the high-level components and design.
 
 ## Prerequisites
 
 **Required Setup:** This guide assumes you have a running MCP Gateway cluster.
 
-See the [installation guide](../guides/how-to-install-and-configure.md) for setup instructions.
+See the [installation guide](./how-to-install-and-configure.md) for setup instructions.
 
 ## Step 1: Understanding Configuration and State
 
@@ -331,7 +331,7 @@ INFO Sending MCP routing instructions to Envoy: request_body:{response:{header_m
 INFO [EXT-PROC] Processing response body... (size: 136, end_of_stream: true)
 INFO [EXT-PROC] Response body content: event: message
 id: 3_0
-data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Hi Patryk"}],"structuredContent":{}}} 
+data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Hi Patryk"}],"structuredContent":{}}}
 ```
 
 ## Step 6: Troubleshooting Common Scenarios


### PR DESCRIPTION
Closes #473 
The new file at docs/guides/README.md serves as the entry point for user docs for 0.5 release (dev preview).
It's a table of contents only.
This TOC is intended to map to a structure in future when publishing to docs.kuadrant.io (that is, unholding https://github.com/Kuadrant/docs.kuadrant.io/pull/213 and updating/merging), and a possible downstream TOC for 0.6/tech preview.

I moved the docs/dev/understanding-mcp-gateway-architecture.md file under docs/guides as it was the only doc file in there, and makes more sense to have under guides as a possible user facing doc (though it's not in the TOC right now).
