### PR TITLE
Add claude command to sync top level github issues in a milestone to jira

### DIFF
--- a/.claude/commands/sync-jira.md
+++ b/.claude/commands/sync-jira.md
@@ -1,110 +1,54 @@
 # GitHub-Jira Sync
 
-Sync GitHub milestone issues with Jira Feature epics for MCP Gateway.
+Sync GitHub milestone issues with Jira Feature epics.
 
 ## Arguments
 
 - `$ARGUMENTS` - Format: `<MILESTONE> <JIRA_FEATURE>` (e.g., `v0.6 OCPSTRAT-2798`)
 
-## Instructions
+## Rules
 
-Sync GitHub milestone issues to Jira epics under a Feature. Follow rules exactly.
+**Sync:** GitHub Features/Tasks without a parent → Jira Epic
 
-### What Gets Synced
+**Skip:** Bugs, issues with a parent, sub-issues
 
-- GitHub Features (no parent) → Create Jira Epic
-- GitHub Tasks (no parent) → Create Jira Epic
+## Process
 
-### What Does NOT Get Synced
-
-- Bugs → Never sync
-- Issues with a parent → Skip (parent's Epic covers them)
-- Sub-issues → Stay in GitHub only
-
-### Process
-
-1. Parse arguments: `$ARGUMENTS` contains `<MILESTONE> <JIRA_FEATURE>`
-
-2. Get bearer token:
+1. List GitHub issues:
 ```bash
-TOKEN=$(jira issue view CONNLINK-1 --debug 2>&1 | grep "Authorization: Bearer" | head -1 | awk '{print $3}')
+./utils/jira-sync-list.sh <MILESTONE>
+```
+Output: `github_num, title, state, labels, parent`
+
+2. List existing Jira epics:
+```bash
+./utils/jira-sync-epics.sh <JIRA_FEATURE>
+```
+Output: `jira_key, summary, github_num`
+
+3. Match GitHub issues to Jira epics using the `github_num` column from epics output.
+
+4. Build table. For each GitHub issue:
+   - `parent != "none"` → Skip
+   - Labels contain "bug" → Skip
+   - Has matching Jira epic → Check bidirectional link
+   - No matching epic, no parent, not bug → Create Epic
+
+5. For new epics:
+```bash
+./utils/jira-sync-create.sh <GITHUB_NUM> "<TITLE>" <JIRA_FEATURE>
 ```
 
-3. List GitHub issues in milestone:
+6. For missing GitHub→Jira links:
 ```bash
-gh issue list --repo Kuadrant/mcp-gateway --milestone "<MILESTONE>" --state all \
-  --json number,title,state,labels \
-  --jq '.[] | "\(.number)\t\(.state)\t\(.title)\t\([.labels[].name] | join(","))"'
+./utils/jira-sync-link.sh <GITHUB_NUM> <JIRA_KEY>
 ```
 
-4. For each issue, check if it has a parent using the GraphQL API:
-```bash
-gh api graphql -f query='
-{
-  repository(owner: "Kuadrant", name: "mcp-gateway") {
-    issue(number: <NUMBER>) {
-      parent {
-        number
-        title
-      }
-    }
-  }
-}' --jq '.data.repository.issue.parent.number // "none"'
-```
+## Scripts
 
-If parent is not "none", skip the issue.
-
-5. List existing Jira epics:
-```bash
-jira issue list --project CONNLINK \
-  --jql "type = Epic AND 'Parent Link' = <JIRA_FEATURE>" \
-  --plain --columns key,summary,status
-```
-
-6. Build table:
-
-| GitHub # | Title | Parent | Jira Epic | Action |
-|----------|-------|--------|-----------|--------|
-| #XXX | Title | none | — | Create Epic |
-| #YYY | Title | #ZZZ | — | Skip |
-| #AAA | Title | none | CONNLINK-XXX | Exists |
-| #BBB | Title | — | — | Skip (Bug) |
-
-7. Create missing epics:
-```bash
-jira epic create --project CONNLINK \
-  -n "<GitHub Issue Title>" \
-  -s "<GitHub Issue Title>" \
-  --component "MCP Gateway" --label "mcp-gateway" --no-input \
-  -b "GitHub: https://github.com/Kuadrant/mcp-gateway/issues/<NUMBER>"
-```
-
-8. Set Parent Link via REST API:
-```bash
-curl -s -X PUT "https://issues.redhat.com/rest/api/2/issue/<NEW_EPIC_KEY>" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"fields":{"customfield_12313140":"<JIRA_FEATURE>"}}'
-```
-
-9. Verify:
-```bash
-jira issue view <EPIC_KEY> --raw | jq '{parentLink: .fields.customfield_12313140, featureLink: .fields.customfield_12318341.key}'
-```
-
-### CLI Limitations
-
-| Issue | Workaround |
-|-------|------------|
-| `--parent` doesn't work cross-project | Use REST API curl |
-| `--custom "Parent Link=XXX"` ignored | Use REST API curl |
-| `jira issue create --type Epic` fails | Use `jira epic create -n` |
-| Cannot delete issues | Close with "Won't Do" |
-
-### Field Reference
-
-| Field | ID | Set Via |
-|-------|----|---------|
-| Parent Link | customfield_12313140 | REST API |
-| Feature Link | customfield_12318341 | Auto-populated |
-| Epic Name | customfield_12311141 | `jira epic create -n` |
+| Script | Purpose |
+|--------|---------|
+| `jira-sync-list.sh <MILESTONE>` | GitHub issues with parent info |
+| `jira-sync-epics.sh <FEATURE>` | Jira epics with GitHub links |
+| `jira-sync-create.sh <NUM> <TITLE> <FEATURE>` | Create epic + bidirectional links |
+| `jira-sync-link.sh <NUM> <KEY>` | Add Jira link to GitHub issue |

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,6 @@
 # New Words
+CONNLINK
+customfield
 Agentic
 apikey
 dotdot

--- a/utils/jira-sync-create.sh
+++ b/utils/jira-sync-create.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Creates a Jira epic for a GitHub issue with bidirectional linking
+# Usage: ./jira-sync-create.sh <GITHUB_NUM> <GITHUB_TITLE> <JIRA_FEATURE>
+# Output: Created epic key
+
+set -e
+
+GITHUB_NUM="$1"
+GITHUB_TITLE="$2"
+JIRA_FEATURE="$3"
+
+if [ -z "$GITHUB_NUM" ] || [ -z "$GITHUB_TITLE" ] || [ -z "$JIRA_FEATURE" ]; then
+  echo "Usage: $0 <GITHUB_NUM> <GITHUB_TITLE> <JIRA_FEATURE>" >&2
+  exit 1
+fi
+
+# Get bearer token
+TOKEN=$(jira issue view CONNLINK-1 --debug 2>&1 | grep "Authorization: Bearer" | head -1 | awk '{print $3}')
+
+if [ -z "$TOKEN" ]; then
+  echo "Error: Could not get Jira bearer token" >&2
+  exit 1
+fi
+
+# Create epic
+EPIC_URL=$(jira epic create --project CONNLINK \
+  -n "$GITHUB_TITLE" \
+  -s "$GITHUB_TITLE" \
+  --component "MCP Gateway" --label "mcp-gateway" --no-input \
+  -b "GitHub: https://github.com/Kuadrant/mcp-gateway/issues/$GITHUB_NUM" 2>&1)
+
+EPIC_KEY=$(echo "$EPIC_URL" | grep -oE 'CONNLINK-[0-9]+')
+
+if [ -z "$EPIC_KEY" ]; then
+  echo "Error: Failed to create epic" >&2
+  echo "$EPIC_URL" >&2
+  exit 1
+fi
+
+# Set Parent Link via REST API
+curl -s -X PUT "https://issues.redhat.com/rest/api/2/issue/$EPIC_KEY" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"fields\":{\"customfield_12313140\":\"$JIRA_FEATURE\"}}"
+
+# Add Jira link to GitHub issue
+current_body=$(gh api repos/Kuadrant/mcp-gateway/issues/$GITHUB_NUM --jq '.body')
+new_body="Jira: https://issues.redhat.com/browse/$EPIC_KEY
+
+$current_body"
+gh issue edit "$GITHUB_NUM" --repo Kuadrant/mcp-gateway --body "$new_body" >/dev/null
+
+echo "$EPIC_KEY"

--- a/utils/jira-sync-epics.sh
+++ b/utils/jira-sync-epics.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Lists Jira epics under a Feature with their GitHub issue links
+# Usage: ./utils/jira-sync-epics.sh <JIRA_FEATURE>
+# Output: TSV with columns: jira_key, summary, github_num
+
+set -e
+
+JIRA_FEATURE="$1"
+
+if [ -z "$JIRA_FEATURE" ]; then
+  echo "Usage: $0 <JIRA_FEATURE>" >&2
+  exit 1
+fi
+
+# Get epics and extract GitHub issue numbers from descriptions
+jira issue list --project CONNLINK \
+  --jql "type = Epic AND 'Parent Link' = $JIRA_FEATURE" \
+  --plain --columns key,summary 2>/dev/null | tail -n +2 | \
+while IFS=$'\t' read -r key summary; do
+  # Get description and extract GitHub issue number
+  desc=$(jira issue view "$key" --raw 2>/dev/null | jq -r '.fields.description // ""')
+  github_num=$(echo "$desc" | grep -oE 'github\.com/Kuadrant/mcp-gateway/issues/([0-9]+)' | grep -oE '[0-9]+$' | head -1)
+  if [ -z "$github_num" ]; then
+    github_num="none"
+  fi
+  printf "%s\t%s\t%s\n" "$key" "$summary" "$github_num"
+done

--- a/utils/jira-sync-link.sh
+++ b/utils/jira-sync-link.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Adds Jira link to GitHub issue if not already present
+# Usage: ./jira-sync-link.sh <GITHUB_NUM> <JIRA_KEY>
+# Output: "added" or "exists"
+
+set -e
+
+GITHUB_NUM="$1"
+JIRA_KEY="$2"
+
+if [ -z "$GITHUB_NUM" ] || [ -z "$JIRA_KEY" ]; then
+  echo "Usage: $0 <GITHUB_NUM> <JIRA_KEY>" >&2
+  exit 1
+fi
+
+# Check if link already exists
+current_body=$(gh api repos/Kuadrant/mcp-gateway/issues/$GITHUB_NUM --jq '.body')
+if echo "$current_body" | grep -q "$JIRA_KEY"; then
+  echo "exists"
+  exit 0
+fi
+
+# Add link
+new_body="Jira: https://issues.redhat.com/browse/$JIRA_KEY
+
+$current_body"
+gh issue edit "$GITHUB_NUM" --repo Kuadrant/mcp-gateway --body "$new_body" >/dev/null
+echo "added"

--- a/utils/jira-sync-list.sh
+++ b/utils/jira-sync-list.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Lists GitHub milestone issues with parent info
+# Usage: ./utils/jira-sync-list.sh <MILESTONE>
+# Output: TSV with columns: github_num, title, state, labels, parent
+
+set -e
+
+MILESTONE="$1"
+
+if [ -z "$MILESTONE" ]; then
+  echo "Usage: $0 <MILESTONE>" >&2
+  exit 1
+fi
+
+# Get GitHub issues in milestone
+gh issue list --repo Kuadrant/mcp-gateway --milestone "$MILESTONE" --state all --limit 100 \
+  --json number,title,state,labels \
+  --jq '.[] | [.number, .title, .state, ([.labels[].name] | join(","))] | @tsv' | \
+while IFS=$'\t' read -r num title state labels; do
+  # Check for parent
+  parent=$(gh api graphql -f query="
+  {
+    repository(owner: \"Kuadrant\", name: \"mcp-gateway\") {
+      issue(number: $num) {
+        parent { number }
+      }
+    }
+  }" --jq '.data.repository.issue.parent.number // "none"' 2>/dev/null)
+
+  # Output TSV
+  printf "%s\t%s\t%s\t%s\t%s\n" "$num" "$title" "$state" "$labels" "$parent"
+done


### PR DESCRIPTION
`/sync-jira <milestone> <feature>` - Syncs GitHub milestone issues to Jira epics under a Feature, using
  the GraphQL API to check parent relationships and REST API to set cross-project Parent Links

Example in https://issues.redhat.com/browse/OCPSTRAT-2798 & https://github.com/Kuadrant/mcp-gateway/milestone/3