### PR TITLE
Authorise test2_headers tool by default

### DIFF
--- a/config/keycloak/realm-import.yaml
+++ b/config/keycloak/realm-import.yaml
@@ -200,6 +200,9 @@ data:
             "mcp-test/test-server1": [
               "greet"
             ],
+            "mcp-test/test-server2": [
+              "headers"
+            ],
             "mcp-test/test-server3": [
               "add"
             ],


### PR DESCRIPTION
test-server2's `headers` tool is often used in demos. This change adds the tool by default to the `accounting` Keycloak group so users trying the auth setup don't have to do it manually.

<img width="1441" height="792" alt="Screenshot 2026-01-29 at 12 13 31" src="https://github.com/user-attachments/assets/276434e3-ca84-4ae9-952b-8879ea845694" />

<img width="1441" height="792" alt="Screenshot 2026-01-29 at 12 12 48" src="https://github.com/user-attachments/assets/0d852405-47e6-4e5a-9669-0c6e8d280391" />
