### PR TITLE
cherry pick rc2

### DIFF
--- a/.github/workflows/ci-docs-skip.yaml
+++ b/.github/workflows/ci-docs-skip.yaml
@@ -1,0 +1,55 @@
+name: CI Docs Skip
+
+# Provides pass statuses for required checks when only non-code files change.
+# Without this, PRs touching only these paths can never merge because the real
+# workflows use paths-ignore and never report a status for the required checks.
+# The paths list below is the union of all paths-ignore entries from
+# images.yaml, tests.yaml, and code-style.yaml.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: ['main']
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - 'tests/servers/**'
+      - '.coderabbit.yaml'
+      - '.gitignore'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: mcp-gateway
+          - image: mcp-controller
+    steps:
+      - run: echo "Docs-only change, skipping build"
+
+  unit-tests:
+    name: Unit Tests
+    strategy:
+      matrix:
+        go-version: [1.22.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - run: echo "Docs-only change, skipping tests"
+
+  code-style:
+    name: Code Style Checks
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change, skipping code style"

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -2,7 +2,7 @@ name: Code Style
 
 on:
   pull_request:
-    branches: [ 'main',  ]
+    branches: ['main', 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -48,5 +48,9 @@ jobs:
           go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
           make yq
 
-          # Check if generated resources are synchronized
-          make check
+          # Skip bundle sync on release branches (versions are set by the release process)
+          if [[ "${{ github.base_ref || github.ref_name }}" == release-* ]]; then
+            make check-crd-sync check-rbac-sync
+          else
+            make check
+          fi

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -2,7 +2,7 @@ name: MCP Conformance Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -13,7 +13,7 @@ on:
       - '.coderabbit.yaml'
       - '.gitignore'
   push:
-    branches: [main]
+    branches: [main, 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -13,7 +13,7 @@ on:
       - '.coderabbit.yaml'
       - '.gitignore'
   push:
-    branches: [main]
+    branches: [main, 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -2,7 +2,7 @@ name: Helm Install Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths:
       - 'charts/**'
       - 'config/crd/**'

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -3,7 +3,7 @@ name: Build Images
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main, 'release-*']
     tags: [ 'v*' ]
     paths-ignore:
       - '**.md'
@@ -14,7 +14,7 @@ on:
       - 'evals/**'
       - 'tests/servers/**'
   pull_request:
-    branches: [ main ]
+    branches: [main, 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -3,13 +3,13 @@ name: Build Test Server Images
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, 'release-*']
     paths:
       - 'tests/servers/**'
       - 'internal/tests/**'
       - '.github/workflows/test-images.yaml'
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths:
       - 'tests/servers/**'
       - 'internal/tests/**'

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -2,14 +2,14 @@ name: Verify CRD Sync
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths:
       - 'api/**'
       - 'config/crd/**'
       - 'charts/mcp-gateway/crds/**'
       - 'bundle/manifests/**'
   push:
-    branches: [main]
+    branches: [main, 'release-*']
     paths:
       - 'api/**'
       - 'config/crd/**'
@@ -61,7 +61,13 @@ jobs:
       run: make yq
 
     - name: Verify generated resources are in sync
-      run: make check
+      run: |
+        if [[ "${{ github.base_ref || github.ref_name }}" == release-* ]]; then
+          echo "Skipping bundle sync on release branch (versions are set by the release process)"
+          make check-crd-sync check-rbac-sync
+        else
+          make check
+        fi
 
     - name: Verify Helm chart can be templated
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ This allows AuthPolicy to validate the OAuth token while backends receive their 
 ## Test Servers
 
 Six test servers in `config/test-servers/`:
-- **Server1**: Go SDK (tools: hi, time, slow, headers)
+- **Server1**: Go SDK (tools: greet, time, slow, headers)
 - **Server2**: Go SDK (tools: hello_world, time, headers, auth1234, slow)
 - **Server3**: Python FastMCP (tools: time, add, dozen, pi, get_weather, slow)
 - **API Key Server**: Validates Bearer token authentication (tool: hello_world)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ This allows AuthPolicy to validate the OAuth token while backends receive their 
 ## Test Servers
 
 Test servers in `config/test-servers/`:
-- **Server1**: Go SDK (tools: hi, time, slow, headers)
+- **Server1**: Go SDK (tools: greet, time, slow, headers)
 - **Server2**: Go SDK (tools: hello_world, time, headers, auth1234, slow)
 - **Server3**: Python FastMCP (tools: time, add, dozen, pi, get_weather, slow)
 - **API Key Server**: Validates Bearer token authentication (tool: hello_world)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ type ConfigReaderWriter interface {
 
 ### Quick Start
 ```bash
-make local-env-setup     # Create Kind cluster with everything
+make local-env-setup     # Create Kind cluster with gateway and everything server
 make reload              # Build, load to Kind, and restart controller and broker
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,20 @@ deploy-example: install-crd ## Deploy example MCPServerRegistration resource
 	@echo "Waiting for broker-router to be ready..."
 	@kubectl wait --for=condition=Available deployment/$(BROKER_ROUTER_NAME) -n mcp-system --timeout=$(WAIT_TIME)
 
+# Deploy example MCPServerRegistration for everything server only
+deploy-example-minimal: install-crd ## Deploy MCPServerRegistration for everything server
+	@echo "Waiting for everything server to be ready..."
+	@kubectl wait --for=condition=Available deployment -n mcp-test -l app=everything-server --timeout=$(WAIT_TIME)
+	@echo "Deploying MCPServerRegistration for everything server..."
+	kubectl apply -f config/samples/mcpserverregistration-everything-server.yaml
+	@echo "Waiting for MCPServerRegistration to be ready..."
+	@kubectl wait --for=condition=Ready mcpserverregistration/everything-server -n mcp-test --timeout=$(WAIT_TIME)
+
+# Build everything server image only
+build-everything-server: ## Build everything server Docker image
+	@echo "Building everything server image..."
+	cd tests/servers/everything-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest .
+
 # Build test server Docker images
 build-test-servers: ## Build test server Docker images locally
 	@echo "Building test server images..."
@@ -321,16 +335,25 @@ kind-load-test-servers: kind build-test-servers ## Load test server images into 
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest)
 
+# Load everything server image into Kind cluster
+kind-load-everything-server: kind build-everything-server ## Load everything server image into Kind cluster
+	@echo "Loading everything server image into Kind cluster..."
+	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest)
+
 # Load conformance server image into Kind cluster
 .PHONY: kind-load-conformance-server
 kind-load-conformance-server: kind build-conformance-server ## Load conformance server image into Kind cluster
 	@echo "Loading conformance server image into Kind cluster..."
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-conformance-server:latest)
 
-# Deploy test servers excluding oidc
-deploy-simple-test-servers: kind-load-test-servers ## Deploy test MCP servers for local testing
-	@echo "Deploying test MCP servers..."
-	kubectl apply -k config/test-servers/
+# Deploy everything server only (for local dev)
+deploy-everything-server: kind-load-everything-server ## Deploy only the everything server for local dev
+	@echo "Deploying everything server..."
+	kubectl apply -f config/test-servers/namespace.yaml
+	kubectl apply -f config/test-servers/everything-server-deployment.yaml -n mcp-test
+	kubectl apply -f config/test-servers/everything-server-service.yaml -n mcp-test
+	kubectl apply -f config/test-servers/everything-server-httproute.yaml -n mcp-test
+
 # Deploy test servers
 deploy-test-servers: kind-load-test-servers ## Deploy test MCP servers for local testing
 	@echo "Deploying test MCP servers..."
@@ -580,9 +603,9 @@ else
 	"$(MAKE)" deploy
 endif
 	"${MAKE}" add-jwt-key
-	# Deploy and configure test servers
-	"$(MAKE)" deploy-test-servers
-	"$(MAKE)" deploy-example
+	# Deploy everything server for local dev (use 'make deploy-test-servers' for all servers)
+	"$(MAKE)" deploy-everything-server
+	"$(MAKE)" deploy-example-minimal
 	@echo "Local environment setup complete"
 
 .PHONY: local-bare-setup

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [config/install/README.md](./config/install/README.md) for details and prere
 
 ### Development Environment
 
-For a complete local environment with all dependencies (Istio, Gateway API, Keycloak, MCP test servers):
+For a complete local environment with all dependencies (Istio, Gateway API, Keycloak, everything test server):
 
 ```bash
 make local-env-setup
@@ -43,8 +43,10 @@ This sets up:
 - a `kind` cluster
 - Istio as a Gateway API provider
 - MCP Gateway components (Broker / Router / Controller)
-- Test MCP servers
-- example configurations
+- the everything test server
+- example MCPServerRegistration
+
+To deploy all test servers, run `make deploy-test-servers` after setup.
 
 #### Adding e2e tests
 
@@ -54,7 +56,7 @@ If you are adding an e2e test, please consider using the claude slash command pr
 
 Set up a local kind cluster with the Broker, Router & Controller running.
 These components are built during the make target into a single image and loaded into the cluster.
-Also sets up an Istio Gateway API Gateway, and HTTPRoutes for test mcp servers, which are added to the broker/router.
+Also sets up an Istio Gateway API Gateway with the everything test server behind the broker/router.
 
 ```bash
 make local-env-setup

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This will:
 - Configure the mcp-broker with OAuth environment variables
 - Apply AuthPolicy for token validation/exchange on the /mcp endpoint, including tool authorization via keycloak group mappings (both via Keycloak)
 - Apply additional OAuth configurations
+- Deploy several test MCP servers including OIDC-enabled MCP server
 
 The mcp-broker now serves OAuth discovery information at `/.well-known/oauth-protected-resource`.
 

--- a/api/v1alpha1/mcpgatewayextension_types.go
+++ b/api/v1alpha1/mcpgatewayextension_types.go
@@ -207,8 +207,9 @@ type MCPGatewayExtensionTargetReference struct {
 
 	// sectionName is the name of a listener on the target Gateway. The controller will
 	// read the listener's port and hostname to configure the MCP Gateway instance.
-	// This allows multiple MCPGatewayExtensions to target different listeners on the
-	// same Gateway, each with their own MCP Gateway instance.
+	// Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+	// different namespaces may target different listeners on the same Gateway, provided
+	// those listeners use different ports.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253

--- a/build/auth.mk
+++ b/build/auth.mk
@@ -14,7 +14,7 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo ""
 	@echo "Prerequisites: make local-env-setup should be completed"
 	@echo ""
-	@echo "Step 1/5: Configuring OAuth environment variables..."
+	@echo "Step 1/6: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-gateway \
 		OAUTH_RESOURCE_NAME="MCP Server" \
 		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
@@ -24,23 +24,28 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 		-n mcp-system
 	@echo "✅ OAuth environment variables configured"
 	@echo ""
-	@echo "Step 2/5: Installing Vault..."
+	@echo "Step 2/6: Installing Vault..."
 	@bin/kustomize build config/vault | bin/yq 'select(.kind == "Deployment").spec.template.spec.containers[0].args += ["-dev-root-token-id=root"] | .' | kubectl apply -f -
 	@echo "✅ Vault installed"
 	@echo ""
-	@echo "Step 3/5: Applying AuthPolicy configurations..."
+	@echo "Step 3/6: Applying AuthPolicy configurations..."
 	@kubectl apply -k ./config/samples/oauth-token-exchange/
 	@kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
 		-p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
 	@echo "✅ AuthPolicy configurations applied"
 	@echo ""
-	@echo "Step 4/5: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
+	@echo "Step 4/6: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
 	@kubectl apply -f ./config/keycloak/preflight_envoyfilter.yaml
 	@echo "✅ CORS configured"
 	@echo ""
-	@echo "Step 5/5: Patch Authorino deployment to be able to connect to Keycloak..."
+	@echo "Step 5/6: Patch Authorino deployment to be able to connect to Keycloak..."
 	@./utils/patch-authorino-to-keycloak.sh
 	@echo "✅ Authorino deployment patched"
+	@echo ""
+	@echo "Step 6/6: Deploying test MCP servers..."
+	@"$(MAKE)" deploy-test-servers
+	@"$(MAKE)" deploy-example
+	@echo "✅ Test MCP servers deployed and configured"
 	@echo ""
 	@echo "🎉 OAuth example setup complete!"
 	@echo ""

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"toolPrefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:latest
-    createdAt: "2026-03-24T10:49:03Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+    createdAt: "2026-03-30T09:23:13Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.0.0
+  name: mcp-gateway.v0.6.0-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -181,8 +181,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:latest
-                    image: ghcr.io/kuadrant/mcp-controller:latest
+                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -242,6 +242,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:latest
+    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
       name: router-broker
-  version: 0.0.0
+  version: 0.6.0-rc1

--- a/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -130,8 +130,9 @@ spec:
                     description: |-
                       sectionName is the name of a listener on the target Gateway. The controller will
                       read the listener's port and hostname to configure the MCP Gateway instance.
-                      This allows multiple MCPGatewayExtensions to target different listeners on the
-                      same Gateway, each with their own MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -130,8 +130,9 @@ spec:
                     description: |-
                       sectionName is the name of a listener on the target Gateway. The controller will
                       read the listener's port and hostname to configure the MCP Gateway instance.
-                      This allows multiple MCPGatewayExtensions to target different listeners on the
-                      same Gateway, each with their own MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -34,10 +34,10 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 30080
-    hostPort: 7001
+    hostPort: 8001
     protocol: TCP
   - containerPort: 30089
-    hostPort: 7002
+    hostPort: 8002
     protocol: TCP
 EOF
 fi
@@ -130,7 +130,7 @@ echo "================================================================"
 echo "Setup complete!"
 echo "================================================================"
 echo "MCP Inspector: http://localhost:6274"
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "Check status:"
 echo "  kubectl get pods -n mcp-system"
@@ -141,7 +141,7 @@ echo ""
 echo "Press Ctrl+C to stop and cleanup."
 echo "================================================================"
 
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
 
 # Cleanup function
 cleanup() {

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc1}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -41,11 +41,10 @@ var (
 )
 
 var (
-	mcpConfig            = &config.MCPServersConfig{}
-	mutex                sync.RWMutex
-	logger               = slog.New(slog.NewTextHandler(os.Stdout, nil))
-	scheme               = runtime.NewScheme()
-	defaultJWTSigningKey = "default-not-secure"
+	mcpConfig = &config.MCPServersConfig{}
+	mutex     sync.RWMutex
+	logger    = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scheme    = runtime.NewScheme()
 )
 
 func init() {
@@ -120,7 +119,7 @@ func main() {
 	)
 	flag.StringVar(&jwtSigningKeyFlag,
 		"session-signing-key",
-		goenv.GetDefault("JWT_SESSION_SIGNING_KEY", defaultJWTSigningKey),
+		goenv.GetDefault("JWT_SESSION_SIGNING_KEY", ""),
 		"JWT signing key for session tokens (env: JWT_SESSION_SIGNING_KEY)",
 	)
 	//"redis://redis.mcp-system.svc.cluster.local:6379
@@ -186,10 +185,9 @@ func main() {
 
 	var jwtSessionMgr *session.JWTManager
 	if jwtSigningKeyFlag == "" {
-		panic("jwt session signing key is empty. Cannot proceed")
-	}
-	if jwtSigningKeyFlag == defaultJWTSigningKey {
-		logger.Warn("jwt session signing key is set to the default value. This is not recommended for production")
+		panic("JWT_SESSION_SIGNING_KEY is required but not set. " +
+			"When running via the controller, this is managed automatically. " +
+			"For standalone use, set the JWT_SESSION_SIGNING_KEY environment variable.")
 	}
 
 	jwtmgr, err := session.NewJWTManager(jwtSigningKeyFlag, sessionDurationInMins, logger, sessionCache)

--- a/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -130,8 +130,9 @@ spec:
                     description: |-
                       sectionName is the name of a listener on the target Gateway. The controller will
                       read the listener's port and hostname to configure the MCP Gateway instance.
-                      This allows multiple MCPGatewayExtensions to target different listeners on the
-                      same Gateway, each with their own MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:main
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0-rc1
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:latest
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.0.0
+  name: mcp-gateway.v0.6.0-rc1
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.0.0
+  version: 0.6.0-rc1

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:latest
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:latest
+              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:latest
+          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:latest
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-local}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0-rc1}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/config/samples/mcpserverregistration-everything-server.yaml
+++ b/config/samples/mcpserverregistration-everything-server.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: everything-server
+  namespace: mcp-test
+  labels:
+    mcp.kuadrant.io/managed: 'true'
+spec:
+  toolPrefix: everything_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: everything-server-route

--- a/config/samples/mcpserverregistration-test-servers-base.yaml
+++ b/config/samples/mcpserverregistration-test-servers-base.yaml
@@ -10,7 +10,7 @@ spec:
   # Tool prefix applied to all servers in this MCPServer
   toolPrefix: test1_
   targetRef:
-    # Server 1 - Go SDK based (hi, time, slow, headers tools)
+    # Server 1 - Go SDK based (greet, time, slow, headers tools)
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server1-route

--- a/config/samples/singleserver.yaml
+++ b/config/samples/singleserver.yaml
@@ -9,7 +9,7 @@ spec:
   # Tool prefix applied to all servers in this MCPServer
   toolPrefix: test_
   targetRef:
-    # Server 1 - Go SDK based (hi, time, slow, headers tools)
+    # Server 1 - Go SDK based (greet, time, slow, headers tools)
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server1-route

--- a/config/test-servers/CLAUDE.md
+++ b/config/test-servers/CLAUDE.md
@@ -1,7 +1,7 @@
 # Test Servers
 
 Test servers in `config/test-servers/`:
-- **Server1**: Go SDK (tools: hi, time, slow, headers)
+- **Server1**: Go SDK (tools: greet, time, slow, headers)
 - **Server2**: Go SDK (tools: hello_world, time, headers, auth1234, slow)
 - **Server3**: Python FastMCP (tools: time, add, dozen, pi, get_weather, slow)
 - **API Key Server**: Validates Bearer token authentication (tool: hello_world)

--- a/config/test-servers/oidc-server-deployment.yaml
+++ b/config/test-servers/oidc-server-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: ISSUER_URL
           value: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
         - name: EXPECTED_AUD
-          value: mcp-test/mcp-oidc-server-route
+          value: mcp-test/oidc-server
         - name: EXPECTED_ADMIN_TOKEN
           value: test-api-key-secret-token-for-oidc-server
         - name: LOG_LEVEL

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -119,7 +119,10 @@ kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/con
 kubectl wait --for=condition=available --timeout=90s deployment/authorino -n kuadrant-system
 
 # Patch Authorino deployment to resolve Keycloak's host name to MCP gateway IP (Development environment only):
-export GATEWAY_IP=$(kubectl get gateway/mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)
+export GATEWAY_IP=$(kubectl get gateway/mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+if [ -z "$GATEWAY_IP" ]; then
+  GATEWAY_IP=$(kubectl get pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system -o jsonpath='{.items[0].status.podIP}')
+fi
 kubectl patch deployment authorino -n kuadrant-system --type='json' -p="[
   {
     \"op\": \"add\",
@@ -199,7 +202,9 @@ curl http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
 #   ],
 #   "scopes_supported": [
 #     "basic",
-#     "groups"
+#     "groups",
+#     "roles",
+#     "profile"
 #   ]
 # }
 ```
@@ -225,6 +230,8 @@ You should get a response like this:
 ## Step 5: Test Authentication Flow
 
 Use the MCP Inspector to test the complete OAuth flow.
+
+> **Note:** If you set up your cluster using the [Quick Start Guide](./quick-start.md), Keycloak (port 8002) is not exposed to the host. Run `kubectl port-forward -n gateway-system svc/mcp-gateway-np 8002:8002` in a separate terminal before proceeding.
 
 ```bash
 # Start MCP Inspector (requires Node.js/npm)

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -47,7 +47,7 @@ The issued OAuth token should include claims similar to:
 }
 ```
 
-> **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of both `accounting` group, which map to different tool permissions.
+> **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of the `accounting` group, which maps to specific tool permissions.
 
 ## Step 2: Configure Tool-Level Authorization
 
@@ -133,13 +133,13 @@ open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-
 
 **Test Scenarios:**
 
-1. **Login as mcp/mcp** (has both `accounting` and `developers` groups)
+1. **Login as mcp/mcp** (has `accounting` and `engineering` groups)
 2. **Try allowed tools**:
    - `test1_greet`
    - `test2_headers`
    - `test3_add`
 3. **Try restricted tools**:
-   - `apikey_hello_world` - Should return 403 Forbidden
+   - `test1_time` - Should return 403 Forbidden (accounting group only has the `greet` role for test-server1)
 
 ## Alternative Authorization Mechanisms
 
@@ -154,7 +154,7 @@ Monitor authorization decisions:
 kubectl get authpolicy -A
 
 # View authorization logs
-kubectl logs -n kuadrant-system -l app=authorino
+kubectl logs -n kuadrant-system -l authorino-resource=authorino
 ```
 
 ## Next Steps

--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -159,7 +159,7 @@ The `mcp.kuadrant.io/secret=true` label is required. Without it the MCPServerReg
 
 ## Step 5: Create the MCPServerRegistration Resource
 
-Create the `MCPServer` resource that registers the GitHub MCP server with the gateway:
+Create the `MCPServerRegistration` resource that registers the GitHub MCP server with the gateway:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -213,37 +213,24 @@ This AuthPolicy extracts the API key from the OAuth token and sets it as the `x-
 
 **Note:** This step is only required if you're using AuthPolicy for OAuth authentication. For simple bearer token auth, the router handles the Authorization header automatically.
 
-## Step 7: Wait for Configuration Sync
+## Step 7: Verify the Registration
 
-Wait for the configuration to sync to the broker:
-
-```bash
-echo "Waiting for GitHub tools to be discovered..."
-until kubectl logs -n mcp-system deploy/mcp-gateway | grep "Discovered.*tools.*github"; do
-  echo "Still waiting..."
-  sleep 5
-done
-echo "GitHub tools discovered!"
-```
-
-## Verification
-
-Check that the MCPServerRegistration is registered:
+Wait for the MCPServerRegistration to become ready:
 
 ```bash
-kubectl get mcpsrs -n mcp-test
-kubectl logs -n mcp-system deployment/mcp-gateway | grep "Discovered.*tools.*github"
+kubectl get mcpsr -n mcp-test
 ```
+
+The `github` entry should show `READY = True` and a non-zero `TOOLS` count:
+
+```text
+NAME     PREFIX    TARGET                PATH   READY   TOOLS   CREDENTIALS    AGE
+github   github_   github-mcp-external   /mcp   True    41      github-token   30s
+```
+
+If `READY` is still `False`, wait a few seconds and re-run the command.
 
 ## Test Integration
-
-Test tools/list through the gateway:
-
-```bash
-curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
-```
 
 To test tool calls, open the MCP Inspector:
 
@@ -259,7 +246,7 @@ associated with your access token.
 ## Cleanup
 
 ```bash
-kubectl delete mcpserver github -n mcp-test
+kubectl delete mcpserverregistration github -n mcp-test
 kubectl delete httproute github-mcp-external -n mcp-test
 kubectl delete serviceentry github-mcp-external -n mcp-test
 kubectl delete destinationrule github-mcp-external -n mcp-test

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.6.0-rc1
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.6.0-rc1
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -193,7 +193,7 @@ kubectl get pods -n team-b
 
 ## Step 8: Expose Gateways Externally
 
-### OpenShift (Routes)
+### OpenShift
 
 OpenShift Routes expose the Gateways externally with TLS termination.
 
@@ -248,21 +248,49 @@ Verify routes are created:
 oc get routes -n gateway-system
 ```
 
-## Exposing via NodePort
+### Kubernetes (NodePort)
 
-For a local kind or kubernetes setup you can configure helm to setup the NodePort service. Re-run the commands with the following flags set
+Re-run the Team A and Team B Helm commands from Steps 4 and 6 with NodePort flags added:
 
 ```bash
-# Team A gateway
---set gateway.nodePort.create=true \
---set gateway.nodePort.mcpPort=30080 \
+helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
+  --namespace team-a \
+  --set controller.enabled=false \
+  --set broker.create=true \
+  --set gateway.create=true \
+  --set gateway.name=team-a-gateway \
+  --set gateway.namespace=gateway-system \
+  --set gateway.publicHost="$TEAM_A_HOST" \
+  --set gateway.internalHostPattern="*.team-a.mcp.local" \
+  --set mcpGatewayExtension.create=true \
+  --set mcpGatewayExtension.gatewayRef.name=team-a-gateway \
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
+  --set envoyFilter.create=true \
+  --set envoyFilter.name=team-a-gateway \
+  --set gateway.nodePort.create=true \
+  --set gateway.nodePort.mcpPort=30080
 ```
 
 ```bash
-# Team B gateway
---set gateway.nodePort.create=true \
---set gateway.nodePort.mcpPort=30471 \
+helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
+  --namespace team-b \
+  --set controller.enabled=false \
+  --set broker.create=true \
+  --set gateway.create=true \
+  --set gateway.name=team-b-gateway \
+  --set gateway.namespace=gateway-system \
+  --set gateway.publicHost="$TEAM_B_HOST" \
+  --set gateway.internalHostPattern="*.team-b.mcp.local" \
+  --set mcpGatewayExtension.create=true \
+  --set mcpGatewayExtension.gatewayRef.name=team-b-gateway \
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
+  --set envoyFilter.create=true \
+  --set envoyFilter.name=team-b-gateway \
+  --set gateway.nodePort.create=true \
+  --set gateway.nodePort.mcpPort=30471
 ```
+
+> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30471) to host ports. See the [Kind cluster setup guide](./kind-cluster-setup.md) for details.
 
 ## Next Steps: Register MCP Servers
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -20,7 +20,7 @@ curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/qu
 
 The script checks prerequisites, then runs through each step automatically:
 
-1. **Create Kind cluster** with port mapping (`localhost:7001`)
+1. **Create Kind cluster** with port mapping (`localhost:8001`)
 2. **Install Gateway API CRDs and Istio** as the Gateway API provider
 3. **Create the Gateway** with listeners and a NodePort service
 4. **Install MCP Gateway** CRDs, controller, and MCPGatewayExtension (the controller automatically deploys the broker-router)
@@ -37,7 +37,7 @@ DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
 Open the inspector at [http://localhost:6274](http://localhost:6274) and configure:
 
 - **Transport**: Streamable HTTP
-- **URL**: `http://mcp.127-0-0-1.sslip.io:7001/mcp`
+- **URL**: `http://mcp.127-0-0-1.sslip.io:8001/mcp`
 
 Click **Connect**, then browse and test the available tools:
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.6.0-rc1
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -18,15 +18,13 @@ export MCP_GATEWAY_VERSION=0.6.0-rc1
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 
-The script checks prerequisites, then walks through each step interactively:
+The script checks prerequisites, then runs through each step automatically:
 
 1. **Create Kind cluster** with port mapping (`localhost:7001`)
 2. **Install Gateway API CRDs and Istio** as the Gateway API provider
 3. **Create the Gateway** with listeners and a NodePort service
 4. **Install MCP Gateway** CRDs, controller, and MCPGatewayExtension (the controller automatically deploys the broker-router)
 5. **Deploy test MCP servers** and register them with the gateway
-
-Each step describes what it will do and waits for confirmation before proceeding.
 
 ## Test with MCP Inspector
 
@@ -45,12 +43,18 @@ Click **Connect**, then browse and test the available tools:
 
 | Tool | Description |
 |------|-------------|
-| `test1_hi` | Simple greeting |
+| `test1_greet` | Simple greeting |
 | `test1_time` | Current time |
+| `test1_slow` | Delay N seconds |
 | `test1_headers` | HTTP header inspection |
+| `test1_add_tool` | Dynamically add a new tool |
 | `test2_hello_world` | Greeting from server 2 |
 | `test2_time` | Current time from server 2 |
 | `test2_headers` | HTTP headers from server 2 |
+| `test2_auth1234` | Auth test from server 2 |
+| `test2_slow` | Delay from server 2 |
+| `test2_set_time` | Set time from server 2 |
+| `test2_pour_chocolate_into_mold` | Chocolate mold from server 2 |
 
 ## Cleanup
 

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -10,18 +10,13 @@ You must register your MCP servers to be discovered and routed by the MCP Gatewa
 
 ## Procedure
 
-To connect an MCP server to MCP Gateway, you need:
-1. An MCPGatewayExtension resource that targets your Gateway
-2. A ReferenceGrant if the MCPGatewayExtension is in a different namespace than the Gateway
-3. An HTTPRoute that routes to your MCP server
-4. An MCPServerRegistration resource that references the HTTPRoute
+## Step 1: Ensure MCPGatewayExtension exists
 
-The MCPGatewayExtension tells the controller which Gateway this MCP Gateway instance serves. Without it, MCPServerRegistration resources will remain in NotReady status.
+An MCPGatewayExtension tells the controller which Gateway this MCP Gateway instance serves. Without it, MCPServerRegistration resources will remain in NotReady status.
 
-## Step 1: Create MCPGatewayExtension
+> **Note:** Only one MCPGatewayExtension is allowed per namespace. The `sectionName` field selects which listener on the Gateway to use, but each namespace can only have one MCPGatewayExtension. If you followed the [quick start](./quick-start.md) or [install guide](./how-to-install-and-configure.md), an MCPGatewayExtension already exists. Check with `kubectl get mcpgatewayextension -A`. If one is already present and Ready, skip to Step 2.
 
-First, create an MCPGatewayExtension in the same namespace as your MCP Gateway broker/router deployment. It should target a unique Gateway resource. 
-
+If you need to create one:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -36,17 +31,11 @@ spec:
     kind: Gateway
     name: mcp-gateway
     namespace: gateway-system
-    sectionName: mcp  # Name of the listener on the Gateway
+    sectionName: mcp  # must match a listener name on the Gateway
 EOF
 ```
 
-Wait for it to become ready:
-
-```bash
-kubectl wait --for=condition=Ready mcpgatewayextension/mcp-extension -n mcp-test --timeout=60s
-```
-
-If your target Gateway is in a different namespace than your MCPGatewayExtension, you will also need to create a ReferenceGrant:
+If your MCPGatewayExtension is in a different namespace than the Gateway, create a ReferenceGrant first:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -66,7 +55,13 @@ spec:
 EOF
 ```
 
-Skip the ReferenceGrant if the MCPGatewayExtension is in the same namespace as the Gateway.
+Wait for it to become ready:
+
+```bash
+kubectl wait --for=condition=Ready mcpgatewayextension/mcp-extension -n mcp-test --timeout=60s
+```
+
+## Step 2: Create an HTTPRoute
 
 Create an `HTTPRoute` that routes to your MCP server:
 
@@ -96,7 +91,7 @@ spec:
 EOF
 ```
 
-### Step 2: Create MCPServerRegistration Resource
+## Step 3: Create MCPServerRegistration Resource
 
 Create an `MCPServerRegistration` resource that references the HTTPRoute:
 
@@ -117,22 +112,34 @@ spec:
 EOF
 ```
 
-### Step 3: Verify Registration
+## Step 4: Verify Registration
 
-Check that the `MCPServerRegistration` was created and discovered:
+Wait for the MCPServerRegistration to become ready (the broker needs a moment to connect and discover tools):
 
 ```bash
-# Check MCPServerRegistration status
-kubectl get mcpsr -A
-
-# Check controller logs
-kubectl logs -n mcp-system deployment/mcp-gateway-controller
-
-# Check broker logs for tool discovery
-kubectl logs -n mcp-system deployment/mcp-gateway | grep "Discovered tools"
+kubectl wait --for=condition=Ready mcpsr/my-mcp-server -n mcp-test --timeout=120s
 ```
 
-### Step 4: Test Tool Discovery
+Then check the status:
+
+```bash
+kubectl get mcpsr -A
+```
+
+The `READY` column should show `True` and the `TOOLS` column should show the number of tools discovered. For example:
+
+```text
+NAMESPACE   NAME            PREFIX      TARGET                     PATH   READY   TOOLS   CREDENTIALS   AGE
+mcp-test    my-mcp-server   myserver_   mcp-api-key-server-route   /mcp   True    4                     30s
+```
+
+If the status is not Ready, check the MCPServerRegistration conditions for details:
+
+```bash
+kubectl describe mcpsr my-mcp-server -n mcp-test
+```
+
+## Step 5: Test Tool Discovery
 
 Verify that your MCP server tools are available through the gateway by using the following commands:
 
@@ -141,7 +148,7 @@ Verify that your MCP server tools are available through the gateway by using the
 # Use -D to dump headers to a file, then read the session ID
 curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 
 # Extract the MCP session ID from response headers
 SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d '\r')

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -82,8 +82,10 @@ kubectl rollout status deployment/redis -n your-namespace
 
 Create a secret containing the Redis connection URL. The secret must have the `mcp.kuadrant.io/secret: "true"` label — without it, the MCPGatewayExtension will fail validation.
 
+> **Note:** The secret must be created in the **same namespace as the MCPGatewayExtension**. The Redis deployment itself can run in any namespace — just ensure the connection string in the secret points to it correctly.
+
 ```bash
-kubectl apply -n your-namespace -f - <<EOF
+kubectl apply -n mcp-system -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -132,10 +134,10 @@ kubectl rollout status deployment/mcp-gateway -n mcp-system
 
 ## Step 5: Verify Session Sharing
 
-Confirm that the external store is active by checking the gateway logs. You should see `session cache using external store` on startup:
+Confirm that the external store is active by checking the gateway logs. You should see `cache using external redis store` on startup:
 
 ```bash
-kubectl logs -n mcp-system deployment/mcp-gateway | grep "session cache"
+kubectl logs -n mcp-system deployment/mcp-gateway | grep "cache using external"
 ```
 
 Test that sessions are shared across replicas by making multiple tool calls from the same client. The backend session ID should remain consistent regardless of which replica handles the request.

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -44,61 +44,31 @@ To force faster revocation, reduce the access token lifespan in your identity pr
 
 ## Step 3: Verify Revocation
 
-After revoking a tool, verify that the user can no longer access it.
+After revoking a tool, verify that the user can no longer access it. The simplest way is using MCP Inspector.
+
+Find your gateway address:
+
+```bash
+kubectl get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}'
+```
+
+Open MCP Inspector and connect to your gateway's `/mcp` endpoint (e.g., `http://<gateway-address>:8001/mcp`). Authenticate as the affected user through the OAuth flow.
 
 **Check `tools/list` filtering:**
 
-Authenticate as the affected user and list tools. The revoked tool should no longer appear:
-
-```bash
-# Obtain a token as the affected user, then:
-curl -X POST http://your-gateway-host/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
-```
+Under **Tools > List Tools**, the revoked tool should no longer appear in the list.
 
 **Check `tools/call` denial:**
 
-Attempt to call the revoked tool. You should receive a 403 Forbidden response:
-
-```bash
-curl -X POST http://your-gateway-host/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "revoked_tool"}}'
-```
-
-Expected response:
-
-```json
-{
-  "error": "Forbidden",
-  "message": "MCP Tool Access denied: Insufficient permissions for this tool."
-}
-```
+Attempt to call the revoked tool. Since the tool is no longer in the user's authorized set, the request should fail.
 
 ## Step 4: Monitor Revocation Enforcement
 
-Use existing observability to track denied access attempts after revocation.
-
-### Authorino Logs
-
-Authorino logs all authorization decisions, including denials. Check for authorization failures:
-
-```bash
-kubectl logs -n kuadrant-system -l app=authorino | grep -i "unauthorized\|denied\|forbidden"
-```
-
-### OpenTelemetry Traces
-
-If [OpenTelemetry](./opentelemetry.md) is enabled, the MCP Router emits trace spans for every request. Denied requests include `http.status_code: 403` on the response span. You can query your trace backend for these:
+If [OpenTelemetry](./opentelemetry.md) is enabled, denied requests appear as trace spans with `http.status_code: 403`. Query your trace backend to find them:
 
 - Filter by `http.status_code = 403`
 - Use `gen_ai.tool.name` to identify which tool was denied
 - Use `mcp.session.id` to correlate with the client session
-
-### Loki / Log Aggregation
 
 If the [observability stack](./observability.md) is deployed, query gateway logs for revocation-related activity:
 
@@ -106,7 +76,7 @@ If the [observability stack](./observability.md) is deployed, query gateway logs
 {namespace="mcp-system"} |= `x-mcp-toolname` | json | line_format "{{.msg}}"
 ```
 
-The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `tools/call` request. Combined with the 403 status from Authorino, this gives visibility into which users are attempting to call revoked tools.
+The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `tools/call` request. Combined with the 403 status, this gives visibility into which users are attempting to call revoked tools.
 
 ## Next Steps
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -189,13 +189,7 @@ kubectl describe mcpsr <name> -n <namespace>
 ```bash
 # Check MCPServerRegistration resource status
 kubectl get mcpsr -A
-kubectl describe mcpserver <server-name> -n <namespace>
-
-# Check controller logs
-kubectl logs -n mcp-system -l app=mcp-controller | grep <server-name>
-
-# Check broker logs
-kubectl logs -n mcp-system -l app=mcp-gateway | grep "Discovered tools"
+kubectl describe mcpserverregistration <server-name> -n <namespace>
 ```
 
 **Solutions**:

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -150,7 +150,7 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	})
 
 	mcpBkr.listeningMCPServer = server.NewMCPServer(
-		"Kagenti MCP Broker",
+		"Kuadrant MCP Gateway",
 		"0.0.1",
 		server.WithHooks(hooks),
 		server.WithToolCapabilities(true),

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -53,6 +53,7 @@ var managedCommandFlags = []string{
 var managedEnvVarNames = []string{
 	"TRUSTED_HEADER_PUBLIC_KEY",
 	"CACHE_CONNECTION_STRING",
+	sessionSigningKeyEnvVar,
 }
 
 func brokerRouterLabels() map[string]string {
@@ -76,7 +77,19 @@ func (r *MCPGatewayExtensionReconciler) buildBrokerRouterDeployment(mcpExt *mcpv
 	command = append(command, "--mcp-gateway-public-host="+publicHost)
 	command = append(command, "--mcp-router-key="+routerKey(mcpExt))
 
-	var envVars []corev1.EnvVar
+	envVars := []corev1.EnvVar{
+		{
+			Name: sessionSigningKeyEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: sessionSigningKeySecretName,
+					},
+					Key: sessionSigningKeyDataKey,
+				},
+			},
+		},
+	}
 	if mcpExt.Spec.TrustedHeadersKey != nil {
 		envVars = append(envVars, corev1.EnvVar{
 			Name: "TRUSTED_HEADER_PUBLIC_KEY",

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -606,20 +606,20 @@ func TestBuildBrokerRouterDeployment_TrustedHeadersKey(t *testing.T) {
 	tests := []struct {
 		name             string
 		trustedHeaderKey *mcpv1alpha1.TrustedHeadersKey
-		wantEnvVar       bool
+		wantTrustedEnv   bool
 		wantSecretName   string
 	}{
 		{
-			name:             "no env var when TrustedHeadersKey is nil",
+			name:             "no trusted header env var when TrustedHeadersKey is nil",
 			trustedHeaderKey: nil,
-			wantEnvVar:       false,
+			wantTrustedEnv:   false,
 		},
 		{
-			name: "env var set when TrustedHeadersKey has SecretName",
+			name: "trusted header env var set when TrustedHeadersKey has SecretName",
 			trustedHeaderKey: &mcpv1alpha1.TrustedHeadersKey{
 				SecretName: "my-trusted-key-secret",
 			},
-			wantEnvVar:     true,
+			wantTrustedEnv: true,
 			wantSecretName: "my-trusted-key-secret",
 		},
 	}
@@ -646,28 +646,49 @@ func TestBuildBrokerRouterDeployment_TrustedHeadersKey(t *testing.T) {
 			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080))
 			container := deployment.Spec.Template.Spec.Containers[0]
 
-			if !tt.wantEnvVar {
-				if len(container.Env) != 0 {
-					t.Errorf("expected no env vars, got %+v", container.Env)
+			// JWT_SESSION_SIGNING_KEY should always be present
+			var jwtEnv *corev1.EnvVar
+			var trustedEnv *corev1.EnvVar
+			for i := range container.Env {
+				switch container.Env[i].Name {
+				case "JWT_SESSION_SIGNING_KEY":
+					jwtEnv = &container.Env[i]
+				case "TRUSTED_HEADER_PUBLIC_KEY":
+					trustedEnv = &container.Env[i]
+				}
+			}
+
+			if jwtEnv == nil {
+				t.Fatal("expected JWT_SESSION_SIGNING_KEY env var to always be present")
+			}
+			if jwtEnv.ValueFrom == nil || jwtEnv.ValueFrom.SecretKeyRef == nil {
+				t.Fatal("expected JWT_SESSION_SIGNING_KEY to have secretKeyRef")
+			}
+			if jwtEnv.ValueFrom.SecretKeyRef.Name != sessionSigningKeySecretName {
+				t.Errorf("expected JWT secret name %q, got %q", sessionSigningKeySecretName, jwtEnv.ValueFrom.SecretKeyRef.Name)
+			}
+			if jwtEnv.ValueFrom.SecretKeyRef.Key != sessionSigningKeyDataKey {
+				t.Errorf("expected JWT secret key %q, got %q", sessionSigningKeyDataKey, jwtEnv.ValueFrom.SecretKeyRef.Key)
+			}
+
+			if !tt.wantTrustedEnv {
+				if trustedEnv != nil {
+					t.Errorf("expected no TRUSTED_HEADER_PUBLIC_KEY env var, but found one")
 				}
 				return
 			}
 
-			if len(container.Env) != 1 {
-				t.Fatalf("expected 1 env var, got %d", len(container.Env))
+			if trustedEnv == nil {
+				t.Fatal("expected TRUSTED_HEADER_PUBLIC_KEY env var to be present")
 			}
-			env := container.Env[0]
-			if env.Name != "TRUSTED_HEADER_PUBLIC_KEY" {
-				t.Errorf("expected env var name %q, got %q", "TRUSTED_HEADER_PUBLIC_KEY", env.Name)
+			if trustedEnv.ValueFrom == nil || trustedEnv.ValueFrom.SecretKeyRef == nil {
+				t.Fatal("expected TRUSTED_HEADER_PUBLIC_KEY to have secretKeyRef")
 			}
-			if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
-				t.Fatal("expected env var to have secretKeyRef")
+			if trustedEnv.ValueFrom.SecretKeyRef.Name != tt.wantSecretName {
+				t.Errorf("expected secret name %q, got %q", tt.wantSecretName, trustedEnv.ValueFrom.SecretKeyRef.Name)
 			}
-			if env.ValueFrom.SecretKeyRef.Name != tt.wantSecretName {
-				t.Errorf("expected secret name %q, got %q", tt.wantSecretName, env.ValueFrom.SecretKeyRef.Name)
-			}
-			if env.ValueFrom.SecretKeyRef.Key != "key" {
-				t.Errorf("expected secret key %q, got %q", "key", env.ValueFrom.SecretKeyRef.Key)
+			if trustedEnv.ValueFrom.SecretKeyRef.Key != "key" {
+				t.Errorf("expected secret key %q, got %q", "key", trustedEnv.ValueFrom.SecretKeyRef.Key)
 			}
 		})
 	}

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -119,7 +119,7 @@ type MCPGatewayExtensionReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;delete
@@ -210,6 +210,14 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	}
 
 	if err := r.reconcileTrustedHeaders(ctx, mcpExt); err != nil {
+		var valErr *validationError
+		if errors.As(err, &valErr) {
+			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileSessionSigningKey(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
 			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)

--- a/internal/controller/session_signing_key.go
+++ b/internal/controller/session_signing_key.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	sessionSigningKeySecretName = "mcp-gateway-session-signing-key" //nolint:gosec // not a credential
+	sessionSigningKeyDataKey    = "key"
+	sessionSigningKeyEnvVar     = "JWT_SESSION_SIGNING_KEY"
+	sessionSigningKeyBytes      = 32 // 256-bit key for HS256
+)
+
+// reconcileSessionSigningKey ensures a secret containing a random JWT signing
+// key exists. Corrupted or misconfigured secrets are repaired in-place.
+func (r *MCPGatewayExtensionReconciler) reconcileSessionSigningKey(ctx context.Context, mcpExt *mcpv1alpha1.MCPGatewayExtension) error {
+	existing := &corev1.Secret{}
+	err := r.DirectAPIReader.Get(ctx, client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: mcpExt.Namespace,
+	}, existing)
+	if err == nil {
+		needsUpdate := false
+
+		// ensure owner reference is set
+		if !hasOwnerReference(existing, mcpExt) {
+			if err := controllerutil.SetControllerReference(mcpExt, existing, r.Scheme); err != nil {
+				return fmt.Errorf("failed to set owner reference on session signing key secret: %w", err)
+			}
+			needsUpdate = true
+		}
+
+		// ensure required labels are present
+		if existing.Labels == nil {
+			existing.Labels = map[string]string{}
+		}
+		if existing.Labels[labelManagedBy] != labelManagedByValue {
+			existing.Labels[labelManagedBy] = labelManagedByValue
+			needsUpdate = true
+		}
+		if existing.Labels[ManagedSecretLabel] != ManagedSecretValue {
+			existing.Labels[ManagedSecretLabel] = ManagedSecretValue
+			needsUpdate = true
+		}
+
+		// verify key data
+		if existing.Data == nil || len(existing.Data[sessionSigningKeyDataKey]) == 0 {
+			keyBytes := make([]byte, sessionSigningKeyBytes)
+			if _, err := rand.Read(keyBytes); err != nil {
+				return fmt.Errorf("failed to generate session signing key: %w", err)
+			}
+			existing.Data = map[string][]byte{
+				sessionSigningKeyDataKey: []byte(hex.EncodeToString(keyBytes)),
+			}
+			needsUpdate = true
+			r.log.Info("regenerating corrupted session signing key", "name", sessionSigningKeySecretName)
+		}
+
+		if needsUpdate {
+			if err := r.Update(ctx, existing); err != nil {
+				return fmt.Errorf("failed to update session signing key secret: %w", err)
+			}
+		}
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check session signing key secret: %w", err)
+	}
+
+	// generate a random key
+	keyBytes := make([]byte, sessionSigningKeyBytes)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return fmt.Errorf("failed to generate session signing key: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: mcpExt.Namespace,
+			Labels: map[string]string{
+				labelManagedBy:     labelManagedByValue,
+				ManagedSecretLabel: ManagedSecretValue,
+			},
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte(hex.EncodeToString(keyBytes)),
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(mcpExt, secret, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on session signing key secret: %w", err)
+	}
+
+	r.log.Info("creating session signing key secret", "name", sessionSigningKeySecretName)
+	if err := r.Create(ctx, secret); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to create session signing key secret: %w", err)
+	}
+
+	return nil
+}
+
+func hasOwnerReference(secret *corev1.Secret, owner *mcpv1alpha1.MCPGatewayExtension) bool {
+	for _, ref := range secret.OwnerReferences {
+		if ref.UID == owner.UID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/session_signing_key_test.go
+++ b/internal/controller/session_signing_key_test.go
@@ -1,0 +1,224 @@
+package controller
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testReconciler(objs ...client.Object) *MCPGatewayExtensionReconciler {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = mcpv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+
+	return &MCPGatewayExtensionReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		DirectAPIReader: fakeClient,
+		log:             slog.Default(),
+	}
+}
+
+func testMCPExt() *mcpv1alpha1.MCPGatewayExtension {
+	return &mcpv1alpha1.MCPGatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ext",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+}
+
+func TestReconcileSessionSigningKey_CreatesSecret(t *testing.T) {
+	r := testReconciler()
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret)
+	if err != nil {
+		t.Fatalf("expected secret to be created: %v", err)
+	}
+
+	key, ok := secret.Data[sessionSigningKeyDataKey]
+	if !ok {
+		t.Fatal("secret missing key data entry")
+	}
+	if len(key) == 0 {
+		t.Fatal("secret key data is empty")
+	}
+	// hex-encoded 32 bytes = 64 characters
+	if len(key) != 64 {
+		t.Errorf("expected 64-char hex key, got %d chars", len(key))
+	}
+
+	if secret.Labels[labelManagedBy] != labelManagedByValue {
+		t.Errorf("expected managed-by label %q, got %q", labelManagedByValue, secret.Labels[labelManagedBy])
+	}
+	if secret.Labels[ManagedSecretLabel] != ManagedSecretValue {
+		t.Errorf("expected managed secret label %q=%q, got %q", ManagedSecretLabel, ManagedSecretValue, secret.Labels[ManagedSecretLabel])
+	}
+
+	// verify owner reference
+	if len(secret.OwnerReferences) == 0 {
+		t.Fatal("expected owner reference to be set")
+	}
+	if secret.OwnerReferences[0].UID != mcpExt.UID {
+		t.Errorf("expected owner UID %q, got %q", mcpExt.UID, secret.OwnerReferences[0].UID)
+	}
+}
+
+func TestReconcileSessionSigningKey_ExistingSecretIsNoop(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte("existing-key-value"),
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// verify the key was not changed
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if string(secret.Data[sessionSigningKeyDataKey]) != "existing-key-value" {
+		t.Errorf("expected key to remain unchanged, got %q", secret.Data[sessionSigningKeyDataKey])
+	}
+}
+
+func TestReconcileSessionSigningKey_EmptyKeyRegenerates(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte(""),
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if len(secret.Data[sessionSigningKeyDataKey]) != 64 {
+		t.Errorf("expected regenerated 64-char hex key, got %d chars", len(secret.Data[sessionSigningKeyDataKey]))
+	}
+}
+
+func TestReconcileSessionSigningKey_NilDataRegenerates(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if len(secret.Data[sessionSigningKeyDataKey]) != 64 {
+		t.Errorf("expected regenerated 64-char hex key, got %d chars", len(secret.Data[sessionSigningKeyDataKey]))
+	}
+}
+
+func TestReconcileSessionSigningKey_RepairsMissingLabels(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionSigningKeySecretName,
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			sessionSigningKeyDataKey: []byte("existing-key-value-that-is-valid"),
+		},
+	}
+
+	r := testReconciler(existing)
+	mcpExt := testMCPExt()
+
+	if err := r.reconcileSessionSigningKey(context.Background(), mcpExt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      sessionSigningKeySecretName,
+		Namespace: "test-ns",
+	}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+
+	// key should be unchanged
+	if string(secret.Data[sessionSigningKeyDataKey]) != "existing-key-value-that-is-valid" {
+		t.Errorf("expected key unchanged, got %q", secret.Data[sessionSigningKeyDataKey])
+	}
+
+	// labels should be repaired
+	if secret.Labels[labelManagedBy] != labelManagedByValue {
+		t.Errorf("expected managed-by label repaired, got %q", secret.Labels[labelManagedBy])
+	}
+	if secret.Labels[ManagedSecretLabel] != ManagedSecretValue {
+		t.Errorf("expected managed secret label repaired, got %q", secret.Labels[ManagedSecretLabel])
+	}
+
+	// owner reference should be added
+	if len(secret.OwnerReferences) == 0 {
+		t.Fatal("expected owner reference to be set on repair")
+	}
+	if secret.OwnerReferences[0].UID != mcpExt.UID {
+		t.Errorf("expected owner UID %q, got %q", mcpExt.UID, secret.OwnerReferences[0].UID)
+	}
+}

--- a/internal/controller/session_store.go
+++ b/internal/controller/session_store.go
@@ -71,6 +71,12 @@ func (r *MCPGatewayExtensionReconciler) enqueueMCPGatewayExtForSecret(ctx contex
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: ext.Name, Namespace: ext.Namespace},
 			})
+			continue
+		}
+		if secret.Name == sessionSigningKeySecretName {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: ext.Name, Namespace: ext.Namespace},
+			})
 		}
 	}
 	return requests

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -45,7 +45,7 @@ if [ ${#missing[@]} -gt 0 ]; then
 fi
 echo ""
 
-output "Step 1: Create Kind cluster with port mapping (localhost:7001 -> NodePort 30080)"
+output "Step 1: Create Kind cluster with port mapping (localhost:8001 -> NodePort 30080)"
 
 if kind get clusters 2>/dev/null | grep -q '^kind$'; then
     echo "Kind cluster already exists, reusing it."
@@ -63,7 +63,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 30080
-    hostPort: 7001
+    hostPort: 8001
     protocol: TCP
 EOF
 fi
@@ -121,12 +121,12 @@ echo ""
 echo "============================================================"
 echo "MCP Gateway is ready!"
 echo ""
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "To test with MCP Inspector (requires Node.js):"
 echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest"
 echo ""
-echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"
 echo ""
 echo "To clean up:"


### PR DESCRIPTION
- **Update version to 0.6.0-rc1**
- **generate JWT session signing key via controller-managed secret, instead of hardcoded default**
- **add conformance and e2e tests for release branches**
- **only deploy everything server for local dev**
- **Kagenti Broker -> Kuadrant MCP Gateway**
- **fix: align OIDC server expected audience with Keycloak client ID**
- **Merge pull request #727 from trepel/auth-setup-servers**
- **Merge pull request #730 from Kuadrant/update-quick-start-guide**
- **Merge pull request #733 from jasonmadigan/731-fix-register-guide**
- **Merge pull request #734 from Kuadrant/authentication-review**
- **Merge pull request #736 from jasonmadigan/735-fix-external-mcp-server-guide**
- **Merge pull request #738 from jasonmadigan/737-fix-tool-revocation-guide**
- **Merge pull request #744 from Kuadrant/743-fix-isolated-gateway-guide**
- **Merge pull request #747 from Kuadrant/review-authorization-guide-0.6.0-rc1**
- **Merge pull request #752 from Kuadrant/review-scaling-guide-0.6.0-rc1**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session signing key management for secure JWT operations in the broker router.
  * Expanded CI/CD automation to support release branches alongside main.

* **Chores**
  * Upgraded release version to v0.6.0-rc1 across all components.
  * Simplified local development setup to use a dedicated test server.
  * Updated local development port mapping from 7001 to 8001.
  * Updated tool naming and documentation references.
  * Enhanced documentation for registration and authorization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->