### PR TITLE
fix(make) Fixed race condition on Makefile. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,9 +498,11 @@ local-env-teardown: ## Tear down the local Kind cluster
 
 .PHONY: add-jwt-key
 add-jwt-key: #add the public key needed to validate any incoming jwt based headers such as x-allowed-tools
-	@kubectl get deployment/mcp-broker-router -n mcp-system -o yaml | \
+	@for i in 1 2 3 4 5; do \
+		kubectl get deployment/mcp-broker-router -n mcp-system -o yaml | \
 		bin/yq '.spec.template.spec.containers[0].env += [{"name":"TRUSTED_HEADER_PUBLIC_KEY","valueFrom":{"secretKeyRef":{"name":"trusted-headers-public-key","key":"key"}}}] | .spec.template.spec.containers[0].env |= unique_by(.name)' | \
-		kubectl apply -f -
+		kubectl apply -f - && break || (echo "Retry $$i/5 failed, waiting 2s..." && sleep 2); \
+	done
 
 .PHONY: dev
 dev: ## Setup cluster for local development (binaries run on host)


### PR DESCRIPTION
Fixes #587 

 The problem was that deploy-broker applies a patch to the mcp-broker-router deployment, and then immediately  add-jwt-key tries to patch it again, causing Kubernetes to reject the second patch due to a changed resource version.

  The fix adds a retry mechanism to the add-jwt-key target that will:
  - Retry up to 5 times
  - Wait 2 seconds between retries
  - Break out of the loop on success

