### PR TITLE
fixes: tool revocation guide

### DIFF
--- a/.github/workflows/ci-docs-skip.yaml
+++ b/.github/workflows/ci-docs-skip.yaml
@@ -1,8 +1,14 @@
 name: CI Docs Skip
 
-# Provides pass statuses for required checks when only docs/markdown files change.
-# Without this, docs-only PRs can never merge because the real workflows use
-# paths-ignore and never report a status for the required checks.
+# Provides pass statuses for required checks when only non-code files change.
+# Without this, PRs touching only these paths can never merge because the real
+# workflows use paths-ignore and never report a status for the required checks.
+# The paths list below is the union of all paths-ignore entries from
+# images.yaml, tests.yaml, and code-style.yaml.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:
@@ -12,6 +18,11 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - 'tests/servers/**'
+      - '.coderabbit.yaml'
+      - '.gitignore'
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/ci-docs-skip.yaml
+++ b/.github/workflows/ci-docs-skip.yaml
@@ -1,0 +1,44 @@
+name: CI Docs Skip
+
+# Provides pass statuses for required checks when only docs/markdown files change.
+# Without this, docs-only PRs can never merge because the real workflows use
+# paths-ignore and never report a status for the required checks.
+
+on:
+  pull_request:
+    branches: ['main']
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: mcp-gateway
+          - image: mcp-controller
+    steps:
+      - run: echo "Docs-only change, skipping build"
+
+  unit-tests:
+    name: Unit Tests
+    strategy:
+      matrix:
+        go-version: [1.22.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - run: echo "Docs-only change, skipping tests"
+
+  code-style:
+    name: Code Style Checks
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change, skipping code style"

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -44,61 +44,31 @@ To force faster revocation, reduce the access token lifespan in your identity pr
 
 ## Step 3: Verify Revocation
 
-After revoking a tool, verify that the user can no longer access it.
+After revoking a tool, verify that the user can no longer access it. The simplest way is using MCP Inspector.
+
+Find your gateway address:
+
+```bash
+kubectl get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}'
+```
+
+Open MCP Inspector and connect to your gateway's `/mcp` endpoint (e.g., `http://<gateway-address>:8001/mcp`). Authenticate as the affected user through the OAuth flow.
 
 **Check `tools/list` filtering:**
 
-Authenticate as the affected user and list tools. The revoked tool should no longer appear:
-
-```bash
-# Obtain a token as the affected user, then:
-curl -X POST http://your-gateway-host/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
-```
+Under **Tools > List Tools**, the revoked tool should no longer appear in the list.
 
 **Check `tools/call` denial:**
 
-Attempt to call the revoked tool. You should receive a 403 Forbidden response:
-
-```bash
-curl -X POST http://your-gateway-host/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "revoked_tool"}}'
-```
-
-Expected response:
-
-```json
-{
-  "error": "Forbidden",
-  "message": "MCP Tool Access denied: Insufficient permissions for this tool."
-}
-```
+Attempt to call the revoked tool directly. The request should be denied with a 403 Forbidden response.
 
 ## Step 4: Monitor Revocation Enforcement
 
-Use existing observability to track denied access attempts after revocation.
-
-### Authorino Logs
-
-Authorino logs all authorization decisions, including denials. Check for authorization failures:
-
-```bash
-kubectl logs -n kuadrant-system -l app=authorino | grep -i "unauthorized\|denied\|forbidden"
-```
-
-### OpenTelemetry Traces
-
-If [OpenTelemetry](./opentelemetry.md) is enabled, the MCP Router emits trace spans for every request. Denied requests include `http.status_code: 403` on the response span. You can query your trace backend for these:
+If [OpenTelemetry](./opentelemetry.md) is enabled, denied requests appear as trace spans with `http.status_code: 403`. Query your trace backend to find them:
 
 - Filter by `http.status_code = 403`
 - Use `gen_ai.tool.name` to identify which tool was denied
 - Use `mcp.session.id` to correlate with the client session
-
-### Loki / Log Aggregation
 
 If the [observability stack](./observability.md) is deployed, query gateway logs for revocation-related activity:
 
@@ -106,7 +76,7 @@ If the [observability stack](./observability.md) is deployed, query gateway logs
 {namespace="mcp-system"} |= `x-mcp-toolname` | json | line_format "{{.msg}}"
 ```
 
-The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `tools/call` request. Combined with the 403 status from Authorino, this gives visibility into which users are attempting to call revoked tools.
+The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `tools/call` request. Combined with the 403 status, this gives visibility into which users are attempting to call revoked tools.
 
 ## Next Steps
 

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -60,7 +60,7 @@ Under **Tools > List Tools**, the revoked tool should no longer appear in the li
 
 **Check `tools/call` denial:**
 
-Attempt to call the revoked tool directly. The request should be denied with a 403 Forbidden response.
+Attempt to call the revoked tool. Since the tool is no longer in the user's authorized set, the request should fail.
 
 ## Step 4: Monitor Revocation Enforcement
 


### PR DESCRIPTION
Resolves https://github.com/Kuadrant/mcp-gateway/issues/737

## Changes

- **Step 3 (Verify Revocation)**: Replace broken curl commands with MCP Inspector workflow. The curls lacked session initialisation (`Invalid session ID`), used an unexplained `your-gateway-host` placeholder, and gave no guidance on obtaining `$TOKEN`. Added `kubectl get gateway` command so users can discover their gateway address.
- **Step 4 (Monitor Revocation)**: Remove Authorino logs section -- used wrong pod label (`app=authorino` vs `authorino-resource=authorino`), and users likely won't have access to `kuadrant-system` namespace anyway. Kept OpenTelemetry and Loki sections as proper observability paths.
- Removed incorrect 403 JSON response example (actual behaviour depends on which gateway listener handles the request).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Switched tool revocation verification to an MCP Inspector-based workflow (UI-driven checks for/tools list and call behavior).
  * Simplified observability guidance: removed specialized log sections and describe denied requests as OpenTelemetry traces with HTTP 403; retained gateway log instructions (header-based logging) without prior correlation wording.

* **Chores**
  * Added a CI workflow to skip full build/test/style runs for documentation-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->