### PR TITLE
cherry-pick docs fixes to release-0.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Users must create the Istio ServiceEntry, DestinationRule, and HTTPRoute resourc
 
 MCP servers can require authentication:
 1. MCPServerRegistration spec includes `credentialRef` pointing to a Kubernetes secret
-   - **Important**: Secret must have label `mcp.kuadrant.io/credential=true`
+   - **Important**: Secret must have label `mcp.kuadrant.io/secret=true`
    - Without this label, the MCPServerRegistration will fail validation
 2. Controller reads the credential from the referenced secret and includes it in the config Secret
 3. Broker receives the credential via the config and passes it to the upstream connection
@@ -255,7 +255,7 @@ metadata:
   name: weather-secret
   namespace: mcp-test
   labels:
-    mcp.kuadrant.io/credential: "true"  # required label
+    mcp.kuadrant.io/secret: "true"  # required label
 type: Opaque
 stringData:
   token: "Bearer your-api-token"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you already have a Kubernetes cluster with [Gateway API](https://gateway-api.
 
 ```bash
 # Install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
 # Install MCP Gateway (quotes required for zsh)
 kubectl apply -k 'https://github.com/Kuadrant/mcp-gateway/config/install?ref=main'
 ```
@@ -110,7 +110,7 @@ Uses a YAML configuration file to define MCP servers:
 ```bash
 make run
 # Or directly:
-./bin/mcp-broker-router --mcp-gateway-config ./config/mcp-system/config.yaml
+./bin/mcp-broker-router --mcp-gateway-config ./config/samples/config.yaml
 ```
 
 The broker watches the config file for changes and hot-reloads configuration automatically.
@@ -133,7 +133,7 @@ In controller mode:
 ## Configuration
 
 ### Standalone Configuration
-Edit `config/mcp-system/config.yaml`:
+Edit `config/samples/config.yaml`:
 
 ```yaml
 servers:
@@ -192,7 +192,7 @@ spec:
 ```bash
 --mcp-router-address            # gRPC ext_proc address (default: 0.0.0.0:50051)
 --mcp-broker-public-address     # HTTP broker address (default: 0.0.0.0:8080)
---mcp-gateway-config            # Config file path (default: ./config/mcp-system/config.yaml)
+--mcp-gateway-config            # Config file path (default: ./config/samples/config.yaml)
 --controller                    # Enable Kubernetes controller mode
 ```
 

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"toolPrefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
-    createdAt: "2026-03-30T09:23:13Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
+    createdAt: "2026-04-13T09:49:48Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.6.0-rc1
+  name: mcp-gateway.v0.6.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -181,8 +181,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
-                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+                        value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
+                    image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -242,6 +242,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+    - image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
       name: router-broker
-  version: 0.6.0-rc1
+  version: 0.6.0-rc2

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -122,7 +122,7 @@ echo "Waiting for Istio gateway pod to be ready..."
 kubectl wait --for=condition=ready --timeout=300s pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system
 
 echo "Starting MCP inspector..."
-MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest &
+MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1 &
 INSPECTOR_PID=$!
 
 sleep 3

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc1}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc2}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -108,7 +108,7 @@ func main() {
 	flag.StringVar(
 		&mcpConfigFile,
 		"mcp-gateway-config",
-		"./config/mcp-system/config.yaml",
+		"./config/samples/config.yaml",
 		"where to locate the mcp server config",
 	)
 	flag.IntVar(

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0-rc1
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0-rc2
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.6.0-rc1
+  name: mcp-gateway.v0.6.0-rc2
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.6.0-rc1
+  version: 0.6.0-rc2

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+              value: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc1
+          image: ghcr.io/kuadrant/mcp-gateway:v0.6.0-rc2
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc1
+          image: ghcr.io/kuadrant/mcp-controller:v0.6.0-rc2
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0-rc1}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.6.0-rc2}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -37,7 +37,7 @@ The MCP router is an envoy focused ext_proc component that is capable of parsing
 
 - Parsing and validation of the MCP [JSON-RPC](https://www.jsonrpc.org/) body
 - Setting the key request headers: 
-    - x-destination-mcp, x-mcp-tool, mcp-session-id
+    - x-mcp-servername, x-mcp-toolname, mcp-session-id
 - Watching for 404 responses from MCP servers and invalidating the  session store.
 - Handling session initialization and storage on behalf of a requesting  MCP client during a tools/call
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -16,7 +16,6 @@ Key concepts:
 
 - MCP Gateway installed and configured
 - Identity provider supporting OAuth 2.1 (this guide uses Keycloak)
-- [Kuadrant operator](https://docs.kuadrant.io/1.2.x/install-helm/) installed
 - [Node.js and npm](https://nodejs.org/en/download/) installed (for MCP Inspector testing)
 
 **Note**: This guide demonstrates authentication using Kuadrant's AuthPolicy, but MCP Gateway supports any Istio/Gateway API compatible authentication mechanism.
@@ -231,11 +230,9 @@ You should get a response like this:
 
 Use the MCP Inspector to test the complete OAuth flow.
 
-> **Note:** If you set up your cluster using the [Quick Start Guide](./quick-start.md), Keycloak (port 8002) is not exposed to the host. Run `kubectl port-forward -n gateway-system svc/mcp-gateway-np 8002:8002` in a separate terminal before proceeding.
-
 ```bash
 # Start MCP Inspector (requires Node.js/npm)
-npx @modelcontextprotocol/inspector@latest &
+npx @modelcontextprotocol/inspector@0.21.1 &
 INSPECTOR_PID=$!
 
 # Wait a moment for services to start

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -116,7 +116,7 @@ Test that authorization now controls tool access by setting up the MCP Inspector
 
 ```bash
 # Start MCP Inspector (requires Node.js/npm)
-npx @modelcontextprotocol/inspector@latest &
+npx @modelcontextprotocol/inspector@0.21.1 &
 INSPECTOR_PID=$!
 
 # Wait for services to start
@@ -137,7 +137,6 @@ open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-
 2. **Try allowed tools**:
    - `test1_greet`
    - `test2_headers`
-   - `test3_add`
 3. **Try restricted tools**:
    - `test1_time` - Should return 403 Forbidden (accounting group only has the `greet` role for test-server1)
 

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -22,7 +22,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 
 ## Prerequisites
 
-- [Go 1.21+](https://golang.org/doc/install) installed (for building from source)
+- [Go 1.25+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
 - [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed and configured
 - Access to MCP servers you want to aggregate
@@ -73,13 +73,13 @@ Save this as `config/servers.yaml` or any location you prefer.
 ```bash
 # Run with your configuration
 ./bin/mcp-broker-router \
-  --config=config/servers.yaml \
+  --mcp-gateway-config=config/servers.yaml \
   --mcp-gateway-public-host=your-hostname.example.com \
   --log-level=-4
 ```
 
 **Command Options**:
-- `--config`: Path to your YAML configuration file
+- `--mcp-gateway-config`: Path to your YAML configuration file
 - `--mcp-gateway-public-host`: **Required** - Public hostname for MCP Gateway (must match your Gateway listener hostname)
 - `--mcp-router-address`: Address for gRPC router (default: `0.0.0.0:50051`)
 - `--log-level`: Logging verbosity
@@ -174,8 +174,8 @@ envoy -c envoy.yaml
 ## Step 5: Verify Installation
 
 ```bash
-# Check health endpoint (direct to broker)
-curl http://localhost:8080/health
+# Check broker status (direct to broker)
+curl http://localhost:8080/status
 
 # Test through Envoy proxy
 curl http://localhost:8888/mcp \
@@ -201,7 +201,7 @@ lsof -i :50051 # Router
 cat config/servers.yaml
 
 # Run with debug logging
-./bin/mcp-broker-router --config=config/servers.yaml --log-level=-4
+./bin/mcp-broker-router --mcp-gateway-config=config/servers.yaml --log-level=-4
 ```
 
 ### Tools Not Appearing
@@ -223,7 +223,7 @@ curl -X POST http://weather.example.com:8080/mcp \
 ps aux | grep envoy
 
 # Verify Envoy can reach broker
-curl http://localhost:8080/health
+curl http://localhost:8080/status
 
 # Check Envoy logs for ext_proc errors
 # Ensure gRPC router (port 50051) is accessible from Envoy

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -5,7 +5,7 @@ This guide covers adding an MCP listener to your existing Gateway. The controlle
 
 ## Prerequisites
 
-- MCP Gateway [installed in your cluster](./quick-start-guide.md)
+- MCP Gateway [installed in your cluster](./quick-start.md)
 - Existing [Gateway](https://gateway-api.sigs.k8s.io/) resource
 - Gateway API provider (e.g. Istio) configured
 

--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -12,7 +12,7 @@ Clients call your Gateway's hostname, and the Gateway rewrites and routes traffi
 - Authentication credentials for the external server (if required)
 - **MCPGatewayExtension** targeting the Gateway (required for MCPServerRegistration to work)
 
-**Note:** If you're trying this locally, `make local-env-setup` already meets all prerequisites except the GitHub PAT.
+**Note:** If you're trying this locally, `make local-env-setup` meets all prerequisites except the GitHub PAT. The optional AuthPolicy step (Step 6) additionally requires Kuadrant (`make auth-example-setup`).
 
 If you haven't created an MCPGatewayExtension yet, see [Configure MCP Servers](./register-mcp-servers.md#step-1-create-mcpgatewayextension) for instructions.
 

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -41,7 +41,12 @@ Note: CRDs are also installed automatically when deploying via Helm.
 
 ### Step 2: Install MCP Gateway
 
-Install from GitHub Container Registry:
+Find your Gateway name and namespace, then install from GitHub Container Registry:
+
+```bash
+# find your gateway
+kubectl get gateway -A
+```
 
 ```bash
 helm upgrade -i mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -99,8 +99,7 @@ helm upgrade -i mcp-controller ./charts/mcp-gateway \
   --create-namespace \
   --set controller.enabled=true \
   --set gateway.create=false \
-  --set mcpGatewayExtension.create=false \
-  --set envoyFilter.create=false
+  --set mcpGatewayExtension.create=false
 ```
 
 Verify the controller is running:
@@ -118,7 +117,6 @@ helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
   --namespace team-a \
   --create-namespace \
   --set controller.enabled=false \
-  --set broker.create=true \
   --set gateway.create=true \
   --set gateway.name=team-a-gateway \
   --set gateway.namespace=gateway-system \
@@ -126,9 +124,7 @@ helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
   --set gateway.internalHostPattern="*.team-a.mcp.local" \
   --set mcpGatewayExtension.create=true \
   --set mcpGatewayExtension.gatewayRef.name=team-a-gateway \
-  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
-  --set envoyFilter.create=true \
-  --set envoyFilter.name=team-a-gateway
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system
 ```
 
 The Helm chart creates:
@@ -140,7 +136,7 @@ The controller then automatically creates:
 - HTTPRoute for the MCP endpoint
 - Broker/Router deployment
 - Service for the broker
-- ServiceAccount and RBAC
+- ServiceAccount
 - Config Secret for MCP server configuration
 
 ## Step 5: Verify Team A Deployment
@@ -165,7 +161,6 @@ helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
   --namespace team-b \
   --create-namespace \
   --set controller.enabled=false \
-  --set broker.create=true \
   --set gateway.create=true \
   --set gateway.name=team-b-gateway \
   --set gateway.namespace=gateway-system \
@@ -173,9 +168,7 @@ helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
   --set gateway.internalHostPattern="*.team-b.mcp.local" \
   --set mcpGatewayExtension.create=true \
   --set mcpGatewayExtension.gatewayRef.name=team-b-gateway \
-  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
-  --set envoyFilter.create=true \
-  --set envoyFilter.name=team-b-gateway
+  --set mcpGatewayExtension.gatewayRef.namespace=gateway-system
 ```
 
 ## Step 7: Verify Team B Deployment
@@ -256,7 +249,6 @@ Re-run the Team A and Team B Helm commands from Steps 4 and 6 with NodePort flag
 helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
   --namespace team-a \
   --set controller.enabled=false \
-  --set broker.create=true \
   --set gateway.create=true \
   --set gateway.name=team-a-gateway \
   --set gateway.namespace=gateway-system \
@@ -265,8 +257,6 @@ helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
   --set mcpGatewayExtension.create=true \
   --set mcpGatewayExtension.gatewayRef.name=team-a-gateway \
   --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
-  --set envoyFilter.create=true \
-  --set envoyFilter.name=team-a-gateway \
   --set gateway.nodePort.create=true \
   --set gateway.nodePort.mcpPort=30080
 ```
@@ -275,7 +265,6 @@ helm upgrade -i team-a-mcp-gateway ./charts/mcp-gateway \
 helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
   --namespace team-b \
   --set controller.enabled=false \
-  --set broker.create=true \
   --set gateway.create=true \
   --set gateway.name=team-b-gateway \
   --set gateway.namespace=gateway-system \
@@ -284,8 +273,6 @@ helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
   --set mcpGatewayExtension.create=true \
   --set mcpGatewayExtension.gatewayRef.name=team-b-gateway \
   --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
-  --set envoyFilter.create=true \
-  --set envoyFilter.name=team-b-gateway \
   --set gateway.nodePort.create=true \
   --set gateway.nodePort.mcpPort=30471
 ```
@@ -460,7 +447,5 @@ helm install team-a-mcp-gateway ./charts/mcp-gateway \
   --set gateway.name=team-a-gateway \
   --set gateway.namespace=gateway-system \
   --set gateway.publicHost="$TEAM_A_HOST" \
-  --set envoyFilter.create=true \
-  --set envoyFilter.name=team-a-gateway \
   --set mcpGatewayExtension.create=false
 ```

--- a/docs/guides/kind-cluster-setup.md
+++ b/docs/guides/kind-cluster-setup.md
@@ -40,7 +40,7 @@ EOF
 
 ```bash
 # Install Gateway API standard CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
 
 # Verify installation
 kubectl get crd gateways.gateway.networking.k8s.io

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -15,16 +15,18 @@ make olm-install
 Deploy from a release tag using kustomize with a remote ref:
 
 ```bash
-kubectl apply -k https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v0.5.1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
+kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
 ```
 
-Replace `v0.5.1` with the desired release tag.
-
-Wait for the controller to be ready:
+Wait for the controller to be ready. The CSV may take a moment to appear while OLM processes the subscription:
 
 ```bash
-kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system="" --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
+kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
 ```
+
+If the command returns "no matching resources found", wait a few seconds and retry -- the CSV has not been created yet.
 
 ## Next Steps
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc1
+export MCP_GATEWAY_VERSION=0.6.0-rc2
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -31,7 +31,7 @@ The script checks prerequisites, then runs through each step automatically:
 Once the script completes, you can use [MCP Inspector](https://github.com/modelcontextprotocol/inspector) to interact with the gateway. This requires [Node.js and npm](https://nodejs.org/en/download/).
 
 ```bash
-DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
+DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1
 ```
 
 Open the inspector at [http://localhost:6274](http://localhost:6274) and configure:

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -70,23 +70,21 @@ kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-api-key-server-route
+  name: my-mcp-server-route
   namespace: mcp-test
-  labels:
-    mcp-server: 'true'
 spec:
   parentRefs:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'api-key-server.mcp.local'  # Internal routing hostname
+    - 'my-mcp-server.mcp.local'  # Internal routing hostname
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: mcp-api-key-server  # Your MCP server service name
+        - name: mcp-test-server1    # Your MCP server service name
           port: 9090                # Your MCP server port
 EOF
 ```
@@ -107,7 +105,7 @@ spec:
   targetRef:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
-    name: "mcp-api-key-server-route"  # The name and namespace of your MCP Server HTTPRoute
+    name: "my-mcp-server-route"  # Must match the HTTPRoute name
     namespace: "mcp-test"
 EOF
 ```
@@ -129,8 +127,8 @@ kubectl get mcpsr -A
 The `READY` column should show `True` and the `TOOLS` column should show the number of tools discovered. For example:
 
 ```text
-NAMESPACE   NAME            PREFIX      TARGET                     PATH   READY   TOOLS   CREDENTIALS   AGE
-mcp-test    my-mcp-server   myserver_   mcp-api-key-server-route   /mcp   True    4                     30s
+NAMESPACE   NAME            PREFIX      TARGET               PATH   READY   TOOLS   CREDENTIALS   AGE
+mcp-test    my-mcp-server   myserver_   my-mcp-server-route   /mcp   True    5                     30s
 ```
 
 If the status is not Ready, check the MCPServerRegistration conditions for details:

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -30,7 +30,15 @@ To revoke a tool for a single user:
 1. Go to **Users** > select the user
 2. Go to **Role mapping** > remove the tool role from the relevant client
 
-## Step 2: Understand When Revocation Takes Effect
+## Step 2: Verify tools/call Denial
+
+After revoking a tool, verify that the user can no longer call it. Log out of any existing MCP Inspector session and log back in as the affected user to get a fresh token.
+
+Open MCP Inspector and connect to your gateway's `/mcp` endpoint. Authenticate through the OAuth flow.
+
+Under **Tools > List Tools**, the revoked tool will still appear (this is expected — `tools/list` filtering is configured in Step 4). Try calling the revoked tool — the request should return 403 Forbidden.
+
+## Step 3: Understand When Revocation Takes Effect
 
 Revocation is not instantaneous. Access is governed by the JWT token, and tokens are valid until they expire.
 
@@ -42,27 +50,132 @@ To force faster revocation, reduce the access token lifespan in your identity pr
 
 > **Note:** There is no mechanism to revoke a specific in-flight token. Revocation relies on token expiry and re-issuance.
 
-## Step 3: Verify Revocation
+## Step 4: Enable tools/list Filtering
 
-After revoking a tool, verify that the user can no longer access it. The simplest way is using MCP Inspector.
+By default, revoking a tool only blocks `tools/call` requests (returning 403). The revoked tool still appears in `tools/list` responses. To filter revoked tools from the list, the broker needs a signed header that carries the user's authorized tools.
 
-Find your gateway address:
+This step configures Authorino to generate that header using a wristband JWT signed with an ECDSA key pair.
+
+### Generate an ECDSA key pair
 
 ```bash
-kubectl get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}'
+openssl ecparam -name prime256v1 -genkey -noout -out private-key.pem
+openssl ec -in private-key.pem -pubout -out public-key.pem
 ```
 
-Open MCP Inspector and connect to your gateway's `/mcp` endpoint (e.g., `http://<gateway-address>:8001/mcp`). Authenticate as the affected user through the OAuth flow.
+### Create Kubernetes secrets
 
-**Check `tools/list` filtering:**
+The public key goes in the broker's namespace; the private key goes in Authorino's namespace:
 
-Under **Tools > List Tools**, the revoked tool should no longer appear in the list.
+```bash
+kubectl create secret generic trusted-headers-public-key \
+  --from-file=key=public-key.pem \
+  -n mcp-system \
+  --dry-run=client -o yaml | kubectl apply -f -
 
-**Check `tools/call` denial:**
+kubectl create secret generic trusted-headers-private-key \
+  --from-file=key.pem=private-key.pem \
+  -n kuadrant-system \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
 
-Attempt to call the revoked tool. Since the tool is no longer in the user's authorized set, the request should fail.
+### Update the AuthPolicy to generate the x-authorized-tools header
 
-## Step 4: Monitor Revocation Enforcement
+Delete the existing `mcp-auth-policy` and create a new version that adds authorization rules and a wristband response. The policy must be deleted first because the original uses `defaults.rules` while this version uses `rules`, and `kubectl apply` would merge both instead of replacing:
+
+```bash
+kubectl delete authpolicy mcp-auth-policy -n gateway-system --ignore-not-found
+kubectl create -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: mcp-auth-policy
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: mcp-gateway
+    sectionName: mcp
+  when:
+    - predicate: "!request.path.contains('/.well-known')"
+  rules:
+    authentication:
+      'keycloak':
+        jwt:
+          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
+    authorization:
+      'allow-mcp-method':
+        patternMatching:
+          patterns:
+          - predicate: |
+              !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
+      'authorized-tools':
+        opa:
+          rego: |
+            allow = true
+            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+          allValues: true
+    response:
+      success:
+        headers:
+          x-authorized-tools:
+            wristband:
+              issuer: 'authorino'
+              customClaims:
+                'allowed-tools':
+                  selector: auth.authorization.authorized-tools.tools.@tostr
+              tokenDuration: 300
+              signingKeyRefs:
+                - name: trusted-headers-private-key
+                  algorithm: ES256
+      unauthenticated:
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+        body:
+          value: |
+            {
+              "error": "Unauthorized",
+              "message": "Access denied: Authentication required."
+            }
+      unauthorized:
+        code: 401
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+        body:
+          value: |
+            {
+              "error": "Forbidden",
+              "message": "Access denied: Unsupported method. New authentication required (401)."
+            }
+EOF
+```
+
+### Configure the broker to validate the signed header
+
+The patch triggers an automatic broker redeployment that loads the public key from the secret created earlier:
+
+```bash
+kubectl patch mcpgatewayextension mcp-gateway-extension -n mcp-system --type='merge' \
+  -p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
+
+kubectl rollout status deployment/mcp-gateway -n mcp-system --timeout=60s
+```
+
+Verify the AuthPolicy is enforced:
+
+```bash
+kubectl get authpolicy mcp-auth-policy -n gateway-system -o jsonpath='{.status.conditions[?(@.type=="Enforced")].status}'
+# Expected: True
+```
+
+## Step 5: Verify tools/list Filtering
+
+Log out and log back in to get a fresh token. Under **Tools > List Tools**, the revoked tool should no longer appear in the list. Only tools matching the user's `resource_access` roles are returned.
+
+## Step 6: Monitor Revocation Enforcement
 
 If [OpenTelemetry](./opentelemetry.md) is enabled, denied requests appear as trace spans with `http.status_code: 403`. Query your trace backend to find them:
 
@@ -80,6 +193,5 @@ The router logs the `x-mcp-toolname` and `x-mcp-servername` headers for every `t
 
 ## Next Steps
 
-- **[Authorization](./authorization.md)** - Configure tool-level access control
 - **[OpenTelemetry](./opentelemetry.md)** - Enable distributed tracing
 - **[Troubleshooting](./troubleshooting.md)** - Debug authorization issues

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -39,7 +39,7 @@ kubectl get deployment -n mcp-system
 ```
 
 **Solutions**:
-- Install Gateway API CRDs first: `kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml`
+- Install Gateway API CRDs first: `kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml`
 - Delete existing resources if upgrading: `kubectl delete -k 'https://github.com/Kuadrant/mcp-gateway/config/install?ref=main'`
 
 ### Pods Not Starting
@@ -194,7 +194,6 @@ kubectl describe mcpserverregistration <server-name> -n <namespace>
 
 **Solutions**:
 - Verify MCPServerRegistration `targetRef` points to correct HTTPRoute name and namespace
-- Ensure HTTPRoute has `mcp-server: 'true'` label
 - Check that backend MCP server is running: `kubectl get pods -n <mcp-server-namespace>`
 - Verify backend service exists: `kubectl get svc -n <namespace> <service-name>`
 - Check HTTPRoute has valid backend reference: `kubectl describe httproute <route-name>`
@@ -213,7 +212,7 @@ kubectl run -it --rm debug --image=nicolaka/netshoot --restart=Never -- \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
 
 # Check broker router logs for errors
-kubectl logs -n mcp-system -l app=mcp-gateway
+kubectl logs -n mcp-system -l app.kubernetes.io/name=mcp-gateway
 ```
 
 **Solutions**:
@@ -476,7 +475,7 @@ curl -D - -X POST http://<mcp-hostname>/mcp \
 
 ```bash
 # Check broker session storage
-kubectl logs -n mcp-system -l app=mcp-gateway | grep -i session
+kubectl logs -n mcp-system -l app.kubernetes.io/name=mcp-gateway | grep -i session
 ```
 
 **Solutions**:
@@ -523,7 +522,7 @@ kubectl get httproute -A
 ```bash
 # Test broker from within cluster
 kubectl run -it --rm test --image=curlimages/curl --restart=Never -- \
-  curl -v http://mcp-gateway.mcp-system.svc.cluster.local:8080/health
+  curl -v http://mcp-gateway.mcp-system.svc.cluster.local:8080/status
 ```
 
 ## Getting Help
@@ -533,7 +532,7 @@ If you continue to experience issues:
 1. Collect logs from all components:
    ```bash
    kubectl logs -n mcp-system -l app=mcp-controller > controller.log
-   kubectl logs -n mcp-system -l app=mcp-gateway > broker.log
+   kubectl logs -n mcp-system -l app.kubernetes.io/name=mcp-gateway > broker.log
    kubectl get mcpsr -A -o yaml > mcpservers.yaml
    kubectl get httproute -A -o yaml > httproutes.yaml
    kubectl get gateway -A -o yaml > gateways.yaml

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -20,6 +20,7 @@ Virtual servers work by filtering the complete tool list based on a curated sele
 - MCP Gateway installed and configured
 - [MCP servers configured](./register-mcp-servers.md) with tools available
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) installed
+- [jq](https://jqlang.github.io/jq/download/) installed
 
 ## Understanding Virtual Servers
 
@@ -58,10 +59,9 @@ metadata:
 spec:
   description: "Development and debugging tools"
   tools:
-  - test1_hello_world      # replace with your actual tool names
+  - test1_greet             # replace with your actual tool names
   - test1_headers
-  - github_get_me
-  - github_list_repos
+  - test2_hello_world
 EOF
 ```
 
@@ -77,9 +77,9 @@ metadata:
 spec:
   description: "Data analysis and reporting tools"
   tools:
-  - test2_time            # replace with your actual tool names
+  - test2_time             # replace with your actual tool names
   - test3_dozen
-  - github_get_repo_stats
+  - test3_add
 EOF
 ```
 

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -36,7 +36,7 @@ When a client includes the virtual server header, MCP Gateway filters responses 
 Before creating virtual servers, check which tools are available in your gateway. You can browse them using [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
 ```bash
-DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest
+DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1
 ```
 
 > **Note:** `DANGEROUSLY_OMIT_AUTH=true` is for local testing only. Do not use it in shared or production environments.

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -66,6 +66,9 @@ nodes:
   - containerPort: 30080
     hostPort: 8001
     protocol: TCP
+  - containerPort: 30089 # keycloak
+    hostPort: 8002
+    protocol: TCP
 EOF
 fi
 
@@ -125,7 +128,7 @@ echo ""
 echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo ""
 echo "To test with MCP Inspector (requires Node.js):"
-echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest"
+echo "  DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1"
 echo ""
 echo "  Then connect to: http://mcp.127-0-0-1.sslip.io:8001/mcp"
 echo "  Transport: Streamable HTTP"

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.6.0-rc2}
 GIT_REF="v${VERSION}"
 REPO="https://github.com/${GITHUB_ORG}/mcp-gateway"
 RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/mcp-gateway/${GIT_REF}"


### PR DESCRIPTION
## Summary
- Cherry-picks 8 docs/scripts fixes from main onto release-0.6.0
- Covers guide fixes for: authentication, authorisation, tool revocation, virtual MCP servers, quick-start, OLM install, external MCP server, register, install, isolated gateway, binary install, kind cluster setup, troubleshooting, configure listener
- Also includes fixes to README, CLAUDE.md, main.go (corrected config path defaults), and scripts (inspector version pin, keycloak port)

## Commits cherry-picked
- `ba90a21` doc-verification skill suggested fixes
- `72164ae` rc2 isolated gateway deployment guide review
- `521b976` fix virtual mcp servers guide: wrong tool names, missing jq prerequisite
- `41b62aa` fix install guide: add hint on finding gateway name for helm values
- `22f1899` fix register guide: switch from api-key-server to test-server1
- `bd7132d` fix external mcp server guide: clarify make targets for auth prerequisites
- `0e1cc87` fix olm install guide: quote kustomize url, update version, add csv wait note
- `2773beb` review of revocation,authz,auth guides for 0.6.0-rc2