### PR TITLE
Fix issuerUrl scheme to https across docs

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -86,7 +86,7 @@ Configure the MCP Gateway broker to respond with OAuth discovery information:
 kubectl set env deployment/mcp-gateway \
   OAUTH_RESOURCE_NAME="MCP Server" \
   OAUTH_RESOURCE="http://mcp.127-0-0-1.sslip.io:8001/mcp" \
-  OAUTH_AUTHORIZATION_SERVERS="http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp" \
+  OAUTH_AUTHORIZATION_SERVERS="https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp" \
   OAUTH_BEARER_METHODS_SUPPORTED="header" \
   OAUTH_SCOPES_SUPPORTED="basic,groups,roles,profile,offline_access" \
   -n mcp-system
@@ -158,7 +158,7 @@ spec:
       authentication:
         'keycloak':
           jwt:
-            issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
+            issuerUrl: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
       response:
         unauthenticated:
           code: 401
@@ -194,7 +194,7 @@ curl http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
 #   "resource_name": "MCP Server",
 #   "resource": "http://mcp.127-0-0-1.sslip.io:8001/mcp",
 #   "authorization_servers": [
-#     "http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp"
+#     "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp"
 #   ],
 #   "bearer_methods_supported": [
 #     "header"
@@ -203,7 +203,8 @@ curl http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
 #     "basic",
 #     "groups",
 #     "roles",
-#     "profile"
+#     "profile",
+#     "offline_access"
 #   ]
 # }
 ```

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -70,7 +70,7 @@ spec:
     authentication:
       'sso-server':
         jwt:
-          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
+          issuerUrl: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
     authorization:
       'tool-access-check':
         patternMatching:

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -103,7 +103,7 @@ spec:
     authentication:
       'keycloak':
         jwt:
-          issuerUrl: http://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
+          issuerUrl: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
     authorization:
       'allow-mcp-method':
         patternMatching:


### PR DESCRIPTION
Standardize Keycloak issuerUrl to https:// across all guides. Previously authentication.md, authorization.md, and tool-revocation.md used http:// while auth.mk and the samples in #782 use https://. JWT validation requires an exact issuer match. Also adds offline_access to the example scopes_supported output in authentication.md to match the current OAUTH_SCOPES_SUPPORTED value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guide to use HTTPS for OAuth/Keycloak realm endpoints and added `offline_access` scope to supported scopes examples.
  * Updated authorization and tool revocation guides with HTTPS protocol for Keycloak JWT issuer URL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->