### PR TITLE
add custom-response-server image build and improve Dockerfiles

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -55,6 +55,10 @@ jobs:
             context: tests/servers/custom-path-server
             dockerfile: Dockerfile
             image-name: test-custom-path-server
+          - server: custom-response-server
+            context: tests/servers/custom-response-server
+            dockerfile: Dockerfile
+            image-name: test-custom-response-server
           - server: oidc-server
             context: tests/servers/oidc-server
             dockerfile: Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 # Gateway API version for CRDs
 GATEWAY_API_VERSION ?= v1.4.1
 
+# The KIND cluster name must match ./build/kind.mk
+KIND_CLUSTER_NAME ?= mcp-gateway
+
 .PHONY: help
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -154,7 +157,7 @@ define load-image
 	echo "Loading image $(1) into Kind cluster..."
 	$(eval TMP_DIR := $(shell mktemp -d))
 	$(CONTAINER_ENGINE) save -o $(TMP_DIR)/image.tar $(1) \
-	   && KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive $(TMP_DIR)/image.tar --name mcp-gateway ; \
+	   && KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive $(TMP_DIR)/image.tar --name $(KIND_CLUSTER_NAME) ; \
 	   EXITVAL=$$? ; \
 	   rm -rf $(TMP_DIR) ;\
 	   exit $${EXITVAL}
@@ -210,7 +213,7 @@ build-test-servers: ## Build test server Docker images locally
 	cd tests/servers/custom-path-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-custom-path-server:latest .
 	cd tests/servers/oidc-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-oidc-server:latest .
 	cd tests/servers/everything-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-everything-server:latest .
-	cd tests/servers/custom-response-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/custom-response-server:latest .	
+	cd tests/servers/custom-response-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest .	
 
 # Build conformance server Docker image
 .PHONY: build-conformance-server
@@ -229,7 +232,7 @@ kind-load-test-servers: kind build-test-servers ## Load test server images into 
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-custom-path-server:latest)
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-oidc-server:latest)
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-everything-server:latest)
-	$(call load-image,ghcr.io/kagenti/mcp-gateway/custom-response-server:latest)
+	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest)
 
 # Load conformance server image into Kind cluster
 .PHONY: kind-load-conformance-server

--- a/config/test-servers/custom-response-deployment.yaml
+++ b/config/test-servers/custom-response-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: mcp-custom-response
-          image: ghcr.io/kagenti/mcp-gateway/custom-response-server:latest
+          image: ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest
           imagePullPolicy: IfNotPresent
           command: ['/mcp-test-server']
           args: ['--http', '0.0.0.0:9090']

--- a/tests/servers/broken-server/Dockerfile
+++ b/tests/servers/broken-server/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server
 # Runtime stage
 FROM alpine:latest
 
-WORKDIR /root/
+WORKDIR /app
 
 # Copy the binary from builder stage
 COPY --from=builder /mcp-test-server .
@@ -25,4 +25,4 @@ COPY --from=builder /mcp-test-server .
 EXPOSE 9090
 
 # Set default command  
-CMD ["./mcp-test-server", "--http", "0.0.0.0:9090"]
+CMD ["/app/mcp-test-server", "--http", "0.0.0.0:9090"]

--- a/tests/servers/custom-path-server/Dockerfile
+++ b/tests/servers/custom-path-server/Dockerfile
@@ -9,6 +9,6 @@ COPY *.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o custom-path-server .
 
 FROM alpine:latest
-WORKDIR /root/
+WORKDIR /app
 COPY --from=builder /app/custom-path-server .
-ENTRYPOINT ["./custom-path-server", "-http", ":8080"]
+ENTRYPOINT ["/app/custom-path-server", "-http", ":8080"]


### PR DESCRIPTION
Add custom-response-server image build and improve Dockerfiles.

  - Rename custom-response-server to test-custom-response-server for consistency
  - Build custom-response-server via test-images.yaml workflow - same as for other test server images
  - Update custom-response-server repository from kagenti to kuadrant
  - Improve Dockerfile for broken-server and custom-path-server:
    - Use /app workdir instead of /root/ since using /root/ fails on Openshift: `exec container process `/root/./mcp-test-server`: Permission denied`
  - Add KIND_CLUSTER_NAME variable to Makefile for configurability
  
### Verification Steps
`KIND_CLUSTER_NAME=mykind make local-env-setup`

Ideal would be to try on OpenShift too - to validate that `/app` change in Dockerfiles but I did that and it worked.
