### PR TITLE
bug: use mcpserverregistration in the remote-github sample

### DIFF
--- a/config/samples/remote-github/create_resources.sh
+++ b/config/samples/remote-github/create_resources.sh
@@ -43,8 +43,8 @@ echo "==> Step 4: Creating Secret with Authentication..."
 envsubst < "$SCRIPT_DIR/secret.yaml" | kubectl apply -f -
 
 echo ""
-echo "==> Step 5: Creating MCPServer Resource..."
-kubectl apply -f "$SCRIPT_DIR/mcpserver.yaml"
+echo "==> Step 5: Creating MCPServerRegistration Resource..."
+kubectl apply -f "$SCRIPT_DIR/mcpserverregistration.yaml"
 
 echo ""
 echo "==> Step 6: Applying AuthPolicy..."


### PR DESCRIPTION
Typo in the `remote-github` sample missed by the rename - fixed up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource creation workflow to initialize MCPServerRegistration resources instead of MCPServer resources during deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->