### PR TITLE
Fix/remove links to developer content

### DIFF
--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -277,7 +277,7 @@ helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
   --set gateway.nodePort.mcpPort=30471
 ```
 
-> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30471) to host ports. See the [Kind cluster setup guide](./kind-cluster-setup.md) for details.
+> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30471) to host ports.
 
 ## Next Steps: Register MCP Servers
 

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -7,7 +7,7 @@ This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distribut
 - MCP Gateway installed and configured
 - An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent)
 
-> **Note:** For a pre-configured local stack with OTEL Collector, Tempo, Loki, and Grafana, see the [observability example](../../examples/otel/README.md).
+> **Note:** For a pre-configured local stack with OTEL Collector, Tempo, Loki, and Grafana, see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/release-0.6.0/examples/otel).
 
 ## Step 1: Enable OpenTelemetry
 
@@ -37,18 +37,6 @@ kubectl set env deployment/mcp-gateway -n mcp-system \
   OTEL_EXPORTER_OTLP_ENDPOINT="http://your-collector:4318" \
   OTEL_EXPORTER_OTLP_INSECURE="true"
 ```
-
-### Standalone Binary
-
-Export the variables before starting the process:
-
-```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-collector:4318"
-export OTEL_EXPORTER_OTLP_INSECURE="true"
-./bin/mcp-broker-router
-```
-
-See the [standalone binary install guide](./binary-install.md) for full configuration details.
 
 ## Step 2: Verify Traces Are Being Exported
 
@@ -157,5 +145,5 @@ echo "Search for trace: $TRACE_ID"
 
 ## Next Steps
 
-- For a pre-configured local observability stack (OTEL Collector, Tempo, Loki, Grafana), see the [observability example](../../examples/otel/README.md).
+- For a pre-configured local observability stack (OTEL Collector, Tempo, Loki, Grafana), see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/release-0.6.0/examples/otel).
 - To scale the gateway with shared session state, see the [scaling guide](./scaling.md).


### PR DESCRIPTION
Fix broken links in user-facing docs

  - Remove link to local dev focused kind-cluster-setup.md from isolated gateway guide
  - Replace relative examples/otel/ links with absolute GitHub URLs in otel guide (don't want to have those examples slurped into docs site)
  - Remove standalone binary section from otel guide (untested install path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability example references to use GitHub URLs instead of local paths
  * Removed standalone binary deployment instructions, including OTEL endpoint configuration steps
  * Simplified Kubernetes NodePort exposure documentation for Kind clusters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->