### PR TITLE
fix: GET /mcp after authentication

### DIFF
--- a/config/samples/oauth-token-exchange/tools-list-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-list-auth.yaml
@@ -17,10 +17,11 @@ spec:
         jwt:
           issuerUrl: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
     authorization:
-      'allow-tool-list':
+      'allow-mcp-method':
         patternMatching:
           patterns:
-            - predicate: request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"] # check method header
+          - predicate: |
+              !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
       'authorized-tools':
         opa:
           rego: |


### PR DESCRIPTION
Authorises GET requests sent by the MCP client to the MCP endpoint after authentication.

These requests are typically sent by the MCP clients to initiate SSE streams for listening for messages from the server. Ref: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server.

See also: https://github.com/Kuadrant/mcp-gateway/blob/main/docs/design/notifications.md#notification-architecture

Without this change, Authorino will deny access to these GET requests due to the absence of the `x-mcp-method` request header, which is not set by the ext_proc filter in this case. As a result, the MCP client's attempt to establish the connection fails and the following message can be seen in the broker-router logs:

```
time=2026-01-28T10:06:38.458Z level=DEBUG msg="[ext_proc ] Process: ProcessingRequest_RequestHeaders" component=router "request id:"=ae5573c3-162f-4d34-ad71-626ec2ff4360 path=/mcp method=GET
time=2026-01-28T10:06:38.458Z level=DEBUG msg="Sending header processing instructions to Envoy: request_headers:{response:{header_mutation:{set_headers:{header:{key:\":authority\"  raw_value:\"mcp.127-0-0-1.sslip.io\"}}}  clear_route_cache:true}}" component=router
time=2026-01-28T10:06:38.461Z level=ERROR msg="[ext_proc] Process: Error receiving request" component=router error=EOF
```