### PR TITLE
Cherry-picks for v0.6.0-rc2

### DIFF
--- a/.github/workflows/ci-docs-skip.yaml
+++ b/.github/workflows/ci-docs-skip.yaml
@@ -1,0 +1,55 @@
+name: CI Docs Skip
+
+# Provides pass statuses for required checks when only non-code files change.
+# Without this, PRs touching only these paths can never merge because the real
+# workflows use paths-ignore and never report a status for the required checks.
+# The paths list below is the union of all paths-ignore entries from
+# images.yaml, tests.yaml, and code-style.yaml.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: ['main']
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - 'charts/**'
+      - 'evals/**'
+      - 'tests/servers/**'
+      - '.coderabbit.yaml'
+      - '.gitignore'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: mcp-gateway
+          - image: mcp-controller
+    steps:
+      - run: echo "Docs-only change, skipping build"
+
+  unit-tests:
+    name: Unit Tests
+    strategy:
+      matrix:
+        go-version: [1.22.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - run: echo "Docs-only change, skipping tests"
+
+  code-style:
+    name: Code Style Checks
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change, skipping code style"

--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -39,8 +39,8 @@ jobs:
     name: Run MCP Evaluation
     runs-on: ubuntu-latest
     env:
-      MODEL_KEY: ${{ secrets.MODEL_KEY }}
-      MODEL_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.MODEL_KEY }}
+      OPENAI_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
 
     steps:
       - name: Checkout
@@ -77,52 +77,62 @@ jobs:
           echo "Gateway is ready!"
 
       - name: Setup Fallback LLM (Ollama)
-        if: env.MODEL_KEY == ''
+        if: env.OPENAI_API_KEY == ''
         uses: ai-action/setup-ollama@v2
 
       - name: Cache Ollama Models
-        if: env.MODEL_KEY == ''
+        if: env.OPENAI_API_KEY == ''
         uses: actions/cache@v4
         with:
           path: ~/.ollama
           key: ${{ runner.os }}-ollama-qwen2.5-1.5b
 
       - name: Run Agent (Fallback)
-        if: env.MODEL_KEY == ''
+        if: env.OPENAI_API_KEY == ''
         run: |
           echo "No MODEL_KEY secret found. Starting Ollama..."
-          
+
           # Start Ollama in background
           ollama serve &
-          
+
           # Wait for Ollama to be ready
           echo "Waiting for Ollama to be ready..."
           timeout 60s bash -c 'until curl -s http://localhost:11434 > /dev/null; do sleep 2; done'
-          
+
           MODEL_NAME="qwen2.5:1.5b"
-          
+
           # Pull the model (Ollama will skip if cached/present)
           echo "Pulling model $MODEL_NAME..."
           ollama pull $MODEL_NAME
-          
+
           # Configure environment for mcpchecker
-          echo "MODEL_BASE_URL=http://localhost:11434/v1" >> $GITHUB_ENV
-          echo "MODEL_KEY=ollama" >> $GITHUB_ENV
-          
+          echo "OPENAI_BASE_URL=http://localhost:11434/v1" >> $GITHUB_ENV
+          echo "OPENAI_API_KEY=ollama" >> $GITHUB_ENV
+
           # Update agent.yaml to use the fallback model
-          sed -i "s/model: .*/model: \"$MODEL_NAME\"/" evals/gemini-agent/agent.yaml
-          
+          sed -i "s/model: .*/model: \"openai:$MODEL_NAME\"/" evals/gemini-agent/agent.yaml
+
           echo "Ollama setup complete using model $MODEL_NAME"
 
-      - name: Run mcpchecker (Manual)
+      - name: Run mcpchecker
         run: |
           echo "Installing mcpchecker..."
           go install github.com/mcpchecker/mcpchecker/cmd/mcpchecker@latest
-          
+
           echo "Running mcpchecker..."
-          # Ensure GOBIN is in PATH if not already (github actions usually has it)
           export PATH=$PATH:$(go env GOPATH)/bin
           mcpchecker check --verbose evals/gemini-agent/eval.yaml
+
+      - name: Verify Results
+        if: always()
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          RESULTS_FILE=$(ls mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -z "$RESULTS_FILE" ]; then
+            echo "No results file found — mcpchecker may have crashed"
+            exit 1
+          fi
+          mcpchecker verify --task 1.0 --assertion 1.0 "$RESULTS_FILE"
 
       - name: Upload Evaluation Results
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file provides guidance to AI Agents when working with this repository.
 MCP Gateway is an Envoy-based gateway for Model Context Protocol (MCP) servers. Single binary (`mcp-broker-router`) with three components:
 - **MCP Router**: Envoy external processor that routes MCP requests (gRPC on :50051)
 - **MCP Broker**: HTTP service that aggregates tools from multiple MCP servers (HTTP on :8080/mcp)
-- **MCP Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
+- **MCP Gateway Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ This allows AuthPolicy to validate the OAuth token while backends receive their 
 ## Test Servers
 
 Six test servers in `config/test-servers/`:
-- **Server1**: Go SDK (tools: hi, time, slow, headers)
+- **Server1**: Go SDK (tools: greet, time, slow, headers)
 - **Server2**: Go SDK (tools: hello_world, time, headers, auth1234, slow)
 - **Server3**: Python FastMCP (tools: time, add, dozen, pi, get_weather, slow)
 - **API Key Server**: Validates Bearer token authentication (tool: hello_world)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with this repository.
 MCP Gateway is an Envoy-based gateway for Model Context Protocol (MCP) servers. Single binary (`mcp-broker-router`) with three components:
 - **MCP Router**: Envoy external processor that routes MCP requests (gRPC on :50051)
 - **MCP Broker**: HTTP service that aggregates tools from multiple MCP servers (HTTP on :8080/mcp)
-- **MCP Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
+- **MCP Gateway Controller**: Kubernetes controller that discovers MCP servers via MCPServerRegistration CRDs (optional, `--controller` flag)
 
 # Exploration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ This allows AuthPolicy to validate the OAuth token while backends receive their 
 ## Test Servers
 
 Test servers in `config/test-servers/`:
-- **Server1**: Go SDK (tools: hi, time, slow, headers)
+- **Server1**: Go SDK (tools: greet, time, slow, headers)
 - **Server2**: Go SDK (tools: hello_world, time, headers, auth1234, slow)
 - **Server3**: Python FastMCP (tools: time, add, dozen, pi, get_weather, slow)
 - **API Key Server**: Validates Bearer token authentication (tool: hello_world)

--- a/Makefile
+++ b/Makefile
@@ -233,13 +233,13 @@ deploy-redis: ## deploy redis to mcp-system namespace
 
 .PHONY: configure-redis
 configure-redis: deploy-redis ## deploy redis and patch deployment with redis connection
-	kubectl patch deployment $(BROKER_ROUTER_NAME) -n mcp-system --patch-file config/mcp-gateway/overlays/mcp-system/deployment-controller-redis-patch.yaml
+	kubectl patch deployment $(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) --patch-file config/mcp-gateway/overlays/mcp-system/deployment-controller-redis-patch.yaml
 
 # Deploy only the controller
 deploy-controller: install-crd ## Deploy only the controller
 	kubectl apply -k config/mcp-gateway/overlays/mcp-system/
 	@echo "Waiting for controller to be ready..."
-	@kubectl wait --for=condition=Available deployment/mcp-controller -n mcp-system --timeout=$(WAIT_TIME)
+	@kubectl wait --for=condition=Available deployment/mcp-gateway-controller -n mcp-system --timeout=$(WAIT_TIME)
 	@echo "Waiting for MCPGatewayExtension to be ready..."
 	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n mcp-system --timeout=$(WAIT_TIME)
 	@echo "Controller and broker-router are ready"
@@ -256,8 +256,8 @@ endef
 
 .PHONY: restart-all
 restart-all:
-	kubectl rollout restart deployment/$(BROKER_ROUTER_NAME) -n mcp-system 2>/dev/null || true
-	kubectl rollout restart deployment/mcp-controller -n mcp-system 2>/dev/null || true
+	kubectl rollout restart deployment/$(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) 2>/dev/null || true
+	kubectl rollout restart deployment/mcp-gateway-controller -n $(MCP_GATEWAY_NAMESPACE) 2>/dev/null || true
 
 .PHONY: build-and-load-image
 build-and-load-image: kind build-image load-image restart-all  ## Build & load router/broker/controller image into the Kind cluster and restart
@@ -287,7 +287,7 @@ deploy-example: install-crd ## Deploy example MCPServerRegistration resource
 	kubectl apply -f config/samples/mcpserverregistration-test-servers-base.yaml
 	kubectl apply -f config/samples/mcpserverregistration-test-servers-extended.yaml
 	@echo "Waiting for broker-router to be ready..."
-	@kubectl wait --for=condition=Available deployment/$(BROKER_ROUTER_NAME) -n mcp-system --timeout=$(WAIT_TIME)
+	@kubectl wait --for=condition=Available deployment/$(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) --timeout=$(WAIT_TIME)
 
 # Deploy example MCPServerRegistration for everything server only
 deploy-example-minimal: install-crd ## Deploy MCPServerRegistration for everything server
@@ -410,8 +410,8 @@ endef
 reload-controller: build kind ## Build, load to Kind, and restart controller
 	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --file Dockerfile.controller -t $(IMAGE_TAG_BASE):$(IMAGE_TAG) .
 	$(call load-image,$(IMAGE_TAG_BASE):$(IMAGE_TAG))
-	@kubectl rollout restart -n mcp-system deployment/mcp-controller
-	@kubectl rollout status -n mcp-system deployment/mcp-controller --timeout=60s
+	@kubectl rollout restart -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller
+	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller --timeout=60s
 
 .PHONY: reload-broker
 reload-broker: build docker-build kind ## Build, load to Kind, and restart broker
@@ -422,8 +422,8 @@ reload-broker: build docker-build kind ## Build, load to Kind, and restart broke
 .PHONY: reload
 reload: build docker-build kind ## Build, load to Kind, and restart both controller and broker
 	$(call reload-image)
-	@kubectl rollout restart -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-controller deployment/$(BROKER_ROUTER_NAME)
-	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE)deployment/mcp-controller --timeout=60s
+	@kubectl rollout restart -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller deployment/$(BROKER_ROUTER_NAME)
+	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller --timeout=60s
 	@kubectl rollout status -n $(MCP_GATEWAY_NAMESPACE) deployment/$(BROKER_ROUTER_NAME) --timeout=60s
 
 ##@ E2E Testing
@@ -726,9 +726,9 @@ ifeq ($(ISTIO_TRACING),1)
 		-p='{"spec":{"values":{"meshConfig":{"enableTracing":true,"defaultConfig":{"tracing":{}},"extensionProviders":[{"name":"tempo-otlp","opentelemetry":{"port":4317,"service":"$(OTEL_COLLECTOR_HOST)"}}]}}}}'
 	@sleep 5
 endif
-	kubectl set env deployment/mcp-gateway -n mcp-system \
+	kubectl set env deployment/mcp-gateway -n $(MCP_GATEWAY_NAMESPACE) \
 		OTEL_EXPORTER_OTLP_ENDPOINT="$(OTEL_COLLECTOR_HTTP)" OTEL_EXPORTER_OTLP_INSECURE="true"
-	@kubectl rollout status deployment/mcp-gateway -n mcp-system --timeout=120s
+	@kubectl rollout status deployment/mcp-gateway -n $(MCP_GATEWAY_NAMESPACE) --timeout=120s
 ifeq ($(AUTH_TRACING),1)
 	@if ! kubectl get authorino -n kuadrant-system 2>/dev/null | grep -q authorino; then \
 		$(MAKE) auth-example-setup; \

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This will:
 - Configure the mcp-broker with OAuth environment variables
 - Apply AuthPolicy for token validation/exchange on the /mcp endpoint, including tool authorization via keycloak group mappings (both via Keycloak)
 - Apply additional OAuth configurations
+- Deploy several test MCP servers including OIDC-enabled MCP server
 
 The mcp-broker now serves OAuth discovery information at `/.well-known/oauth-protected-resource`.
 

--- a/api/v1alpha1/mcpgatewayextension_types.go
+++ b/api/v1alpha1/mcpgatewayextension_types.go
@@ -207,8 +207,9 @@ type MCPGatewayExtensionTargetReference struct {
 
 	// sectionName is the name of a listener on the target Gateway. The controller will
 	// read the listener's port and hostname to configure the MCP Gateway instance.
-	// This allows multiple MCPGatewayExtensions to target different listeners on the
-	// same Gateway, each with their own MCP Gateway instance.
+	// Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+	// different namespaces may target different listeners on the same Gateway, provided
+	// those listeners use different ports.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253

--- a/build/auth.mk
+++ b/build/auth.mk
@@ -14,7 +14,7 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo ""
 	@echo "Prerequisites: make local-env-setup should be completed"
 	@echo ""
-	@echo "Step 1/5: Configuring OAuth environment variables..."
+	@echo "Step 1/6: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-gateway \
 		OAUTH_RESOURCE_NAME="MCP Server" \
 		OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
@@ -24,23 +24,28 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 		-n mcp-system
 	@echo "✅ OAuth environment variables configured"
 	@echo ""
-	@echo "Step 2/5: Installing Vault..."
+	@echo "Step 2/6: Installing Vault..."
 	@bin/kustomize build config/vault | bin/yq 'select(.kind == "Deployment").spec.template.spec.containers[0].args += ["-dev-root-token-id=root"] | .' | kubectl apply -f -
 	@echo "✅ Vault installed"
 	@echo ""
-	@echo "Step 3/5: Applying AuthPolicy configurations..."
+	@echo "Step 3/6: Applying AuthPolicy configurations..."
 	@kubectl apply -k ./config/samples/oauth-token-exchange/
 	@kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
 		-p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
 	@echo "✅ AuthPolicy configurations applied"
 	@echo ""
-	@echo "Step 4/5: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
+	@echo "Step 4/6: Configuring CORS rules for the OpenID Connect Client Registration endpoint..."
 	@kubectl apply -f ./config/keycloak/preflight_envoyfilter.yaml
 	@echo "✅ CORS configured"
 	@echo ""
-	@echo "Step 5/5: Patch Authorino deployment to be able to connect to Keycloak..."
+	@echo "Step 5/6: Patch Authorino deployment to be able to connect to Keycloak..."
 	@./utils/patch-authorino-to-keycloak.sh
 	@echo "✅ Authorino deployment patched"
+	@echo ""
+	@echo "Step 6/6: Deploying test MCP servers..."
+	@"$(MAKE)" deploy-test-servers
+	@"$(MAKE)" deploy-example
+	@echo "✅ Test MCP servers deployed and configured"
 	@echo ""
 	@echo "🎉 OAuth example setup complete!"
 	@echo ""

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -63,7 +63,7 @@ ci-auth-setup: cert-manager-install kuadrant-install ## Setup auth infrastructur
 .PHONY: ci-debug-logs
 ci-debug-logs: ## Collect logs for debugging CI failures
 	@echo "=== Controller logs ==="
-	-$(KUBECTL) logs -n mcp-system deployment/mcp-controller --tail=100
+	-$(KUBECTL) logs -n mcp-system deployment/mcp-gateway-controller --tail=100
 	@echo "=== MCPGatewayExtensions ==="
 	-$(KUBECTL) get mcpgatewayextensions -A
 	@echo "=== MCPServerRegistrations ==="

--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -48,8 +48,8 @@ test-e2e-auth-ci: test-e2e-deps enable-debug-logging ## Run auth e2e tests only 
 
 .PHONY: enable-debug-logging
 enable-debug-logging: ## Enable debug logging on controller and wait for restart
-	@echo "Enabling debug logging on mcp-controller..."
-	kubectl patch deployment mcp-controller -n mcp-system --type='json' \
+	@echo "Enabling debug logging on mcp-gateway-controller..."
+	kubectl patch deployment mcp-gateway-controller -n mcp-system --type='json' \
 		-p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["./mcp_controller", "--log-level=-4"]}]'
 	@echo "Waiting for controller rollout..."
-	kubectl rollout status deployment/mcp-controller -n mcp-system --timeout=120s
+	kubectl rollout status deployment/mcp-gateway-controller -n mcp-system --timeout=120s

--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -24,7 +24,7 @@ test-e2e: ci-setup test-e2e-run ## Run full e2e test suite (setup + run)
 .PHONY: test-e2e-happy
 test-e2e-happy: test-e2e-deps ## Quick e2e test run for local development (no setup)
 	@echo "Running e2e tests (local mode)..."
-	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --focus="[Happy]" ./tests/e2e
+	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --focus="\[Happy\]" ./tests/e2e
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: ## Clean up e2e test resources

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -10,7 +10,7 @@ setup-cluster-base: tools kind-create-cluster build-and-load-image gateway-api-i
 deploy-controller-only: ## Deploy only the controller (tests create their own MCPGatewayExtensions)
 	$(KUBECTL) apply -k config/mcp-gateway/overlays/ci/
 	@echo "Waiting for controller to be ready..."
-	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-controller -n mcp-system
+	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-gateway-controller -n mcp-system
 
 # Wait for test server deployments
 .PHONY: wait-test-servers

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ spec:
         - label:
             app: mcp-controller
             component: controller
-          name: mcp-controller
+          name: mcp-gateway-controller
           spec:
             replicas: 1
             selector:

--- a/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -130,8 +130,9 @@ spec:
                     description: |-
                       sectionName is the name of a listener on the target Gateway. The controller will
                       read the listener's port and hostname to configure the MCP Gateway instance.
-                      This allows multiple MCPGatewayExtensions to target different listeners on the
-                      same Gateway, each with their own MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/charts/README.md
+++ b/charts/README.md
@@ -7,7 +7,7 @@ This directory contains the Helm chart for deploying MCP Gateway to Kubernetes.
 ## Overview
 
 The MCP Gateway Helm chart deploys:
-- **MCP Controller**: Manages MCPGatewayExtension, MCPServerRegistration, and MCPVirtualServer custom resources
+- **MCP Gateway Controller**: Manages MCPGatewayExtension, MCPServerRegistration, and MCPVirtualServer custom resources
 - **MCPGatewayExtension**: Custom resource that triggers the controller to deploy the broker-router
 - **Custom Resource Definitions (CRDs)**: MCPGatewayExtension, MCPServerRegistration, and MCPVirtualServer
 - **RBAC**: Service accounts, roles, and bindings for secure operation

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -130,8 +130,9 @@ spec:
                     description: |-
                       sectionName is the name of a listener on the target Gateway. The controller will
                       read the listener's port and hostname to configure the MCP Gateway instance.
-                      This allows multiple MCPGatewayExtensions to target different listeners on the
-                      same Gateway, each with their own MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/charts/mcp-gateway/templates/_helpers.tpl
+++ b/charts/mcp-gateway/templates/_helpers.tpl
@@ -54,6 +54,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Controller selector labels - distinct from broker to avoid service selector overlap
+*/}}
+{{- define "mcp-gateway.controllerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}-controller
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the controller service account to use
 */}}
 {{- define "mcp-gateway.controllerServiceAccountName" -}}

--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -11,13 +11,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
-      component: controller
+      {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "mcp-gateway.selectorLabels" . | nindent 8 }}
-        component: controller
+        {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
       containers:

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -17,11 +17,12 @@ echo "Using local chart: $USE_LOCAL_CHART"
 echo "Setting up MCP Gateway using Helm chart..."
 
 # Create Kind cluster with inline configuration (skip if already exists)
-if kind get clusters 2>/dev/null | grep -q '^kind$'; then
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-mcp-gateway}
+if kind get clusters 2>/dev/null | grep -Fxq -- "$KIND_CLUSTER_NAME"; then
     echo "Kind cluster already exists, reusing it."
 else
     echo "Creating Kind cluster..."
-    cat <<EOF | kind create cluster --config=-
+    cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -42,7 +43,7 @@ nodes:
 EOF
 fi
 
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
 
 helm repo add istio https://istio-release.storage.googleapis.com/charts
 helm repo update

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -34,10 +34,10 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 30080
-    hostPort: 7001
+    hostPort: 8001
     protocol: TCP
   - containerPort: 30089
-    hostPort: 7002
+    hostPort: 8002
     protocol: TCP
 EOF
 fi
@@ -130,7 +130,7 @@ echo "================================================================"
 echo "Setup complete!"
 echo "================================================================"
 echo "MCP Inspector: http://localhost:6274"
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "Check status:"
 echo "  kubectl get pods -n mcp-system"
@@ -141,7 +141,7 @@ echo ""
 echo "Press Ctrl+C to stop and cleanup."
 echo "================================================================"
 
-open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:7001/mcp"
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8001/mcp"
 
 # Cleanup function
 cleanup() {

--- a/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -130,8 +130,9 @@ spec:
                     description: |-
                       sectionName is the name of a listener on the target Gateway. The controller will
                       read the listener's port and hostname to configure the MCP Gateway instance.
-                      This allows multiple MCPGatewayExtensions to target different listeners on the
-                      same Gateway, each with their own MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mcp-controller
+  name: mcp-gateway-controller
   labels:
     app: mcp-controller
     component: controller

--- a/config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml
+++ b/config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/redis:7-alpine
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mcp-controller
+  name: mcp-gateway-controller
   namespace: mcp-system
   labels:
     app: mcp-controller

--- a/config/mcp-system/redis-deployment.yaml
+++ b/config/mcp-system/redis-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/redis:7-alpine
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis

--- a/config/samples/mcpserverregistration-test-servers-base.yaml
+++ b/config/samples/mcpserverregistration-test-servers-base.yaml
@@ -10,7 +10,7 @@ spec:
   # Tool prefix applied to all servers in this MCPServer
   toolPrefix: test1_
   targetRef:
-    # Server 1 - Go SDK based (hi, time, slow, headers tools)
+    # Server 1 - Go SDK based (greet, time, slow, headers tools)
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server1-route

--- a/config/samples/singleserver.yaml
+++ b/config/samples/singleserver.yaml
@@ -9,7 +9,7 @@ spec:
   # Tool prefix applied to all servers in this MCPServer
   toolPrefix: test_
   targetRef:
-    # Server 1 - Go SDK based (hi, time, slow, headers tools)
+    # Server 1 - Go SDK based (greet, time, slow, headers tools)
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server1-route

--- a/config/test-servers/CLAUDE.md
+++ b/config/test-servers/CLAUDE.md
@@ -1,7 +1,7 @@
 # Test Servers
 
 Test servers in `config/test-servers/`:
-- **Server1**: Go SDK (tools: hi, time, slow, headers)
+- **Server1**: Go SDK (tools: greet, time, slow, headers)
 - **Server2**: Go SDK (tools: hello_world, time, headers, auth1234, slow)
 - **Server3**: Python FastMCP (tools: time, add, dozen, pi, get_weather, slow)
 - **API Key Server**: Validates Bearer token authentication (tool: hello_world)

--- a/docs/design/backend-mcp-management.md
+++ b/docs/design/backend-mcp-management.md
@@ -2,7 +2,7 @@
 
 ### Problem
 
-The MCP Gateway needs to discover and register backend MCP servers so that their tools can be aggregated and presented to clients as a unified MCP server. When an MCPServerRegistration custom resource is created or updated in Kubernetes, the MCP Controller must:
+The MCP Gateway needs to discover and register backend MCP servers so that their tools can be aggregated and presented to clients as a unified MCP server. When an MCPServerRegistration custom resource is created or updated in Kubernetes, the MCP Gateway Controller must:
 
 1. Discover the MCP server endpoint from the referenced HTTPRoute
 2. Update the broker and router configuration
@@ -18,7 +18,7 @@ The broker needs a robust mechanism to manage the lifecycle of each upstream MCP
 
 The MCP Gateway uses a two-phase registration process:
 
-1. **Controller Phase**: The MCP Controller watches for MCPServerRegistration resources, discovers server endpoints from HTTPRoutes, and writes aggregated configuration to ConfigMaps
+1. **Controller Phase**: The MCP Gateway Controller watches for MCPServerRegistration resources, discovers server endpoints from HTTPRoutes, and writes aggregated configuration to ConfigMaps
 2. **Broker Phase**: The MCP Broker reads configuration changes and manages each upstream MCP server through an `MCPManager` struct that handles the full lifecycle of the connection
 
 Each upstream MCP server is managed by a dedicated `MCPManager` instance that runs as a background routine, handling:
@@ -31,7 +31,7 @@ Each upstream MCP server is managed by a dedicated `MCPManager` instance that ru
 
 ```mermaid
 sequenceDiagram
-  participant Controller as MCP Controller
+  participant Controller as MCP Gateway Controller
   participant ConfigMap as ConfigMap
   participant Broker as MCP Broker
   participant Manager as MCPManager

--- a/docs/design/isolated-gateway-deployment.md
+++ b/docs/design/isolated-gateway-deployment.md
@@ -13,7 +13,7 @@
 
 > Note: The existing MCP controller component is expected to evolve into a full MCP operator capable of both reconciling MCPServerRegistration instances and deploying MCP Gateway instances into targeted namespaces. This design reflects a step towards that future.
 
-The existing behavior of the MCP Controller, which has remained in place from the proof of concept (PoC), is to:
+The existing behavior of the MCP Gateway Controller, which has remained in place from the proof of concept (PoC), is to:
 1. Discover all MCPServerRegistration resources across the cluster
 2. Construct a unified MCP configuration from them
 3. Create that configuration in a known secret in the `mcp-system` namespace
@@ -73,7 +73,7 @@ spec:
 
 ### MCPGatewayExtension Controller Behavior
 
-The MCP Controller will reconcile this new resource in a dedicated MCPGatewayExtension controller. This controller will:
+The MCP Gateway Controller will reconcile this new resource in a dedicated MCPGatewayExtension controller. This controller will:
 
 1. Verify that if an MCPGatewayExtension targets a Gateway in another namespace, an associated ReferenceGrant exists
 2. Update the MCPGatewayExtension status accordingly (without revealing whether the targeted Gateway resource exists)
@@ -101,7 +101,7 @@ In this initial phase, users will use the Helm charts to deploy the broker and r
 
 **Diagram**
 
-> Note: The MCP Controller does not need to be in the same namespace as the MCPGatewayExtension. It is shown that way here purely to reduce noise.
+> Note: The MCP Gateway Controller does not need to be in the same namespace as the MCPGatewayExtension. It is shown that way here purely to reduce noise.
 
 ![Isolated Gateway Deployment Diagram](./images/isolated-gateway.jpg)
 

--- a/docs/design/routing.md
+++ b/docs/design/routing.md
@@ -16,11 +16,11 @@ MCP Gateway router component as ext_proc intercept all requests hitting the /mcp
 
 ### The Router
 
-The router component is configured to know about the different backend MCP Servers that have been registered. This MCPSever configuration is managed by the MCP Controller component. The router should also be configured with the public listener hostname via `required` flag `--mcp-gateway-public-host`. The router intercepts all requests to the gateway MCP listener before routing has happened and based on its configuration decides whether the request should be processed by the MCP Broker or configure the routing to ensure the request is sent to the correct MCP Server. The router only re-routes `tools/calls` but validates all calls hitting the MCP gateway listener to ensure clients cannot explicitly bypass the broker (note they can never bypass the router).
+The router component is configured to know about the different backend MCP Servers that have been registered. This MCPSever configuration is managed by the MCP Gateway Controller component. The router should also be configured with the public listener hostname via `required` flag `--mcp-gateway-public-host`. The router intercepts all requests to the gateway MCP listener before routing has happened and based on its configuration decides whether the request should be processed by the MCP Broker or configure the routing to ensure the request is sent to the correct MCP Server. The router only re-routes `tools/calls` but validates all calls hitting the MCP gateway listener to ensure clients cannot explicitly bypass the broker (note they can never bypass the router).
 
 #### The MCPServerRegistration resource
 
-The MCP Server resource is a Kubernetes CRD used to register and configure an MCP server to be exposed via the Gateway. It targets a HTTPRoute and sets some additional configuration. This resource is reconciled by the MCP Controller into configuration that the router can consume to make routing decisions.
+The MCP Server resource is a Kubernetes CRD used to register and configure an MCP server to be exposed via the Gateway. It targets a HTTPRoute and sets some additional configuration. This resource is reconciled by the MCP Gateway Controller into configuration that the router can consume to make routing decisions.
 
 ### The Gateway Listeners
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -119,7 +119,10 @@ kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/con
 kubectl wait --for=condition=available --timeout=90s deployment/authorino -n kuadrant-system
 
 # Patch Authorino deployment to resolve Keycloak's host name to MCP gateway IP (Development environment only):
-export GATEWAY_IP=$(kubectl get gateway/mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)
+export GATEWAY_IP=$(kubectl get gateway/mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+if [ -z "$GATEWAY_IP" ]; then
+  GATEWAY_IP=$(kubectl get pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system -o jsonpath='{.items[0].status.podIP}')
+fi
 kubectl patch deployment authorino -n kuadrant-system --type='json' -p="[
   {
     \"op\": \"add\",
@@ -199,7 +202,9 @@ curl http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
 #   ],
 #   "scopes_supported": [
 #     "basic",
-#     "groups"
+#     "groups",
+#     "roles",
+#     "profile"
 #   ]
 # }
 ```
@@ -225,6 +230,8 @@ You should get a response like this:
 ## Step 5: Test Authentication Flow
 
 Use the MCP Inspector to test the complete OAuth flow.
+
+> **Note:** If you set up your cluster using the [Quick Start Guide](./quick-start.md), Keycloak (port 8002) is not exposed to the host. Run `kubectl port-forward -n gateway-system svc/mcp-gateway-np 8002:8002` in a separate terminal before proceeding.
 
 ```bash
 # Start MCP Inspector (requires Node.js/npm)

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -47,7 +47,7 @@ The issued OAuth token should include claims similar to:
 }
 ```
 
-> **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of both `accounting` group, which map to different tool permissions.
+> **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of the `accounting` group, which maps to specific tool permissions.
 
 ## Step 2: Configure Tool-Level Authorization
 
@@ -133,13 +133,13 @@ open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-
 
 **Test Scenarios:**
 
-1. **Login as mcp/mcp** (has both `accounting` and `developers` groups)
+1. **Login as mcp/mcp** (has `accounting` and `engineering` groups)
 2. **Try allowed tools**:
    - `test1_greet`
    - `test2_headers`
    - `test3_add`
 3. **Try restricted tools**:
-   - `apikey_hello_world` - Should return 403 Forbidden
+   - `test1_time` - Should return 403 Forbidden (accounting group only has the `greet` role for test-server1)
 
 ## Alternative Authorization Mechanisms
 
@@ -154,7 +154,7 @@ Monitor authorization decisions:
 kubectl get authpolicy -A
 
 # View authorization logs
-kubectl logs -n kuadrant-system -l app=authorino
+kubectl logs -n kuadrant-system -l authorino-resource=authorino
 ```
 
 ## Next Steps

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -5,32 +5,31 @@ This guide covers adding an MCP listener to your existing Gateway. The controlle
 
 ## Prerequisites
 
-- MCP Gateway installed in your cluster
-- Existing Gateway resource
-- Gateway API Provider (Istio) configured
+- MCP Gateway [installed in your cluster](./quick-start-guide.md)
+- Existing [Gateway](https://gateway-api.sigs.k8s.io/) resource
+- Gateway API provider (e.g. Istio) configured
 
 ## Step 1: Add MCP Listener to Gateway
 
-Add a listener for MCP traffic to your existing Gateway:
+Add a listener for MCP traffic to your existing Gateway. Patch it to add a new listener entry:
 
-```yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: your-gateway-name
-  namespace: your-gateway-namespace
+```bash
+kubectl patch gateway your-gateway-name -n your-gateway-namespace --type merge -p '
 spec:
-  gatewayClassName: istio
   listeners:
-  # ... your existing listeners ...
   - name: mcp
-    hostname: 'mcp.127-0-0-1.sslip.io'  # Change to your hostname
+    hostname: "mcp.example.com"
     port: 8080
     protocol: HTTP
     allowedRoutes:
       namespaces:
         from: All
+'
 ```
+
+Replace `your-gateway-name`, `your-gateway-namespace`, and the hostname with your values. The hostname must resolve to your Gateway's external address.
+
+> **Note:** The patch above replaces all listeners. To preserve existing listeners, use a JSON patch or edit the Gateway directly with `kubectl edit gateway your-gateway-name -n your-gateway-namespace`.
 
 > **Important:** If you installed MCP Gateway using Helm, ensure the `gateway.publicHost` value in your Helm values matches the hostname above. For example:
 > ```bash
@@ -56,8 +55,9 @@ kubectl get httproute mcp-gateway-route -n mcp-system
 
 If you need a custom HTTPRoute (e.g. with CORS headers, additional path rules, or OAuth well-known endpoints), disable automatic creation and manage your own:
 
-1. Set `httpRouteManagement: Disabled` on your MCPGatewayExtension:
+1. Find your MCPGatewayExtension name and set `httpRouteManagement: Disabled`:
    ```bash
+   kubectl get mcpgatewayextension -n mcp-system
    kubectl patch mcpgatewayextension -n mcp-system your-extension-name \
      --type merge -p '{"spec":{"httpRouteManagement":"Disabled"}}'
    ```
@@ -79,6 +79,7 @@ If you need a custom HTTPRoute (e.g. with CORS headers, additional path rules, o
      parentRefs:
        - name: your-gateway-name
          namespace: your-gateway-namespace
+         sectionName: mcp
      hostnames:
        - 'mcp.127-0-0-1.sslip.io'
      rules:
@@ -141,7 +142,7 @@ If you see the EnvoyFilter, you can proceed to verification. If the EnvoyFilter 
 Test that the MCP endpoint is accessible through your Gateway:
 
 ```bash
-curl -X POST http://mcp.127-0-0-1.sslip.io:8080/mcp \
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize"}'
 ```
@@ -149,7 +150,7 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8080/mcp \
 You should get a response like this:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Kagenti MCP Broker","version":"0.0.1"}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Kuadrant MCP Gateway","version":"0.0.1"}}}
 ```
 
 ## Next Steps

--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -159,7 +159,7 @@ The `mcp.kuadrant.io/secret=true` label is required. Without it the MCPServerReg
 
 ## Step 5: Create the MCPServerRegistration Resource
 
-Create the `MCPServer` resource that registers the GitHub MCP server with the gateway:
+Create the `MCPServerRegistration` resource that registers the GitHub MCP server with the gateway:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -213,37 +213,24 @@ This AuthPolicy extracts the API key from the OAuth token and sets it as the `x-
 
 **Note:** This step is only required if you're using AuthPolicy for OAuth authentication. For simple bearer token auth, the router handles the Authorization header automatically.
 
-## Step 7: Wait for Configuration Sync
+## Step 7: Verify the Registration
 
-Wait for the configuration to sync to the broker:
-
-```bash
-echo "Waiting for GitHub tools to be discovered..."
-until kubectl logs -n mcp-system deploy/mcp-gateway | grep "Discovered.*tools.*github"; do
-  echo "Still waiting..."
-  sleep 5
-done
-echo "GitHub tools discovered!"
-```
-
-## Verification
-
-Check that the MCPServerRegistration is registered:
+Wait for the MCPServerRegistration to become ready:
 
 ```bash
-kubectl get mcpsrs -n mcp-test
-kubectl logs -n mcp-system deployment/mcp-gateway | grep "Discovered.*tools.*github"
+kubectl get mcpsr -n mcp-test
 ```
+
+The `github` entry should show `READY = True` and a non-zero `TOOLS` count:
+
+```text
+NAME     PREFIX    TARGET                PATH   READY   TOOLS   CREDENTIALS    AGE
+github   github_   github-mcp-external   /mcp   True    41      github-token   30s
+```
+
+If `READY` is still `False`, wait a few seconds and re-run the command.
 
 ## Test Integration
-
-Test tools/list through the gateway:
-
-```bash
-curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
-```
 
 To test tool calls, open the MCP Inspector:
 
@@ -259,7 +246,7 @@ associated with your access token.
 ## Cleanup
 
 ```bash
-kubectl delete mcpserver github -n mcp-test
+kubectl delete mcpserverregistration github -n mcp-test
 kubectl delete httproute github-mcp-external -n mcp-test
 kubectl delete serviceentry github-mcp-external -n mcp-test
 kubectl delete destinationrule github-mcp-external -n mcp-test

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -56,7 +56,7 @@ helm upgrade -i mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ```
 
 This automatically installs:
-- **MCP Controller** - Watches MCPGatewayExtension and MCPServerRegistration resources
+- **MCP Gateway Controller** - Watches MCPGatewayExtension and MCPServerRegistration resources
 - **MCPGatewayExtension** - Custom resource targeting your Gateway
 
 When the MCPGatewayExtension becomes ready, the controller automatically creates:

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -51,7 +51,7 @@ Note: CRDs are also installed automatically when deploying the controller via He
 ┌──────────────────────────────────────────────────────────────────────┐
 │                        MCP System Namespace                          │
 ├──────────────────────────────────────────────────────────────────────┤
-│                    MCP Controller (cluster-wide)                     │
+│                 MCP Gateway Controller (cluster-wide)                │
 └──────────────────────────────────────────────────────────────────────┘
                                     │
               ┌─────────────────────┴─────────────────────┐
@@ -89,9 +89,9 @@ export TEAM_A_HOST="team-a.127-0-0-1.sslip.io"
 export TEAM_B_HOST="team-b.127-0-0-1.sslip.io"
 ```
 
-## Step 3: Deploy the MCP Controller
+## Step 3: Deploy the MCP Gateway Controller
 
-The MCP Controller runs cluster-wide and reconciles MCPGatewayExtension and MCPServerRegistration resources. Deploy it once in a central namespace:
+The MCP Gateway Controller runs cluster-wide and reconciles MCPGatewayExtension and MCPServerRegistration resources. Deploy it once in a central namespace:
 
 ```bash
 helm upgrade -i mcp-controller ./charts/mcp-gateway \

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -193,7 +193,7 @@ kubectl get pods -n team-b
 
 ## Step 8: Expose Gateways Externally
 
-### OpenShift (Routes)
+### OpenShift
 
 OpenShift Routes expose the Gateways externally with TLS termination.
 
@@ -248,21 +248,49 @@ Verify routes are created:
 oc get routes -n gateway-system
 ```
 
-## Exposing via NodePort
+### Kubernetes (NodePort)
 
-For a local kind or kubernetes setup you can configure helm to setup the NodePort service. Re-run the commands with the following flags set
+Re-run the Team A and Team B Helm commands from Steps 4 and 6 with NodePort flags added:
 
 ```bash
-# Team A gateway
---set gateway.nodePort.create=true \
---set gateway.nodePort.mcpPort=30080 \
+helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
+  --namespace team-a \
+  --set controller.enabled=false \
+  --set broker.create=true \
+  --set gateway.create=true \
+  --set gateway.name=team-a-gateway \
+  --set gateway.namespace=gateway-system \
+  --set gateway.publicHost="$TEAM_A_HOST" \
+  --set gateway.internalHostPattern="*.team-a.mcp.local" \
+  --set mcpGatewayExtension.create=true \
+  --set mcpGatewayExtension.gatewayRef.name=team-a-gateway \
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
+  --set envoyFilter.create=true \
+  --set envoyFilter.name=team-a-gateway \
+  --set gateway.nodePort.create=true \
+  --set gateway.nodePort.mcpPort=30080
 ```
 
 ```bash
-# Team B gateway
---set gateway.nodePort.create=true \
---set gateway.nodePort.mcpPort=30471 \
+helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
+  --namespace team-b \
+  --set controller.enabled=false \
+  --set broker.create=true \
+  --set gateway.create=true \
+  --set gateway.name=team-b-gateway \
+  --set gateway.namespace=gateway-system \
+  --set gateway.publicHost="$TEAM_B_HOST" \
+  --set gateway.internalHostPattern="*.team-b.mcp.local" \
+  --set mcpGatewayExtension.create=true \
+  --set mcpGatewayExtension.gatewayRef.name=team-b-gateway \
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
+  --set envoyFilter.create=true \
+  --set envoyFilter.name=team-b-gateway \
+  --set gateway.nodePort.create=true \
+  --set gateway.nodePort.mcpPort=30471
 ```
+
+> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30471) to host ports. See the [Kind cluster setup guide](./kind-cluster-setup.md) for details.
 
 ## Next Steps: Register MCP Servers
 

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,10 +1,17 @@
 # OpenTelemetry Integration
 
-The MCP Gateway supports OpenTelemetry (OTel) for distributed tracing and log export. When enabled, the MCP Router (ext_proc) emits trace spans for every request and can export structured logs via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
+This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing and log export. When enabled, the MCP Router (ext_proc) emits trace spans for every request and can export structured logs via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
 
-## Enabling OpenTelemetry
+## Prerequisites
 
-Set the following environment variables on the `mcp-broker-router` process:
+- MCP Gateway installed and configured
+- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent)
+
+> **Note:** For a pre-configured local stack with OTEL Collector, Tempo, Loki, and Grafana, see the [observability example](../../examples/otel/README.md).
+
+## Step 1: Enable OpenTelemetry
+
+Set the following environment variables on the MCP Gateway deployment:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -13,7 +20,7 @@ Set the following environment variables on the `mcp-broker-router` process:
 
 ### Helm Install
 
-After installing the MCP Gateway with Helm, set the environment variables on the broker-router deployment:
+After installing the MCP Gateway with Helm, set the environment variables on the deployment. Use `helm list -A` to find your release name and namespace:
 
 ```bash
 kubectl set env deployment/<release-name> -n <namespace> \
@@ -42,6 +49,10 @@ export OTEL_EXPORTER_OTLP_INSECURE="true"
 ```
 
 See the [standalone binary install guide](./binary-install.md) for full configuration details.
+
+## Step 2: Verify Traces Are Being Exported
+
+After enabling OTel, generate some traffic against the gateway (e.g., an `initialize` or `tools/list` request) and confirm traces appear in your collector backend. The gateway emits spans under the service name `mcp-gateway` by default.
 
 ## Environment Variables
 
@@ -99,9 +110,11 @@ mcp-router.process
 Span attributes follow [OpenTelemetry MCP Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#server) and include:
 
 - `mcp.method.name` -- MCP method (initialize, tools/call, tools/list)
+- `gen_ai.operation.name` -- same as `mcp.method.name`
 - `gen_ai.tool.name` -- tool name (for tools/call requests)
 - `mcp.session.id` -- gateway session ID
 - `mcp.server` -- resolved backend server name
+- `mcp.route` -- routing decision (`tool-call`, `broker`, or `elicitation-response`)
 - `http.method`, `http.path`, `http.request_id`, `http.status_code`
 - `jsonrpc.request.id`, `jsonrpc.protocol.version`
 - `client.address` -- from x-forwarded-for header
@@ -129,12 +142,12 @@ The router extracts [W3C Trace Context](https://www.w3.org/TR/trace-context/) (`
 - Clients can pass a `traceparent` header to create end-to-end traces from outside the mesh.
 - If no `traceparent` is present, the router creates a new root trace.
 
-Example with explicit trace propagation:
+Example with explicit trace propagation (replace the URL with your gateway endpoint):
 
 ```bash
 TRACE_ID=$(openssl rand -hex 16)
 
-curl -s -X POST http://mcp.example.com/mcp \
+curl -s -X POST http://your-gateway-host/mcp \
   -H "Content-Type: application/json" \
   -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
@@ -142,6 +155,7 @@ curl -s -X POST http://mcp.example.com/mcp \
 echo "Search for trace: $TRACE_ID"
 ```
 
-## Local Development
+## Next Steps
 
-For a pre-configured local observability stack (OTEL Collector, Tempo, Loki, Grafana), see the [examples/otel/README.md](../../examples/otel/README.md).
+- For a pre-configured local observability stack (OTEL Collector, Tempo, Loki, Grafana), see the [observability example](../../examples/otel/README.md).
+- To scale the gateway with shared session state, see the [scaling guide](./scaling.md).

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -20,7 +20,7 @@ curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/qu
 
 The script checks prerequisites, then runs through each step automatically:
 
-1. **Create Kind cluster** with port mapping (`localhost:7001`)
+1. **Create Kind cluster** with port mapping (`localhost:8001`)
 2. **Install Gateway API CRDs and Istio** as the Gateway API provider
 3. **Create the Gateway** with listeners and a NodePort service
 4. **Install MCP Gateway** CRDs, controller, and MCPGatewayExtension (the controller automatically deploys the broker-router)
@@ -37,7 +37,7 @@ DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
 Open the inspector at [http://localhost:6274](http://localhost:6274) and configure:
 
 - **Transport**: Streamable HTTP
-- **URL**: `http://mcp.127-0-0-1.sslip.io:7001/mcp`
+- **URL**: `http://mcp.127-0-0-1.sslip.io:8001/mcp`
 
 Click **Connect**, then browse and test the available tools:
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -18,15 +18,13 @@ export MCP_GATEWAY_VERSION=0.6.0-rc1
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 
-The script checks prerequisites, then walks through each step interactively:
+The script checks prerequisites, then runs through each step automatically:
 
 1. **Create Kind cluster** with port mapping (`localhost:7001`)
 2. **Install Gateway API CRDs and Istio** as the Gateway API provider
 3. **Create the Gateway** with listeners and a NodePort service
 4. **Install MCP Gateway** CRDs, controller, and MCPGatewayExtension (the controller automatically deploys the broker-router)
 5. **Deploy test MCP servers** and register them with the gateway
-
-Each step describes what it will do and waits for confirmation before proceeding.
 
 ## Test with MCP Inspector
 
@@ -45,12 +43,18 @@ Click **Connect**, then browse and test the available tools:
 
 | Tool | Description |
 |------|-------------|
-| `test1_hi` | Simple greeting |
+| `test1_greet` | Simple greeting |
 | `test1_time` | Current time |
+| `test1_slow` | Delay N seconds |
 | `test1_headers` | HTTP header inspection |
+| `test1_add_tool` | Dynamically add a new tool |
 | `test2_hello_world` | Greeting from server 2 |
 | `test2_time` | Current time from server 2 |
 | `test2_headers` | HTTP headers from server 2 |
+| `test2_auth1234` | Auth test from server 2 |
+| `test2_slow` | Delay from server 2 |
+| `test2_set_time` | Set time from server 2 |
+| `test2_pour_chocolate_into_mold` | Chocolate mold from server 2 |
 
 ## Cleanup
 

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -10,18 +10,13 @@ You must register your MCP servers to be discovered and routed by the MCP Gatewa
 
 ## Procedure
 
-To connect an MCP server to MCP Gateway, you need:
-1. An MCPGatewayExtension resource that targets your Gateway
-2. A ReferenceGrant if the MCPGatewayExtension is in a different namespace than the Gateway
-3. An HTTPRoute that routes to your MCP server
-4. An MCPServerRegistration resource that references the HTTPRoute
+## Step 1: Ensure MCPGatewayExtension exists
 
-The MCPGatewayExtension tells the controller which Gateway this MCP Gateway instance serves. Without it, MCPServerRegistration resources will remain in NotReady status.
+An MCPGatewayExtension tells the controller which Gateway this MCP Gateway instance serves. Without it, MCPServerRegistration resources will remain in NotReady status.
 
-## Step 1: Create MCPGatewayExtension
+> **Note:** Only one MCPGatewayExtension is allowed per namespace. The `sectionName` field selects which listener on the Gateway to use, but each namespace can only have one MCPGatewayExtension. If you followed the [quick start](./quick-start.md) or [install guide](./how-to-install-and-configure.md), an MCPGatewayExtension already exists. Check with `kubectl get mcpgatewayextension -A`. If one is already present and Ready, skip to Step 2.
 
-First, create an MCPGatewayExtension in the same namespace as your MCP Gateway broker/router deployment. It should target a unique Gateway resource. 
-
+If you need to create one:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -36,17 +31,11 @@ spec:
     kind: Gateway
     name: mcp-gateway
     namespace: gateway-system
-    sectionName: mcp  # Name of the listener on the Gateway
+    sectionName: mcp  # must match a listener name on the Gateway
 EOF
 ```
 
-Wait for it to become ready:
-
-```bash
-kubectl wait --for=condition=Ready mcpgatewayextension/mcp-extension -n mcp-test --timeout=60s
-```
-
-If your target Gateway is in a different namespace than your MCPGatewayExtension, you will also need to create a ReferenceGrant:
+If your MCPGatewayExtension is in a different namespace than the Gateway, create a ReferenceGrant first:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -66,7 +55,13 @@ spec:
 EOF
 ```
 
-Skip the ReferenceGrant if the MCPGatewayExtension is in the same namespace as the Gateway.
+Wait for it to become ready:
+
+```bash
+kubectl wait --for=condition=Ready mcpgatewayextension/mcp-extension -n mcp-test --timeout=60s
+```
+
+## Step 2: Create an HTTPRoute
 
 Create an `HTTPRoute` that routes to your MCP server:
 
@@ -96,7 +91,7 @@ spec:
 EOF
 ```
 
-### Step 2: Create MCPServerRegistration Resource
+## Step 3: Create MCPServerRegistration Resource
 
 Create an `MCPServerRegistration` resource that references the HTTPRoute:
 
@@ -117,22 +112,34 @@ spec:
 EOF
 ```
 
-### Step 3: Verify Registration
+## Step 4: Verify Registration
 
-Check that the `MCPServerRegistration` was created and discovered:
+Wait for the MCPServerRegistration to become ready (the broker needs a moment to connect and discover tools):
 
 ```bash
-# Check MCPServerRegistration status
-kubectl get mcpsr -A
-
-# Check controller logs
-kubectl logs -n mcp-system deployment/mcp-gateway-controller
-
-# Check broker logs for tool discovery
-kubectl logs -n mcp-system deployment/mcp-gateway | grep "Discovered tools"
+kubectl wait --for=condition=Ready mcpsr/my-mcp-server -n mcp-test --timeout=120s
 ```
 
-### Step 4: Test Tool Discovery
+Then check the status:
+
+```bash
+kubectl get mcpsr -A
+```
+
+The `READY` column should show `True` and the `TOOLS` column should show the number of tools discovered. For example:
+
+```text
+NAMESPACE   NAME            PREFIX      TARGET                     PATH   READY   TOOLS   CREDENTIALS   AGE
+mcp-test    my-mcp-server   myserver_   mcp-api-key-server-route   /mcp   True    4                     30s
+```
+
+If the status is not Ready, check the MCPServerRegistration conditions for details:
+
+```bash
+kubectl describe mcpsr my-mcp-server -n mcp-test
+```
+
+## Step 5: Test Tool Discovery
 
 Verify that your MCP server tools are available through the gateway by using the following commands:
 
@@ -141,7 +148,7 @@ Verify that your MCP server tools are available through the gateway by using the
 # Use -D to dump headers to a file, then read the session ID
 curl -s -D /tmp/mcp_headers -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 
 # Extract the MCP session ID from response headers
 SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d '\r')

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/redis:7-alpine
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -82,8 +82,10 @@ kubectl rollout status deployment/redis -n your-namespace
 
 Create a secret containing the Redis connection URL. The secret must have the `mcp.kuadrant.io/secret: "true"` label — without it, the MCPGatewayExtension will fail validation.
 
+> **Note:** The secret must be created in the **same namespace as the MCPGatewayExtension**. The Redis deployment itself can run in any namespace — just ensure the connection string in the secret points to it correctly.
+
 ```bash
-kubectl apply -n your-namespace -f - <<EOF
+kubectl apply -n mcp-system -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -132,10 +134,10 @@ kubectl rollout status deployment/mcp-gateway -n mcp-system
 
 ## Step 5: Verify Session Sharing
 
-Confirm that the external store is active by checking the gateway logs. You should see `session cache using external store` on startup:
+Confirm that the external store is active by checking the gateway logs. You should see `cache using external redis store` on startup:
 
 ```bash
-kubectl logs -n mcp-system deployment/mcp-gateway | grep "session cache"
+kubectl logs -n mcp-system deployment/mcp-gateway | grep "cache using external"
 ```
 
 Test that sessions are shared across replicas by making multiple tool calls from the same client. The backend session ID should remain consistent regardless of which replica handles the request.

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -44,61 +44,31 @@ To force faster revocation, reduce the access token lifespan in your identity pr
 
 ## Step 3: Verify Revocation
 
-After revoking a tool, verify that the user can no longer access it.
+After revoking a tool, verify that the user can no longer access it. The simplest way is using MCP Inspector.
+
+Find your gateway address:
+
+```bash
+kubectl get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}'
+```
+
+Open MCP Inspector and connect to your gateway's `/mcp` endpoint (e.g., `http://<gateway-address>:8001/mcp`). Authenticate as the affected user through the OAuth flow.
 
 **Check `tools/list` filtering:**
 
-Authenticate as the affected user and list tools. The revoked tool should no longer appear:
-
-```bash
-# Obtain a token as the affected user, then:
-curl -X POST http://your-gateway-host/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
-```
+Under **Tools > List Tools**, the revoked tool should no longer appear in the list.
 
 **Check `tools/call` denial:**
 
-Attempt to call the revoked tool. You should receive a 403 Forbidden response:
-
-```bash
-curl -X POST http://your-gateway-host/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "revoked_tool"}}'
-```
-
-Expected response:
-
-```json
-{
-  "error": "Forbidden",
-  "message": "MCP Tool Access denied: Insufficient permissions for this tool."
-}
-```
+Attempt to call the revoked tool. Since the tool is no longer in the user's authorized set, the request should fail.
 
 ## Step 4: Monitor Revocation Enforcement
 
-Use existing observability to track denied access attempts after revocation.
-
-### Authorino Logs
-
-Authorino logs all authorization decisions, including denials. Check for authorization failures:
-
-```bash
-kubectl logs -n kuadrant-system -l app=authorino | grep -i "unauthorized\|denied\|forbidden"
-```
-
-### OpenTelemetry Traces
-
-If [OpenTelemetry](./opentelemetry.md) is enabled, the MCP Router emits trace spans for every request. Denied requests include `http.status_code: 403` on the response span. You can query your trace backend for these:
+If [OpenTelemetry](./opentelemetry.md) is enabled, denied requests appear as trace spans with `http.status_code: 403`. Query your trace backend to find them:
 
 - Filter by `http.status_code = 403`
 - Use `gen_ai.tool.name` to identify which tool was denied
 - Use `mcp.session.id` to correlate with the client session
-
-### Loki / Log Aggregation
 
 If the [observability stack](./observability.md) is deployed, query gateway logs for revocation-related activity:
 
@@ -106,7 +76,7 @@ If the [observability stack](./observability.md) is deployed, query gateway logs
 {namespace="mcp-system"} |= `x-mcp-toolname` | json | line_format "{{.msg}}"
 ```
 
-The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `tools/call` request. Combined with the 403 status from Authorino, this gives visibility into which users are attempting to call revoked tools.
+The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `tools/call` request. Combined with the 403 status, this gives visibility into which users are attempting to call revoked tools.
 
 ## Next Steps
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -189,13 +189,7 @@ kubectl describe mcpsr <name> -n <namespace>
 ```bash
 # Check MCPServerRegistration resource status
 kubectl get mcpsr -A
-kubectl describe mcpserver <server-name> -n <namespace>
-
-# Check controller logs
-kubectl logs -n mcp-system -l app=mcp-controller | grep <server-name>
-
-# Check broker logs
-kubectl logs -n mcp-system -l app=mcp-gateway | grep "Discovered tools"
+kubectl describe mcpserverregistration <server-name> -n <namespace>
 ```
 
 **Solutions**:

--- a/docs/guides/understanding-mcp-gateway-architecture.md
+++ b/docs/guides/understanding-mcp-gateway-architecture.md
@@ -227,7 +227,7 @@ For detailed routing logs, enable debug logging:
 kubectl set env deployment/mcp-gateway LOG_LEVEL=-4 -n mcp-system
 ```
 
-### MCP Controller Logs: Dynamic Discovery
+### MCP Gateway Controller Logs: Dynamic Discovery
 
 The controller is responsible for:
 - Watching MCPServerRegistration custom resources
@@ -239,7 +239,7 @@ The controller is responsible for:
 
 ```bash
 # Watch controller logs
-kubectl logs -f deployment/mcp-controller -n mcp-system
+kubectl logs -f deployment/mcp-gateway-controller -n mcp-system
 ```
 
 **Key log patterns:**

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -30,9 +30,21 @@ A virtual MCP server is defined by an `MCPVirtualServer` custom resource that sp
 
 When a client includes the virtual server header, MCP Gateway filters responses to only include the specified tools.
 
-## Step 1: Create Virtual Server Definitions
+## Step 1: Discover Available Tools
 
-Create virtual servers for different use cases using tools from your configured MCP servers:
+Before creating virtual servers, check which tools are available in your gateway. You can browse them using [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
+```
+
+> **Note:** `DANGEROUSLY_OMIT_AUTH=true` is for local testing only. Do not use it in shared or production environments.
+
+Open the inspector at [http://localhost:6274](http://localhost:6274) and connect to your gateway using **Streamable HTTP** transport with your gateway URL (e.g. `http://mcp.127-0-0-1.sslip.io:8001/mcp`). The **Tools** tab lists all available tool names -- you'll use these in the next step.
+
+## Step 2: Create Virtual Server Definitions
+
+Create virtual servers for different use cases. Replace the example tool names below with tools from your gateway:
 
 ### Development Tools Virtual Server
 
@@ -46,7 +58,7 @@ metadata:
 spec:
   description: "Development and debugging tools"
   tools:
-  - test1_hello_world      # Example: replace with your actual tool names
+  - test1_hello_world      # replace with your actual tool names
   - test1_headers
   - github_get_me
   - github_list_repos
@@ -65,24 +77,29 @@ metadata:
 spec:
   description: "Data analysis and reporting tools"
   tools:
-  - test2_time            # Example: replace with your actual tool names
+  - test2_time            # replace with your actual tool names
   - test3_dozen
   - github_get_repo_stats
 EOF
 ```
 
-**Important**: Replace the example tool names above with actual tools from your configured MCP servers.
-
-## Step 2: Verify Virtual Server Creation
+## Step 3: Verify Virtual Server Creation
 
 Check that your virtual servers were created successfully:
 
 ```bash
-# List all virtual servers
 kubectl get mcpvirtualserver -A
 ```
 
-## Step 3: Test Virtual Server Access
+Expected output:
+
+```text
+NAMESPACE    NAME         TOOLS   AGE
+mcp-system   data-tools           10s
+mcp-system   dev-tools            15s
+```
+
+## Step 4: Test Virtual Server Access
 
 Test your virtual servers using curl with the appropriate header:
 
@@ -133,15 +150,14 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
 
 **Expected Response**: All tools from all configured MCP servers
 
-## Step 4: Use with MCP Inspector
+## Step 5: Use with MCP Inspector
 
-You can also test virtual servers using the MCP Inspector by setting the virtual server header. The MCP Inspector allows you to configure custom headers for testing different virtual server configurations.
+You can also test virtual servers using MCP Inspector. Connect to your gateway as described in [Step 1](#step-1-discover-available-tools), then add the `X-Mcp-Virtualserver` header with the `namespace/name` of your virtual server (e.g. `mcp-system/dev-tools`) under the **Headers** section. The tools list will show only the tools defined in that virtual server.
 
 ## Remove Virtual Servers
 
 ```bash
-# Delete a virtual server
-kubectl delete mcpvirtualserver dev-tools -n mcp-system
+kubectl delete mcpvirtualserver dev-tools data-tools -n mcp-system
 ```
 
 ## Authorization and Tool Filtering

--- a/evals/gemini-agent/agent.yaml
+++ b/evals/gemini-agent/agent.yaml
@@ -7,6 +7,6 @@ builtin:
   # or any other OpenAI-compatible endpoint.
   type: "openai-acp"
 
-  model: "qwen2.5:1.5b"
+  model: "openai:qwen2.5:1.5b"
   params:
     temperature: 0.1

--- a/evals/tasks/basic/echo.yaml
+++ b/evals/tasks/basic/echo.yaml
@@ -1,0 +1,8 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: basic-echo
+  difficulty: easy
+spec:
+  prompt:
+    inline: "Call the 'everything_echo' tool with name 'World'. Verify it replies with 'Echo: World'."

--- a/evals/tasks/basic/hi.yaml
+++ b/evals/tasks/basic/hi.yaml
@@ -1,8 +1,0 @@
-kind: Task
-apiVersion: mcpchecker/v1alpha2
-metadata:
-  name: basic-hi
-  difficulty: easy
-spec:
-  prompt:
-    inline: "Call the 'test1_greet' tool with name 'World'. Verify it replies with 'Hi World'."

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -209,9 +209,7 @@ func (r *MCPGatewayExtensionReconciler) buildBrokerRouterService(mcpExt *mcpv1al
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				labelAppName: brokerRouterName,
-			},
+			Selector: brokerRouterLabels(),
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "http",

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -47,10 +47,11 @@ echo ""
 
 output "Step 1: Create Kind cluster with port mapping (localhost:8001 -> NodePort 30080)"
 
-if kind get clusters 2>/dev/null | grep -q '^kind$'; then
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-mcp-gateway}
+if kind get clusters 2>/dev/null | grep -Fxq -- "$KIND_CLUSTER_NAME"; then
     echo "Kind cluster already exists, reusing it."
 else
-    cat <<EOF | kind create cluster --config=-
+    cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -130,5 +131,5 @@ echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"
 echo ""
 echo "To clean up:"
-echo "  kind delete cluster"
+echo "  kind delete cluster --name ${KIND_CLUSTER_NAME}"
 echo "============================================================"

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -45,7 +45,7 @@ if [ ${#missing[@]} -gt 0 ]; then
 fi
 echo ""
 
-output "Step 1: Create Kind cluster with port mapping (localhost:7001 -> NodePort 30080)"
+output "Step 1: Create Kind cluster with port mapping (localhost:8001 -> NodePort 30080)"
 
 if kind get clusters 2>/dev/null | grep -q '^kind$'; then
     echo "Kind cluster already exists, reusing it."
@@ -63,7 +63,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 30080
-    hostPort: 7001
+    hostPort: 8001
     protocol: TCP
 EOF
 fi
@@ -121,12 +121,12 @@ echo ""
 echo "============================================================"
 echo "MCP Gateway is ready!"
 echo ""
-echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "To test with MCP Inspector (requires Node.js):"
 echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest"
 echo ""
-echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:7001/mcp"
+echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"
 echo ""
 echo "To clean up:"

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -88,7 +88,7 @@ kubectl apply -k "${REPO}/config/crd?ref=${GIT_REF}"
 kubectl apply -k "${REPO}/config/mcp-gateway/overlays/mcp-system?ref=${GIT_REF}"
 
 echo "Waiting for controller..."
-kubectl wait --for=condition=available --timeout=120s deployment/mcp-controller -n mcp-system
+kubectl wait --for=condition=available --timeout=120s deployment/mcp-gateway-controller -n mcp-system
 echo "Waiting for broker-router (deployed automatically by the controller)..."
 kubectl wait --for=condition=available --timeout=120s deployment/mcp-gateway -n mcp-system
 echo "Waiting for gateway pod..."

--- a/scripts/set-release-version.sh
+++ b/scripts/set-release-version.sh
@@ -38,15 +38,18 @@ else
     echo "Warning: $OPENSHIFT_SCRIPT not found"
 fi
 
-# Update charts/sample_local_helm_setup.sh default version
-SAMPLE_SCRIPT="$REPO_ROOT/charts/sample_local_helm_setup.sh"
-if [ -f "$SAMPLE_SCRIPT" ]; then
-    sed -i.bak -E "s/MCP_GATEWAY_VERSION:-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?/MCP_GATEWAY_VERSION:-$VERSION/" "$SAMPLE_SCRIPT"
-    rm -f "$SAMPLE_SCRIPT.bak"
-    echo "Updated: $SAMPLE_SCRIPT"
-else
-    echo "Warning: $SAMPLE_SCRIPT not found"
-fi
+# Update scripts with MCP_GATEWAY_VERSION bash defaults
+for SCRIPT in \
+    "$REPO_ROOT/scripts/quick-start.sh" \
+    "$REPO_ROOT/charts/sample_local_helm_setup.sh"; do
+    if [ -f "$SCRIPT" ]; then
+        sed -i.bak -E "s/MCP_GATEWAY_VERSION:-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?/MCP_GATEWAY_VERSION:-$VERSION/" "$SCRIPT"
+        rm -f "$SCRIPT.bak"
+        echo "Updated: $SCRIPT"
+    else
+        echo "Warning: $SCRIPT not found"
+    fi
+done
 
 # Update config/mcp-system deployment images
 CONTROLLER_DEPLOY="$REPO_ROOT/config/mcp-system/deployment-controller.yaml"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -29,7 +29,7 @@ make test-e2e-watch
 If tests fail, check:
 ```bash
 # Controller logs
-kubectl logs -n mcp-system deployment/mcp-controller
+kubectl logs -n mcp-system deployment/mcp-gateway-controller
 
 # Broker logs  
 kubectl logs -n mcp-system deployment/mcp-broker-router


### PR DESCRIPTION
## Summary

Cherry-picks from main into release-0.6.0 for rc2.

### Fixes
- #704 — Fix broker service selecting controller pods due to shared helm labels
- #707 — Update quick-start script default version
- #723 — Fix: escape ginkgo focus regex, use gcr mirror for redis, and make kind cluster name configurable
- #724 — Fix gevals workflow and add failure detection
- #729 — Rename mcp-controller Deployment to mcp-gateway-controller

### Docs
- #727 — Deploy test MCP servers as part of auth-example-setup
- #730 — Update quick start guide
- #733 — Fixes for register MCP servers guide
- #734 — Authentication guide review
- #736 — Fix external MCP server guide
- #738 — Fixes: tool revocation guide
- #744 — Isolated gateway deployment guide fixes
- #746 — Virtual MCP servers guide tweaks
- #747 — Update authorization guide
- #749 — OpenTelemetry guide fixes
- #751 — Fix configure-mcp-gateway-listener-and-router guide
- #752 — Update scaling guide

Ref: #709