### PR TITLE
feat(elicitations): add idmap package to map request ids

### DIFF
--- a/internal/idmap/map.go
+++ b/internal/idmap/map.go
@@ -1,0 +1,72 @@
+// Package idmap maps gateway-assigned request IDs to backend server request IDs.
+package idmap
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Map stores and retrieves request ID mappings.
+type Map interface {
+	// Store a new id mapping, returning the downstream gateway id
+	Store(backendID any, serverName string, sessionID string) string
+	// Lookup gets an entry for a gateway id, deleting the entry in the map
+	// This is done as once there has been an elicitation response, we don't want the request entry anymore
+	Lookup(gatewayID string) (Entry, bool)
+	// Explicit removal for a gateway id
+	Remove(gatewayID string)
+}
+
+// Entry holds a backend request ID and its associated server/session info.
+type Entry struct {
+	BackendID  any // per mcp spec, the ID can be string, int64, or float64
+	ServerName string
+	SessionID  string
+}
+
+type idmap struct {
+	mu      sync.Mutex
+	entries map[string]Entry
+}
+
+// New returns an initialized Map.
+func New() Map {
+	return &idmap{entries: make(map[string]Entry)}
+}
+
+func (m *idmap) Store(backendID any, serverName string, sessionID string) string {
+	id := uuid.NewString()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.entries[id] = Entry{
+		BackendID:  backendID,
+		ServerName: serverName,
+		SessionID:  sessionID,
+	}
+
+	return id
+}
+
+func (m *idmap) Lookup(gatewayID string) (Entry, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.entries[gatewayID]
+	if !ok {
+		return Entry{}, false
+	}
+
+	delete(m.entries, gatewayID)
+
+	return entry, ok
+}
+
+func (m *idmap) Remove(gatewayID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.entries, gatewayID)
+}

--- a/internal/idmap/map_test.go
+++ b/internal/idmap/map_test.go
@@ -1,0 +1,203 @@
+package idmap
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreLookup(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []struct {
+			backendID  any
+			serverName string
+			sessionID  string
+		}
+		expectFound   bool
+		expectDeleted bool
+	}{
+		{
+			name: "string backend ID",
+			entries: []struct {
+				backendID  any
+				serverName string
+				sessionID  string
+			}{
+				{backendID: "req-42", serverName: "weather-server", sessionID: "upstream-session-1"},
+			},
+			expectFound: true,
+		},
+		{
+			name: "int64 backend ID",
+			entries: []struct {
+				backendID  any
+				serverName string
+				sessionID  string
+			}{
+				{backendID: int64(42), serverName: "time-server", sessionID: "upstream-session-2"},
+			},
+			expectFound: true,
+		},
+		{
+			name: "float64 backend ID",
+			entries: []struct {
+				backendID  any
+				serverName string
+				sessionID  string
+			}{
+				{backendID: float64(3.14), serverName: "calc-server", sessionID: "upstream-session-3"},
+			},
+			expectFound: true,
+		},
+		{
+			name:        "lookup miss returns zero entry",
+			entries:     nil,
+			expectFound: false,
+		},
+		{
+			name: "lookup deletes entry",
+			entries: []struct {
+				backendID  any
+				serverName string
+				sessionID  string
+			}{
+				{backendID: "req-1", serverName: "server1", sessionID: "session-1"},
+			},
+			expectFound:   true,
+			expectDeleted: true,
+		},
+		{
+			name: "multiple entries are independent",
+			entries: []struct {
+				backendID  any
+				serverName string
+				sessionID  string
+			}{
+				{backendID: "req-1", serverName: "server1", sessionID: "session-1"},
+				{backendID: int64(2), serverName: "server2", sessionID: "session-2"},
+				{backendID: float64(3.0), serverName: "server3", sessionID: "session-3"},
+			},
+			expectFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New()
+
+			if len(tt.entries) == 0 {
+				entry, ok := m.Lookup("nonexistent")
+				require.False(t, ok)
+				require.Equal(t, Entry{}, entry)
+				return
+			}
+
+			ids := make([]string, len(tt.entries))
+			for i, e := range tt.entries {
+				ids[i] = m.Store(e.backendID, e.serverName, e.sessionID)
+				require.NotEmpty(t, ids[i])
+			}
+
+			// verify unique IDs
+			for i := range ids {
+				for j := i + 1; j < len(ids); j++ {
+					require.NotEqual(t, ids[i], ids[j])
+				}
+			}
+
+			for i, id := range ids {
+				entry, ok := m.Lookup(id)
+				require.Equal(t, tt.expectFound, ok)
+
+				if tt.expectFound {
+					require.IsType(t, tt.entries[i].backendID, entry.BackendID)
+					require.Equal(t, tt.entries[i].backendID, entry.BackendID)
+					require.Equal(t, tt.entries[i].serverName, entry.ServerName)
+					require.Equal(t, tt.entries[i].sessionID, entry.SessionID)
+				}
+			}
+
+			if tt.expectDeleted {
+				for _, id := range ids {
+					_, ok := m.Lookup(id)
+					require.False(t, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	tests := []struct {
+		name    string
+		storeID bool
+	}{
+		{
+			name:    "removes existing entry",
+			storeID: true,
+		},
+		{
+			name:    "no-op for unknown ID",
+			storeID: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New()
+
+			id := "nonexistent"
+			if tt.storeID {
+				id = m.Store("req-1", "server1", "session-1")
+			}
+
+			m.Remove(id)
+
+			_, ok := m.Lookup(id)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	m := New()
+	var wg sync.WaitGroup
+
+	ids := make([]string, 100)
+	for i := range ids {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ids[i] = m.Store(int64(i), "server", "session")
+		}(i)
+	}
+	wg.Wait()
+
+	// even indices: lookup and verify values; odd indices: remove
+	results := make([]Entry, len(ids))
+	found := make([]bool, len(ids))
+	for i, id := range ids {
+		wg.Add(1)
+		if i%2 == 0 {
+			go func(i int, id string) {
+				defer wg.Done()
+				results[i], found[i] = m.Lookup(id)
+			}(i, id)
+		} else {
+			go func(id string) {
+				defer wg.Done()
+				m.Remove(id)
+			}(id)
+		}
+	}
+	wg.Wait()
+
+	for i := 0; i < len(ids); i += 2 {
+		require.True(t, found[i], "entry %d should be found", i)
+		require.Equal(t, int64(i), results[i].BackendID)
+		require.Equal(t, "server", results[i].ServerName)
+		require.Equal(t, "session", results[i].SessionID)
+	}
+}

--- a/project-words.txt
+++ b/project-words.txt
@@ -170,6 +170,7 @@ hostnames
 htmlcov
 httproute
 httproutes
+idmap
 ingester
 ingressgateway
 inmemory


### PR DESCRIPTION
Part of #349 

This PR is the first part of adding support for elicitation. It adds a idmap package to handle request ID mapping, associating the gateway assigned request ID (created in this package), the original backend server request ID, and original backend server name/session ID.

For expiration the idea is that on lookup the entry is deleted, as there would only be one reply to the the request. There is also an explicit Remove method, for cases where e.g. a Tool Call is cancelled, and we want to clean up any elicitations that did not have a reply yet.

I avoided a TTL on the elicitations as it was not clear what would be a reasonable timeout for removing those, and there seemed to be alternatives (mentioned above) to do the cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gateway-to-backend ID mapping to improve request routing and tracking, with unique gateway IDs and reliable entry lifecycle (store, lookup, remove).

* **Tests**
  * Added comprehensive tests covering storage, lookup, deletion, type consistency, uniqueness, and concurrent access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->