### PR TITLE
Add path matching/ignore rules for heavier workflows

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -3,6 +3,14 @@ name: Code Style
 on:
   pull_request:
     branches: [ 'main',  ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'evals/**'
+      - '.coderabbit.yaml'
+      - '.gitignore'
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -3,8 +3,24 @@ name: MCP Conformance Tests
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - '.coderabbit.yaml'
+      - '.gitignore'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,8 +3,24 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - '.coderabbit.yaml'
+      - '.gitignore'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -3,6 +3,14 @@ name: Gevals Integration Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'internal/**'
+      - 'pkg/**'
+      - 'cmd/**'
+      - 'evals/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/gevals.yaml'
   workflow_dispatch:
     inputs:
       task-filter:

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -3,6 +3,12 @@ name: Helm Install Test
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'charts/**'
+      - 'config/crd/**'
+      - 'api/**'
+      - 'Dockerfile*'
+      - '.github/workflows/helm-install-test.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -5,8 +5,24 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - 'tests/servers/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - 'tests/servers/**'
   merge_group:
     types: [ checks_requested ]
 


### PR DESCRIPTION
Add path-based filters to various CI workflows (heavier ones) so they skip when changes are isolated to docs, charts, evals, or other unrelated paths.
This avoids wasting CI resources (e.g. Kind cluster workflows) & time on PRs that can't affect the components being tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to skip runs for non-critical updates (docs, examples, licenses, certain config files), reducing unnecessary CI executions.
  * Added path-based triggers so specific integration and install tests only run when relevant code or configuration areas change, improving pipeline efficiency and targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->