### PR TITLE
fix: mcp inspector oauth redirect

### DIFF
--- a/config/samples/oauth-token-exchange/tools-call-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-call-auth.yaml
@@ -84,23 +84,21 @@ spec:
               expression: |
                 "Bearer " + ((has(auth.metadata.vault.data) && has(auth.metadata.vault.data.data) && has(auth.metadata.vault.data.data.token) && type(auth.metadata.vault.data.data.token) == string) ? auth.metadata.vault.data.data.token : auth.authorization.token.jwt)
       unauthenticated:
-        code: 401
         headers:
           'WWW-Authenticate':
             value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
         body:
           value: |
             {
-              "error": "Forbidden",
-              "message": "MCP Tool Access denied. Unauthenticated."
+              "error": "Unauthorized",
+              "message": "MCP Tool Access denied: Authentication required."
             }
       unauthorized:
-        code: 403
         body:
           value: |
             {
               "error": "Forbidden",
-              "message": "MCP Tool Access denied. Insufficient permissions for this tool."
+              "message": "MCP Tool Access denied: Insufficient permissions for this tool."
             }
 ---
 apiVersion: v1

--- a/config/samples/oauth-token-exchange/tools-list-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-list-auth.yaml
@@ -41,6 +41,16 @@ spec:
               signingKeyRefs:
                 - name: trusted-headers-private-key
                   algorithm: ES256
+      unauthenticated:
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+        body:
+          value: |
+            {
+              "error": "Unauthorized",
+              "message": "Access denied: Authentication required."
+            }
       unauthorized:
         code: 401
         headers:
@@ -50,16 +60,5 @@ spec:
           value: |
             {
               "error": "Forbidden",
-              "message": "Access denied."
-            }
-      unauthenticated:
-        code: 401
-        headers:
-          'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
-        body:
-          value: |
-            {
-              "error": "Forbidden",
-              "message": "Access denied."
+              "message": "Access denied: Unsupported method. New authentication required (401)."
             }

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -79,7 +79,6 @@ spec:
                 request.headers['x-mcp-toolname'] in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
     response:
       unauthenticated:
-        code: 401
         headers:
           'WWW-Authenticate':
             value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
@@ -87,15 +86,14 @@ spec:
           value: |
             {
               "error": "Unauthorized",
-              "message": "MCP Tool Access denied. Authentication required."
+              "message": "MCP Tool Access denied: Authentication required."
             }
       unauthorized:
-        code: 403
         body:
           value: |
             {
               "error": "Forbidden",
-              "message": "MCP Tool Access denied. Insufficient permissions for this tool."
+              "message": "MCP Tool Access denied: Insufficient permissions for this tool."
             }
 EOF
 ```

--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -264,23 +264,21 @@ spec:
               expression: |
                 "Bearer " + auth.authorization.token.jwt
       unauthenticated:
-        code: 401
         headers:
           'WWW-Authenticate':
             value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
         body:
           value: |
             {
-              "error": "Forbidden",
-              "message": "MCP Tool Access denied. Unauthenticated."
+              "error": "Unauthorized",
+              "message": "MCP Tool Access denied: Authentication required."
             }
       unauthorized:
-        code: 403
         body:
           value: |
             {
               "error": "Forbidden",
-              "message": "MCP Tool Access denied. Insufficient permissions for this tool."
+              "message": "MCP Tool Access denied: Insufficient permissions for this tool."
             }
 EOF
 ```


### PR DESCRIPTION
Fixes MCP Inspector OAuth redirect on _Connect_ without an auth provider configured, for streamable HTTP transport and connection via Proxy.

The redirect wasn't working due to how the MCP Inspector [detects 401s](https://github.com/modelcontextprotocol/inspector/blob/main/client/src/lib/hooks/useConnection.ts#L382-L391) and a [generic error message](https://github.com/modelcontextprotocol/typescript-sdk/blob/b392f02ffcf37c088dbd114fedf25026ec3913d3/src/client/streamableHttp.ts#L551) issued by an SDK the Inspector relies upon to handle the streams. This is apparently is [known issue](https://github.com/modelcontextprotocol/inspector/blob/main/server/src/index.ts#L52-L53) that has already motivated MCP Inspector to try to detect 401s based on the response messages. See https://github.com/modelcontextprotocol/inspector/pull/966 and https://github.com/modelcontextprotocol/inspector/pull/999.

However, the custom response messages enforced by the AuthPolicy with a 401 did not match MCP Inspector's criteria, and therefore would not trigger the redirect on the client. As a workaround, this PR explicitly adds to the custom response body messages in the AuthPolicy configs at least one of the detectable substrings: `401`, `Unauthorized`.

Tested with: MCP Inspector v0.19.0

Closes #520 