### PR TITLE
Preserve user-added env vars on broker-router deployment (fixes #677)

### DIFF
--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -48,6 +48,13 @@ var managedCommandFlags = []string{
 	"--mcp-router-key",
 }
 
+// managedEnvVarNames are the env var names the controller owns and reconciles.
+// Any env var not in this list is user-managed and preserved as-is.
+var managedEnvVarNames = []string{
+	"TRUSTED_HEADER_PUBLIC_KEY",
+	"CACHE_CONNECTION_STRING",
+}
+
 func brokerRouterLabels() map[string]string {
 	return map[string]string{
 		labelAppName:   brokerRouterName,
@@ -311,7 +318,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Contex
 		existingContainer.Command = mergeCommand(desiredContainer.Command, existingContainer.Command)
 		existingContainer.Image = desiredContainer.Image
 		existingContainer.Ports = desiredContainer.Ports
-		existingContainer.Env = desiredContainer.Env
+		existingContainer.Env = mergeEnvVars(desiredContainer.Env, existingContainer.Env)
 		existingContainer.VolumeMounts = desiredContainer.VolumeMounts
 		existingDeployment.Spec.Template.Spec.Containers[0] = existingContainer
 		existingDeployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes
@@ -430,8 +437,11 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 	if !equality.Semantic.DeepEqual(desired.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
 		return true, fmt.Sprintf("volumes changed: %+v -> %+v", existing.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes)
 	}
-	if !equality.Semantic.DeepEqual(desiredContainer.Env, existingContainer.Env) {
-		return true, fmt.Sprintf("env changed: %+v -> %+v", existingContainer.Env, desiredContainer.Env)
+	// only compare env vars the controller manages; user-added env vars are preserved
+	desiredEnv := filterManagedEnvVars(desiredContainer.Env)
+	existingEnv := filterManagedEnvVars(existingContainer.Env)
+	if !equality.Semantic.DeepEqual(desiredEnv, existingEnv) {
+		return true, fmt.Sprintf("env changed: %+v -> %+v", existingEnv, desiredEnv)
 	}
 	return false, ""
 }
@@ -466,6 +476,30 @@ func mergeCommand(desired, existing []string) []string {
 		}
 	}
 	return slices.Concat(desired, userFlags)
+}
+
+// filterManagedEnvVars returns only env vars the controller manages.
+func filterManagedEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
+	var out []corev1.EnvVar
+	for _, ev := range envVars {
+		if slices.Contains(managedEnvVarNames, ev.Name) {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// mergeEnvVars takes the desired env vars from the controller and the existing
+// env vars from the deployment. It returns a merged list that preserves any
+// user-added env vars while updating controller-managed env vars.
+func mergeEnvVars(desired, existing []corev1.EnvVar) []corev1.EnvVar {
+	var userEnvVars []corev1.EnvVar
+	for _, ev := range existing {
+		if !slices.Contains(managedEnvVarNames, ev.Name) {
+			userEnvVars = append(userEnvVars, ev)
+		}
+	}
+	return slices.Concat(desired, userEnvVars)
 }
 
 func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1alpha1.MCPGatewayExtension, publicHost string) *gatewayv1.HTTPRoute {

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -7,6 +7,7 @@ import (
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1314,6 +1315,124 @@ func TestMergeCommand(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFilterManagedEnvVars(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []corev1.EnvVar
+		want []corev1.EnvVar
+	}{
+		{
+			name: "only managed vars returned",
+			env: []corev1.EnvVar{
+				{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"},
+				{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+				{Name: "CACHE_CONNECTION_STRING", Value: "redis://localhost"},
+			},
+			want: []corev1.EnvVar{
+				{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"},
+				{Name: "CACHE_CONNECTION_STRING", Value: "redis://localhost"},
+			},
+		},
+		{
+			name: "no managed vars",
+			env: []corev1.EnvVar{
+				{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+			},
+			want: nil,
+		},
+		{
+			name: "empty input",
+			env:  nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterManagedEnvVars(tt.env)
+			if !equality.Semantic.DeepEqual(got, tt.want) {
+				t.Errorf("filterManagedEnvVars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  []corev1.EnvVar
+		existing []corev1.EnvVar
+		want     []corev1.EnvVar
+	}{
+		{
+			name:     "no user vars",
+			desired:  []corev1.EnvVar{{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"}},
+			existing: []corev1.EnvVar{{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"}},
+			want:     []corev1.EnvVar{{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"}},
+		},
+		{
+			name:    "preserves user vars from existing",
+			desired: []corev1.EnvVar{{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"}},
+			existing: []corev1.EnvVar{
+				{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "old-key"},
+				{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+				{Name: "OAUTH_AUTHORIZATION_SERVERS", Value: "http://keycloak/realms/mcp"},
+			},
+			want: []corev1.EnvVar{
+				{Name: "TRUSTED_HEADER_PUBLIC_KEY", Value: "key1"},
+				{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+				{Name: "OAUTH_AUTHORIZATION_SERVERS", Value: "http://keycloak/realms/mcp"},
+			},
+		},
+		{
+			name:    "no desired managed vars still preserves user vars",
+			desired: nil,
+			existing: []corev1.EnvVar{
+				{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+			},
+			want: []corev1.EnvVar{
+				{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeEnvVars(tt.desired, tt.existing)
+			if !equality.Semantic.DeepEqual(got, tt.want) {
+				t.Errorf("mergeEnvVars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeploymentNeedsUpdate_UserEnvVarsIgnored(t *testing.T) {
+	base := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "mcp-gateway",
+							Image: "test:latest",
+						}},
+					},
+				},
+			},
+		}
+	}
+
+	desired := base()
+	existing := base()
+	existing.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+		{Name: "OAUTH_RESOURCE_NAME", Value: "MCP Server"},
+		{Name: "OAUTH_AUTHORIZATION_SERVERS", Value: "http://keycloak/realms/mcp"},
+	}
+
+	needsUpdate, _ := deploymentNeedsUpdate(desired, existing)
+	if needsUpdate {
+		t.Error("deploymentNeedsUpdate() should not trigger for user-added env vars")
 	}
 }
 


### PR DESCRIPTION
Fixes #677 

Using the same pattern as with user provided flags. This change stops the controller from overriding user provided env vars. For example those to control OAUTH responses.

The controller now only manages 
"TRUSTED_HEADER_PUBLIC_KEY",
"CACHE_CONNECTION_STRING",

Which can be specified via the spec of the MCPGatewayExtension resource


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment updates to preserve user-configured environment variables while applying controller-managed updates. Refined change detection to avoid unnecessary updates when only user-added variables differ.

* **Tests**
  * Added comprehensive unit tests for environment variable filtering, merging, and deployment change detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->