### PR TITLE
Pin conformance server to v0.1.9

### DIFF
--- a/tests/servers/conformance-server/Dockerfile
+++ b/tests/servers/conformance-server/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache git
 
 # Clone conformance repository and extract MCP conformance server
 WORKDIR /tmp
-RUN git clone --depth 1 https://github.com/modelcontextprotocol/conformance.git && \
+RUN git clone --branch v0.1.9 --depth 1 https://github.com/modelcontextprotocol/conformance.git && \
     mkdir -p /app && \
     cp -r conformance/examples/servers/typescript/* /app
 


### PR DESCRIPTION
Pin conformance server to v0.1.9

This is based on @bentito 's PR: https://github.com/Kuadrant/mcp-gateway/pull/539

@bentito 's reasoning about the change:
```
Pinning to v0.1.9 to ensure reproducible builds and prevent failures due to upstream changes (such as strict Host header validation) that were breaking CI.
```
It should make our conformance test PR check pass.