### PR TITLE
Support 'OPTIONS /mcp' (used by MCP Inspector)

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -309,7 +309,7 @@ func setUpBroker(address string, toolFiltering bool, sessionManager *session.JWT
 
 	// Allow direct connections with MCP Inspector
 	mux.HandleFunc("OPTIONS /mcp", func(w http.ResponseWriter, r *http.Request) {
-		logger.Warn("Handling OPTIONS", "mcp-session-id", r.Header.Get("mcp-session-id"))
+		logger.Debug("Handling OPTIONS", "Mcp-Session-Id", r.Header.Get("Mcp-Session-Id"))
 		w.WriteHeader(http.StatusOK)
 	})
 


### PR DESCRIPTION
Resolves #604

This PR shows an experiment to get the MCP Inspector working using Direct Connection instead of via its proxy.

Originally direct connections were failing, and the Chrome Console showed `Access to fetch at 'http://mcp.127-0-0-1.sslip.io:8080/mcp' from origin 'http://mcp-inspector.localtest.me:8080' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.`

This gets past that problem.  However, it still doesn't work.  A subsequent call by MCP Inspector with the payload `{"method":"notifications/initialized","jsonrpc":"2.0"}` fails because there was no MCP Session ID, and we return 400 for that.  The second problem is [a bug in MCP Inspector](https://github.com/modelcontextprotocol/inspector/issues/905) that they have yet to triage.