### PR TITLE
Deploy test MCP servers as part of auth-example-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This will:
 - Configure the mcp-broker with OAuth environment variables
 - Apply AuthPolicy for token validation/exchange on the /mcp endpoint, including tool authorization via keycloak group mappings (both via Keycloak)
 - Apply additional OAuth configurations
+- Deploy several test MCP servers including OIDC-enabled MCP server
 
 The mcp-broker now serves OAuth discovery information at `/.well-known/oauth-protected-resource`.
 

--- a/build/auth.mk
+++ b/build/auth.mk
@@ -14,7 +14,7 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo ""
 	@echo "Prerequisites: make local-env-setup should be completed"
 	@echo ""
-	@echo "Step 1/5: Configuring OAuth environment variables..."
+	@echo "Step 1/6: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-gateway \
 		OAUTH_RESOURCE_NAME="MCP Server" \
 		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
@@ -24,23 +24,28 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 		-n mcp-system
 	@echo "✅ OAuth environment variables configured"
 	@echo ""
-	@echo "Step 2/5: Installing Vault..."
+	@echo "Step 2/6: Installing Vault..."
 	@bin/kustomize build config/vault | bin/yq 'select(.kind == "Deployment").spec.template.spec.containers[0].args += ["-dev-root-token-id=root"] | .' | kubectl apply -f -
 	@echo "✅ Vault installed"
 	@echo ""
-	@echo "Step 3/5: Applying AuthPolicy configurations..."
+	@echo "Step 3/6: Applying AuthPolicy configurations..."
 	@kubectl apply -k ./config/samples/oauth-token-exchange/
 	@kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
 		-p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
 	@echo "✅ AuthPolicy configurations applied"
 	@echo ""
-	@echo "Step 4/5: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
+	@echo "Step 4/6: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
 	@kubectl apply -f ./config/keycloak/preflight_envoyfilter.yaml
 	@echo "✅ CORS configured"
 	@echo ""
-	@echo "Step 5/5: Patch Authorino deployment to be able to connect to Keycloak..."
+	@echo "Step 5/6: Patch Authorino deployment to be able to connect to Keycloak..."
 	@./utils/patch-authorino-to-keycloak.sh
 	@echo "✅ Authorino deployment patched"
+	@echo ""
+	@echo "Step 6/6: Deploying test MCP servers..."
+	@"$(MAKE)" deploy-test-servers
+	@"$(MAKE)" deploy-example
+	@echo "✅ Test MCP servers deployed and configured"
 	@echo ""
 	@echo "🎉 OAuth example setup complete!"
 	@echo ""


### PR DESCRIPTION
### Summary

Previously, after running `make auth-example-setup`, users had to manually run `make deploy-test-servers` and `make deploy-example` to get test MCP server deployed. Deployment of these test MCP servers used to be part of `make local-env-setup` but it has changed recently and now it only deploys everything MCP Serves.

This adds an automated 6th step in the auth setup flow to deploy other test MCP servers to demonstrate various tool permissions.

### Changes

  - Add step 6/6 to auth-example-setup in build/auth.mk that calls deploy-test-servers and deploy-example
  - Update README.md to document that auth setup now deploys test MCP servers 
  
### Verification Steps

  - Run `make local-env-setup` followed by `make auth-example-setup`                                                                                                                                   
  - Run `make inspect-gateway`, connect to MCP Gateway (OIDC flow: mcp/mcp credentials). You might need to import the Keycloak certificate to your browser for OIDC flow to work
  - Confirm that only 4 tools are listed
  - Call `oidc_hello_world` tool to validate that OIDC MCP server has proper certificate configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth example setup documentation to explicitly reference test MCP server deployment procedures and OIDC-enabled server configuration options.

* **Chores**
  * Enhanced the build system workflow to automatically deploy test servers and configure examples as part of the OAuth setup sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->