### PR TITLE
docs: isolated-gateway-deployment guide has confusing Kind/NodePort section

### DIFF
--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -193,7 +193,7 @@ kubectl get pods -n team-b
 
 ## Step 8: Expose Gateways Externally
 
-### OpenShift (Routes)
+### OpenShift
 
 OpenShift Routes expose the Gateways externally with TLS termination.
 
@@ -248,21 +248,49 @@ Verify routes are created:
 oc get routes -n gateway-system
 ```
 
-## Exposing via NodePort
+### Kubernetes (NodePort)
 
-For a local kind or kubernetes setup you can configure helm to setup the NodePort service. Re-run the commands with the following flags set
+Re-run the Team A and Team B Helm commands from Steps 4 and 6 with NodePort flags added:
 
 ```bash
-# Team A gateway
---set gateway.nodePort.create=true \
---set gateway.nodePort.mcpPort=30080 \
+helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
+  --namespace team-a \
+  --set controller.enabled=false \
+  --set broker.create=true \
+  --set gateway.create=true \
+  --set gateway.name=team-a-gateway \
+  --set gateway.namespace=gateway-system \
+  --set gateway.publicHost="$TEAM_A_HOST" \
+  --set gateway.internalHostPattern="*.team-a.mcp.local" \
+  --set mcpGatewayExtension.create=true \
+  --set mcpGatewayExtension.gatewayRef.name=team-a-gateway \
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
+  --set envoyFilter.create=true \
+  --set envoyFilter.name=team-a-gateway \
+  --set gateway.nodePort.create=true \
+  --set gateway.nodePort.mcpPort=30080
 ```
 
 ```bash
-# Team B gateway
---set gateway.nodePort.create=true \
---set gateway.nodePort.mcpPort=30471 \
+helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
+  --namespace team-b \
+  --set controller.enabled=false \
+  --set broker.create=true \
+  --set gateway.create=true \
+  --set gateway.name=team-b-gateway \
+  --set gateway.namespace=gateway-system \
+  --set gateway.publicHost="$TEAM_B_HOST" \
+  --set gateway.internalHostPattern="*.team-b.mcp.local" \
+  --set mcpGatewayExtension.create=true \
+  --set mcpGatewayExtension.gatewayRef.name=team-b-gateway \
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
+  --set envoyFilter.create=true \
+  --set envoyFilter.name=team-b-gateway \
+  --set gateway.nodePort.create=true \
+  --set gateway.nodePort.mcpPort=30471
 ```
+
+> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30471) to host ports. See the [Kind cluster setup guide](./kind-cluster-setup.md) for details.
 
 ## Next Steps: Register MCP Servers
 


### PR DESCRIPTION
Fixes #743

## Summary

The "Expose Gateways Externally" section (Step 8) of the isolated gateway deployment guide had three issues found during an end-to-end walkthrough:

1. **Step 8 was OpenShift-only** — Kind/NodePort was in a separate unnumbered section outside the step flow, with no signpost for Kind users to skip Step 8
2. **NodePort section gave incomplete commands** — showed only the extra `--set` flags, not the full `helm upgrade` commands
3. **Kind port mapping requirement not mentioned** — NodePorts on Kind require `extraPortMappings` in the cluster config, but this was never noted

## Changes

- Moved the NodePort section into Step 8 as a `### Kind/Kubernetes` subsection (matching the pattern already used in Step 2)
- Replaced bare flags with full `helm upgrade` commands for both Team A and Team B
- Added a note about Kind `extraPortMappings` requirement with a link to the Kind cluster setup guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified OpenShift gateway exposure section heading for clarity
  * Added new Kind/Kubernetes cluster deployment guidance with NodePort configuration
  * Included detailed Helm upgrade commands with required parameters for gateway exposure
  * Added Kind-specific cluster configuration requirements for NodePort accessibility from the host

<!-- end of auto-generated comment: release notes by coderabbit.ai -->