### PR TITLE
Set gateway public host and internal mcp servers listener in gateway …

### DIFF
--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -44,12 +44,18 @@ oc apply -k "$SCRIPT_BASE_DIR/kustomize/connectivity-link/instance/base"
 
 # Install MCP Gateway using Helm
 echo "Installing MCP Gateway using Helm..."
-helm upgrade -i mcp-gateway -n $MCP_GATEWAY_NAMESPACE --create-namespace oci://ghcr.io/kuadrant/charts/mcp-gateway --version $MCP_GATEWAY_HELM_VERSION
+helm upgrade -i mcp-gateway -n $MCP_GATEWAY_NAMESPACE --create-namespace oci://ghcr.io/kuadrant/charts/mcp-gateway --version $MCP_GATEWAY_HELM_VERSION \
+  --set gateway.publicHost="$MCP_GATEWAY_HOST"
 
 # Configure MCP Gateway Ingress using Helm
 echo "Configuring MCP Gateway Ingress using Helm..."
 helm upgrade -i mcp-gateway-ingress -n $GATEWAY_NAMESPACE --create-namespace "$SCRIPT_BASE_DIR/charts/mcp-gateway-ingress" \
-  --set mcpGateway.host="$MCP_GATEWAY_HOST"
+  --set mcpGateway.host="$MCP_GATEWAY_HOST" \
+  --set 'extraGatewayListeners[0].name=mcp-local' \
+  --set 'extraGatewayListeners[0].hostname=*.mcp.local' \
+  --set 'extraGatewayListeners[0].port=8080' \
+  --set 'extraGatewayListeners[0].protocol=HTTP' \
+  --set 'extraGatewayListeners[0].allowedRoutes.namespaces.from=All'
 
 echo
 echo "MCP Gateway deployment completed successfully."


### PR DESCRIPTION
…for openshift install script

After running the install script at `config/openshift/deploy_openshift.sh`

You can curl the server with:
```
curl -k -v -LX POST https://$(oc get routes -n gateway-system -o jsonpath='{ .items[0].spec.host }')/mcp   -H "Content-Type: application/json"   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize"}'
```

You should get a response like:
```
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Kagenti MCP Broker","version":"0.0.1"}}}
```

Optional: Deploy and register a test MCP Server

Deploy the MCP server:

```
oc apply -f https://gist.githubusercontent.com/david-martin/f5a08d382e8bd3ce914ffe0fcc6b2bfb/raw/8ae1ef2c666909baea020c950c85fa6f45e04c6c/test-mcp-server-deployment.yaml
```
Register the MCP server with the gateway:
```
oc apply -f https://gist.githubusercontent.com/david-martin/f5a08d382e8bd3ce914ffe0fcc6b2bfb/raw/db9237fdffd9c16f165d61f67f22ed4322ddb7b2/test-mcp-server-resource.yaml
```
Now when you do a tool list, you should see tools from the test server (It may take a minute or 2 before the list is updated):
```
NODE_TLS_REJECT_UNAUTHORIZED="0" npx @modelcontextprotocol/inspector --cli https://$(oc get routes -n gateway-system -o jsonpath='{ .items[0].spec.host }')/mcp --transport http --method tools/list
```
A tool call should work as well:
```
NODE_TLS_REJECT_UNAUTHORIZED="0" npx @modelcontextprotocol/inspector --cli https://$(oc get routes -n gateway-system -o jsonpath='{ .items[0].spec.host }')/mcp --transport http --method tools/call --tool-name test_time
```