### PR TITLE
409 fix inspect server targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,9 +426,7 @@ reload: build docker-build kind ## Build, load to Kind, and restart both control
 	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller --timeout=60s
 	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/$(BROKER_ROUTER_NAME) --timeout=60s
 
-##@ E2E Testing
-
-# E2E test targets are in build/e2e.mk
+##@ Build
 
 # Build multi-platform image
 docker-buildx: ## Build multi-platform container image
@@ -464,6 +462,8 @@ golangci-lint:
 	fi
 
 KUBE_API_LINTER_VERSION ?= v0.0.0-20260320123815-c9b9b51b278a
+
+##@ Linting
 
 .PHONY: kube-api-linter
 kube-api-linter: bin/golangci-lint-kube-api-linter ## Run kube-api-linter on API types
@@ -550,7 +550,9 @@ fix-newlines:
 	done
 
 
-test-unit:
+##@ Testing
+
+test-unit: ## Run unit tests
 	go test -v -race ./...
 
 .PHONY: test-controller-integration
@@ -764,8 +766,6 @@ otel-status: ## Show status of OpenTelemetry observability stack
 otel-forward: ## Port-forward Grafana (3000)
 	@echo "Grafana: http://localhost:3000"
 	@kubectl port-forward -n observability svc/grafana 3000:3000
-
-##@ Testing
 
 .PHONY: testwithcoverage
 testwithcoverage:

--- a/build/inspect.mk
+++ b/build/inspect.mk
@@ -2,6 +2,29 @@
 
 open := $(shell { which xdg-open || which open; } 2>/dev/null)
 
+INSPECT_LOCAL_PORT ?= 9999
+
+# generic template for inspecting MCP servers via port-forward
+# args: $(1) = server name, $(2) = service name, $(3) = namespace, $(4) = service port, $(5) = mcp path, $(6) = extra notes
+define inspect-server-template
+	@set -eu; \
+		echo "Port-forwarding to $(1) ($(2).$(3):$(4))..."; \
+		kubectl port-forward -n $(3) svc/$(2) $(INSPECT_LOCAL_PORT):$(4) & \
+		PF_PID=$$!; \
+		trap "echo 'Cleaning up...'; kill $$PF_PID 2>/dev/null || true; exit" EXIT INT TERM; \
+		sleep 2; \
+		$(if $(6),echo "$(6)";) \
+		INSPECTOR_URL="http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:$(INSPECT_LOCAL_PORT)$(5)"; \
+		echo "MCP server: http://localhost:$(INSPECT_LOCAL_PORT)$(5)"; \
+		echo "Inspector:  $$INSPECTOR_URL"; \
+		echo ""; \
+		MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
+		sleep 2; \
+		$(open) "$$INSPECTOR_URL" 2>/dev/null || echo "(Could not open browser automatically)"; \
+		echo "Press Ctrl+C to stop and cleanup"; \
+		wait
+endef
+
 # URLs for services
 urls-impl:
 	@echo "=== MCP Gateway URLs ==="
@@ -12,59 +35,39 @@ urls-impl:
 
 .PHONY: inspect-server1
 inspect-server1: ## Open MCP Inspector for test server 1
-	$(call inspect-server-template,test server 1,mcp-test-server1,9090,hi time slow headers)
+	$(call inspect-server-template,test server 1,mcp-test-server1,mcp-test,9090,/mcp)
 
 .PHONY: inspect-server2
 inspect-server2: ## Open MCP Inspector for test server 2
-	$(call inspect-server-template,test server 2,mcp-test-server2,9091,similar to server1 different implementation)
+	$(call inspect-server-template,test server 2,mcp-test-server2,mcp-test,9090,/mcp)
 
 .PHONY: inspect-server3
 inspect-server3: ## Open MCP Inspector for test server 3
-	$(call inspect-server-template,test server 3,mcp-test-server3,9092,time add dozen pi get_weather slow)
+	$(call inspect-server-template,test server 3,mcp-test-server3,mcp-test,9090,/mcp)
 
 .PHONY: inspect-api-key-server
 inspect-api-key-server: ## Open MCP Inspector for API key test server (requires auth)
-	$(call inspect-server-template,API key test server,mcp-api-key-server,9093,hello_world tool with authentication,NOTE: This server requires Bearer token authentication)
-
-.PHONY: inspect-custom-path
-inspect-custom-path: ## Open MCP Inspector for custom path server
-	@echo "Setting up port-forward to custom path server..."
-	@kubectl -n mcp-test port-forward svc/mcp-custom-path-server 9094:8080 > /dev/null 2>&1 & \
-		PF_PID=$$!; \
-		trap "echo '\nCleaning up...'; kill $$PF_PID 2>/dev/null || true; exit" INT TERM; \
-		sleep 2; \
-		echo "Opening MCP Inspector for custom path server at http://localhost:9094/v1/special/mcp"; \
-		echo "NOTE: This server uses a custom path /v1/special/mcp instead of /mcp"; \
-		echo ""; \
-		MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
-		sleep 2; \
-		$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:9094/v1/special/mcp"; \
-		echo "Press Ctrl+C to stop and cleanup"; \
-		wait; \
-		kill $$PF_PID 2>/dev/null || true
+	$(call inspect-server-template,API key test server,mcp-api-key-server,mcp-test,9090,/mcp,NOTE: This server requires Bearer token authentication)
 
 .PHONY: inspect-oidc-server
 inspect-oidc-server: ## Open MCP Inspector for OpenID Connect test server (requires auth)
-	$(call inspect-server-template,OIDC test server,mcp-oidc-server,9094,hello_world tool with authentication,NOTE: This server requires Bearer token authentication)
+	$(call inspect-server-template,OIDC test server,mcp-oidc-server,mcp-test,9090,/mcp,NOTE: This server requires OIDC Bearer token authentication)
 
 .PHONY: inspect-everything-server
 inspect-everything-server: ## Open MCP Inspector for test everything server
-	$(call inspect-server-template,test everything server,everything-server,9095,echo add longRunningOperation printEnv sampleLLM getTinyImage annotatedMessage getResourceReference startElicitation structuredContent listRoots)
-
-# Legacy alias for compatibility
-inspect-mock-impl: inspect-server1
+	$(call inspect-server-template,test everything server,everything-server,mcp-test,9090,/mcp)
 
 # Open MCP Inspector for gateway (broker via gateway)
 .PHONY: inspect-gateway
 inspect-gateway: ## Open MCP Inspector for the gateway
-	echo "Opening MCP Inspector for gateway"; \
+	@echo "Opening MCP Inspector for gateway"; \
 	echo "URL: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
 	echo ""; \
 	MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest & \
 	sleep 2; \
 	$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
 	echo "Press Ctrl+C to stop and cleanup"; \
-	wait; \
+	wait
 
 # Show status of all MCP components implementation
 status-impl:

--- a/build/inspect.mk
+++ b/build/inspect.mk
@@ -8,6 +8,8 @@ urls-impl:
 	@echo "Gateway: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
 	@echo "Keycloak: https://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"
 
+##@ Inspection
+
 .PHONY: inspect-server1
 inspect-server1: ## Open MCP Inspector for test server 1
 	$(call inspect-server-template,test server 1,mcp-test-server1,9090,hi time slow headers)

--- a/project-words.txt
+++ b/project-words.txt
@@ -401,3 +401,4 @@ unmarshal
 omitempty
 Errorf
 authpolicies
+


### PR DESCRIPTION
Re: https://github.com/Kuadrant/mcp-gateway/issues/409

- Fixes up the individual server inspect targets; adds an httproute temporarily for each, removes on ctrl+c/exit
- Small cleanup of `make help` (we sure do have a lot of commands!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized inspector commands for simpler, consistent usage.

* **Chores**
  * Reorganized Makefile help sections for clearer grouping.
  * Added a descriptive label for the unit test command.
  * Updated maintained word list with a new entry ("authpolicies").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->