### PR TITLE
Reference latest released version on main always

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,9 @@ cd tests/e2e && go test -v -tags=e2e -run TestE2E -ginkgo.focus="test descriptio
 ginkgo run -v --tags=e2e --focus="test description" tests/e2e/
 ```
 
+### Version References
+Docs and scripts on `main` always reference the latest published release version (plain SemVer, e.g., `0.5.1`). Git refs use a `v` prefix (e.g., `v${MCP_GATEWAY_VERSION}`), Helm `--version` uses bare SemVer. The `scripts/set-release-version.sh` script updates all version references and is run as part of the release process and the post-release bump on `main`.
+
 ### Important Ports
 - 8080: Broker HTTP (/mcp endpoint)
 - 50051: Router gRPC (ext_proc)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,14 +24,7 @@ Run the version update script with the full version including any RC suffix:
 ./scripts/set-release-version.sh X.Y.Z
 ```
 
-This updates version references in:
-- `config/openshift/deploy_openshift.sh`
-- `charts/sample_local_helm_setup.sh`
-- `docs/guides/quick-start.md`
-- `config/mcp-system/deployment-controller.yaml`
-- `config/mcp-system/deployment-broker.yaml`
-- `config/manifests/bases/mcp-gateway.clusterserviceversion.yaml`
-- `config/deploy/olm/catalogsource.yaml`
+This updates version references across deployment scripts, docs, and manifests. Review changes with `git diff`.
 
 If CRD or API type changes are included in this release, regenerate all manifests first:
 ```bash
@@ -49,10 +42,7 @@ make bundle VERSION=X.Y.Z
 
 Commit and push:
 ```bash
-git add config/openshift/deploy_openshift.sh charts/sample_local_helm_setup.sh \
-  docs/guides/quick-start.md config/mcp-system/deployment-controller.yaml \
-  config/mcp-system/deployment-broker.yaml config/manifests/bases/ \
-  config/deploy/olm/catalogsource.yaml bundle/
+git add -u config/ charts/ docs/ bundle/
 git commit -s -m "Update version to X.Y.Z-rcN"
 git push -u origin release-X.Y
 ```
@@ -103,10 +93,7 @@ git pull
 git checkout -b bump-version-X.Y.Z
 ./scripts/set-release-version.sh X.Y.Z
 make bundle VERSION=X.Y.Z
-git add config/openshift/deploy_openshift.sh charts/sample_local_helm_setup.sh \
-  docs/guides/quick-start.md config/mcp-system/deployment-controller.yaml \
-  config/mcp-system/deployment-broker.yaml config/manifests/bases/ \
-  config/deploy/olm/catalogsource.yaml bundle/
+git add -u config/ charts/ docs/ bundle/
 git commit -s -m "Update version to X.Y.Z"
 git push -u origin bump-version-X.Y.Z
 ```

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -5,12 +5,13 @@
 
 set -e
 
-# Allow specifying a different GitHub org/user and branch via environment variables
+# Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-BRANCH=${MCP_GATEWAY_BRANCH:-main}
+VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"
-echo "Using branch: $BRANCH"
+echo "Using version: $VERSION (git ref: $GIT_REF)"
 echo "Using local chart: $USE_LOCAL_CHART"
 
 echo "Setting up MCP Gateway using Helm chart..."
@@ -52,15 +53,15 @@ helm upgrade --install istiod istio/istiod -n istio-system --wait
 kubectl create namespace gateway-system --dry-run=client -o yaml | kubectl apply -f -
 
 # Deploy test servers
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server1-deployment.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server1-service.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server1-httproute.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server1-httproute-ext.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server2-deployment.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server2-service.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server2-httproute.yaml -n mcp-test
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/test-servers/server2-httproute-ext.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server1-deployment.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server1-service.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server1-httproute.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server1-httproute-ext.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server2-deployment.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server2-service.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server2-httproute.yaml -n mcp-test
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/test-servers/server2-httproute-ext.yaml -n mcp-test
 
 # Patch test server images, usually used for local dev built images, to pull images from remote
 kubectl patch deployment mcp-test-server1 -n mcp-test --type='json' -p='[{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}]'
@@ -88,7 +89,7 @@ else
     helm upgrade --install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
         --create-namespace \
         --namespace mcp-system \
-        --version 0.5.0 \
+        --version $VERSION \
         --set broker.create=true \
         --set gateway.create=true \
         --set gateway.name=mcp-gateway \
@@ -102,7 +103,7 @@ else
 fi
 
 # Apply MCPServerRegistration samples
-kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$BRANCH/config/samples/mcpserverregistration-test-servers-base.yaml
+kubectl apply -f https://raw.githubusercontent.com/$GITHUB_ORG/mcp-gateway/$GIT_REF/config/samples/mcpserverregistration-test-servers-base.yaml
 
 echo "Waiting for MCP Gateway deployments to be created..."
 for deploy in mcp-gateway mcp-gateway-controller; do

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,8 +27,8 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=main  # or a specific version tag
-kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=${MCP_GATEWAY_VERSION}"
+export MCP_GATEWAY_VERSION=0.5.1
+kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 
 Verify CRDs are installed:

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,8 +33,8 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=main #change this to the version you want
-kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=${MCP_GATEWAY_VERSION}"
+export MCP_GATEWAY_VERSION=0.5.1
+kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 
 Verify the CRDs are installed:

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -28,14 +28,14 @@ Perfect for evaluation, demos, and getting started quickly.
 Set the release version to install:
 
 ```bash
-export MCP_GATEWAY_BRANCH=release-0.5.0
+export MCP_GATEWAY_VERSION=0.5.1
 ```
 
 Run the automated setup script:
 
 ```bash
 # Download and run the setup script
-curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/${MCP_GATEWAY_BRANCH}/charts/sample_local_helm_setup.sh | bash
+curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/v${MCP_GATEWAY_VERSION}/charts/sample_local_helm_setup.sh | bash
 ```
 
 **Or clone the repository and run locally:**
@@ -43,7 +43,7 @@ curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/${MCP_GATEWAY_B
 ```bash
 git clone https://github.com/Kuadrant/mcp-gateway.git
 cd mcp-gateway
-git checkout $MCP_GATEWAY_BRANCH
+git checkout v${MCP_GATEWAY_VERSION}
 USE_LOCAL_CHART=true ./charts/sample_local_helm_setup.sh
 ```
 

--- a/scripts/set-release-version.sh
+++ b/scripts/set-release-version.sh
@@ -38,26 +38,14 @@ else
     echo "Warning: $OPENSHIFT_SCRIPT not found"
 fi
 
-# Update charts/sample_local_helm_setup.sh
+# Update charts/sample_local_helm_setup.sh default version
 SAMPLE_SCRIPT="$REPO_ROOT/charts/sample_local_helm_setup.sh"
 if [ -f "$SAMPLE_SCRIPT" ]; then
-    sed -i.bak -E "s/--version [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?/--version $VERSION/" "$SAMPLE_SCRIPT"
+    sed -i.bak -E "s/MCP_GATEWAY_VERSION:-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?/MCP_GATEWAY_VERSION:-$VERSION/" "$SAMPLE_SCRIPT"
     rm -f "$SAMPLE_SCRIPT.bak"
     echo "Updated: $SAMPLE_SCRIPT"
 else
     echo "Warning: $SAMPLE_SCRIPT not found"
-fi
-
-# Update docs/guides/quick-start.md release branch reference
-QUICK_START="$REPO_ROOT/docs/guides/quick-start.md"
-if [ -f "$QUICK_START" ]; then
-    # extract major.minor.patch (strip any pre-release suffix) for branch name
-    BRANCH_VERSION=$(echo "$VERSION" | sed -E 's/-.*//')
-    sed -i.bak -E "s/MCP_GATEWAY_BRANCH=release-[0-9]+\.[0-9]+\.[0-9]+/MCP_GATEWAY_BRANCH=release-$BRANCH_VERSION/" "$QUICK_START"
-    rm -f "$QUICK_START.bak"
-    echo "Updated: $QUICK_START"
-else
-    echo "Warning: $QUICK_START not found"
 fi
 
 # Update config/mcp-system deployment images
@@ -89,6 +77,20 @@ else
     echo "Warning: $CSV_BASE not found"
 fi
 
+# Update docs/guides MCP_GATEWAY_VERSION
+for GUIDE in \
+    "$REPO_ROOT/docs/guides/quick-start.md" \
+    "$REPO_ROOT/docs/guides/isolated-gateway-deployment.md" \
+    "$REPO_ROOT/docs/guides/how-to-install-and-configure.md"; do
+    if [ -f "$GUIDE" ]; then
+        sed -i.bak -E "s/MCP_GATEWAY_VERSION=[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?/MCP_GATEWAY_VERSION=$VERSION/" "$GUIDE"
+        rm -f "$GUIDE.bak"
+        echo "Updated: $GUIDE"
+    else
+        echo "Warning: $GUIDE not found"
+    fi
+done
+
 # Update OLM CatalogSource image tag
 CATALOG_SOURCE="$REPO_ROOT/config/deploy/olm/catalogsource.yaml"
 if [ -f "$CATALOG_SOURCE" ]; then
@@ -100,15 +102,6 @@ else
 fi
 
 echo "Done. Version set to $VERSION"
-echo ""
-echo "Files updated:"
-echo "  - config/openshift/deploy_openshift.sh"
-echo "  - charts/sample_local_helm_setup.sh"
-echo "  - docs/guides/quick-start.md"
-echo "  - config/mcp-system/deployment-controller.yaml"
-echo "  - config/mcp-system/deployment-broker.yaml"
-echo "  - config/manifests/bases/mcp-gateway.clusterserviceversion.yaml"
-echo "  - config/deploy/olm/catalogsource.yaml"
 echo ""
 echo "After updating, regenerate the bundle with: make bundle VERSION=$VERSION"
 echo "Review changes with: git diff"


### PR DESCRIPTION
Versions of images, branch names and helm chart versions don't always align.
This is a problem in some of our docs where we say to install CRDs from a particular branch, or install via helm from a particular version. The version to use differs.
It's also a problem on main where currently the intent is to always deploy the bleeding edge. That won't work if installing via helm as there is no 'nightly' or equivalent build that equates to the 'main' branch.

These changes swap things around so that the latest released version is what's referenced in docs and scripts on main.

To do this, we unify MCP_GATEWAY_VERSION as a single env var across all docs and scripts, using plain semver for helm (e.g. 0.5.1) and a v prefix for git refs (e.g. v0.5.1). This replaces the old MCP_GATEWAY_BRANCH var and the use of main as a default, so docs on main always reference the latest published release. The set-release-version.sh script and RELEASING.md are updated to keep everything in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides to pin MCP Gateway to version 0.5.1 with consistent version reference formatting.
  * Added clarification on how version strings are referenced across documentation and deployment scripts.

* **Chores**
  * Updated release and setup scripts to use version-based selection instead of branch references for consistent versioning across all deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->