### PR TITLE
fix: escape ginkgo focus regex, use gcr mirror for redis, and make ki…

### DIFF
--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -24,7 +24,7 @@ test-e2e: ci-setup test-e2e-run ## Run full e2e test suite (setup + run)
 .PHONY: test-e2e-happy
 test-e2e-happy: test-e2e-deps ## Quick e2e test run for local development (no setup)
 	@echo "Running e2e tests (local mode)..."
-	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --focus="[Happy]" ./tests/e2e
+	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --focus="\[Happy\]" ./tests/e2e
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: ## Clean up e2e test resources

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -17,11 +17,12 @@ echo "Using local chart: $USE_LOCAL_CHART"
 echo "Setting up MCP Gateway using Helm chart..."
 
 # Create Kind cluster with inline configuration (skip if already exists)
-if kind get clusters 2>/dev/null | grep -q '^kind$'; then
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-mcp-gateway}
+if kind get clusters 2>/dev/null | grep -Fxq -- "$KIND_CLUSTER_NAME"; then
     echo "Kind cluster already exists, reusing it."
 else
     echo "Creating Kind cluster..."
-    cat <<EOF | kind create cluster --config=-
+    cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -42,7 +43,7 @@ nodes:
 EOF
 fi
 
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
 
 helm repo add istio https://istio-release.storage.googleapis.com/charts
 helm repo update

--- a/config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml
+++ b/config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/redis:7-alpine
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis

--- a/config/mcp-system/redis-deployment.yaml
+++ b/config/mcp-system/redis-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/redis:7-alpine
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/redis:7-alpine
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -47,10 +47,11 @@ echo ""
 
 output "Step 1: Create Kind cluster with port mapping (localhost:8001 -> NodePort 30080)"
 
-if kind get clusters 2>/dev/null | grep -q '^kind$'; then
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-mcp-gateway}
+if kind get clusters 2>/dev/null | grep -Fxq -- "$KIND_CLUSTER_NAME"; then
     echo "Kind cluster already exists, reusing it."
 else
-    cat <<EOF | kind create cluster --config=-
+    cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -130,5 +131,5 @@ echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"
 echo ""
 echo "To clean up:"
-echo "  kind delete cluster"
+echo "  kind delete cluster --name ${KIND_CLUSTER_NAME}"
 echo "============================================================"


### PR DESCRIPTION
…nd cluster name configurable

### Summary

  Several small fixes across scripts, manifests, and docs:
  - fix a regex bug in the e2e happy-path make target
  - switch Redis images to the GCR mirror to avoid Docker Hub rate limits
  - bump Gateway API version
  - align Kind cluster name in scripts with what's in Makefile and ./build/kind.mk
  
### Verification Steps

`MCP_GATEWAY_VERSION=0.6.0-rc1 ./scripts/quick-start.sh`
- It should finish successfully, `mcp-gateway` KIND cluster should be created

```
kubectl delete mcpgatewayextension mcp-gateway-extension -n mcp-system
GATEWAY_URL=http://mcp.127-0-0-1.sslip.io:7001/mcp make test-e2e-happy
```
- It should only trigger Happy tests (20), not all (34) tests we currently have

Note: Not all tests pass, the quick-start.sh does not set resources for multi-gateway tests etc.

`KIND_CLUSTER_NAME=test MCP_GATEWAY_VERSION=does.not.exists ./scripts/quick-start.sh`
- This should fail early but it's enough to validate that `test` KIND cluster got created

To validate the redis image change you can just try to pull it:
`podman pull mirror.gcr.io/redis:7-alpine`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made local Kind cluster name configurable in setup and quick-start scripts (default: "mcp-gateway").
  * Switched Redis container image source to mirror.gcr.io while keeping the same version and settings.
  * Upgraded Gateway API installation reference to v1.3.0.
  * Adjusted end-to-end test invocation so focus expressions with square brackets are escaped correctly.

* **Documentation**
  * Updated scaling guide examples to reflect the Redis image change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->