### PR TITLE
fix: everything server multi-arch build is flaky

### DIFF
--- a/tests/servers/everything-server/Dockerfile
+++ b/tests/servers/everything-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:22.12-alpine AS builder
 
 # Install git to clone the upstream repo
 RUN apk add --no-cache git


### PR DESCRIPTION
Re: https://github.com/Kuadrant/mcp-gateway/issues/687

The everything server's multi-arch Docker build intermittently crashes when QEMU emulates arm64 during the  heavy npm install && npm run build step. 

Fix: add `--platform=$BUILDPLATFORM` to the builder stage so it always runs natively. 

The compiled JS is platform-independent anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for multi-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->