### PR TITLE
docs: update authorization guide

### DIFF
--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -47,7 +47,7 @@ The issued OAuth token should include claims similar to:
 }
 ```
 
-> **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of both `accounting` group, which map to different tool permissions.
+> **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of the `accounting` group, which maps to specific tool permissions.
 
 ## Step 2: Configure Tool-Level Authorization
 
@@ -133,13 +133,13 @@ open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-
 
 **Test Scenarios:**
 
-1. **Login as mcp/mcp** (has both `accounting` and `developers` groups)
+1. **Login as mcp/mcp** (has `accounting` and `engineering` groups)
 2. **Try allowed tools**:
    - `test1_greet`
    - `test2_headers`
    - `test3_add`
 3. **Try restricted tools**:
-   - `apikey_hello_world` - Should return 403 Forbidden
+   - `test1_time` - Should return 403 Forbidden (accounting group only has the `greet` role for test-server1)
 
 ## Alternative Authorization Mechanisms
 
@@ -154,7 +154,7 @@ Monitor authorization decisions:
 kubectl get authpolicy -A
 
 # View authorization logs
-kubectl logs -n kuadrant-system -l app=authorino
+kubectl logs -n kuadrant-system -l authorino-resource=authorino
 ```
 
 ## Next Steps


### PR DESCRIPTION
 **Fixed incorrect group name:** 
   Changed developers to accounting and engineering to match the actual Keycloak realm configuration (config/keycloak/realm-import.yaml)
 
**Fixed unreachable test tool:** 
Replaced apikey_hello_world with test1_time as the restricted tool example — the api-key server isn't deployed by the prerequisite guides, while test1_time exists in the default setup and is correctly denied for the accounting group

**Fixed broken kubectl label selector**: 
Changed app=authorino to authorino-resource=authorino to match the actual Authorino pod labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authorization guide to clarify group permissions mapping
  * Revised authorization test scenarios with updated role configurations
  * Modified observability commands for retrieving logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->