### PR TITLE
review of revocation,authz,auth guides for 0.6.0-rc2

### DIFF
--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -122,7 +122,7 @@ echo "Waiting for Istio gateway pod to be ready..."
 kubectl wait --for=condition=ready --timeout=300s pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system
 
 echo "Starting MCP inspector..."
-MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest &
+MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1 &
 INSPECTOR_PID=$!
 
 sleep 3

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -16,7 +16,6 @@ Key concepts:
 
 - MCP Gateway installed and configured
 - Identity provider supporting OAuth 2.1 (this guide uses Keycloak)
-- [Kuadrant operator](https://docs.kuadrant.io/1.2.x/install-helm/) installed
 - [Node.js and npm](https://nodejs.org/en/download/) installed (for MCP Inspector testing)
 
 **Note**: This guide demonstrates authentication using Kuadrant's AuthPolicy, but MCP Gateway supports any Istio/Gateway API compatible authentication mechanism.
@@ -231,11 +230,9 @@ You should get a response like this:
 
 Use the MCP Inspector to test the complete OAuth flow.
 
-> **Note:** If you set up your cluster using the [Quick Start Guide](./quick-start.md), Keycloak (port 8002) is not exposed to the host. Run `kubectl port-forward -n gateway-system svc/mcp-gateway-np 8002:8002` in a separate terminal before proceeding.
-
 ```bash
 # Start MCP Inspector (requires Node.js/npm)
-npx @modelcontextprotocol/inspector@latest &
+npx @modelcontextprotocol/inspector@0.21.1 &
 INSPECTOR_PID=$!
 
 # Wait a moment for services to start

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -116,7 +116,7 @@ Test that authorization now controls tool access by setting up the MCP Inspector
 
 ```bash
 # Start MCP Inspector (requires Node.js/npm)
-npx @modelcontextprotocol/inspector@latest &
+npx @modelcontextprotocol/inspector@0.21.1 &
 INSPECTOR_PID=$!
 
 # Wait for services to start
@@ -137,7 +137,6 @@ open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-
 2. **Try allowed tools**:
    - `test1_greet`
    - `test2_headers`
-   - `test3_add`
 3. **Try restricted tools**:
    - `test1_time` - Should return 403 Forbidden (accounting group only has the `greet` role for test-server1)
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -31,7 +31,7 @@ The script checks prerequisites, then runs through each step automatically:
 Once the script completes, you can use [MCP Inspector](https://github.com/modelcontextprotocol/inspector) to interact with the gateway. This requires [Node.js and npm](https://nodejs.org/en/download/).
 
 ```bash
-DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
+DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1
 ```
 
 Open the inspector at [http://localhost:6274](http://localhost:6274) and configure:

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -30,7 +30,15 @@ To revoke a tool for a single user:
 1. Go to **Users** > select the user
 2. Go to **Role mapping** > remove the tool role from the relevant client
 
-## Step 2: Understand When Revocation Takes Effect
+## Step 2: Verify tools/call Denial
+
+After revoking a tool, verify that the user can no longer call it. Log out of any existing MCP Inspector session and log back in as the affected user to get a fresh token.
+
+Open MCP Inspector and connect to your gateway's `/mcp` endpoint. Authenticate through the OAuth flow.
+
+Under **Tools > List Tools**, the revoked tool will still appear (this is expected — `tools/list` filtering is configured in Step 4). Try calling the revoked tool — the request should return 403 Forbidden.
+
+## Step 3: Understand When Revocation Takes Effect
 
 Revocation is not instantaneous. Access is governed by the JWT token, and tokens are valid until they expire.
 
@@ -42,27 +50,132 @@ To force faster revocation, reduce the access token lifespan in your identity pr
 
 > **Note:** There is no mechanism to revoke a specific in-flight token. Revocation relies on token expiry and re-issuance.
 
-## Step 3: Verify Revocation
+## Step 4: Enable tools/list Filtering
 
-After revoking a tool, verify that the user can no longer access it. The simplest way is using MCP Inspector.
+By default, revoking a tool only blocks `tools/call` requests (returning 403). The revoked tool still appears in `tools/list` responses. To filter revoked tools from the list, the broker needs a signed header that carries the user's authorized tools.
 
-Find your gateway address:
+This step configures Authorino to generate that header using a wristband JWT signed with an ECDSA key pair.
+
+### Generate an ECDSA key pair
 
 ```bash
-kubectl get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}'
+openssl ecparam -name prime256v1 -genkey -noout -out private-key.pem
+openssl ec -in private-key.pem -pubout -out public-key.pem
 ```
 
-Open MCP Inspector and connect to your gateway's `/mcp` endpoint (e.g., `http://<gateway-address>:8001/mcp`). Authenticate as the affected user through the OAuth flow.
+### Create Kubernetes secrets
 
-**Check `tools/list` filtering:**
+The public key goes in the broker's namespace; the private key goes in Authorino's namespace:
 
-Under **Tools > List Tools**, the revoked tool should no longer appear in the list.
+```bash
+kubectl create secret generic trusted-headers-public-key \
+  --from-file=key=public-key.pem \
+  -n mcp-system \
+  --dry-run=client -o yaml | kubectl apply -f -
 
-**Check `tools/call` denial:**
+kubectl create secret generic trusted-headers-private-key \
+  --from-file=key.pem=private-key.pem \
+  -n kuadrant-system \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
 
-Attempt to call the revoked tool. Since the tool is no longer in the user's authorized set, the request should fail.
+### Update the AuthPolicy to generate the x-authorized-tools header
 
-## Step 4: Monitor Revocation Enforcement
+Delete the existing `mcp-auth-policy` and create a new version that adds authorization rules and a wristband response. The policy must be deleted first because the original uses `defaults.rules` while this version uses `rules`, and `kubectl apply` would merge both instead of replacing:
+
+```bash
+kubectl delete authpolicy mcp-auth-policy -n gateway-system --ignore-not-found
+kubectl create -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: mcp-auth-policy
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: mcp-gateway
+    sectionName: mcp
+  when:
+    - predicate: "!request.path.contains('/.well-known')"
+  rules:
+    authentication:
+      'keycloak':
+        jwt:
+          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
+    authorization:
+      'allow-mcp-method':
+        patternMatching:
+          patterns:
+          - predicate: |
+              !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
+      'authorized-tools':
+        opa:
+          rego: |
+            allow = true
+            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+          allValues: true
+    response:
+      success:
+        headers:
+          x-authorized-tools:
+            wristband:
+              issuer: 'authorino'
+              customClaims:
+                'allowed-tools':
+                  selector: auth.authorization.authorized-tools.tools.@tostr
+              tokenDuration: 300
+              signingKeyRefs:
+                - name: trusted-headers-private-key
+                  algorithm: ES256
+      unauthenticated:
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+        body:
+          value: |
+            {
+              "error": "Unauthorized",
+              "message": "Access denied: Authentication required."
+            }
+      unauthorized:
+        code: 401
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+        body:
+          value: |
+            {
+              "error": "Forbidden",
+              "message": "Access denied: Unsupported method. New authentication required (401)."
+            }
+EOF
+```
+
+### Configure the broker to validate the signed header
+
+The patch triggers an automatic broker redeployment that loads the public key from the secret created earlier:
+
+```bash
+kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
+  -p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
+
+kubectl rollout status deployment/mcp-gateway -n mcp-system --timeout=60s
+```
+
+Verify the AuthPolicy is enforced:
+
+```bash
+kubectl get authpolicy mcp-auth-policy -n gateway-system -o jsonpath='{.status.conditions[?(@.type=="Enforced")].status}'
+# Expected: True
+```
+
+## Step 5: Verify tools/list Filtering
+
+Log out and log back in to get a fresh token. Under **Tools > List Tools**, the revoked tool should no longer appear in the list. Only tools matching the user's `resource_access` roles are returned.
+
+## Step 6: Monitor Revocation Enforcement
 
 If [OpenTelemetry](./opentelemetry.md) is enabled, denied requests appear as trace spans with `http.status_code: 403`. Query your trace backend to find them:
 
@@ -80,6 +193,5 @@ The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `t
 
 ## Next Steps
 
-- **[Authorization](./authorization.md)** - Configure tool-level access control
 - **[OpenTelemetry](./opentelemetry.md)** - Enable distributed tracing
 - **[Troubleshooting](./troubleshooting.md)** - Debug authorization issues

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -35,7 +35,7 @@ When a client includes the virtual server header, MCP Gateway filters responses 
 Before creating virtual servers, check which tools are available in your gateway. You can browse them using [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
 ```bash
-DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
+DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1
 ```
 
 > **Note:** `DANGEROUSLY_OMIT_AUTH=true` is for local testing only. Do not use it in shared or production environments.

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -66,6 +66,9 @@ nodes:
   - containerPort: 30080
     hostPort: 8001
     protocol: TCP
+  - containerPort: 30089 # keycloak
+    hostPort: 8002
+    protocol: TCP
 EOF
 fi
 
@@ -125,7 +128,7 @@ echo ""
 echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "To test with MCP Inspector (requires Node.js):"
-echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest"
+echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1"
 echo ""
 echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"


### PR DESCRIPTION
 **MCP Inspector version pin** 
All references to @modelcontextprotocol/inspector@latest are pinned to @0.21.1. Using @latest risks pulling in breaking changes that can disrupt the developer workflow, and
  the inspector processes on ports 6274/6277 don't always clean up properly across versions.

  **Tool revocation guide (docs/guides/tool-revocation.md)** 
Previously, following authentication → authorization → tool-revocation only blocked tools/call (returning 403). The revoked tool still appeared in tools/list because the broker had no way to know which tools to filter. The guide now includes:
  - Step 2: Verify tools/call denial immediately after revoking (while the tool is still visible in the list)
  - Step 4: Full setup for tools/list filtering — ECDSA key pair generation, Kubernetes secrets, MCPGatewayExtension config, and the updated AuthPolicy with Authorino's wristband feature to inject a
  signed x-authorized-tools header
  - Step 5: Verify the tool no longer appears in tools/list

  **Authentication guide (docs/guides/authentication.md)** 
Removed Kuadrant operator from prerequisites. It was listed as a prerequisite but is actually installed as part of Step 3 in the same guide.

  **Authorization guide (docs/guides/authorization.md)**
Removed test3_add from the "Try allowed tools" test scenarios. Test server 3 is not deployed by the authorization guide's prerequisites, so users following the guide wouldn't have that tool available.

  **Quick-start script (scripts/quick-start.sh)**
Added keycloak NodePort mapping (port 8002) to the Kind cluster config so Keycloak is accessible from the host after running quick-start, which is needed for the authentication guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced tool revocation guide with clearer verification steps, re-sequencing, and an added workflow to filter revoked tools via authorization wristband verification
  * Removed an outdated prerequisite and a deprecated test tool from examples; clarified OAuth testing instructions across guides
  * Standardized Inspector usage across guides

* **Chores**
  * Pinned the Inspector to v0.21.1 in setup instructions and scripts
  * Added local Keycloak port mapping to local setup instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->