### PR TITLE
Olm dependency Kuadrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,6 +611,7 @@ local-env-setup-olm: setup-cluster-base ## Setup local environment with MCP Gate
 	"$(MAKE)" deploy-gateway
 	"$(MAKE)" deploy-namespaces
 	kubectl apply -f config/mcp-gateway/overlays/mcp-system/trusted-header-public-key.yaml -n $(MCP_GATEWAY_NAMESPACE)
+	"$(MAKE)" cert-manager-install
 	"$(MAKE)" deploy-olm
 	"$(MAKE)" deploy-kuadrant-catalog
 	# apply MCPGatewayExtension CR and HTTPRoute (not OLM resources — those are in deploy-olm)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(IMAGE_TAG)
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
 CHANNELS ?= preview
 DEFAULT_CHANNEL ?= preview
-INSTALL_OLM ?= false
+
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
@@ -595,19 +595,8 @@ local-env-setup: setup-cluster-base ## Setup complete local demo environment wit
 	@echo "========================================="
 	@echo "Setting up Local Demo Environment"
 	@echo "========================================="
-	# Deploy single gateway for local demo
 	"$(MAKE)" deploy-gateway
-ifeq ($(INSTALL_OLM),true)
-	# Deploy controller via OLM (default)
-	"$(MAKE)" deploy-namespaces
-	kubectl apply -f config/mcp-gateway/overlays/mcp-system/trusted-header-public-key.yaml -n $(MCP_GATEWAY_NAMESPACE)
-	"$(MAKE)" deploy-olm
-	kubectl apply -k config/mcp-gateway/base/ -n $(MCP_GATEWAY_NAMESPACE)
-	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --timeout=$(WAIT_TIME)
-else
-	# Deploy controller via kustomize (non-OLM fallback)
 	"$(MAKE)" deploy
-endif
 	"${MAKE}" add-jwt-key
 	# Deploy everything server for local dev (use 'make deploy-test-servers' for all servers)
 	"$(MAKE)" deploy-everything-server

--- a/Makefile
+++ b/Makefile
@@ -614,6 +614,24 @@ endif
 	"$(MAKE)" deploy-example-minimal
 	@echo "Local environment setup complete"
 
+.PHONY: local-env-setup-olm
+local-env-setup-olm: setup-cluster-base ## Setup local environment with MCP Gateway and Kuadrant via OLM
+	@echo "========================================="
+	@echo "Setting up Local OLM Environment"
+	@echo "========================================="
+	"$(MAKE)" deploy-gateway
+	"$(MAKE)" deploy-namespaces
+	kubectl apply -f config/mcp-gateway/overlays/mcp-system/trusted-header-public-key.yaml -n $(MCP_GATEWAY_NAMESPACE)
+	"$(MAKE)" deploy-kuadrant-catalog
+	"$(MAKE)" deploy-olm
+	# apply MCPGatewayExtension CR and HTTPRoute (not OLM resources — those are in deploy-olm)
+	kubectl apply -k config/mcp-gateway/base/ -n $(MCP_GATEWAY_NAMESPACE)
+	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --timeout=$(WAIT_TIME)
+	"${MAKE}" add-jwt-key
+	"$(MAKE)" deploy-everything-server
+	"$(MAKE)" deploy-example-minimal
+	@echo "Local OLM environment setup complete"
+
 .PHONY: local-bare-setup
 local-bare-setup: setup-cluster-base ## Setup minimal cluster infrastructure (no MCP components)
 	@echo "Bare cluster setup complete (no MCP components deployed)"

--- a/Makefile
+++ b/Makefile
@@ -622,8 +622,8 @@ local-env-setup-olm: setup-cluster-base ## Setup local environment with MCP Gate
 	"$(MAKE)" deploy-gateway
 	"$(MAKE)" deploy-namespaces
 	kubectl apply -f config/mcp-gateway/overlays/mcp-system/trusted-header-public-key.yaml -n $(MCP_GATEWAY_NAMESPACE)
-	"$(MAKE)" deploy-kuadrant-catalog
 	"$(MAKE)" deploy-olm
+	"$(MAKE)" deploy-kuadrant-catalog
 	# apply MCPGatewayExtension CR and HTTPRoute (not OLM resources — those are in deploy-olm)
 	kubectl apply -k config/mcp-gateway/base/ -n $(MCP_GATEWAY_NAMESPACE)
 	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --timeout=$(WAIT_TIME)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ GATEWAY_API_VERSION ?= v1.4.1
 # The KIND cluster name must match ./build/kind.mk
 KIND_CLUSTER_NAME ?= mcp-gateway
 MCP_GATEWAY_NAMESPACE ?= mcp-system
+
+# Detect the namespace where Kuadrant is installed (kuadrant-system for Helm, mcp-system for OLM).
+# Usage in recipes: $(call detect-kuadrant-ns) sets $$KUADRANT_NS
+detect-kuadrant-ns = if kubectl get namespace kuadrant-system >/dev/null 2>&1; then KUADRANT_NS=kuadrant-system; else KUADRANT_NS=mcp-system; fi
+
 MCP_GATEWAY_SUBDOMAIN ?= mcp
 MCP_GATEWAY_HOST ?= $(MCP_GATEWAY_SUBDOMAIN).127-0-0-1.sslip.io
 MCP_GATEWAY_NAME ?= mcp-gateway

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This will start MCP Inspector and automatically open it with the correct URL for
 
 ## Example OAuth setup: Keycloak as an ACL Server
 
-After running the Quick start above, configure OAuth authentication with a single command:
+After running the Quick start above (either `make local-env-setup` or `make local-env-setup-olm`), configure OAuth authentication with a single command:
 
 ```bash
 make auth-example-setup

--- a/build/auth.mk
+++ b/build/auth.mk
@@ -1,7 +1,7 @@
 ##@ Auth Examples
 
 .PHONY: auth-example-setup
-auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Setup auth example of OAuth2 authentication using Kuadrant, tool list filtering based on RBAC permissions configured in Keycloak, OAuth2 Token Exchange, and integration with Vault (requires: make local-env-setup)
+auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Setup auth example of OAuth2 authentication using Kuadrant, tool list filtering based on RBAC permissions configured in Keycloak, OAuth2 Token Exchange, and integration with Vault (requires: make local-env-setup or local-env-setup-olm)
 	@echo "========================================="
 	@echo "Setting up OAuth Example"
 	@echo "========================================="
@@ -12,7 +12,7 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo "  - OAuth2 Token Exchange to obtain access tokens for backend services"
 	@echo "  - Integration with HashiCorp Vault (alternative to OAuth2 Token Exchange)"
 	@echo ""
-	@echo "Prerequisites: make local-env-setup should be completed"
+	@echo "Prerequisites: make local-env-setup or make local-env-setup-olm should be completed"
 	@echo ""
 	@echo "Step 1/6: Configuring OAuth environment variables..."
 	@kubectl set env deployment/mcp-gateway \
@@ -30,6 +30,13 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo ""
 	@echo "Step 3/6: Applying AuthPolicy configurations..."
 	@kubectl apply -k ./config/samples/oauth-token-exchange/
+	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
+		KUADRANT_NS=kuadrant-system; \
+	else \
+		KUADRANT_NS=mcp-system; \
+	fi; \
+	kubectl apply -f ./config/samples/oauth-token-exchange/trusted-headers-private-key.yaml -n $$KUADRANT_NS; \
+	kubectl apply -f ./config/samples/oauth-token-exchange/token-exchange-secret.yaml -n $$KUADRANT_NS
 	@kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
 		-p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
 	@echo "✅ AuthPolicy configurations applied"
@@ -39,7 +46,11 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo "✅ CORS configured"
 	@echo ""
 	@echo "Step 5/6: Patch Authorino deployment to be able to connect to Keycloak..."
-	@./utils/patch-authorino-to-keycloak.sh
+	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
+		./utils/patch-authorino-to-keycloak.sh kuadrant-system; \
+	else \
+		./utils/patch-authorino-to-keycloak.sh mcp-system; \
+	fi
 	@echo "✅ Authorino deployment patched"
 	@echo ""
 	@echo "Step 6/6: Deploying test MCP servers..."

--- a/build/auth.mk
+++ b/build/auth.mk
@@ -30,11 +30,7 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo ""
 	@echo "Step 3/6: Applying AuthPolicy configurations..."
 	@kubectl apply -k ./config/samples/oauth-token-exchange/
-	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
-		KUADRANT_NS=kuadrant-system; \
-	else \
-		KUADRANT_NS=mcp-system; \
-	fi; \
+	@$(detect-kuadrant-ns); \
 	kubectl apply -f ./config/samples/oauth-token-exchange/trusted-headers-private-key.yaml -n $$KUADRANT_NS; \
 	kubectl apply -f ./config/samples/oauth-token-exchange/token-exchange-secret.yaml -n $$KUADRANT_NS
 	@kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
@@ -46,11 +42,8 @@ auth-example-setup: cert-manager-install kuadrant-install keycloak-install ## Se
 	@echo "✅ CORS configured"
 	@echo ""
 	@echo "Step 5/6: Patch Authorino deployment to be able to connect to Keycloak..."
-	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
-		./utils/patch-authorino-to-keycloak.sh kuadrant-system; \
-	else \
-		./utils/patch-authorino-to-keycloak.sh mcp-system; \
-	fi
+	@$(detect-kuadrant-ns); \
+	./utils/patch-authorino-to-keycloak.sh $$KUADRANT_NS
 	@echo "✅ Authorino deployment patched"
 	@echo ""
 	@echo "Step 6/6: Deploying test MCP servers..."

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -52,11 +52,20 @@ ci-auth-setup: cert-manager-install kuadrant-install ## Setup auth infrastructur
 		docker exec mcp-gateway-control-plane bash -c "grep -q 'keycloak.127-0-0-1.sslip.io' /etc/hosts || echo '$$GATEWAY_IP keycloak.127-0-0-1.sslip.io' >> /etc/hosts"
 	# apply AuthPolicies: reuse sample secrets + mcp-auth-policy, add simplified mcps policy (no Vault)
 	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/trusted-header-public-key.yaml
-	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/trusted-headers-private-key.yaml
+	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
+		KUADRANT_NS=kuadrant-system; \
+	else \
+		KUADRANT_NS=mcp-system; \
+	fi; \
+	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/trusted-headers-private-key.yaml -n $$KUADRANT_NS
 	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/tools-list-auth.yaml
 	$(KUBECTL) apply -f ./config/e2e/auth/mcps-auth-policy.yaml
 	# patch Authorino to reach Keycloak
-	./utils/patch-authorino-to-keycloak.sh
+	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
+		./utils/patch-authorino-to-keycloak.sh kuadrant-system; \
+	else \
+		./utils/patch-authorino-to-keycloak.sh mcp-system; \
+	fi
 	@echo "CI auth setup complete"
 
 # Collect debug info on failure

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -52,20 +52,13 @@ ci-auth-setup: cert-manager-install kuadrant-install ## Setup auth infrastructur
 		docker exec mcp-gateway-control-plane bash -c "grep -q 'keycloak.127-0-0-1.sslip.io' /etc/hosts || echo '$$GATEWAY_IP keycloak.127-0-0-1.sslip.io' >> /etc/hosts"
 	# apply AuthPolicies: reuse sample secrets + mcp-auth-policy, add simplified mcps policy (no Vault)
 	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/trusted-header-public-key.yaml
-	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
-		KUADRANT_NS=kuadrant-system; \
-	else \
-		KUADRANT_NS=mcp-system; \
-	fi; \
+	@$(detect-kuadrant-ns); \
 	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/trusted-headers-private-key.yaml -n $$KUADRANT_NS
 	$(KUBECTL) apply -f ./config/samples/oauth-token-exchange/tools-list-auth.yaml
 	$(KUBECTL) apply -f ./config/e2e/auth/mcps-auth-policy.yaml
 	# patch Authorino to reach Keycloak
-	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then \
-		./utils/patch-authorino-to-keycloak.sh kuadrant-system; \
-	else \
-		./utils/patch-authorino-to-keycloak.sh mcp-system; \
-	fi
+	@$(detect-kuadrant-ns); \
+	./utils/patch-authorino-to-keycloak.sh $$KUADRANT_NS
 	@echo "CI auth setup complete"
 
 # Collect debug info on failure

--- a/build/kuadrant.mk
+++ b/build/kuadrant.mk
@@ -7,30 +7,34 @@ KUBECTL ?= kubectl
 
 .PHONY: kuadrant-install
 kuadrant-install-impl: $(HELM)
-	@echo "Installing Kuadrant operator..."
-	@-$(HELM) repo add kuadrant https://kuadrant.io/helm-charts 2>/dev/null
-	@$(HELM) repo update
-	@if $(HELM) list -n $(KUADRANT_NAMESPACE) | grep -q kuadrant-operator; then \
-		echo "Kuadrant operator already installed, upgrading..."; \
-		$(HELM) upgrade \
-			kuadrant-operator kuadrant/kuadrant-operator \
-			--wait \
-			--timeout=600s \
-			--namespace $(KUADRANT_NAMESPACE); \
+	@if kubectl get crd kuadrants.kuadrant.io >/dev/null 2>&1; then \
+		echo "Kuadrant CRDs already present (installed via OLM or Helm), skipping Helm install."; \
 	else \
-		$(HELM) install \
-			kuadrant-operator kuadrant/kuadrant-operator \
-			--create-namespace \
-			--wait \
-			--timeout=600s \
-			--namespace $(KUADRANT_NAMESPACE); \
+		echo "Installing Kuadrant operator..."; \
+		$(HELM) repo add kuadrant https://kuadrant.io/helm-charts 2>/dev/null || true; \
+		$(HELM) repo update; \
+		if $(HELM) list -n $(KUADRANT_NAMESPACE) | grep -q kuadrant-operator; then \
+			echo "Kuadrant operator already installed, upgrading..."; \
+			$(HELM) upgrade \
+				kuadrant-operator kuadrant/kuadrant-operator \
+				--wait \
+				--timeout=600s \
+				--namespace $(KUADRANT_NAMESPACE); \
+		else \
+			$(HELM) install \
+				kuadrant-operator kuadrant/kuadrant-operator \
+				--create-namespace \
+				--wait \
+				--timeout=600s \
+				--namespace $(KUADRANT_NAMESPACE); \
+		fi; \
+		echo ""; \
+		echo "Instantiating Kuadrant..."; \
+		$(KUBECTL) apply -f config/kuadrant/kuadrant.yaml; \
+		echo ""; \
+		echo "Kuadrant operator installed and instantiated!"; \
+		echo "You can now create RateLimitPolicy, AuthPolicy, and other Kuadrant resources."; \
 	fi
-	@echo ""
-	@echo "Instantiating Kuadrant..."
-	@$(KUBECTL) apply -f config/kuadrant/kuadrant.yaml
-	@echo ""
-	@echo "Kuadrant operator installed and instantiated!"
-	@echo "You can now create RateLimitPolicy, AuthPolicy, and other Kuadrant resources."
 
 .PHONY: kuadrant-uninstall
 kuadrant-uninstall-impl: $(HELM)

--- a/build/kuadrant.mk
+++ b/build/kuadrant.mk
@@ -28,12 +28,14 @@ kuadrant-install-impl: $(HELM)
 				--timeout=600s \
 				--namespace $(KUADRANT_NAMESPACE); \
 		fi; \
-		echo ""; \
-		echo "Instantiating Kuadrant..."; \
-		$(KUBECTL) apply -f config/kuadrant/kuadrant.yaml; \
-		echo ""; \
-		echo "Kuadrant operator installed and instantiated!"; \
-		echo "You can now create RateLimitPolicy, AuthPolicy, and other Kuadrant resources."; \
+	fi
+	@if kubectl get namespace kuadrant-system >/dev/null 2>&1; then KUADRANT_NS=kuadrant-system; else KUADRANT_NS=mcp-system; fi; \
+	if kubectl get kuadrant -A 2>/dev/null | grep -q kuadrant; then \
+		echo "Kuadrant CR already exists, skipping."; \
+	else \
+		echo "Instantiating Kuadrant in namespace $$KUADRANT_NS..."; \
+		$(KUBECTL) apply -f config/kuadrant/kuadrant.yaml -n $$KUADRANT_NS; \
+		echo "Kuadrant CR created."; \
 	fi
 
 .PHONY: kuadrant-uninstall

--- a/build/olm.mk
+++ b/build/olm.mk
@@ -108,7 +108,8 @@ deploy-olm: olm-install ## Deploy controller via OLM on local cluster
 	# refs (@sha256:...) get IfNotPresent. Extract the digest from containerd inside Kind,
 	# create a digest-based ref, and use that so OLM uses the locally loaded image.
 	CATALOG_DIGEST=$$(docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images ls 2>/dev/null | grep '$(IMAGE_TAG_BASE)-catalog:local' | awk '{print $$3}') && \
-	(docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images tag $(IMAGE_TAG_BASE)-catalog:local $(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST 2>/dev/null || true) && \
+	(TAG_ERR=$$(docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images tag $(IMAGE_TAG_BASE)-catalog:local $(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST 2>&1) || \
+		if echo "$$TAG_ERR" | grep -q "already exists"; then true; else echo "$$TAG_ERR" >&2; false; fi) && \
 	"$(MAKE)" deploy-catalog CATALOG_IMG=$(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST
 
 KUADRANT_CATALOG_TAG ?= v1.4.3

--- a/build/olm.mk
+++ b/build/olm.mk
@@ -115,7 +115,7 @@ KUADRANT_CATALOG_TAG ?= v1.4.3
 
 .PHONY: deploy-kuadrant-catalog
 deploy-kuadrant-catalog: ## Deploy Kuadrant OLM catalog from upstream repo
-	kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/tags/$(KUADRANT_CATALOG_TAG)/config/deploy/olm/catalogsource.yaml
+	kubectl apply -n olm -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/tags/$(KUADRANT_CATALOG_TAG)/config/deploy/olm/catalogsource.yaml
 
 .PHONY: undeploy-olm
 undeploy-olm: operator-sdk ## Remove OLM-deployed controller

--- a/build/olm.mk
+++ b/build/olm.mk
@@ -111,6 +111,12 @@ deploy-olm: olm-install ## Deploy controller via OLM on local cluster
 	docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images tag $(IMAGE_TAG_BASE)-catalog:local $(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST && \
 	"$(MAKE)" deploy-catalog CATALOG_IMG=$(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST
 
+KUADRANT_CATALOG_TAG ?= v1.4.3
+
+.PHONY: deploy-kuadrant-catalog
+deploy-kuadrant-catalog: ## Deploy Kuadrant OLM catalog from upstream repo
+	kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/tags/$(KUADRANT_CATALOG_TAG)/config/deploy/olm/catalogsource.yaml
+
 .PHONY: undeploy-olm
 undeploy-olm: operator-sdk ## Remove OLM-deployed controller
 	$(OPERATOR_SDK) cleanup mcp-gateway --namespace $(MCP_GATEWAY_NAMESPACE)

--- a/build/olm.mk
+++ b/build/olm.mk
@@ -108,7 +108,7 @@ deploy-olm: olm-install ## Deploy controller via OLM on local cluster
 	# refs (@sha256:...) get IfNotPresent. Extract the digest from containerd inside Kind,
 	# create a digest-based ref, and use that so OLM uses the locally loaded image.
 	CATALOG_DIGEST=$$(docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images ls 2>/dev/null | grep '$(IMAGE_TAG_BASE)-catalog:local' | awk '{print $$3}') && \
-	docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images tag $(IMAGE_TAG_BASE)-catalog:local $(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST && \
+	(docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io images tag $(IMAGE_TAG_BASE)-catalog:local $(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST 2>/dev/null || true) && \
 	"$(MAKE)" deploy-catalog CATALOG_IMG=$(IMAGE_TAG_BASE)-catalog@$$CATALOG_DIGEST
 
 KUADRANT_CATALOG_TAG ?= v1.4.3

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - type: olm.package
+    value:
+      packageName: kuadrant-operator
+      version: ">=1.4.3"

--- a/config/kuadrant/kuadrant.yaml
+++ b/config/kuadrant/kuadrant.yaml
@@ -2,4 +2,3 @@ apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
   name: kuadrant
-  namespace: kuadrant-system

--- a/config/samples/oauth-token-exchange/kustomization.yaml
+++ b/config/samples/oauth-token-exchange/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
 - tools-list-auth.yaml
 - tools-call-auth.yaml
 - trusted-header-public-key.yaml
-- trusted-headers-private-key.yaml

--- a/config/samples/oauth-token-exchange/token-exchange-secret.yaml
+++ b/config/samples/oauth-token-exchange/token-exchange-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: token-exchange
+stringData:
+  oauth-client-basic-auth: bWNwLWdhdGV3YXk6c2VjcmV0
+  vault-token: root
+type: Opaque

--- a/config/samples/oauth-token-exchange/tools-call-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-call-auth.yaml
@@ -100,13 +100,3 @@ spec:
               "error": "Forbidden",
               "message": "MCP Tool Access denied: Insufficient permissions for this tool."
             }
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: token-exchange
-  namespace: kuadrant-system
-stringData:
-  oauth-client-basic-auth: bWNwLWdhdGV3YXk6c2VjcmV0
-  vault-token: root
-type: Opaque

--- a/config/samples/oauth-token-exchange/trusted-headers-private-key.yaml
+++ b/config/samples/oauth-token-exchange/trusted-headers-private-key.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: trusted-headers-private-key
-  namespace: kuadrant-system
 stringData:
   key.pem: |
     -----BEGIN EC PRIVATE KEY-----

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -113,7 +113,7 @@ helm install kuadrant-operator kuadrant/kuadrant-operator \
 	--timeout=600s \
 	--namespace kuadrant-system;
 
-kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/config/kuadrant/kuadrant.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/config/kuadrant/kuadrant.yaml -n kuadrant-system
 
 kubectl wait --for=condition=available --timeout=90s deployment/authorino -n kuadrant-system
 

--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -10,10 +10,20 @@ The guide has two parts:
 ## Prerequisites
 
 - MCP Gateway installed and configured
-- Gateway API provider (Istio) with ServiceEntry and DestinationRule support
-- Network egress access to the external MCP server
-- A GitHub Personal Access Token with `read:user` scope — [create one here](https://github.com/settings/tokens/new)
-- **MCPGatewayExtension** targeting the Gateway (see [Configure MCP Servers](./register-mcp-servers.md#step-1-create-mcpgatewayextension))
+- Gateway API Provider (Istio) with ServiceEntry and DestinationRule support
+- Network egress access to external MCP server
+- Authentication credentials for the external server (if required)
+- **MCPGatewayExtension** targeting the Gateway (required for MCPServerRegistration to work)
+
+**Note:** If you're trying this locally, `make local-env-setup` or `make local-env-setup-olm` meets all prerequisites except the GitHub PAT. The optional AuthPolicy step (Step 6) additionally requires Kuadrant (`make auth-example-setup`).
+
+If you haven't created an MCPGatewayExtension yet, see [Configure MCP Servers](./register-mcp-servers.md#step-1-create-mcpgatewayextension) for instructions.
+
+## About the GitHub MCP Server
+
+The GitHub MCP server (https://api.githubcopilot.com/mcp/) provides programmatic access to GitHub functionality through the Model Context Protocol. It exposes tools for repository management, issues, pull requests, and code operations.
+
+For this example, you'll need a GitHub Personal Access Token with `read:user` permissions. Get one at https://github.com/settings/tokens/new
 
 ```bash
 export GITHUB_PAT="ghp_YOUR_GITHUB_TOKEN_HERE"

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -46,13 +46,13 @@ The default `local-env-setup` target uses kustomize:
 make local-env-setup
 ```
 
-To use the OLM-based deployment instead:
+To use the OLM-based deployment instead (installs both MCP Gateway and Kuadrant via OLM):
 
 ```bash
-make local-env-setup INSTALL_OLM=true
+make local-env-setup-olm
 ```
 
-This builds the bundle and catalog images locally, loads them into the Kind cluster, and sets `imagePullPolicy: Never` on the CatalogSource so no remote registry is needed.
+This builds the bundle and catalog images locally, loads them into the Kind cluster, deploys the Kuadrant OLM catalog, and lets OLM resolve Kuadrant as a dependency automatically.
 
 ## Available Make Targets
 
@@ -66,4 +66,6 @@ This builds the bundle and catalog images locally, loads them into the Kind clus
 | `make olm-install` | Install OLM on the cluster |
 | `make olm-uninstall` | Uninstall OLM from the cluster |
 | `make deploy-olm` | Deploy controller via OLM on local cluster |
+| `make deploy-kuadrant-catalog` | Deploy Kuadrant OLM catalog from upstream |
+| `make local-env-setup-olm` | Full local setup with MCP Gateway and Kuadrant via OLM |
 | `make undeploy-olm` | Remove OLM-deployed controller |

--- a/utils/patch-authorino-to-keycloak.sh
+++ b/utils/patch-authorino-to-keycloak.sh
@@ -3,11 +3,13 @@
 # Patches the Authorino deployment to resolve Keycloak's external test domain name to the MCP gateway IP
 # and accept its TLS certificate – used for demos, do not use in production
 
-echo "Patching Authorino to trust Keycloak's TLS certificate..."
+AUTHORINO_NS="${1:-kuadrant-system}"
 
-kubectl create configmap mcp-gateway-keycloak-cert -n kuadrant-system --from-file=keycloak.crt=./out/certs/ca.crt
+echo "Patching Authorino in namespace $AUTHORINO_NS to trust Keycloak's TLS certificate..."
 
-kubectl patch authorino authorino -n kuadrant-system --type merge -p '
+kubectl create configmap mcp-gateway-keycloak-cert -n "$AUTHORINO_NS" --from-file=keycloak.crt=./out/certs/ca.crt
+
+kubectl patch authorino authorino -n "$AUTHORINO_NS" --type merge -p '
 {
   "spec": {
     "volumes": {
@@ -39,6 +41,6 @@ if [[ -z "$GATEWAY_IP" ]]; then
   exit 1
 fi
 
-kubectl patch deployment authorino -n kuadrant-system --type='json' -p="$(cat config/keycloak/patch-hostaliases.json | envsubst)"
+kubectl patch deployment authorino -n "$AUTHORINO_NS" --type='json' -p="$(cat config/keycloak/patch-hostaliases.json | envsubst)"
 
-kubectl wait --for=condition=available --timeout=90s deployment/authorino -n kuadrant-system
+kubectl wait --for=condition=available --timeout=90s deployment/authorino -n "$AUTHORINO_NS"

--- a/utils/patch-authorino-to-keycloak.sh
+++ b/utils/patch-authorino-to-keycloak.sh
@@ -7,7 +7,7 @@ AUTHORINO_NS="${1:-kuadrant-system}"
 
 echo "Patching Authorino in namespace $AUTHORINO_NS to trust Keycloak's TLS certificate..."
 
-kubectl create configmap mcp-gateway-keycloak-cert -n "$AUTHORINO_NS" --from-file=keycloak.crt=./out/certs/ca.crt
+kubectl create configmap mcp-gateway-keycloak-cert -n "$AUTHORINO_NS" --from-file=keycloak.crt=./out/certs/ca.crt --dry-run=client -o yaml | kubectl apply -f -
 
 kubectl patch authorino authorino -n "$AUTHORINO_NS" --type merge -p '
 {


### PR DESCRIPTION
fixes #763 
Adds a OLM dependency to our OLM manifests. 
Updates the make file with a `make local-env-setup-olm` 
Removed the INSTALL_OLM env flag
Updates doc references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated OLM-based local environment target and a configurable Kuadrant OLM catalog deployment.
  * Added a new token-exchange secret manifest for OAuth token exchange examples.

* **Documentation**
  * Updated guides and README to document both non-OLM and OLM local setup workflows, new make targets, and clarified prerequisites and example setup steps.

* **Chores**
  * Simplified local setup flow, made auth/CI steps namespace-aware, adjusted sample manifests for trusted key/secret handling, and made operator installation conditional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->