### PR TITLE
fix bug with tool look up

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -219,7 +218,7 @@ func (m *mcpBrokerImpl) ToolAnnotations(serverID config.UpstreamMCPID, tool stri
 	if !ok {
 		return mcp.ToolAnnotation{}, false
 	}
-	t := upstream.GetManagedTool(tool)
+	t := upstream.GetServedManagedTool(tool)
 	if t != nil {
 		return t.Annotations, true
 	}
@@ -229,8 +228,7 @@ func (m *mcpBrokerImpl) ToolAnnotations(serverID config.UpstreamMCPID, tool stri
 // GetServerInfo implements MCPBroker by providing a lookup of the server that implements a tool.
 func (m *mcpBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 	for _, upstream := range m.mcpServers {
-		rawTool := strings.TrimPrefix(tool, upstream.MCP.GetPrefix())
-		t := upstream.GetManagedTool(rawTool)
+		t := upstream.GetServedManagedTool(tool)
 		if t != nil {
 			slog.Info("[EXT-PROC] Found matching server",
 				"toolName", tool,


### PR DESCRIPTION
I noticed an occasional failure in the broker_test [GetServerInfo](https://github.com/Kuadrant/mcp-gateway/blob/main/internal/broker/broker_test.go#L181). On investigation I discovered there is a bug in the code we added to look up servers by tool name. We look up the server by the original tool name, but by design we can have multiple servers with the same tool names. The client will make a request with the served tool name so we need to look up by the served tool name. The test occasionally failes due to the none stable ordering of keys in a map.