### PR TITLE
make e2e test hostnames and gateway URLs configurable via env vars

### DIFF
--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	goenv "github.com/caitlinelfring/go-env-default"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,7 +15,7 @@ import (
 
 // auth tests must target the gateway via hostname, not localhost.
 // AuthPolicy (Authorino) matches on Host header; localhost bypasses enforcement.
-var authGatewayURL = fmt.Sprintf("http://%s:8001/mcp", gatewayPublicHost)
+var authGatewayURL = goenv.GetDefault("AUTH_GATEWAY_URL", fmt.Sprintf("%s://%s:8001/mcp", e2eScheme, gatewayPublicHost))
 
 func authInitBody() []byte {
 	return []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-auth","version":"0.0.1"}}}`)

--- a/tests/e2e/builders.go
+++ b/tests/e2e/builders.go
@@ -237,7 +237,7 @@ func (b *TestResourcesBuilder) buildInternalResources(routeName string) {
 			},
 			Hostnames: []gatewayapiv1.Hostname{
 				gatewayapiv1.Hostname(b.hostname),
-				gatewayapiv1.Hostname(strings.Replace(b.hostname, ".mcp.local", ".127-0-0-1.sslip.io", 1)),
+				gatewayapiv1.Hostname(strings.Replace(b.hostname, ".mcp.local", "."+e2eDomain, 1)),
 			},
 			Rules: []gatewayapiv1.HTTPRouteRule{
 				{

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -38,8 +38,6 @@ const (
 const (
 	E2E1GatewayName  = "e2e-1"
 	E2E1ListenerName = "mcp" // listener name on e2e-1 gateway
-	E2E1PublicHost   = "e2e-1.127-0-0-1.sslip.io"
-	E2E1GatewayURL   = "http://localhost:8004/mcp"
 )
 
 // shared-gateway constants (used by team isolation tests)
@@ -48,22 +46,48 @@ const (
 	// Team A listeners
 	TeamAMCPListenerName  = "team-a-mcp"
 	TeamAMCPSListenerName = "team-a-mcps"
-	TeamAPublicHost       = "team-a.127-0-0-1.sslip.io"
-	TeamAGatewayURL       = "http://localhost:8005/mcp"
 	TeamANamespace        = "team-a"
 	TeamANamespaceLabel   = "mcp-team"
 	TeamANamespaceValue   = "team-a"
 	// Team B listeners
 	TeamBMCPListenerName  = "team-b-mcp"
 	TeamBMCPSListenerName = "team-b-mcps"
-	TeamBPublicHost       = "team-b.127-0-0-1.sslip.io"
-	TeamBGatewayURL       = "http://localhost:8006/mcp"
 	TeamBNamespace        = "team-b"
 	TeamBNamespaceValue   = "team-b"
 )
 
-// Gateway URL (configurable via environment)
-var gatewayURL = goenv.GetDefault("GATEWAY_URL", "http://localhost:8001/mcp")
+const defaultE2EDomain = "127-0-0-1.sslip.io"
+
+// e2e environment configuration
+var (
+	e2eDomain = goenv.GetDefault("E2E_DOMAIN", defaultE2EDomain)
+	e2eScheme = goenv.GetDefault("E2E_SCHEME", "http")
+)
+
+// public hosts - derived from E2E_DOMAIN
+var (
+	gatewayPublicHost = goenv.GetDefault("GATEWAY_PUBLIC_HOST", "mcp."+e2eDomain)
+	E2E1PublicHost    = goenv.GetDefault("E2E1_PUBLIC_HOST", "e2e-1."+e2eDomain)
+	TeamAPublicHost   = goenv.GetDefault("TEAM_A_PUBLIC_HOST", "team-a."+e2eDomain)
+	TeamBPublicHost   = goenv.GetDefault("TEAM_B_PUBLIC_HOST", "team-b."+e2eDomain)
+)
+
+// gateway URLs - on Kind use localhost port mappings, on real clusters derive from public hosts
+var (
+	gatewayURL      = goenv.GetDefault("GATEWAY_URL", gatewayURLDefault(gatewayPublicHost, "http://localhost:8001/mcp"))
+	E2E1GatewayURL  = goenv.GetDefault("E2E1_GATEWAY_URL", gatewayURLDefault(E2E1PublicHost, "http://localhost:8004/mcp"))
+	TeamAGatewayURL = goenv.GetDefault("TEAM_A_GATEWAY_URL", gatewayURLDefault(TeamAPublicHost, "http://localhost:8005/mcp"))
+	TeamBGatewayURL = goenv.GetDefault("TEAM_B_GATEWAY_URL", gatewayURLDefault(TeamBPublicHost, "http://localhost:8006/mcp"))
+)
+
+// gatewayURLDefault returns the Kind-specific localhost URL when using the default domain,
+// otherwise derives the URL from the public host.
+func gatewayURLDefault(host, kindDefault string) string {
+	if e2eDomain == defaultE2EDomain {
+		return kindDefault
+	}
+	return e2eScheme + "://" + host + "/mcp"
+}
 
 // UniqueName generates a unique name with the given prefix
 func UniqueName(prefix string) string {

--- a/tests/e2e/keycloak_helpers.go
+++ b/tests/e2e/keycloak_helpers.go
@@ -15,7 +15,7 @@ import (
 	goenv "github.com/caitlinelfring/go-env-default"
 )
 
-var keycloakTokenURL = goenv.GetDefault("KEYCLOAK_TOKEN_URL", "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token")
+var keycloakTokenURL = goenv.GetDefault("KEYCLOAK_TOKEN_URL", "https://keycloak."+e2eDomain+":8002/realms/mcp/protocol/openid-connect/token")
 
 // obtains an access token via ROPC grant (test automation only)
 func GetKeycloakUserToken(username, password string) (string, error) {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -1,5 +1,28 @@
 //go:build e2e
 
+// E2E Test Environment Configuration
+//
+// By default, tests target a local Kind cluster using localhost port mappings
+// and 127-0-0-1.sslip.io hostnames. To run against a real cluster, set:
+//
+//   E2E_DOMAIN    - base domain for all public hostnames (default: 127-0-0-1.sslip.io)
+//   E2E_SCHEME    - http or https (default: http)
+//
+// Setting E2E_DOMAIN to a non-default value causes gateway URLs to be derived
+// from the public hostnames automatically (e.g. http://mcp.<domain>/mcp) instead
+// of using Kind's localhost port mappings.
+//
+// Individual overrides are also available:
+//
+//   GATEWAY_URL, GATEWAY_PUBLIC_HOST
+//   E2E1_GATEWAY_URL, E2E1_PUBLIC_HOST
+//   TEAM_A_GATEWAY_URL, TEAM_A_PUBLIC_HOST
+//   TEAM_B_GATEWAY_URL, TEAM_B_PUBLIC_HOST
+//   AUTH_GATEWAY_URL
+//   KEYCLOAK_TOKEN_URL
+//
+// See commons.go for the full list of configurable values and their defaults.
+
 package e2e
 
 import (
@@ -36,7 +59,6 @@ var (
 	ctx                  context.Context
 	cancel               context.CancelFunc
 	defaultMCPGatewayExt *MCPGatewayExtensionSetup
-	gatewayPublicHost    = "mcp.127-0-0-1.sslip.io"
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
Replaces hardcoded 127-0-0-1.sslip.io hostnames and localhost gateway URLs with values derived from E2E_DOMAIN env var. When E2E_DOMAIN is set to a non-default value, gateway URLs auto-derive from public hosts instead of using Kind localhost port mappings.

Fixes #728

@trepel 

see https://github.com/Kuadrant/mcp-gateway/compare/main...maleck13:worktree-remove-hard-coded-test-urls?expand=1#diff-265d9afff5b7148558247b1c711ccd6cdda5ab32fe4e14ca2c5f7013f895333cR3