### PR TITLE
generate JWT session signing key via controller-managed secret, instead of hardcoded default

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -41,11 +41,10 @@ var (
 )
 
 var (
-	mcpConfig            = &config.MCPServersConfig{}
-	mutex                sync.RWMutex
-	logger               = slog.New(slog.NewTextHandler(os.Stdout, nil))
-	scheme               = runtime.NewScheme()
-	defaultJWTSigningKey = "default-not-secure"
+	mcpConfig = &config.MCPServersConfig{}
+	mutex     sync.RWMutex
+	logger    = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scheme    = runtime.NewScheme()
 )
 
 func init() {
@@ -120,7 +119,7 @@ func main() {
 	)
 	flag.StringVar(&jwtSigningKeyFlag,
 		"session-signing-key",
-		goenv.GetDefault("JWT_SESSION_SIGNING_KEY", defaultJWTSigningKey),
+		goenv.GetDefault("JWT_SESSION_SIGNING_KEY", ""),
 		"JWT signing key for session tokens (env: JWT_SESSION_SIGNING_KEY)",
 	)
 	//"redis://redis.mcp-system.svc.cluster.local:6379
@@ -186,10 +185,9 @@ func main() {
 
 	var jwtSessionMgr *session.JWTManager
 	if jwtSigningKeyFlag == "" {
-		panic("jwt session signing key is empty. Cannot proceed")
-	}
-	if jwtSigningKeyFlag == defaultJWTSigningKey {
-		logger.Warn("jwt session signing key is set to the default value. This is not recommended for production")
+		panic("JWT_SESSION_SIGNING_KEY is required but not set. " +
+			"When running via the controller, this is managed automatically. " +
+			"For standalone use, set the JWT_SESSION_SIGNING_KEY environment variable.")
 	}
 
 	jwtmgr, err := session.NewJWTManager(jwtSigningKeyFlag, sessionDurationInMins, logger, sessionCache)

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -53,6 +53,7 @@ var managedCommandFlags = []string{
 var managedEnvVarNames = []string{
 	"TRUSTED_HEADER_PUBLIC_KEY",
 	"CACHE_CONNECTION_STRING",
+	sessionSigningKeyEnvVar,
 }
 
 func brokerRouterLabels() map[string]string {
@@ -76,7 +77,19 @@ func (r *MCPGatewayExtensionReconciler) buildBrokerRouterDeployment(mcpExt *mcpv
 	command = append(command, "--mcp-gateway-public-host="+publicHost)
 	command = append(command, "--mcp-router-key="+routerKey(mcpExt))
 
-	var envVars []corev1.EnvVar
+	envVars := []corev1.EnvVar{
+		{
+			Name: sessionSigningKeyEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: sessionSigningKeySecretName,
+					},
+					Key: sessionSigningKeyDataKey,
+				},
+			},
+		},
+	}
 	if mcpExt.Spec.TrustedHeadersKey != nil {
 		envVars = append(envVars, corev1.EnvVar{
 			Name: "TRUSTED_HEADER_PUBLIC_KEY",

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -606,20 +606,20 @@ func TestBuildBrokerRouterDeployment_TrustedHeadersKey(t *testing.T) {
 	tests := []struct {
 		name             string
 		trustedHeaderKey *mcpv1alpha1.TrustedHeadersKey
-		wantEnvVar       bool
+		wantTrustedEnv   bool
 		wantSecretName   string
 	}{
 		{
-			name:             "no env var when TrustedHeadersKey is nil",
+			name:             "no trusted header env var when TrustedHeadersKey is nil",
 			trustedHeaderKey: nil,
-			wantEnvVar:       false,
+			wantTrustedEnv:   false,
 		},
 		{
-			name: "env var set when TrustedHeadersKey has SecretName",
+			name: "trusted header env var set when TrustedHeadersKey has SecretName",
 			trustedHeaderKey: &mcpv1alpha1.TrustedHeadersKey{
 				SecretName: "my-trusted-key-secret",
 			},
-			wantEnvVar:     true,
+			wantTrustedEnv: true,
 			wantSecretName: "my-trusted-key-secret",
 		},
 	}
@@ -646,28 +646,49 @@ func TestBuildBrokerRouterDeployment_TrustedHeadersKey(t *testing.T) {
 			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080))
 			container := deployment.Spec.Template.Spec.Containers[0]
 
-			if !tt.wantEnvVar {
-				if len(container.Env) != 0 {
-					t.Errorf("expected no env vars, got %+v", container.Env)
+			// JWT_SESSION_SIGNING_KEY should always be present
+			var jwtEnv *corev1.EnvVar
+			var trustedEnv *corev1.EnvVar
+			for i := range container.Env {
+				switch container.Env[i].Name {
+				case "JWT_SESSION_SIGNING_KEY":
+					jwtEnv = &container.Env[i]
+				case "TRUSTED_HEADER_PUBLIC_KEY":
+					trustedEnv = &container.Env[i]
+				}
+			}
+
+			if jwtEnv == nil {
+				t.Fatal("expected JWT_SESSION_SIGNING_KEY env var to always be present")
+			}
+			if jwtEnv.ValueFrom == nil || jwtEnv.ValueFrom.SecretKeyRef == nil {
+				t.Fatal("expected JWT_SESSION_SIGNING_KEY to have secretKeyRef")
+			}
+			if jwtEnv.ValueFrom.SecretKeyRef.Name != sessionSigningKeySecretName {
+				t.Errorf("expected JWT secret name %q, got %q", sessionSigningKeySecretName, jwtEnv.ValueFrom.SecretKeyRef.Name)
+			}
+			if jwtEnv.ValueFrom.SecretKeyRef.Key != sessionSigningKeyDataKey {
+				t.Errorf("expected JWT secret key %q, got %q", sessionSigningKeyDataKey, jwtEnv.ValueFrom.SecretKeyRef.Key)
+			}
+
+			if !tt.wantTrustedEnv {
+				if trustedEnv != nil {
+					t.Errorf("expected no TRUSTED_HEADER_PUBLIC_KEY env var, but found one")
 				}
 				return
 			}
 
-			if len(container.Env) != 1 {
-				t.Fatalf("expected 1 env var, got %d", len(container.Env))
+			if trustedEnv == nil {
+				t.Fatal("expected TRUSTED_HEADER_PUBLIC_KEY env var to be present")
 			}
-			env := container.Env[0]
-			if env.Name != "TRUSTED_HEADER_PUBLIC_KEY" {
-				t.Errorf("expected env var name %q, got %q", "TRUSTED_HEADER_PUBLIC_KEY", env.Name)
+			if trustedEnv.ValueFrom == nil || trustedEnv.ValueFrom.SecretKeyRef == nil {
+				t.Fatal("expected TRUSTED_HEADER_PUBLIC_KEY to have secretKeyRef")
 			}
-			if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
-				t.Fatal("expected env var to have secretKeyRef")
+			if trustedEnv.ValueFrom.SecretKeyRef.Name != tt.wantSecretName {
+				t.Errorf("expected secret name %q, got %q", tt.wantSecretName, trustedEnv.ValueFrom.SecretKeyRef.Name)
 			}
-			if env.ValueFrom.SecretKeyRef.Name != tt.wantSecretName {
-				t.Errorf("expected secret name %q, got %q", tt.wantSecretName, env.ValueFrom.SecretKeyRef.Name)
-			}
-			if env.ValueFrom.SecretKeyRef.Key != "key" {
-				t.Errorf("expected secret key %q, got %q", "key", env.ValueFrom.SecretKeyRef.Key)
+			if trustedEnv.ValueFrom.SecretKeyRef.Key != "key" {
+				t.Errorf("expected secret key %q, got %q", "key", trustedEnv.ValueFrom.SecretKeyRef.Key)
 			}
 		})
 	}

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -119,7 +119,7 @@ type MCPGatewayExtensionReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;delete
@@ -210,6 +210,14 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	}
 
 	if err := r.reconcileTrustedHeaders(ctx, mcpExt); err != nil {
+		var valErr *validationError
+		if errors.As(err, &valErr) {
+			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileSessionSigningKey(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
 			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)

--- a/internal/controller/session_signing_key.go
+++ b/internal/controller/session_signing_key.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	sessionSigningKeySecretName = "mcp-gateway-session-signing-key" //nolint:gosec // not a credential
+	sessionSigningKeyDataKey    = "key"
+	sessionSigningKeyEnvVar     = "JWT_SESSION_SIGNING_KEY"
+	sessionSigningKeyBytes      = 32 // 256-bit key for HS256
+)
+
+// reconcileSessionSigningKey ensures a secret containing a random JWT signing
+// key exists. Corrupted or misconfigured secrets are repaired in-place.
+func (r *MCPGatewayExtensionReconciler) reconcileSessionSigningKey(ctx context.Context, mcpExt *mcpv1alpha1.MCPGatewayExtension) error {
+	existing := &corev1.Secret{}
+	err := r.DirectAPIReader.Get(ctx, client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: mcpExt.Namespace,
+	}, existing)
+	if err == nil {
+		needsUpdate := false
+
+		// ensure owner reference is set
+		if !hasOwnerReference(existing, mcpExt) {
+			if err := controllerutil.SetControllerReference(mcpExt, existing, r.Scheme); err != nil {
+				return fmt.Errorf("failed to set owner reference on session signing key secret: %w", err)
+			}
+			needsUpdate = true
+		}
+
+		// ensure required labels are present
+		if existing.Labels == nil {
+			existing.Labels = map[string]string{}
+		}
+		if existing.Labels[labelManagedBy] != labelManagedByValue {
+			existing.Labels[labelManagedBy] = labelManagedByValue
+			needsUpdate = true
+		}
+		if existing.Labels[ManagedSecretLabel] != ManagedSecretValue {
+			existing.Labels[ManagedSecretLabel] = ManagedSecretValue
+			needsUpdate = true
+		}
+
+		// verify key data
+		if existing.Data == nil || len(existing.Data[sessionSigningKeyDataKey]) == 0 {
+			keyBytes := make([]byte, sessionSigningKeyBytes)
+			if _, err := rand.Read(keyBytes); err != nil {
+				return fmt.Errorf("failed to generate session signing key: %w", err)
+			}
+			existing.Data = map[string][]byte{
+				sessionSigningKeyDataKey: []byte(hex.EncodeToString(keyBytes)),
+			}
+			needsUpdate = true
+			r.log.Info("regenerating corrupted session signing key", "name", sessionSigningKeySecretName)
+		}
+
+		if needsUpdate {
+			if err := r.Update(ctx, existing); err != nil {
+				return fmt.Errorf("failed to update session signing key secret: %w", err)
+			}
+		}
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check session signing key secret: %w", err)
+	}
+
+	// generate a random key
+	keyBytes := make([]byte, sessionSigningKeyBytes)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return fmt.Errorf("failed to generate session signing key: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: mcpExt.Namespace,
+			Labels: map[string]string{
+				labelManagedBy:     labelManagedByValue,
+				ManagedSecretLabel: ManagedSecretValue,
+			},
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte(hex.EncodeToString(keyBytes)),
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(mcpExt, secret, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on session signing key secret: %w", err)
+	}
+
+	r.log.Info("creating session signing key secret", "name", sessionSigningKeySecretName)
+	if err := r.Create(ctx, secret); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to create session signing key secret: %w", err)
+	}
+
+	return nil
+}
+
+func hasOwnerReference(secret *corev1.Secret, owner *mcpv1alpha1.MCPGatewayExtension) bool {
+	for _, ref := range secret.OwnerReferences {
+		if ref.UID == owner.UID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/session_signing_key_test.go
+++ b/internal/controller/session_signing_key_test.go
@@ -1,0 +1,224 @@
+package controller
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testReconciler(objs ...client.Object) *MCPGatewayExtensionReconciler {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = mcpv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+
+	return &MCPGatewayExtensionReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		DirectAPIReader: fakeClient,
+		log:             slog.Default(),
+	}
+}
+
+func testMCPExt() *mcpv1alpha1.MCPGatewayExtension {
+	return &mcpv1alpha1.MCPGatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ext",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+}
+
+func TestReconcileSessionSigningKey_CreatesSecret(t *testing.T) {
+	r := testReconciler()
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret)
+	if err != nil {
+		t.Fatalf("expected secret to be created: %v", err)
+	}
+
+	key, ok := secret.Data[sessionSigningKeyDataKey]
+	if !ok {
+		t.Fatal("secret missing key data entry")
+	}
+	if len(key) == 0 {
+		t.Fatal("secret key data is empty")
+	}
+	// hex-encoded 32 bytes = 64 characters
+	if len(key) != 64 {
+		t.Errorf("expected 64-char hex key, got %d chars", len(key))
+	}
+
+	if secret.Labels[labelManagedBy] != labelManagedByValue {
+		t.Errorf("expected managed-by label %q, got %q", labelManagedByValue, secret.Labels[labelManagedBy])
+	}
+	if secret.Labels[ManagedSecretLabel] != ManagedSecretValue {
+		t.Errorf("expected managed secret label %q=%q, got %q", ManagedSecretLabel, ManagedSecretValue, secret.Labels[ManagedSecretLabel])
+	}
+
+	// verify owner reference
+	if len(secret.OwnerReferences) == 0 {
+		t.Fatal("expected owner reference to be set")
+	}
+	if secret.OwnerReferences[0].UID != mcpExt.UID {
+		t.Errorf("expected owner UID %q, got %q", mcpExt.UID, secret.OwnerReferences[0].UID)
+	}
+}
+
+func TestReconcileSessionSigningKey_ExistingSecretIsNoop(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte("existing-key-value"),
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// verify the key was not changed
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if string(secret.Data[sessionSigningKeyDataKey]) != "existing-key-value" {
+		t.Errorf("expected key to remain unchanged, got %q", secret.Data[sessionSigningKeyDataKey])
+	}
+}
+
+func TestReconcileSessionSigningKey_EmptyKeyRegenerates(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte(""),
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if len(secret.Data[sessionSigningKeyDataKey]) != 64 {
+		t.Errorf("expected regenerated 64-char hex key, got %d chars", len(secret.Data[sessionSigningKeyDataKey]))
+	}
+}
+
+func TestReconcileSessionSigningKey_NilDataRegenerates(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if len(secret.Data[sessionSigningKeyDataKey]) != 64 {
+		t.Errorf("expected regenerated 64-char hex key, got %d chars", len(secret.Data[sessionSigningKeyDataKey]))
+	}
+}
+
+func TestReconcileSessionSigningKey_RepairsMissingLabels(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte("existing-key-value-that-is-valid"),
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+
+	// key should be unchanged
+	if string(secret.Data[sessionSigningKeyDataKey]) != "existing-key-value-that-is-valid" {
+		t.Errorf("expected key unchanged, got %q", secret.Data[sessionSigningKeyDataKey])
+	}
+
+	// labels should be repaired
+	if secret.Labels[labelManagedBy] != labelManagedByValue {
+		t.Errorf("expected managed-by label repaired, got %q", secret.Labels[labelManagedBy])
+	}
+	if secret.Labels[ManagedSecretLabel] != ManagedSecretValue {
+		t.Errorf("expected managed secret label repaired, got %q", secret.Labels[ManagedSecretLabel])
+	}
+
+	// owner reference should be added
+	if len(secret.OwnerReferences) == 0 {
+		t.Fatal("expected owner reference to be set on repair")
+	}
+	if secret.OwnerReferences[0].UID != mcpExt.UID {
+		t.Errorf("expected owner UID %q, got %q", mcpExt.UID, secret.OwnerReferences[0].UID)
+	}
+}

--- a/internal/controller/session_store.go
+++ b/internal/controller/session_store.go
@@ -71,6 +71,12 @@ func (r *MCPGatewayExtensionReconciler) enqueueMCPGatewayExtForSecret(ctx contex
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: ext.Name, Namespace: ext.Namespace},
 			})
+			continue
+		}
+		if secret.Name == sessionSigningKeySecretName {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: ext.Name, Namespace: ext.Namespace},
+			})
 		}
 	}
 	return requests


### PR DESCRIPTION
Re: https://github.com/Kuadrant/mcp-gateway/issues/714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic JWT session signing key management: controller ensures a secret exists, generates a secure key when needed, and associates metadata.

* **Bug Fixes**
  * Startup now requires an explicit signing key in standalone mode; clearer validation and failure behavior.
  * Deployment manifests now include the session signing key as a default environment variable.

* **Tests**
  * Added tests covering secret creation, regeneration, repair, and reconciliation behavior.

* **Chores**
  * Expanded controller permissions for secret management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->