### PR TITLE
rename mcp-controller Deployment to mcp-gateway-controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file provides guidance to AI Agents when working with this repository.
 MCP Gateway is an Envoy-based gateway for Model Context Protocol (MCP) servers. Single binary (`mcp-broker-router`) with three components:
 - **MCP Router**: Envoy external processor that routes MCP requests (gRPC on :50051)
 - **MCP Broker**: HTTP service that aggregates tools from multiple MCP servers (HTTP on :8080/mcp)
-- **MCP Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
+- **MCP Gateway Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with this repository.
 MCP Gateway is an Envoy-based gateway for Model Context Protocol (MCP) servers. Single binary (`mcp-broker-router`) with three components:
 - **MCP Router**: Envoy external processor that routes MCP requests (gRPC on :50051)
 - **MCP Broker**: HTTP service that aggregates tools from multiple MCP servers (HTTP on :8080/mcp)
-- **MCP Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
+- **MCP Gateway Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
 
 # Exploration
 

--- a/Makefile
+++ b/Makefile
@@ -233,13 +233,13 @@ deploy-redis: ## deploy redis to mcp-system namespace
 
 .PHONY: configure-redis
 configure-redis: deploy-redis ## deploy redis and patch deployment with redis connection
-	kubectl patch deployment $(BROKER_ROUTER_NAME) -n mcp-system --patch-file config/mcp-gateway/overlays/mcp-system/deployment-controller-redis-patch.yaml
+	kubectl patch deployment $(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) --patch-file config/mcp-gateway/overlays/mcp-system/deployment-controller-redis-patch.yaml
 
 # Deploy only the controller
 deploy-controller: install-crd ## Deploy only the controller
 	kubectl apply -k config/mcp-gateway/overlays/mcp-system/
 	@echo "Waiting for controller to be ready..."
-	@kubectl wait --for=condition=Available deployment/mcp-controller -n mcp-system --timeout=$(WAIT_TIME)
+	@kubectl wait --for=condition=Available deployment/mcp-gateway-controller -n mcp-system --timeout=$(WAIT_TIME)
 	@echo "Waiting for MCPGatewayExtension to be ready..."
 	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n mcp-system --timeout=$(WAIT_TIME)
 	@echo "Controller and broker-router are ready"
@@ -256,8 +256,8 @@ endef
 
 .PHONY: restart-all
 restart-all:
-	kubectl rollout restart deployment/$(BROKER_ROUTER_NAME) -n mcp-system 2>/dev/null || true
-	kubectl rollout restart deployment/mcp-controller -n mcp-system 2>/dev/null || true
+	kubectl rollout restart deployment/$(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) 2>/dev/null || true
+	kubectl rollout restart deployment/mcp-gateway-controller -n $(MCP_GATEWAY_NAMESPACE) 2>/dev/null || true
 
 .PHONY: build-and-load-image
 build-and-load-image: kind build-image load-image restart-all  ## Build & load router/broker/controller image into the Kind cluster and restart
@@ -287,7 +287,7 @@ deploy-example: install-crd ## Deploy example MCPServerRegistration resource
 	kubectl apply -f config/samples/mcpserverregistration-test-servers-base.yaml
 	kubectl apply -f config/samples/mcpserverregistration-test-servers-extended.yaml
 	@echo "Waiting for broker-router to be ready..."
-	@kubectl wait --for=condition=Available deployment/$(BROKER_ROUTER_NAME) -n mcp-system --timeout=$(WAIT_TIME)
+	@kubectl wait --for=condition=Available deployment/$(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) --timeout=$(WAIT_TIME)
 
 # Deploy example MCPServerRegistration for everything server only
 deploy-example-minimal: install-crd ## Deploy MCPServerRegistration for everything server
@@ -410,8 +410,8 @@ endef
 reload-controller: build kind ## Build, load to Kind, and restart controller
 	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --file Dockerfile.controller -t $(IMAGE_TAG_BASE):$(IMAGE_TAG) .
 	$(call load-image,$(IMAGE_TAG_BASE):$(IMAGE_TAG))
-	@kubectl rollout restart -n mcp-system deployment/mcp-controller
-	@kubectl rollout status -n mcp-system deployment/mcp-controller --timeout=60s
+	@kubectl rollout restart -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller
+	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller --timeout=60s
 
 .PHONY: reload-broker
 reload-broker: build docker-build kind ## Build, load to Kind, and restart broker
@@ -422,8 +422,8 @@ reload-broker: build docker-build kind ## Build, load to Kind, and restart broke
 .PHONY: reload
 reload: build docker-build kind ## Build, load to Kind, and restart both controller and broker
 	$(call reload-image)
-	@kubectl rollout restart -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-controller deployment/$(BROKER_ROUTER_NAME)
-	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE)deployment/mcp-controller --timeout=60s
+	@kubectl rollout restart -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller deployment/$(BROKER_ROUTER_NAME)
+	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller --timeout=60s
 	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/$(BROKER_ROUTER_NAME) --timeout=60s
 
 ##@ E2E Testing
@@ -726,9 +726,9 @@ ifeq ($(ISTIO_TRACING),1)
 		-p='{"spec":{"values":{"meshConfig":{"enableTracing":true,"defaultConfig":{"tracing":{}},"extensionProviders":[{"name":"tempo-otlp","opentelemetry":{"port":4317,"service":"$(OTEL_COLLECTOR_HOST)"}}]}}}}'
 	@sleep 5
 endif
-	kubectl set env deployment/mcp-gateway -n mcp-system \
+	kubectl set env deployment/mcp-gateway -n $(MCP_GATEWAY_NAMESPACE) \
 		OTEL_EXPORTER_OTLP_ENDPOINT="$(OTEL_COLLECTOR_HTTP)" OTEL_EXPORTER_OTLP_INSECURE="true"
-	@kubectl rollout status deployment/mcp-gateway -n mcp-system --timeout=120s
+	@kubectl rollout status deployment/mcp-gateway -n $(MCP_GATEWAY_NAMESPACE) --timeout=120s
 ifeq ($(AUTH_TRACING),1)
 	@if ! kubectl get authorino -n kuadrant-system 2>/dev/null | grep -q authorino; then \
 		$(MAKE) auth-example-setup; \

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -63,7 +63,7 @@ ci-auth-setup: cert-manager-install kuadrant-install ## Setup auth infrastructur
 .PHONY: ci-debug-logs
 ci-debug-logs: ## Collect logs for debugging CI failures
 	@echo "=== Controller logs ==="
-	-$(KUBECTL) logs -n mcp-system deployment/mcp-controller --tail=100
+	-$(KUBECTL) logs -n mcp-system deployment/mcp-gateway-controller --tail=100
 	@echo "=== MCPGatewayExtensions ==="
 	-$(KUBECTL) get mcpgatewayextensions -A
 	@echo "=== MCPServerRegistrations ==="

--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -48,8 +48,8 @@ test-e2e-auth-ci: test-e2e-deps enable-debug-logging ## Run auth e2e tests only 
 
 .PHONY: enable-debug-logging
 enable-debug-logging: ## Enable debug logging on controller and wait for restart
-	@echo "Enabling debug logging on mcp-controller..."
-	kubectl patch deployment mcp-controller -n mcp-system --type='json' \
+	@echo "Enabling debug logging on mcp-gateway-controller..."
+	kubectl patch deployment mcp-gateway-controller -n mcp-system --type='json' \
 		-p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["./mcp_controller", "--log-level=-4"]}]'
 	@echo "Waiting for controller rollout..."
-	kubectl rollout status deployment/mcp-controller -n mcp-system --timeout=120s
+	kubectl rollout status deployment/mcp-gateway-controller -n mcp-system --timeout=120s

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -10,7 +10,7 @@ setup-cluster-base: tools kind-create-cluster build-and-load-image gateway-api-i
 deploy-controller-only: ## Deploy only the controller (tests create their own MCPGatewayExtensions)
 	$(KUBECTL) apply -k config/mcp-gateway/overlays/ci/
 	@echo "Waiting for controller to be ready..."
-	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-controller -n mcp-system
+	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-gateway-controller -n mcp-system
 
 # Wait for test server deployments
 .PHONY: wait-test-servers

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ spec:
         - label:
             app: mcp-controller
             component: controller
-          name: mcp-controller
+          name: mcp-gateway-controller
           spec:
             replicas: 1
             selector:

--- a/charts/README.md
+++ b/charts/README.md
@@ -7,7 +7,7 @@ This directory contains the Helm chart for deploying MCP Gateway to Kubernetes.
 ## Overview
 
 The MCP Gateway Helm chart deploys:
-- **MCP Controller**: Manages MCPGatewayExtension, MCPServerRegistration, and MCPVirtualServer custom resources
+- **MCP Gateway Controller**: Manages MCPGatewayExtension, MCPServerRegistration, and MCPVirtualServer custom resources
 - **MCPGatewayExtension**: Custom resource that triggers the controller to deploy the broker-router
 - **Custom Resource Definitions (CRDs)**: MCPGatewayExtension, MCPServerRegistration, and MCPVirtualServer
 - **RBAC**: Service accounts, roles, and bindings for secure operation

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mcp-controller
+  name: mcp-gateway-controller
   labels:
     app: mcp-controller
     component: controller

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mcp-controller
+  name: mcp-gateway-controller
   namespace: mcp-system
   labels:
     app: mcp-controller

--- a/docs/design/backend-mcp-management.md
+++ b/docs/design/backend-mcp-management.md
@@ -2,7 +2,7 @@
 
 ### Problem
 
-The MCP Gateway needs to discover and register backend MCP servers so that their tools can be aggregated and presented to clients as a unified MCP server. When an MCPServerRegistration custom resource is created or updated in Kubernetes, the MCP Controller must:
+The MCP Gateway needs to discover and register backend MCP servers so that their tools can be aggregated and presented to clients as a unified MCP server. When an MCPServerRegistration custom resource is created or updated in Kubernetes, the MCP Gateway Controller must:
 
 1. Discover the MCP server endpoint from the referenced HTTPRoute
 2. Update the broker and router configuration
@@ -18,7 +18,7 @@ The broker needs a robust mechanism to manage the lifecycle of each upstream MCP
 
 The MCP Gateway uses a two-phase registration process:
 
-1. **Controller Phase**: The MCP Controller watches for MCPServerRegistration resources, discovers server endpoints from HTTPRoutes, and writes aggregated configuration to ConfigMaps
+1. **Controller Phase**: The MCP Gateway Controller watches for MCPServerRegistration resources, discovers server endpoints from HTTPRoutes, and writes aggregated configuration to ConfigMaps
 2. **Broker Phase**: The MCP Broker reads configuration changes and manages each upstream MCP server through an `MCPManager` struct that handles the full lifecycle of the connection
 
 Each upstream MCP server is managed by a dedicated `MCPManager` instance that runs as a background routine, handling:
@@ -31,7 +31,7 @@ Each upstream MCP server is managed by a dedicated `MCPManager` instance that ru
 
 ```mermaid
 sequenceDiagram
-  participant Controller as MCP Controller
+  participant Controller as MCP Gateway Controller
   participant ConfigMap as ConfigMap
   participant Broker as MCP Broker
   participant Manager as MCPManager

--- a/docs/design/isolated-gateway-deployment.md
+++ b/docs/design/isolated-gateway-deployment.md
@@ -13,7 +13,7 @@
 
 > Note: The existing MCP controller component is expected to evolve into a full MCP operator capable of both reconciling MCPServerRegistration instances and deploying MCP Gateway instances into targeted namespaces. This design reflects a step towards that future.
 
-The existing behavior of the MCP Controller, which has remained in place from the proof of concept (PoC), is to:
+The existing behavior of the MCP Gateway Controller, which has remained in place from the proof of concept (PoC), is to:
 1. Discover all MCPServerRegistration resources across the cluster
 2. Construct a unified MCP configuration from them
 3. Create that configuration in a known secret in the `mcp-system` namespace
@@ -73,7 +73,7 @@ spec:
 
 ### MCPGatewayExtension Controller Behavior
 
-The MCP Controller will reconcile this new resource in a dedicated MCPGatewayExtension controller. This controller will:
+The MCP Gateway Controller will reconcile this new resource in a dedicated MCPGatewayExtension controller. This controller will:
 
 1. Verify that if an MCPGatewayExtension targets a Gateway in another namespace, an associated ReferenceGrant exists
 2. Update the MCPGatewayExtension status accordingly (without revealing whether the targeted Gateway resource exists)
@@ -101,7 +101,7 @@ In this initial phase, users will use the Helm charts to deploy the broker and r
 
 **Diagram**
 
-> Note: The MCP Controller does not need to be in the same namespace as the MCPGatewayExtension. It is shown that way here purely to reduce noise.
+> Note: The MCP Gateway Controller does not need to be in the same namespace as the MCPGatewayExtension. It is shown that way here purely to reduce noise.
 
 ![Isolated Gateway Deployment Diagram](./images/isolated-gateway.jpg)
 

--- a/docs/design/routing.md
+++ b/docs/design/routing.md
@@ -16,11 +16,11 @@ MCP Gateway router component as ext_proc intercept all requests hitting the /mcp
 
 ### The Router
 
-The router component is configured to know about the different backend MCP Servers that have been registered. This MCPSever configuration is managed by the MCP Controller component. The router should also be configured with the public listener hostname via `required` flag `--mcp-gateway-public-host`. The router intercepts all requests to the gateway MCP listener before routing has happened and based on its configuration decides whether the request should be processed by the MCP Broker or configure the routing to ensure the request is sent to the correct MCP Server. The router only re-routes `tools/calls` but validates all calls hitting the MCP gateway listener to ensure clients cannot explicitly bypass the broker (note they can never bypass the router).
+The router component is configured to know about the different backend MCP Servers that have been registered. This MCPSever configuration is managed by the MCP Gateway Controller component. The router should also be configured with the public listener hostname via `required` flag `--mcp-gateway-public-host`. The router intercepts all requests to the gateway MCP listener before routing has happened and based on its configuration decides whether the request should be processed by the MCP Broker or configure the routing to ensure the request is sent to the correct MCP Server. The router only re-routes `tools/calls` but validates all calls hitting the MCP gateway listener to ensure clients cannot explicitly bypass the broker (note they can never bypass the router).
 
 #### The MCPServerRegistration resource
 
-The MCP Server resource is a Kubernetes CRD used to register and configure an MCP server to be exposed via the Gateway. It targets a HTTPRoute and sets some additional configuration. This resource is reconciled by the MCP Controller into configuration that the router can consume to make routing decisions.
+The MCP Server resource is a Kubernetes CRD used to register and configure an MCP server to be exposed via the Gateway. It targets a HTTPRoute and sets some additional configuration. This resource is reconciled by the MCP Gateway Controller into configuration that the router can consume to make routing decisions.
 
 ### The Gateway Listeners
 

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -56,7 +56,7 @@ helm upgrade -i mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ```
 
 This automatically installs:
-- **MCP Controller** - Watches MCPGatewayExtension and MCPServerRegistration resources
+- **MCP Gateway Controller** - Watches MCPGatewayExtension and MCPServerRegistration resources
 - **MCPGatewayExtension** - Custom resource targeting your Gateway
 
 When the MCPGatewayExtension becomes ready, the controller automatically creates:

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -51,7 +51,7 @@ Note: CRDs are also installed automatically when deploying the controller via He
 ┌──────────────────────────────────────────────────────────────────────┐
 │                        MCP System Namespace                          │
 ├──────────────────────────────────────────────────────────────────────┤
-│                    MCP Controller (cluster-wide)                     │
+│                 MCP Gateway Controller (cluster-wide)                │
 └──────────────────────────────────────────────────────────────────────┘
                                     │
               ┌─────────────────────┴─────────────────────┐
@@ -89,9 +89,9 @@ export TEAM_A_HOST="team-a.127-0-0-1.sslip.io"
 export TEAM_B_HOST="team-b.127-0-0-1.sslip.io"
 ```
 
-## Step 3: Deploy the MCP Controller
+## Step 3: Deploy the MCP Gateway Controller
 
-The MCP Controller runs cluster-wide and reconciles MCPGatewayExtension and MCPServerRegistration resources. Deploy it once in a central namespace:
+The MCP Gateway Controller runs cluster-wide and reconciles MCPGatewayExtension and MCPServerRegistration resources. Deploy it once in a central namespace:
 
 ```bash
 helm upgrade -i mcp-controller ./charts/mcp-gateway \

--- a/docs/guides/understanding-mcp-gateway-architecture.md
+++ b/docs/guides/understanding-mcp-gateway-architecture.md
@@ -227,7 +227,7 @@ For detailed routing logs, enable debug logging:
 kubectl set env deployment/mcp-gateway LOG_LEVEL=-4 -n mcp-system
 ```
 
-### MCP Controller Logs: Dynamic Discovery
+### MCP Gateway Controller Logs: Dynamic Discovery
 
 The controller is responsible for:
 - Watching MCPServerRegistration custom resources
@@ -239,7 +239,7 @@ The controller is responsible for:
 
 ```bash
 # Watch controller logs
-kubectl logs -f deployment/mcp-controller -n mcp-system
+kubectl logs -f deployment/mcp-gateway-controller -n mcp-system
 ```
 
 **Key log patterns:**

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -87,7 +87,7 @@ kubectl apply -k "${REPO}/config/crd?ref=${GIT_REF}"
 kubectl apply -k "${REPO}/config/mcp-gateway/overlays/mcp-system?ref=${GIT_REF}"
 
 echo "Waiting for controller..."
-kubectl wait --for=condition=available --timeout=120s deployment/mcp-controller -n mcp-system
+kubectl wait --for=condition=available --timeout=120s deployment/mcp-gateway-controller -n mcp-system
 echo "Waiting for broker-router (deployed automatically by the controller)..."
 kubectl wait --for=condition=available --timeout=120s deployment/mcp-gateway -n mcp-system
 echo "Waiting for gateway pod..."

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -29,7 +29,7 @@ make test-e2e-watch
 If tests fail, check:
 ```bash
 # Controller logs
-kubectl logs -n mcp-system deployment/mcp-controller
+kubectl logs -n mcp-system deployment/mcp-gateway-controller
 
 # Broker logs  
 kubectl logs -n mcp-system deployment/mcp-broker-router


### PR DESCRIPTION
### Summary

Renames the controller Deployment from mcp-controller to mcp-gateway-controller to align the Deployment name with the name used when MCP Gateway is installed via Helm. The `mcp-gateway-controller` is a preferred name.

In this PR only Deployment is renamed. Other pieces (labels, selectors, image, serviceAccount, etc) are left intact (the `mcp-controller` name remains as is). Deployment name is important because it is used in various make target which makes these target impossible to use if installed via Helm.

### Changes:        
  - Renamed Deployment metadata.name in config/mcp-gateway/components/controller/deployment-controller.yaml, config/mcp-system/deployment-controller.yaml, and OLM CSV
  - Updated all deployment/mcp-controller references in Makefile, build/*.mk, and scripts/quick-start.sh                                                                                           
  - Updated "MCP Controller" to "MCP Gateway Controller" in various *.md files
  - Replace hard-coded `mcp-system` namespace with MCP_GATEWAY_NAMESPACE env var defaulting to `mcp-system`
 
### Verification                                                                                                       
  - run `make local-env-setup` and check the Deployment name
  - `kubectl get deployment mcp-gateway-controller -n mcp-system` shows the controller running
  - run quick-start.sh and check the Deployment name again
  - try modified make targets like `restart-all` or `enable-debug-logging`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides, design docs, and READMEs to consistently use the "MCP Gateway Controller" name and update example commands/logging instructions.

* **Refactor**
  * Renamed the controller component across manifests, deployment/configuration scripts, and build/Makefile targets so tooling and deploy flows reference the new controller name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->