### PR TITLE
docs(elicitation): update design doc to reflect implementation

### DIFF
--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -7,7 +7,9 @@
 | `notifications/tools/list_changed` (upstream detection) | Implemented | MCPManager detects and re-fetches tools |
 | `notifications/tools/list_changed` (client forwarding) | Implemented | Handled by mcp-go library; E2E tested |
 | Progress updates (streamed in tool call POST) | Implemented | Handled by mcp-go library; covered by `tools-call-with-progress` conformance test |
-| Elicitation request/response routing | Not implemented | Requires request ID mapping infrastructure |
+| Elicitation request/response routing (form mode) | Implemented | JSON-RPC request ID mapping; E2E tested |
+| `notifications/elicitation/complete` | No changes needed | Pass-through; see URL Mode Elicitation section |
+| `URLElicitationRequiredError` (code -32042) | No changes needed | Pass-through; see URL Mode Elicitation section |
 | `notifications/resources/list_changed` | Not applicable | Gateway does not federate resources |
 | `notifications/prompts/list_changed` | Not applicable | Gateway does not federate prompts |
 | `notifications/roots/list_changed` | Not applicable | Gateway does not federate roots |
@@ -165,7 +167,7 @@ sequenceDiagram
 
 **How Elicitations Work:**
 
-> **Implementation Note**: Elicitation support is **not yet implemented**. The design below describes the planned approach.
+> **Implementation Note**: Form mode elicitation (request/response routing with JSON-RPC request ID mapping) is implemented and E2E tested. URL mode flows (completion notifications and `URLElicitationRequiredError`) require no gateway changes; see the URL Mode Elicitation section below.
 
 Elicitations allow backend MCP servers to request user input during tool execution. When an `elicitation/create` event is sent, the tool call on the server halts, waiting for the client's response. The elicitation message contains a unique request ID that the client must use when responding. See the [MCP Elicitation specification](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#elicitation) for more details.
 
@@ -236,12 +238,59 @@ sequenceDiagram
 
 **Request ID Mapping for Elicitations:**
 
-Since elicitation responses arrive as new POST requests from the client, the gateway must maintain a mapping that associates:
+Since elicitation responses arrive as new POST requests from the client, the router must maintain a mapping that associates:
 - The gateway-assigned request ID (sent to the client)
 - The original backend server request ID
 - The backend server session (for routing)
+- The gateway session ID (to validate the responding client matches the original)
 
 When forwarding an elicitation to the client, the gateway replaces the backend server's request ID with a gateway-specific ID. When the client responds, the gateway uses the mapping to restore the original request ID and route the response to the correct backend server session.
+
+#### URL Mode Elicitation
+
+URL mode elicitation introduces two additional server-to-client messages. Both work with the current gateway design without changes because the gateway's request ID rewriting is scoped to `elicitation/create` messages only. All other messages in the tool call response stream pass through unmodified.
+
+**`notifications/elicitation/complete`**: After a client completes an out-of-band action at a URL, the backend server may send this notification in the tool call response stream. The notification uses `params.elicitationId` (not the JSON-RPC request ID) to identify the completed elicitation. The gateway does not need to rewrite this notification because:
+- It has no JSON-RPC `id` field (it is a notification, not a request)
+- The `elicitationId` is a value the gateway never modifies — request ID rewriting only applies to the JSON-RPC `id` on `elicitation/create`
+
+The request ID mapping created for the original `elicitation/create` is cleaned up when the tool call response stream ends, so no early cleanup on notification receipt is needed.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/complete",
+  "params": {
+    "elicitationId": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+**`URLElicitationRequiredError` (code -32042)**: When a request cannot proceed until URL mode elicitation is completed, the backend server returns this error response. The gateway does not need to rewrite this because:
+- It is an error response, not an `elicitation/create` request — request ID rewriting does not apply
+- The JSON-RPC `id` in the error matches the client's original request ID, which the gateway does not modify for tool call requests
+- The `elicitationId` and `url` fields inside `error.data` are opaque to the gateway
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "error": {
+    "code": -32042,
+    "message": "This request requires more information.",
+    "data": {
+      "elicitations": [
+        {
+          "mode": "url",
+          "elicitationId": "550e8400-e29b-41d4-a716-446655440000",
+          "url": "https://mcp.example.com/connect?elicitationId=550e8400",
+          "message": "Authorization is required to access your Example Co files."
+        }
+      ]
+    }
+  }
+}
+```
 
 ### Implementation Considerations
 
@@ -252,16 +301,14 @@ When forwarding an elicitation to the client, the gateway replaces the backend s
 
 2. **Capability Detection**: The broker must check the `initialize` response from each backend MCP server to determine which state change event capabilities are supported before establishing GET notification connections.
 
-3. **Request ID Mapping**: The broker must maintain a mapping table for elicitation request IDs that includes:
-   - Gateway-assigned request ID
+3. **Request ID Mapping**: The router maintains a mapping table for elicitation request IDs that includes:
+   - Gateway-assigned request ID (random UUID)
    - Original backend server request ID
-   - Backend server session information
-   - Expiration/TTL to clean up stale mappings
-   
-   **Request ID Type Handling**: Backend MCP servers may use request IDs of different types (string, integer, or float). The gateway implementation must:
-   - Preserve the original backend server request ID type when restoring it in the client's response
-   - From the gateway's perspective, gateway-assigned request IDs could use strings with a pattern (e.g., prefixing the server name) to ensure uniqueness and enable routing, though specific implementation details are left to implementation time
-   - Test scenarios with string, integer, and float request IDs from backend servers to ensure proper type preservation and routing
+   - Backend server name and session
+   - Gateway session ID (for response validation)
+   - Expiration/TTL to clean up stale mappings (1-hour safety-net TTL in Redis)
+
+   **Request ID Type Handling**: Backend MCP servers may use request IDs of different types (string, integer, or float). The mapping preserves the original type so it can be restored when forwarding the client's response to the backend.
 
 4. **Error Handling and Reconnection**: The broker must handle:
    - Backend MCP server connection failures
@@ -276,7 +323,8 @@ When forwarding an elicitation to the client, the gateway replaces the backend s
    - Establish state change event connections when backend servers are discovered (after capability checking)
    - Clean up connections when backend servers are removed
    - Manage long-running POST connections for tool calls with progress/elicitation
-   - Clean up request ID mappings when tool calls complete or timeout
+
+   The router cleans up elicitation request ID mappings when the tool call response stream ends, or when the client's elicitation response is successfully forwarded.
 
 ### Security Considerations
 
@@ -286,6 +334,6 @@ When forwarding an elicitation to the client, the gateway replaces the backend s
 
 3. **Request ID Mapping Security**: The gateway-assigned request IDs in elicitation mappings should be cryptographically random and unguessable to prevent unauthorized access to tool call sessions.
 
-### Open Questions
+### Resolved Questions
 
-1. **Elicitation Mapping Cleanup**: What is the appropriate timeout/TTL for elicitation request ID mappings? Should mappings persist for the entire tool call duration, or should there be a shorter timeout for elicitation responses?
+1. **Elicitation Mapping Cleanup**: Mappings persist for the tool call duration and are removed when the response stream ends. In Redis-backed deployments, a 1-hour TTL acts as a safety net for orphaned entries.


### PR DESCRIPTION
This PR updates the design docs to reflect the implementation, and explains why further changes are not needed for the other two data flows included in URL mode elicitation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated notification and elicitation handling design documentation with clarified implementation details, message flow specifications, and request handling approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->