### PR TITLE
Remove spaces causing helm install failure

### DIFF
--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -89,7 +89,7 @@ else
         --set gateway.publicHost=mcp.127-0-0-1.sslip.io \
         --set gateway.nodePort.create=true \
         --set gateway.nodePort.mcpPort=30080 \
-        --set envoyFilter.name=mcp-gateway \        
+        --set envoyFilter.name=mcp-gateway \
         --set httpRoute.create=true \
         --set mcpGatewayExtension.gatewayRef.name=mcp-gateway \
         --set mcpGatewayExtension.gatewayRef.namespace=gateway-system


### PR DESCRIPTION
Fix for this error when running the `charts/sample_local_helm_setup.sh` script.

```
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments
```