### PR TITLE
ci: gevals cli arg fix

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -132,7 +132,7 @@ jobs:
             echo "No results file found — mcpchecker may have crashed"
             exit 1
           fi
-          mcpchecker verify --task 1.0 --assertion 1.0 "$RESULTS_FILE"
+          mcpchecker result verify --task 1.0 --assertion 1.0 "$RESULTS_FILE"
 
       - name: Upload Evaluation Results
         if: always()


### PR DESCRIPTION
mcpchecker cli has changed args recently. noticed failing CI jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the results verification workflow step to invoke an enhanced verification command, maintaining consistent task and assertion parameters for improved result validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->