### PR TITLE
Cherry-pick rc2 guide fixes to release-0.6.0

### DIFF
--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"toolPrefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
-    createdAt: "2026-03-30T09:23:13Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
+    createdAt: "2026-04-13T09:49:48Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.6.0-rc1
+  name: mcp-gateway.v0.6.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -181,8 +181,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
-                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
+                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -242,6 +242,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
       name: router-broker
-  version: 0.6.0-rc1
+  version: 0.6.0-rc2

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc1}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc2}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0-rc1
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0-rc2
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.6.0-rc1
+  name: mcp-gateway.v0.6.0-rc2
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.6.0-rc1
+  version: 0.6.0-rc2

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0-rc1}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0-rc2}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -12,7 +12,7 @@ Clients call your Gateway's hostname, and the Gateway rewrites and routes traffi
 - Authentication credentials for the external server (if required)
 - **MCPGatewayExtension** targeting the Gateway (required for MCPServerRegistration to work)
 
-**Note:** If you're trying this locally, `make local-env-setup` already meets all prerequisites except the GitHub PAT.
+**Note:** If you're trying this locally, `make local-env-setup` meets all prerequisites except the GitHub PAT. The optional AuthPolicy step (Step 6) additionally requires Kuadrant (`make auth-example-setup`).
 
 If you haven't created an MCPGatewayExtension yet, see [Configure MCP Servers](./register-mcp-servers.md#step-1-create-mcpgatewayextension) for instructions.
 

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -41,7 +41,12 @@ Note: CRDs are also installed automatically when deploying via Helm.
 
 ### Step 2: Install MCP Gateway
 
-Install from GitHub Container Registry:
+Find your Gateway name and namespace, then install from GitHub Container Registry:
+
+```bash
+# find your gateway
+kubectl get gateway -A
+```
 
 ```bash
 helm upgrade -i mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -15,16 +15,18 @@ make olm-install
 Deploy from a release tag using kustomize with a remote ref:
 
 ```bash
-kubectl apply -k https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v0.5.1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
+kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
 ```
 
-Replace `v0.5.1` with the desired release tag.
-
-Wait for the controller to be ready:
+Wait for the controller to be ready. The CSV may take a moment to appear while OLM processes the subscription:
 
 ```bash
-kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system="" --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
+kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
 ```
+
+If the command returns "no matching resources found", wait a few seconds and retry -- the CSV has not been created yet.
 
 ## Next Steps
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -70,23 +70,21 @@ kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-api-key-server-route
+  name: my-mcp-server-route
   namespace: mcp-test
-  labels:
-    mcp-server: 'true'
 spec:
   parentRefs:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'api-key-server.mcp.local'  # Internal routing hostname
+    - 'my-mcp-server.mcp.local'  # Internal routing hostname
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: mcp-api-key-server  # Your MCP server service name
+        - name: mcp-test-server1    # Your MCP server service name
           port: 9090                # Your MCP server port
 EOF
 ```
@@ -107,7 +105,7 @@ spec:
   targetRef:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
-    name: "mcp-api-key-server-route"  # The name and namespace of your MCP Server HTTPRoute
+    name: "my-mcp-server-route"  # Must match the HTTPRoute name
     namespace: "mcp-test"
 EOF
 ```
@@ -129,8 +127,8 @@ kubectl get mcpsr -A
 The `READY` column should show `True` and the `TOOLS` column should show the number of tools discovered. For example:
 
 ```text
-NAMESPACE   NAME            PREFIX      TARGET                     PATH   READY   TOOLS   CREDENTIALS   AGE
-mcp-test    my-mcp-server   myserver_   mcp-api-key-server-route   /mcp   True    4                     30s
+NAMESPACE   NAME            PREFIX      TARGET               PATH   READY   TOOLS   CREDENTIALS   AGE
+mcp-test    my-mcp-server   myserver_   my-mcp-server-route   /mcp   True    5                     30s
 ```
 
 If the status is not Ready, check the MCPServerRegistration conditions for details:

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -20,6 +20,7 @@ Virtual servers work by filtering the complete tool list based on a curated sele
 - MCP Gateway installed and configured
 - [MCP servers configured](./register-mcp-servers.md) with tools available
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) installed
+- [jq](https://jqlang.github.io/jq/download/) installed
 
 ## Understanding Virtual Servers
 
@@ -58,10 +59,9 @@ metadata:
 spec:
   description: "Development and debugging tools"
   tools:
-  - test1_hello_world      # replace with your actual tool names
+  - test1_greet             # replace with your actual tool names
   - test1_headers
-  - github_get_me
-  - github_list_repos
+  - test2_hello_world
 EOF
 ```
 
@@ -77,9 +77,9 @@ metadata:
 spec:
   description: "Data analysis and reporting tools"
   tools:
-  - test2_time            # replace with your actual tool names
+  - test2_time             # replace with your actual tool names
   - test3_dozen
-  - github_get_repo_stats
+  - test3_add
 EOF
 ```
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc2}
 GIT_REF="v${VERSION}"
 REPO="https://github.com/${GITHUB_ORG}/mcp-gateway"
 RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/mcp-gateway/${GIT_REF}"

--- a/scripts/set-release-version.sh
+++ b/scripts/set-release-version.sh
@@ -84,7 +84,8 @@ fi
 for GUIDE in \
     "$REPO_ROOT/docs/guides/quick-start.md" \
     "$REPO_ROOT/docs/guides/isolated-gateway-deployment.md" \
-    "$REPO_ROOT/docs/guides/how-to-install-and-configure.md"; do
+    "$REPO_ROOT/docs/guides/how-to-install-and-configure.md" \
+    "$REPO_ROOT/docs/guides/olm-install.md"; do
     if [ -f "$GUIDE" ]; then
         sed -i.bak -E "s/MCP_GATEWAY_VERSION=[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?/MCP_GATEWAY_VERSION=$VERSION/" "$GUIDE"
         rm -f "$GUIDE.bak"


### PR DESCRIPTION
## Summary
- Cherry-picks guide fixes from #769 to the release branch
- Fixes across virtual MCP servers, install, register, external MCP server, and OLM install guides
- Adds olm-install.md to set-release-version.sh for automatic version updates

## Test plan
- [x] Verify guide version references are correct for 0.6.0 release