### PR TITLE
fix(ci): update mcpchecker verify command to result verify

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -132,7 +132,7 @@ jobs:
             echo "No results file found — mcpchecker may have crashed"
             exit 1
           fi
-          mcpchecker verify --task 1.0 --assertion 1.0 "$RESULTS_FILE"
+          mcpchecker result verify "$RESULTS_FILE" --task 1.0 --assertion 1.0
 
       - name: Upload Evaluation Results
         if: always()


### PR DESCRIPTION
This PR updates the `gevals.yaml` workflow to use the new `mcpchecker result verify` command structure.

The `mcpchecker` tool recently introduced a breaking change where the `verify` command was moved under the `result` subcommand. This change ensures that the CI properly enforces pass/fail thresholds.

Note: The failing run referenced below shows an unmarshaling error which was likely due to a task schema mismatch (which appears to be fixed in the latest version), but this PR is necessary to address the CLI command change and ensure future runs fail correctly if tests do not pass.

References: https://github.com/Kuadrant/mcp-gateway/actions/runs/24562338298/job/71813787675?pr=779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI verification step to use the CLI's revised subcommand structure so result verification runs with the latest interface; no functional behavior or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->