### PR TITLE
Only compare managed flags when checking deployment updates

### DIFF
--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
@@ -36,12 +37,15 @@ const (
 	brokerConfigPort = 8181
 )
 
-// flags that can be changed directly on the deployment without triggering an update
-var ignoredCommandFlags = []string{
-	"--cache-connection-string",
-	"--log-level",
-	"--log-format",
-	"--session-length",
+// managedCommandFlags are the flags the controller owns and reconciles.
+// Any flag not in this list is user-managed and preserved as-is.
+var managedCommandFlags = []string{
+	"--mcp-broker-public-address",
+	"--mcp-gateway-private-host",
+	"--mcp-gateway-config",
+	"--mcp-check-interval",
+	"--mcp-gateway-public-host",
+	"--mcp-router-key",
 }
 
 func brokerRouterLabels() map[string]string {
@@ -288,7 +292,15 @@ func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Contex
 
 	if needsUpdate, reason := deploymentNeedsUpdate(deployment, existingDeployment); needsUpdate {
 		r.log.Info("updating broker-router deployment", "namespace", mcpExt.Namespace, "reason", reason)
-		existingDeployment.Spec.Template.Spec.Containers = deployment.Spec.Template.Spec.Containers
+		desiredContainer := deployment.Spec.Template.Spec.Containers[0]
+		existingContainer := existingDeployment.Spec.Template.Spec.Containers[0]
+		// merge command: update managed flags, preserve user flags
+		existingContainer.Command = mergeCommand(desiredContainer.Command, existingContainer.Command)
+		existingContainer.Image = desiredContainer.Image
+		existingContainer.Ports = desiredContainer.Ports
+		existingContainer.Env = desiredContainer.Env
+		existingContainer.VolumeMounts = desiredContainer.VolumeMounts
+		existingDeployment.Spec.Template.Spec.Containers[0] = existingContainer
 		existingDeployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes
 		if err := r.Update(ctx, existingDeployment); err != nil {
 			return false, fmt.Errorf("failed to update deployment: %w", err)
@@ -390,9 +402,9 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 	if desiredContainer.Image != existingContainer.Image {
 		return true, fmt.Sprintf("image changed: %q -> %q", existingContainer.Image, desiredContainer.Image)
 	}
-	// filter out flags that can be changed directly on the deployment
-	desiredCmd := filterIgnoredFlags(desiredContainer.Command)
-	existingCmd := filterIgnoredFlags(existingContainer.Command)
+	// only compare flags the controller manages; user-added flags are preserved
+	desiredCmd := filterManagedFlags(desiredContainer.Command)
+	existingCmd := filterManagedFlags(existingContainer.Command)
 	if !equality.Semantic.DeepEqual(desiredCmd, existingCmd) {
 		return true, fmt.Sprintf("command changed: %v -> %v", existingCmd, desiredCmd)
 	}
@@ -411,21 +423,36 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 	return false, ""
 }
 
-func filterIgnoredFlags(command []string) []string {
-	filtered := make([]string, 0, len(command))
+// filterManagedFlags returns only the binary name and flags the controller manages.
+func filterManagedFlags(command []string) []string {
+	var out []string
 	for _, arg := range command {
-		ignore := false
-		for _, flag := range ignoredCommandFlags {
-			if strings.HasPrefix(arg, flag) {
-				ignore = true
-				break
-			}
-		}
-		if !ignore {
-			filtered = append(filtered, arg)
+		if !strings.HasPrefix(arg, "--") || slices.ContainsFunc(managedCommandFlags, func(flag string) bool {
+			return strings.HasPrefix(arg, flag)
+		}) {
+			out = append(out, arg)
 		}
 	}
-	return filtered
+	return out
+}
+
+// mergeCommand takes the desired command from the controller and the existing
+// command from the deployment. It returns a merged command that preserves any
+// user-added flags while updating controller-managed flags.
+func mergeCommand(desired, existing []string) []string {
+	// start with all user flags from the existing command
+	var userFlags []string
+	for _, arg := range existing {
+		if !strings.HasPrefix(arg, "--") {
+			continue
+		}
+		if !slices.ContainsFunc(managedCommandFlags, func(flag string) bool {
+			return strings.HasPrefix(arg, flag)
+		}) {
+			userFlags = append(userFlags, arg)
+		}
+	}
+	return slices.Concat(desired, userFlags)
 }
 
 func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1alpha1.MCPGatewayExtension, publicHost string) *gatewayv1.HTTPRoute {

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -28,7 +28,7 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 							{
 								Name:    "test-container",
 								Image:   "test-image:v1",
-								Command: []string{"./app", "--flag=value"},
+								Command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--mcp-gateway-public-host=test.example.com"},
 								Ports: []corev1.ContainerPort{
 									{Name: "http", ContainerPort: 8080},
 									{Name: "grpc", ContainerPort: 50051},
@@ -72,19 +72,33 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "command changed",
+			name: "managed flag changed",
 			modify: func(d *appsv1.Deployment) {
-				d.Spec.Template.Spec.Containers[0].Command = []string{"./app", "--flag=changed"}
+				d.Spec.Template.Spec.Containers[0].Command = []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:9090", "--mcp-gateway-public-host=test.example.com"}
 			},
 			expected: true,
 		},
 		{
-			name: "command added",
+			name: "user-added flag does not trigger update",
 			modify: func(d *appsv1.Deployment) {
 				d.Spec.Template.Spec.Containers[0].Command = append(
 					d.Spec.Template.Spec.Containers[0].Command,
-					"--new-flag",
+					"--log-level=debug",
 				)
+			},
+			expected: false,
+		},
+		{
+			name: "managed flag added triggers update",
+			modify: func(d *appsv1.Deployment) {
+				// remove --mcp-gateway-public-host from existing to simulate a new managed flag
+				var cmd []string
+				for _, arg := range d.Spec.Template.Spec.Containers[0].Command {
+					if !strings.HasPrefix(arg, "--mcp-gateway-public-host=") {
+						cmd = append(cmd, arg)
+					}
+				}
+				d.Spec.Template.Spec.Containers[0].Command = cmd
 			},
 			expected: true,
 		},
@@ -135,7 +149,7 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "ignored flag cache-connection-string changed",
+			name: "user flag cache-connection-string does not trigger update",
 			modify: func(d *appsv1.Deployment) {
 				d.Spec.Template.Spec.Containers[0].Command = append(
 					d.Spec.Template.Spec.Containers[0].Command,
@@ -145,27 +159,7 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "ignored flag log-level changed",
-			modify: func(d *appsv1.Deployment) {
-				d.Spec.Template.Spec.Containers[0].Command = append(
-					d.Spec.Template.Spec.Containers[0].Command,
-					"--log-level=debug",
-				)
-			},
-			expected: false,
-		},
-		{
-			name: "ignored flag log-format changed",
-			modify: func(d *appsv1.Deployment) {
-				d.Spec.Template.Spec.Containers[0].Command = append(
-					d.Spec.Template.Spec.Containers[0].Command,
-					"--log-format=json",
-				)
-			},
-			expected: false,
-		},
-		{
-			name: "ignored flag session-length changed",
+			name: "user flag session-length does not trigger update",
 			modify: func(d *appsv1.Deployment) {
 				d.Spec.Template.Spec.Containers[0].Command = append(
 					d.Spec.Template.Spec.Containers[0].Command,
@@ -175,14 +169,14 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "non-ignored flag still triggers update",
+			name: "arbitrary user flag does not trigger update",
 			modify: func(d *appsv1.Deployment) {
 				d.Spec.Template.Spec.Containers[0].Command = append(
 					d.Spec.Template.Spec.Containers[0].Command,
-					"--some-other-flag=value",
+					"--some-custom-flag=value",
 				)
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "env var added",
@@ -1221,6 +1215,103 @@ func TestBuildGatewayHTTPRoute(t *testing.T) {
 			}
 			if parentRef.SectionName == nil || string(*parentRef.SectionName) != tt.mcpExt.Spec.TargetRef.SectionName {
 				t.Errorf("parentRef sectionName = %v, want %q", parentRef.SectionName, tt.mcpExt.Spec.TargetRef.SectionName)
+			}
+		})
+	}
+}
+
+func TestFilterManagedFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+		want    []string
+	}{
+		{
+			name:    "binary only",
+			command: []string{"./mcp_gateway"},
+			want:    []string{"./mcp_gateway"},
+		},
+		{
+			name:    "all managed flags kept",
+			command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--mcp-gateway-public-host=example.com"},
+			want:    []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--mcp-gateway-public-host=example.com"},
+		},
+		{
+			name:    "user flags stripped",
+			command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug", "--cache-connection-string=redis://localhost"},
+			want:    []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+		},
+		{
+			name:    "empty command",
+			command: []string{},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterManagedFlags(tt.command)
+			if len(got) != len(tt.want) {
+				t.Fatalf("filterManagedFlags() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("filterManagedFlags()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  []string
+		existing []string
+		want     []string
+	}{
+		{
+			name:     "no user flags",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+		},
+		{
+			name:     "preserves user flags from existing",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug"},
+		},
+		{
+			name:     "updates managed flag and preserves user flags",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:9090"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--cache-connection-string=redis://localhost"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:9090", "--cache-connection-string=redis://localhost"},
+		},
+		{
+			name:     "multiple user flags preserved",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug", "--session-length=3600"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug", "--session-length=3600"},
+		},
+		{
+			name:     "existing has no flags",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+			existing: []string{"./mcp_gateway"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeCommand(tt.desired, tt.existing)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mergeCommand() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mergeCommand()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
 			}
 		})
 	}

--- a/project-words.txt
+++ b/project-words.txt
@@ -377,3 +377,4 @@ upserted
 vhost
 wasmplugin
 ztunnels
+operatorframework


### PR DESCRIPTION
Before: The controller maintained an ignoredCommandFlags list — flags it would skip when comparing. Any flag not in that
  list would trigger an update and get reverted. This meant new flags have to be added to that list

After: The controller maintains a managedCommandFlags list — the flags it owns. Only these flags are compared during update detection. Any flag the controller doesn't know about is left untouched.

So this means if we add a flag to the mcp-gateway but it isn't one the controller manages, users can modify it directly without it being overwritten or the controller having to know about it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-provided command flags are now preserved during broker-router deployment updates, preventing loss of custom configurations.

* **Tests**
  * Added comprehensive test coverage for flag filtering and command merging logic.

* **Chores**
  * Updated project word list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->