### PR TITLE
Fix nil pointer when no parent Accepted contition

### DIFF
--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -267,7 +267,7 @@ func (r *MCPReconciler) findValidGatewaysForMCPServer(ctx context.Context, targe
 		// lets fetch the parents that are valid
 		for _, parent := range targetHTTPRoute.Status.Parents {
 			acceptedCond := meta.FindStatusCondition(parent.Conditions, string(gatewayv1.GatewayConditionAccepted))
-			if acceptedCond.Status == metav1.ConditionTrue {
+			if acceptedCond != nil && acceptedCond.Status == metav1.ConditionTrue {
 				pr := parent.ParentRef.DeepCopy()
 				if pr.Namespace == nil {
 					pr.Namespace = ptr.To(gatewayv1.Namespace(targetHTTPRoute.Namespace))


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference panic in `findValidGatewaysForMCPServer` when an HTTPRoute parent status does not contain an `Accepted` condition

This occurs when a non-gateway controller (e.g. Kuadrant's policy controller) adds a parent status entry with conditions that don't include `Accepted`. `meta.FindStatusCondition` returns `nil`, which is dereferenced without a check.

```text
2026-03-03T09:45:10Z	ERROR	Observed a panic	{"controller": "mcpserverregistration", "controllerGroup": "mcp.kagenti.com", "controllerKind": "MCPServerRegistration", "MCPServerRegistration": {"name":"github","namespace":"mcp-test"}, "namespace": "mcp-test", "name": "github", "reconcileID": "2d0fc39e-f899-4aa6-9566-4e51d5645b8f", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 192 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x18ef538, 0xc0041d7020}, {0x149c720, 0x2249a80})\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.0/pkg/util/runtime/runtime.go:132 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:198 +0x10e\npanic({0x149c720?, 0x2249a80?})\n\t/usr/local/go/src/runtime/panic.go:783 +0x132\ngithub.com/Kuadrant/mcp-gateway/internal/controller.(*MCPReconciler).findValidGatewaysForMCPServer(0xc000225cc0, {0x18ef538, 0xc0041d7020}, 0xc002dd6600)\n\t/workspace/internal/controller/mcpserverregistration_controller.go:265 +0x1e5\ngithub.com/Kuadrant/mcp-gateway/internal/controller.(*MCPReconciler).Reconcile(0xc000225cc0, {0x18ef538, 0xc0041d7020}, {{{0xc00042f628?, 0xc0001b7808?}, {0xc00042f620?, 0x0?}}})\n\t/workspace/internal/controller/mcpserverregistration_controller.go:149 +0xc6d\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc0041d6f90?, {0x18ef538?, 0xc0041d7020}, {{{0xc00042f628, 0x0?}, {0xc00042f620?, 0x0?}}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:216 +0x165\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x1903400, {0x18ef570, 0xc000225bd0}, {{{0xc00042f628, 0x8}, {0xc00042f620, 0x6}}}, 0x0)\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:461 +0x3ad\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x1903400, {0x18ef570, 0xc000225bd0})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421 +0x21b\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 103\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:292 +0x26b\n"}
k8s.io/apimachinery/pkg/util/runtime.logPanic
	/go/pkg/mod/k8s.io/apimachinery@v0.35.0/pkg/util/runtime/runtime.go:142
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:198
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:783
runtime.panicmem
	/usr/local/go/src/runtime/panic.go:262
runtime.sigpanic
	/usr/local/go/src/runtime/signal_unix.go:925
github.com/Kuadrant/mcp-gateway/internal/controller.(*MCPReconciler).findValidGatewaysForMCPServer
	/workspace/internal/controller/mcpserverregistration_controller.go:265
github.com/Kuadrant/mcp-gateway/internal/controller.(*MCPReconciler).Reconcile
	/workspace/internal/controller/mcpserverregistration_controller.go:149
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:216
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:461
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296
2026-03-03T09:45:10Z	ERROR	Reconciler error	{"controller": "mcpserverregistration", "controllerGroup": "mcp.kagenti.com", "controllerKind": "MCPServerRegistration", "MCPServerRegistration": {"name":"github","namespace":"mcp-test"}, "namespace": "mcp-test", "name": "github", "reconcileID": "2d0fc39e-f899-4aa6-9566-4e51d5645b8f", "error": "panic: runtime error: invalid memory address or nil pointer dereference [recovered]"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:474
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296
```

## Test plan

- [ ] Deploy to a cluster with Kuadrant AuthPolicy applied to the HTTPRoute
- [ ] Verify controller no longer panics when HTTPRoute parent status only has non-gateway conditions
- [ ] Verify existing functionality still works (MCPServerRegistrations with standard gateway parents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash that could occur when processing gateway configurations with missing status information, improving system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->