### PR TITLE
fix gevals workflow and add failure detection to it

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -39,8 +39,8 @@ jobs:
     name: Run MCP Evaluation
     runs-on: ubuntu-latest
     env:
-      MODEL_KEY: ${{ secrets.MODEL_KEY }}
-      MODEL_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.MODEL_KEY }}
+      OPENAI_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
 
     steps:
       - name: Checkout
@@ -77,52 +77,62 @@ jobs:
           echo "Gateway is ready!"
 
       - name: Setup Fallback LLM (Ollama)
-        if: env.MODEL_KEY == ''
+        if: env.OPENAI_API_KEY == ''
         uses: ai-action/setup-ollama@v2
 
       - name: Cache Ollama Models
-        if: env.MODEL_KEY == ''
+        if: env.OPENAI_API_KEY == ''
         uses: actions/cache@v4
         with:
           path: ~/.ollama
           key: ${{ runner.os }}-ollama-qwen2.5-1.5b
 
       - name: Run Agent (Fallback)
-        if: env.MODEL_KEY == ''
+        if: env.OPENAI_API_KEY == ''
         run: |
           echo "No MODEL_KEY secret found. Starting Ollama..."
-          
+
           # Start Ollama in background
           ollama serve &
-          
+
           # Wait for Ollama to be ready
           echo "Waiting for Ollama to be ready..."
           timeout 60s bash -c 'until curl -s http://localhost:11434 > /dev/null; do sleep 2; done'
-          
+
           MODEL_NAME="qwen2.5:1.5b"
-          
+
           # Pull the model (Ollama will skip if cached/present)
           echo "Pulling model $MODEL_NAME..."
           ollama pull $MODEL_NAME
-          
+
           # Configure environment for mcpchecker
-          echo "MODEL_BASE_URL=http://localhost:11434/v1" >> $GITHUB_ENV
-          echo "MODEL_KEY=ollama" >> $GITHUB_ENV
-          
+          echo "OPENAI_BASE_URL=http://localhost:11434/v1" >> $GITHUB_ENV
+          echo "OPENAI_API_KEY=ollama" >> $GITHUB_ENV
+
           # Update agent.yaml to use the fallback model
-          sed -i "s/model: .*/model: \"$MODEL_NAME\"/" evals/gemini-agent/agent.yaml
-          
+          sed -i "s/model: .*/model: \"openai:$MODEL_NAME\"/" evals/gemini-agent/agent.yaml
+
           echo "Ollama setup complete using model $MODEL_NAME"
 
-      - name: Run mcpchecker (Manual)
+      - name: Run mcpchecker
         run: |
           echo "Installing mcpchecker..."
           go install github.com/mcpchecker/mcpchecker/cmd/mcpchecker@latest
-          
+
           echo "Running mcpchecker..."
-          # Ensure GOBIN is in PATH if not already (github actions usually has it)
           export PATH=$PATH:$(go env GOPATH)/bin
           mcpchecker check --verbose evals/gemini-agent/eval.yaml
+
+      - name: Verify Results
+        if: always()
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          RESULTS_FILE=$(ls mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -z "$RESULTS_FILE" ]; then
+            echo "No results file found — mcpchecker may have crashed"
+            exit 1
+          fi
+          mcpchecker verify --task 1.0 --assertion 1.0 "$RESULTS_FILE"
 
       - name: Upload Evaluation Results
         if: always()

--- a/evals/gemini-agent/agent.yaml
+++ b/evals/gemini-agent/agent.yaml
@@ -7,6 +7,6 @@ builtin:
   # or any other OpenAI-compatible endpoint.
   type: "openai-acp"
 
-  model: "qwen2.5:1.5b"
+  model: "openai:qwen2.5:1.5b"
   params:
     temperature: 0.1

--- a/evals/tasks/basic/echo.yaml
+++ b/evals/tasks/basic/echo.yaml
@@ -1,0 +1,8 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: basic-echo
+  difficulty: easy
+spec:
+  prompt:
+    inline: "Call the 'everything_echo' tool with name 'World'. Verify it replies with 'Echo: World'."

--- a/evals/tasks/basic/hi.yaml
+++ b/evals/tasks/basic/hi.yaml
@@ -1,8 +1,0 @@
-kind: Task
-apiVersion: mcpchecker/v1alpha2
-metadata:
-  name: basic-hi
-  difficulty: easy
-spec:
-  prompt:
-    inline: "Call the 'test1_greet' tool with name 'World'. Verify it replies with 'Hi World'."


### PR DESCRIPTION
### Summary

The gevals CI workflow was silently passing despite broken tests due to incorrect environment variable names, wrong model format, and no result verification. This fixes all three issues so the workflow correctly configures mcpchecker and fails on test failures.

### Changes
- mcpchecker's openai provider reads OPENAI_API_KEY/OPENAI_BASE_URL, not MODEL_KEY/MODEL_BASE_URL.
- The model field requires provider:model-id format (e.g. openai:qwen2.5:1.5b).
- Added a Verify Results step using mcpchecker verify to fail the workflow when tests don't pass.
- Update (and rename) basic task to use everything_echo, everything MCP server is the only one available by default now

### Verification Steps

gevals workflow passing should suffice, but take a closer look whether it indeed passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new basic echo evaluation task.
  * Removed the basic hi evaluation task.

* **Chores**
  * Renamed CI workflow environment variables and adjusted fallback LLM behavior.
  * Added an unconditional results validation step for evaluations.
  * Updated the agent model namespace/endpoint used in evaluations.
  * Renamed the mcpchecker execution step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->