### PR TITLE
fix(oidc-server): handle JWT aud claim as string or array

### DIFF
--- a/tests/servers/oidc-server/main.go
+++ b/tests/servers/oidc-server/main.go
@@ -87,8 +87,8 @@ func (a *authMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		var claims struct {
-			Aud string `json:"aud"`
-			Sub string `json:"sub"`
+			Aud interface{} `json:"aud"` // can be string or []string
+			Sub string      `json:"sub"`
 		}
 		if err := accessToken.Claims(&claims); err != nil {
 			log.Printf("Failed to parse claims: %v", err)
@@ -96,8 +96,22 @@ func (a *authMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if claims.Aud != a.ExpectedAud {
-			log.Printf("Invalid audience: %s", claims.Aud)
+		// check audience - handle both string and array
+		audMatch := false
+		switch aud := claims.Aud.(type) {
+		case string:
+			audMatch = aud == a.ExpectedAud
+		case []interface{}:
+			for _, audItem := range aud {
+				if str, ok := audItem.(string); ok && str == a.ExpectedAud {
+					audMatch = true
+					break
+				}
+			}
+		}
+
+		if !audMatch {
+			log.Printf("Invalid audience: %v", claims.Aud)
 			http.Error(w, `{"error": "Unauthorized: invalid audience"}`, http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
### Summary

resolves https://github.com/Kuadrant/mcp-gateway/issues/792

This fix updates the OIDC test server to accept both formats by:
  - Changing Aud field type from string to interface{}
  - Adding type switch to validate against both string and []interface{}
  - Preventing authentication failures for valid tokens with array audiences

  Fixes authentication errors like `cannot unmarshal array into Go struct
  field .aud of type string` when using tokens from certain OIDC flows.

### Verification Steps

  1. Build and deploy the updated OIDC server:
  ```
cd tests/servers/oidc-server && docker build -t test-oidc-server:latest .
kubectl set image deployment/mcp-oidc-server -n mcp-test oidc-server=test-oidc-server:latest
```
  2. Prepare the env
```
make local-env-setup
make auth-example-setup
```
  3. Call the `hello_world` tool via MCP Inspector - should succeed
 
Note: if using KIND 'aud' seems to be string. On OpenShift it is array.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenID Connect token validation to handle audience claims in both string and array formats, enabling broader compatibility with various OIDC providers that represent audience values differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->