### PR TITLE
Migrate broken-server and custom-path-server images to kuadrant org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,8 +209,8 @@ build-test-servers: ## Build test server Docker images locally
 	cd tests/servers/server2 && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-server2:latest .
 	cd tests/servers/server3 && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-server3:latest .
 	cd tests/servers/api-key-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-api-key-server:latest .
-	cd tests/servers/broken-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-broken-server:latest .
-	cd tests/servers/custom-path-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-custom-path-server:latest .
+	cd tests/servers/broken-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-broken-server:latest .
+	cd tests/servers/custom-path-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-custom-path-server:latest .
 	cd tests/servers/oidc-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-oidc-server:latest .
 	cd tests/servers/everything-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kagenti/mcp-gateway/test-everything-server:latest .
 	cd tests/servers/custom-response-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest .	
@@ -228,8 +228,8 @@ kind-load-test-servers: kind build-test-servers ## Load test server images into 
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-server2:latest)
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-server3:latest)
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-api-key-server:latest)
-	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-broken-server:latest)
-	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-custom-path-server:latest)
+	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-broken-server:latest)
+	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-path-server:latest)
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-oidc-server:latest)
 	$(call load-image,ghcr.io/kagenti/mcp-gateway/test-everything-server:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest)

--- a/config/test-servers/broken-server-deployment.yaml
+++ b/config/test-servers/broken-server-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: mcp-test-broken-server
-          image: ghcr.io/kagenti/mcp-gateway/test-broken-server:latest
+          image: ghcr.io/kuadrant/mcp-gateway/test-broken-server:latest
           imagePullPolicy: IfNotPresent
           command:
             [

--- a/config/test-servers/custom-path-server-deployment.yaml
+++ b/config/test-servers/custom-path-server-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: mcp-custom-path-server
-        image: ghcr.io/kagenti/mcp-gateway/test-custom-path-server:latest
+        image: ghcr.io/kuadrant/mcp-gateway/test-custom-path-server:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/tests/servers/broken-server/README.md
+++ b/tests/servers/broken-server/README.md
@@ -69,13 +69,13 @@ FAILURE_MODE=tool-conflicts ./mcp-test-server --http 0.0.0.0:9090
 
 ```bash
 # Protocol failure (default)
-docker run -p 9090:9090 ghcr.io/kagenti/mcp-gateway/test-Broken-server:latest
+docker run -p 9090:9090 ghcr.io/kuadrant/mcp-gateway/test-broken-server:latest
 
 # No tools capability
-docker run -p 9090:9090 -e FAILURE_MODE=no-tools ghcr.io/kagenti/mcp-gateway/test-Broken-server:latest
+docker run -p 9090:9090 -e FAILURE_MODE=no-tools ghcr.io/kuadrant/mcp-gateway/test-broken-server:latest
 
 # Tool conflicts
-docker run -p 9090:9090 -e FAILURE_MODE=tool-conflicts ghcr.io/kagenti/mcp-gateway/test-Broken-server:latest
+docker run -p 9090:9090 -e FAILURE_MODE=tool-conflicts ghcr.io/kuadrant/mcp-gateway/test-broken-server:latest
 ```
 
 ## Testing with MCP Gateway


### PR DESCRIPTION
Migrate broken-server and custom-path-server images to kuadrant org

We should move everything to kuadrant org but I did not want to produce large PR at this point. The reason I did the move for these two server was that Dockerfiles for these two has changed recently (https://github.com/Kuadrant/mcp-gateway/pull/545) so we need to use latest images from kuadrant org instead of rather old images from kagenti org.

## Verification Steps

 Eye review. Passing checks should suffice.