### PR TITLE
add additional handler for client requesting /.well-known/oauth-prote…

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -304,6 +304,7 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 
 	oauthHandler := broker.ProtectedResourceHandler{Logger: logger}
 	mux.HandleFunc("/.well-known/oauth-protected-resource", oauthHandler.Handle)
+	mux.HandleFunc("/.well-known/oauth-protected-resource/", oauthHandler.Handle)
 
 	// WriteTimeout of 0 (disabled) is important for SSE connections (GET /mcp).
 	// SSE streams notifications indefinitely - any write timeout would kill the connection.


### PR DESCRIPTION
…cted-resource/mcp and not falling back to /.well-known/oauth-protected-resource


Allows for clients requesting `/.well-known/oauth-protected-resource/mcp` and those that might fallback to /.well-known/oauth-protected-resource

related to investigation around #776 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for the OAuth protected resource endpoint to accept requests with and without trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->