### PR TITLE
only deploy everything server for local dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ type ConfigReaderWriter interface {
 
 ### Quick Start
 ```bash
-make local-env-setup     # Create Kind cluster with everything
+make local-env-setup     # Create Kind cluster with gateway and everything server
 make reload              # Build, load to Kind, and restart controller and broker
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,20 @@ deploy-example: install-crd ## Deploy example MCPServerRegistration resource
 	@echo "Waiting for broker-router to be ready..."
 	@kubectl wait --for=condition=Available deployment/$(BROKER_ROUTER_NAME) -n mcp-system --timeout=$(WAIT_TIME)
 
+# Deploy example MCPServerRegistration for everything server only
+deploy-example-minimal: install-crd ## Deploy MCPServerRegistration for everything server
+	@echo "Waiting for everything server to be ready..."
+	@kubectl wait --for=condition=Available deployment -n mcp-test -l app=everything-server --timeout=$(WAIT_TIME)
+	@echo "Deploying MCPServerRegistration for everything server..."
+	kubectl apply -f config/samples/mcpserverregistration-everything-server.yaml
+	@echo "Waiting for MCPServerRegistration to be ready..."
+	@kubectl wait --for=condition=Ready mcpserverregistration/everything-server -n mcp-test --timeout=$(WAIT_TIME)
+
+# Build everything server image only
+build-everything-server: ## Build everything server Docker image
+	@echo "Building everything server image..."
+	cd tests/servers/everything-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest .
+
 # Build test server Docker images
 build-test-servers: ## Build test server Docker images locally
 	@echo "Building test server images..."
@@ -321,16 +335,25 @@ kind-load-test-servers: kind build-test-servers ## Load test server images into 
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest)
 
+# Load everything server image into Kind cluster
+kind-load-everything-server: kind build-everything-server ## Load everything server image into Kind cluster
+	@echo "Loading everything server image into Kind cluster..."
+	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest)
+
 # Load conformance server image into Kind cluster
 .PHONY: kind-load-conformance-server
 kind-load-conformance-server: kind build-conformance-server ## Load conformance server image into Kind cluster
 	@echo "Loading conformance server image into Kind cluster..."
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-conformance-server:latest)
 
-# Deploy test servers excluding oidc
-deploy-simple-test-servers: kind-load-test-servers ## Deploy test MCP servers for local testing
-	@echo "Deploying test MCP servers..."
-	kubectl apply -k config/test-servers/
+# Deploy everything server only (for local dev)
+deploy-everything-server: kind-load-everything-server ## Deploy only the everything server for local dev
+	@echo "Deploying everything server..."
+	kubectl apply -f config/test-servers/namespace.yaml
+	kubectl apply -f config/test-servers/everything-server-deployment.yaml -n mcp-test
+	kubectl apply -f config/test-servers/everything-server-service.yaml -n mcp-test
+	kubectl apply -f config/test-servers/everything-server-httproute.yaml -n mcp-test
+
 # Deploy test servers
 deploy-test-servers: kind-load-test-servers ## Deploy test MCP servers for local testing
 	@echo "Deploying test MCP servers..."
@@ -580,9 +603,9 @@ else
 	"$(MAKE)" deploy
 endif
 	"${MAKE}" add-jwt-key
-	# Deploy and configure test servers
-	"$(MAKE)" deploy-test-servers
-	"$(MAKE)" deploy-example
+	# Deploy everything server for local dev (use 'make deploy-test-servers' for all servers)
+	"$(MAKE)" deploy-everything-server
+	"$(MAKE)" deploy-example-minimal
 	@echo "Local environment setup complete"
 
 .PHONY: local-bare-setup

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [config/install/README.md](./config/install/README.md) for details and prere
 
 ### Development Environment
 
-For a complete local environment with all dependencies (Istio, Gateway API, Keycloak, MCP test servers):
+For a complete local environment with all dependencies (Istio, Gateway API, Keycloak, everything test server):
 
 ```bash
 make local-env-setup
@@ -43,8 +43,10 @@ This sets up:
 - a `kind` cluster
 - Istio as a Gateway API provider
 - MCP Gateway components (Broker / Router / Controller)
-- Test MCP servers
-- example configurations
+- the everything test server
+- example MCPServerRegistration
+
+To deploy all test servers, run `make deploy-test-servers` after setup.
 
 #### Adding e2e tests
 
@@ -54,7 +56,7 @@ If you are adding an e2e test, please consider using the claude slash command pr
 
 Set up a local kind cluster with the Broker, Router & Controller running.
 These components are built during the make target into a single image and loaded into the cluster.
-Also sets up an Istio Gateway API Gateway, and HTTPRoutes for test mcp servers, which are added to the broker/router.
+Also sets up an Istio Gateway API Gateway with the everything test server behind the broker/router.
 
 ```bash
 make local-env-setup

--- a/config/samples/mcpserverregistration-everything-server.yaml
+++ b/config/samples/mcpserverregistration-everything-server.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: everything-server
+  namespace: mcp-test
+  labels:
+    mcp.kuadrant.io/managed: 'true'
+spec:
+  toolPrefix: everything_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: everything-server-route


### PR DESCRIPTION
Re: https://github.com/Kuadrant/mcp-gateway/issues/408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added targets to build, load, and deploy the everything-server test component independently.
  * Added a sample MCPServerRegistration for the everything-server.

* **Documentation**
  * Updated local development setup and README to reflect the everything-server deployment workflow and example MCPServerRegistration.
  * Clarified e2e quick-start to describe gateway-backed everything test server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->