### PR TITLE
fix: re-apply Keycloak CA cert to OIDC test server in auth-example-setup

### DIFF
--- a/build/auth.mk
+++ b/build/auth.mk
@@ -14,7 +14,7 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo ""
 	@echo "Prerequisites: make local-env-setup should be completed"
 	@echo ""
-	@echo "Step 1/5: Configuring OAuth environment variables..."
+	@echo "Step 1/6: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-gateway \
 		OAUTH_RESOURCE_NAME="MCP Server" \
 		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
@@ -24,23 +24,29 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 		-n mcp-system
 	@echo "✅ OAuth environment variables configured"
 	@echo ""
-	@echo "Step 2/5: Installing Vault..."
+	@echo "Step 2/6: Installing Vault..."
 	@bin/kustomize build config/vault | bin/yq 'select(.kind == "Deployment").spec.template.spec.containers[0].args += ["-dev-root-token-id=root"] | .' | kubectl apply -f -
 	@echo "✅ Vault installed"
 	@echo ""
-	@echo "Step 3/5: Applying AuthPolicy configurations..."
+	@echo "Step 3/6: Applying AuthPolicy configurations..."
 	@kubectl apply -k ./config/samples/oauth-token-exchange/
 	@kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
 		-p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
 	@echo "✅ AuthPolicy configurations applied"
 	@echo ""
-	@echo "Step 4/5: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
+	@echo "Step 4/6: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
 	@kubectl apply -f ./config/keycloak/preflight_envoyfilter.yaml
 	@echo "✅ CORS configured"
 	@echo ""
-	@echo "Step 5/5: Patch Authorino deployment to be able to connect to Keycloak..."
+	@echo "Step 5/6: Patch Authorino deployment to be able to connect to Keycloak..."
 	@./utils/patch-authorino-to-keycloak.sh
 	@echo "✅ Authorino deployment patched"
+	@echo ""
+	@echo "Step 6/6: Patch MCP OIDC Server deployment to be able to connect to Keycloak..."
+	@kubectl delete configmap mcp-gateway-keycloak-cert -n mcp-test --wait=true --ignore-not-found=true
+	@kubectl create configmap mcp-gateway-keycloak-cert -n mcp-test --from-file=keycloak.crt=./out/certs/ca.crt
+	@kubectl rollout restart deployment mcp-oidc-server -n mcp-test
+	@echo "✅ MCP OIDC Server deployment patched"
 	@echo ""
 	@echo "🎉 OAuth example setup complete!"
 	@echo ""


### PR DESCRIPTION
### Summary

The mcp-oidc-server deployment mounts a keycloak.crt from a configmap, but `auth-example-setup` never created that configmap in the mcp-test namespace. The configmap is created as part of `local-env-setup` but at that time only "placeholder" certificate is available (Keycloak is not yet deployed, its certificate does not exist yet). This caused the OIDC server to fail TLS validation when connecting to Keycloak.                                                                                                                                                          
                                                                                                                                                                                                   
Add a new step that re-creates the mcp-gateway-keycloak-cert configmap in mcp-test with valid Keycloak certificate and restarts the OIDC server deployment to apply it.

The commands in step are based on https://github.com/Kuadrant/mcp-gateway/blob/main/Makefile#L338-L339

A potentially cleaner fix would be to only create `mcp-oidc-server` in `auth-example-setup` when Keycloak (and its certificate) is already in place rather than creating it in `local-env-setup`.

### Verification Steps

```
rm -rf ./out/certs
make local-env-setup
make auth-example-setup
```
Add an exception for your browser to trust the Keycloak self-signed server certificate.

`make inspect-gateway`

Connect to MCP Gateway (username/password: mcp/mcp), initialize, list tools, and call `oidc_hello_world` tool. It should end up with success or with "Invalid audience" failure (PR for that https://github.com/Kuadrant/mcp-gateway/pull/705)
In MCP OIDC Server log there should not be any error related to TLS and certificates (just this "audience" one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an extra setup step to manage the gateway certificate (remove and recreate from the new CA file) and trigger a rolling restart of the identity server.
  * Updated printed progress indicators to reflect the new six-step sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->