### PR TITLE
bug: fix OpenShift deploy script CatalogSource and CSV wait

### DIFF
--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:latest
+  image: ghcr.io/kuadrant/mcp-controller-catalog:main
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -70,7 +70,7 @@ kubectl apply -f /tmp/mcp-subscription.yaml -n $MCP_GATEWAY_NAMESPACE
 
 echo "Waiting for controller CSV to succeed..."
 retries=0
-until kubectl get csv -n $MCP_GATEWAY_NAMESPACE -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Succeeded"; do
+until kubectl get csv -n $MCP_GATEWAY_NAMESPACE -l operators.coreos.com/mcp-gateway.$MCP_GATEWAY_NAMESPACE="" -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Succeeded"; do
   retries=$((retries + 1))
   if [ $retries -ge 60 ]; then
     echo "Timed out waiting for controller CSV to succeed"


### PR DESCRIPTION
The CatalogSource referenced a non-existent `latest`" image tag, causing ImagePullBackOff. The CI publishes the catalog image with the git ref name (e.g., `main`), so use that tag instead.

The CSV wait loop used items[0] which matched the first CSV alphabetically (e.g., authorino-operator) rather than mcp-gateway, causing the script to proceed before CRDs were established. Use OLM's operator label selector to target the correct CSV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container image reference for deployment
  * Enhanced deployment process with improved controller verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->