### PR TITLE
Authentication review

### DIFF
--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -34,10 +34,10 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 30080
-    hostPort: 7001
+    hostPort: 8001
     protocol: TCP
   - containerPort: 30089
-    hostPort: 7002
+    hostPort: 8002
     protocol: TCP
 EOF
 fi
@@ -130,7 +130,7 @@ echo "================================================================"
 echo "Setup complete!"
 echo "================================================================"
 echo "MCP Inspector: http://localhost:6274"
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "Check status:"
 echo "  kubectl get pods -n mcp-system"
@@ -141,7 +141,7 @@ echo ""
 echo "Press Ctrl+C to stop and cleanup."
 echo "================================================================"
 
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
 
 # Cleanup function
 cleanup() {

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -119,7 +119,10 @@ kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/con
 kubectl wait --for=condition=available --timeout=90s deployment/authorino -n kuadrant-system
 
 # Patch Authorino deployment to resolve Keycloak's host name to MCP gateway IP (Development environment only):
-export GATEWAY_IP=$(kubectl get gateway/mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)
+export GATEWAY_IP=$(kubectl get gateway/mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+if [ -z "$GATEWAY_IP" ]; then
+  GATEWAY_IP=$(kubectl get pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system -o jsonpath='{.items[0].status.podIP}')
+fi
 kubectl patch deployment authorino -n kuadrant-system --type='json' -p="[
   {
     \"op\": \"add\",

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -202,7 +202,9 @@ curl http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
 #   ],
 #   "scopes_supported": [
 #     "basic",
-#     "groups"
+#     "groups",
+#     "roles",
+#     "profile"
 #   ]
 # }
 ```
@@ -228,6 +230,8 @@ You should get a response like this:
 ## Step 5: Test Authentication Flow
 
 Use the MCP Inspector to test the complete OAuth flow.
+
+> **Note:** If you set up your cluster using the [Quick Start Guide](./quick-start.md), Keycloak (port 8002) is not exposed to the host. Run `kubectl port-forward -n gateway-system svc/mcp-gateway-np 8002:8002` in a separate terminal before proceeding.
 
 ```bash
 # Start MCP Inspector (requires Node.js/npm)

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -20,7 +20,7 @@ curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/qu
 
 The script checks prerequisites, then runs through each step automatically:
 
-1. **Create Kind cluster** with port mapping (`localhost:7001`)
+1. **Create Kind cluster** with port mapping (`localhost:8001`)
 2. **Install Gateway API CRDs and Istio** as the Gateway API provider
 3. **Create the Gateway** with listeners and a NodePort service
 4. **Install MCP Gateway** CRDs, controller, and MCPGatewayExtension (the controller automatically deploys the broker-router)
@@ -37,7 +37,7 @@ DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
 Open the inspector at [http://localhost:6274](http://localhost:6274) and configure:
 
 - **Transport**: Streamable HTTP
-- **URL**: `http://mcp.127-0-0-1.sslip.io:7001/mcp`
+- **URL**: `http://mcp.127-0-0-1.sslip.io:8001/mcp`
 
 Click **Connect**, then browse and test the available tools:
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -45,7 +45,7 @@ if [ ${#missing[@]} -gt 0 ]; then
 fi
 echo ""
 
-output "Step 1: Create Kind cluster with port mapping (localhost:7001 -> NodePort 30080)"
+output "Step 1: Create Kind cluster with port mapping (localhost:8001 -> NodePort 30080)"
 
 if kind get clusters 2>/dev/null | grep -q '^kind$'; then
     echo "Kind cluster already exists, reusing it."
@@ -63,7 +63,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 30080
-    hostPort: 7001
+    hostPort: 8001
     protocol: TCP
 EOF
 fi
@@ -121,12 +121,12 @@ echo ""
 echo "============================================================"
 echo "MCP Gateway is ready!"
 echo ""
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "To test with MCP Inspector (requires Node.js):"
 echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest"
 echo ""
-echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"
 echo ""
 echo "To clean up:"


### PR DESCRIPTION
**Quick-start port alignment (8001)**
  - Changed Kind hostPort from 7001 to 8001 in scripts/quick-start.sh, docs/guides/quick-start.md, and
  charts/sample_local_helm_setup.sh
  - Aligns with config/kind/cluster.yaml and all other guides (authentication, authorization, virtual servers, etc.)

  **Authentication guide fixes**
  - Added GATEWAY_IP fallback to pod IP for Kind clusters where gateway has no LoadBalancer address
  - Fixed scopes_supported example response to include all 4 scopes (basic, groups, roles, profile) matching the env var set in Step
   2
  - Added note to Step 5 about port-forwarding Keycloak (port 8002) when using the quick-start setup



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and authentication guides to use new local ports (8001/8002)
  * Added Keycloak port-forward note for local testing
  * Expanded OAuth metadata examples with extra supported scopes
  * Improved Gateway IP resolution in setup instructions

* **Chores**
  * Updated local setup scripts and sample setup to reflect revised port mappings (8001/8002)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->