### PR TITLE
Update version to 0.6.0

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup CI environment
         run: |
           make ci-setup
-          make deploy-controller
+          kubectl apply -k config/mcp-gateway/base/ -n mcp-system
 
       - name: Deploy conformance server
         run: make deploy-conformance-server

--- a/Makefile
+++ b/Makefile
@@ -266,11 +266,15 @@ build-and-load-image: kind build-image load-image restart-all  ## Build & load r
 load-image: kind ## Load the mcp-gateway image into the kind cluster
 	$(call load-image,$(GATEWAY_IMG))
 	$(call load-image,$(IMAGE_TAG_BASE):$(IMAGE_TAG))
+	$(call load-image,$(REGISTRY)/$(ORG)/mcp-gateway:latest)
+	$(call load-image,$(IMAGE_TAG_BASE):latest)
 
 .PHONY: build-image
 build-image: kind ## Build the mcp-gateway image
 	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --build-arg LDFLAGS="$(LDFLAGS)" -t $(GATEWAY_IMG) .
 	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --file Dockerfile.controller -t $(IMAGE_TAG_BASE):$(IMAGE_TAG) .
+	$(CONTAINER_ENGINE) tag $(GATEWAY_IMG) $(REGISTRY)/$(ORG)/mcp-gateway:latest
+	$(CONTAINER_ENGINE) tag $(IMAGE_TAG_BASE):$(IMAGE_TAG) $(IMAGE_TAG_BASE):latest
 
 # Deploy example MCPServerRegistration
 deploy-example: install-crd ## Deploy example MCPServerRegistration resource

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"toolPrefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
-    createdAt: "2026-04-13T09:49:48Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0
+    createdAt: "2026-04-16T10:38:53Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.6.0-rc2
+  name: mcp-gateway.v0.6.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -181,8 +181,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
-                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
+                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0
+                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -242,6 +242,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
+    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0
       name: router-broker
-  version: 0.6.0-rc2
+  version: 0.6.0

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc2}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0-rc2
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.6.0-rc2
+  name: mcp-gateway.v0.6.0
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.6.0-rc2
+  version: 0.6.0

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
+              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-gateway/overlays/ci/kustomization.yaml
+++ b/config/mcp-gateway/overlays/ci/kustomization.yaml
@@ -13,6 +13,14 @@ resources:
 components:
   - ../../components/controller
 
+# override image tags so CI uses locally-built images (tagged 'latest')
+# rather than the release version hardcoded in the base manifests
+images:
+  - name: ghcr.io/kuadrant/mcp-controller
+    newTag: latest
+  - name: ghcr.io/kuadrant/mcp-gateway
+    newTag: latest
+
 patches:
   # patch ClusterRoleBinding to reference correct namespace
   - target:
@@ -24,3 +32,22 @@ patches:
       - op: replace
         path: /subjects/0/namespace
         value: mcp-system
+  # use locally-built broker image in CI (kustomize images: only patches image: fields)
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: mcp-gateway-controller
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: mcp-gateway-controller
+      spec:
+        template:
+          spec:
+            containers:
+              - name: mcp-controller
+                env:
+                  - name: RELATED_IMAGE_ROUTER_BROKER
+                    value: ghcr.io/kuadrant/mcp-gateway:latest

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
+          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0-rc2}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc2
+export MCP_GATEWAY_VERSION=0.6.0
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc2
+export MCP_GATEWAY_VERSION=0.6.0
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -15,7 +15,7 @@ make olm-install
 Deploy from a release tag using kustomize with a remote ref:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc2
+export MCP_GATEWAY_VERSION=0.6.0
 kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc2
+export MCP_GATEWAY_VERSION=0.6.0
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc2}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0}
 GIT_REF="v${VERSION}"
 REPO="https://github.com/${GITHUB_ORG}/mcp-gateway"
 RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/mcp-gateway/${GIT_REF}"


### PR DESCRIPTION
## Summary
- Version bump from 0.6.0-rc2 to 0.6.0 for final release
- Updates version references across docs, scripts, manifests, and OLM bundle
- Fixes CI image mismatch: `build-image` now also tags as `latest`, CI kustomize overlay references `latest` instead of the hardcoded release version, and conformance workflow no longer re-deploys via the mcp-system overlay (which overwrote CI images with unreleased version tags)