### PR TITLE
fix: align OIDC server expected audience with Keycloak client ID

### DIFF
--- a/config/test-servers/oidc-server-deployment.yaml
+++ b/config/test-servers/oidc-server-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: ISSUER_URL
           value: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
         - name: EXPECTED_AUD
-          value: mcp-test/mcp-oidc-server-route
+          value: mcp-test/oidc-server
         - name: EXPECTED_ADMIN_TOKEN
           value: test-api-key-secret-token-for-oidc-server
         - name: LOG_LEVEL


### PR DESCRIPTION
### Summary

The EXPECTED_AUD env var was set to "mcp-test/mcp-oidc-server-route" but the Keycloak realm has the client registered as "mcp-test/oidc-server", causing JWT audience validation to fail with "Invalid audience" errors.

It has to match to https://github.com/Kuadrant/mcp-gateway/blob/main/config/keycloak/realm-import.yaml#L50

### Verification Steps

```
rm -rf ./out/certs
make local-env-setup
make auth-example-setup

kubectl delete configmap mcp-gateway-keycloak-cert -n mcp-test
kubectl create configmap mcp-gateway-keycloak-cert -n mcp-test --from-file=keycloak.crt=./out/certs/ca.crt
kubectl rollout restart deployment mcp-oidc-server -n mcp-test
```

Add an exception for your browser to trust the Keycloak self-signed server certificate.

`make inspect-gateway`

Connect to MCP Gateway (username/password: mcp/mcp), initialize, list tools, and call `oidc_hello_world` tool. Should end up with success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OIDC authentication server configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->