### PR TITLE
claude generated e2e on demand workflow

### DIFF
--- a/.github/workflows/e2e-on-demand.yaml
+++ b/.github/workflows/e2e-on-demand.yaml
@@ -1,0 +1,173 @@
+name: E2E Tests (on-demand)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-permission:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/test-e2e')
+    outputs:
+      is-member: ${{ steps.check-org.outputs.is-member }}
+      suite: ${{ steps.parse-command.outputs.suite }}
+    steps:
+      - name: Check org membership
+        id: check-org
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const response = await github.rest.orgs.checkMembershipForUser({
+                org: 'Kuadrant',
+                username: context.payload.comment.user.login
+              });
+              core.setOutput('is-member', response.status === 204 || response.status === 302);
+            } catch (error) {
+              // 404 means not a member
+              core.setOutput('is-member', false);
+            }
+
+      - name: Parse command
+        id: parse-command
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          # Extract suite from "/test-e2e <suite>"
+          SUITE=$(echo "$COMMENT" | grep -oP '/test-e2e\s+\K\w+' || echo "")
+          if [[ "$SUITE" != "happy" && "$SUITE" != "full" ]]; then
+            echo "Invalid or missing suite. Use: /test-e2e happy or /test-e2e full"
+            SUITE=""
+          fi
+          echo "suite=$SUITE" >> $GITHUB_OUTPUT
+
+      - name: React to comment
+        if: steps.check-org.outputs.is-member == 'true' && steps.parse-command.outputs.suite != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Reject non-members
+        if: steps.check-org.outputs.is-member != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
+            });
+            core.setFailed('User is not a member of the Kuadrant organization');
+
+      - name: Reject invalid suite
+        if: steps.check-org.outputs.is-member == 'true' && steps.parse-command.outputs.suite == ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ Invalid command. Usage: `/test-e2e happy` or `/test-e2e full`'
+            });
+            core.setFailed('Invalid suite specified');
+
+  e2e-tests:
+    needs: check-permission
+    if: needs.check-permission.outputs.is-member == 'true' && needs.check-permission.outputs.suite != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Get PR branch
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Create Kind cluster
+        run: |
+          kind create cluster --name mcp-gateway --config - <<EOF
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+            kubeadmConfigPatches:
+              - |
+                apiVersion: kubelet.config.k8s.io/v1beta1
+                kind: KubeletConfiguration
+                syncFrequency: "10s"
+            extraPortMappings:
+            - containerPort: 30080
+              hostPort: 8001
+              protocol: TCP
+            - containerPort: 8443
+              hostPort: 8443
+              protocol: TCP
+          EOF
+
+      - name: Setup CI environment
+        run: make ci-setup
+
+      - name: Run E2E tests (happy)
+        if: needs.check-permission.outputs.suite == 'happy'
+        run: make test-e2e-happy
+
+      - name: Run E2E tests (full)
+        if: needs.check-permission.outputs.suite == 'full'
+        run: make test-e2e-ci
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          make ci-debug-logs || true
+          make ci-debug-test-servers-logs || true
+
+      - name: Report success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ E2E tests (\`${{ needs.check-permission.outputs.suite }}\`) passed on commit ${{ steps.pr.outputs.sha }}`
+            });
+
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `❌ E2E tests (\`${{ needs.check-permission.outputs.suite }}\`) failed on commit ${{ steps.pr.outputs.sha }}. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`
+            });


### PR DESCRIPTION
I am not hugely familar with github actions but this looks reasonable to allow us to trigger specific e2e suites and keep the happy path quick and focused.

Idea being you can specify /test-e2e full as a comment on the PR for example