### PR TITLE
add URL elicitation design doc for per-user credentials

### DIFF
--- a/docs/design/CLAUDE.md
+++ b/docs/design/CLAUDE.md
@@ -1,0 +1,95 @@
+# Design Documents
+
+## Structure
+
+Each new design gets its own directory under `docs/design/`:
+
+```text
+docs/design/<feature-name>/
+├── <feature-name>-design.md       # design document
+└── tasks/
+    ├── tasks.md                   # implementation plan with ordered tasks
+    └── e2e_test_cases.md          # e2e test cases
+```
+
+Standalone design docs (e.g. `auth-phase-1.md`, `routing.md`) are older designs that predate this convention.
+
+## Design Document
+
+The design doc describes the problem, proposed solution, and key decisions. Structure:
+
+- **Problem** — what's broken or missing
+- **Summary** — one-paragraph description of the solution
+- **Goals / Non-Goals** — scope boundaries
+- **Job Stories** — user-centric scenarios that drive the design (see below)
+- **Design** — the technical solution, containing:
+  - **Prerequisites** — what must be in place before the feature can work
+  - **Flow** — sequence diagrams showing the interaction between components
+  - **Component Responsibilities** — table of which component does what
+  - **API Changes** — CRD fields, config types, request/response schemas
+  - **Data storage** — cache schemas, encryption, storage backends
+- **Security Considerations** — threat model, auth requirements, data protection
+- **Relationship to Existing Approaches** — how this fits alongside other solutions
+- **Future Considerations** — what's explicitly deferred
+- **Execution** — links to `tasks/tasks.md` and `tasks/e2e_test_cases.md` (don't list tasks inline)
+
+Use mermaid diagrams for flows. Reference the MCP spec or other standards where applicable. Keep it focused on _what_ and _why_, not implementation steps.
+
+### Job Stories
+
+Job stories capture _when_ a situation arises, _what_ the actor wants, and _why_. They drive the design by grounding it in real user scenarios rather than abstract requirements. Format:
+
+```text
+### When <situation>
+
+When <actor> <context>, they want <action/outcome> so that <benefit>.
+```
+
+Cover the key personas: platform operator, MCP client user, non-interactive agent. Include both the happy path and important edge cases (expired tokens, existing infrastructure, agents that can't use a browser).
+
+## Implementation Plan (`tasks/tasks.md`)
+
+The plan translates the design into ordered, dependency-aware tasks. Each task should have:
+
+- **Task N: Title** (with Jira story reference)
+- **Files** — which files to create or modify
+- **Acceptance criteria** — checkboxes, testable conditions
+- **Verification** — the `make` commands that prove it works
+
+Start with existing code analysis — document what already exists that the implementation builds on. Order tasks by dependency so each can be implemented and verified independently.
+
+## E2E Test Cases (`tasks/e2e_test_cases.md`)
+
+Follow the format in `tests/e2e/test_cases.md`:
+
+- Header format: `### [Tag1,Tag2] Description`
+- Tags control test grouping and run frequency:
+  - `Happy` — must pass every PR. Core flows and regression safety only.
+  - Feature-specific tags (e.g. `URLElicitation`) — extended coverage: edge cases, error handling, configuration variants.
+  - `Security` — security-focused tests: session validation, phishing prevention, access control.
+- Tests can have multiple tags (e.g. `[Happy,URLElicitation]` or `[URLElicitation,Security]`). Not every test should be `Happy` — reserve it for the critical path so the tag remains meaningful.
+- Single paragraph describing the scenario: given state → action → expected outcome
+- Cover the happy path, error paths, edge cases, and regression safety (existing behavior unaffected)
+
+## Documentation Plan (`tasks/documentation.md`)
+
+Frame documentation around user goals, not features. Use job stories:
+
+```text
+### When I want to <goal>
+
+When <actor> <context>, they want <action/outcome> so that <benefit>.
+
+**Cover:**
+- Key topics this section addresses
+```
+
+Organize by use cases rather than capabilities. Address underlying needs, not implementation details. Group by doc type (user guide, security architecture, API reference) with sections within each.
+
+## Workflow
+
+1. Write the design doc first — get agreement on approach before planning tasks
+2. Create the implementation plan from the approved design
+3. Define e2e test cases alongside the plan
+4. Create GitHub sub-issues from the tasks, linked to the parent feature issue
+5. Implement tasks in order, verifying each before moving to the next

--- a/docs/design/CLAUDE.md
+++ b/docs/design/CLAUDE.md
@@ -45,7 +45,7 @@ Job stories capture _when_ a situation arises, _what_ the actor wants, and _why_
 When <actor> <context>, they want <action/outcome> so that <benefit>.
 ```
 
-Cover the key personas: platform operator, MCP client user, non-interactive agent. Include both the happy path and important edge cases (expired tokens, existing infrastructure, agents that can't use a browser).
+Cover the key personas: platform engineer, MCP client user, MCP Developer, non-interactive agent. Include both the happy path and important edge cases (expired tokens, existing infrastructure, agents that can't use a browser).
 
 ## Implementation Plan (`tasks/tasks.md`)
 

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -92,7 +92,8 @@ sequenceDiagram
     Router->>Upstream: tools/call (with expired PAT)
     Upstream-->>Router: 401 Unauthorized
     Router->>Cache: DeleteUserCredential(sessionID, "github")
-    Note over Client,Router: Next tool call triggers re-elicitation
+    Router-->>Client: URLElicitationRequiredError (-32042)
+    Note over Client,Router: Client prompts user to re-enter credential
 ```
 
 ### Component Responsibilities
@@ -143,7 +144,7 @@ spec:
     url: "https://vault.example.com/ui/vault/secrets/mcp/create"
 ```
 
-When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. When OAuth fields are added in future (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
+When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. If OAuth fields are added (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
 
 #### Config Type
 

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -20,7 +20,7 @@ Enable the MCP Gateway to dynamically request per-user credentials at client too
 - Protocol compliant as per [URLElicitationRequiredError flow](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-with-elicitation-required-error-flow) from the MCP specification
 - Cache credentials encrypted in the shared session cache (Redis / in-memory)
 - Invalidate cached credentials on upstream 401 to trigger re-elicitation
-- Maintain capability of using OIDC authentication the main broker gateway route
+- Maintain capability of using OIDC authentication on the main broker gateway route
 
 ## Non-Goals
 
@@ -197,7 +197,9 @@ Per-user credentials are written by the broker and read by the router. The stora
 
 #### Encryption at Rest
 
-Credentials are encrypted within the cache using AES-GCM before storage. The encryption key is derived from the existing session signing key (`--mcp-session-signing-key`) using HKDF (HMAC-based Key Derivation Function, [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869)), so no additional configuration is required. HKDF derives a cryptographically strong key using a context-specific salt, ensuring the encryption key is distinct from the signing key even though both originate from the same secret.
+When an external cache is configured, credentials are encrypted using AES-GCM before storage. The encryption key is derived from the existing session signing key (`--mcp-session-signing-key`) using HKDF (HMAC-based Key Derivation Function, [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869)), so no additional configuration is required. HKDF derives a cryptographically strong key using a context-specific salt, ensuring the encryption key is distinct from the signing key even though both originate from the same secret.
+
+Encryption is only applied when using an external cache store as the storage backend — it protects credentials in an external store that may be shared or persisted to disk. For the in-memory backend, encryption adds no value since a process memory dump would reveal the encryption key alongside the ciphertext and in order to be used to call a backend the token credential has to be in plain text in memory.
 
 #### Cache Schema
 
@@ -243,13 +245,15 @@ The broker serves a simple HTML form at `/credentials`:
 
 ## Security Considerations
 
+### Credential Page Must Be Auth-Protected
+
+The `/credentials` endpoint must be behind the gateway route's OAuth/OIDC policy. Without authentication, an attacker with a valid or guessed elicitation ID could brute-force inject a malicious credential into another user's session. The OIDC token from the authenticated request also provides the identity needed to bind the credential to the correct session.
+
 ### Identity Verification
 
 The MCP specification [warns about phishing attacks](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#phishing) where an attacker could trick another user into completing an elicitation on their behalf. The credential page must verify that the user opening the URL is the same user who triggered the elicitation.
 
-The initial implementation does not include identity verification. Before production use, the credential page should:
-- Verify the user's OIDC session matches the gateway session that triggered the elicitation
-- Use a signed or encrypted elicitation ID that cannot be forged
+Identity verification is handled by the AuthPolicy attached to the gateway route where the credential page is served. The AuthPolicy validates the OIDC token from the request, ensuring the user opening the URL is the same user who triggered the elicitation.
 
 ### Token Passthrough
 
@@ -288,7 +292,7 @@ The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specifi
 - [ ] Broker: implement `/credentials` page handler (GET form + POST storage)
 - [ ] Register `/credentials` endpoint in `cmd/mcp-broker-router/main.go`
 - [ ] Controller: propagate `elicitation` from CRD to config
-- [ ] Identity verification on credential page (anti-phishing)
+- [ ] Document that operators must configure AuthPolicy on the credential page route (identity verification / anti-phishing)
 - [ ] `notifications/elicitation/complete` — broker notifies client after credential stored
 - [ ] Vault storage backend
 - [ ] E2E test with a test server that validates per-user credentials

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -260,6 +260,24 @@ Identity verification is handled by the AuthPolicy attached to the gateway route
 
 The MCP specification [prohibits token passthrough](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough). This design is distinct from passthrough because credentials are collected out-of-band via the credential page, stored server-side bound to user identity, and never transit through the MCP client or LLM context.
 
+### Non-Interactive Agents (Service Accounts)
+
+Non-interactive agents (CI/CD pipelines, automated MCP clients, agent-to-agent calls) cannot complete browser-based elicitation or OAuth flows. Credential injection for these callers is handled entirely via AuthPolicy — the router's behavior is unchanged.
+
+If the upstream MCP server shares the same identity provider as the gateway, only one credential is needed — the gateway's `Authorization` header is valid for both and the router uses it as-is. When the upstream expects a different credential, an AuthPolicy on the MCP's route reads the credential from an additional header or external store (e.g., Vault) and sets the `Authorization` header before the request reaches the upstream.
+
+#### Disabling Elicitation
+
+Non-interactive agents that cannot handle `URLElicitationRequiredError` (-32042) can send a header to opt out:
+
+```
+x-mcp-no-elicitation: true
+```
+
+When this header is present and no credential is available (cache miss or upstream 401), the router returns a standard error instead of `-32042`. This gives the agent an actionable error rather than a URL it cannot open.
+
+The MCP specification's [token passthrough prohibition](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough) guards against credentials being visible to the LLM context. Non-interactive agents have no LLM observing their headers, so header-based credential delivery does not carry the same risk.
+
 ## Relationship to Existing Approaches
 
 | Approach | When to Use |

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -153,7 +153,7 @@ spec:
     url: "https://vault.example.com/ui/vault/secrets/mcp/create"
 ```
 
-When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. If OAuth fields are added (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
+When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. In future, if OAuth fields are added (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
 
 #### Config Type
 
@@ -172,7 +172,7 @@ The elicitation URL determines how the credential reaches the upstream request. 
 
 #### Pattern 1: Broker Credential Page (default)
 
-When no `elicitation.url` is set, the router generates a URL pointing to the broker's `/credentials` page. The user enters a credential on the broker page, the broker writes it to the session cache, and the router reads from cache on retry to inject the `Authorization` header.
+When no `credentialURLElicitation.url` is set, the router generates a URL pointing to the broker's `/credentials` page. The user enters a credential on the broker page, the broker writes it to the session cache, and the router reads from cache on retry to inject the `Authorization` header.
 
 ```
 Router → -32042 (broker URL) → User enters PAT → Broker stores in cache → Router reads cache → sets header
@@ -182,7 +182,7 @@ The router is responsible for credential injection.
 
 #### Pattern 2: External UI with AuthPolicy
 
-When `elicitation.url` is set to an external UI (e.g., Vault web UI), the user stores their credential there directly. An AuthPolicy on the upstream HTTPRoute reads the credential from the external store and injects it into the `Authorization` header. The router does not need to read from cache — it only needs to detect whether a credential is missing (upstream 401) and re-trigger elicitation.
+When `credentialURLElicitation.url` is set to an external UI (e.g., Vault web UI), the user stores their credential there directly. An AuthPolicy on the upstream HTTPRoute reads the credential from the external store and injects it into the `Authorization` header. The router does not need to read from cache — it only needs to detect whether a credential is missing (upstream 401) and re-trigger elicitation.
 
 ```
 Router → -32042 (external URL) → User stores PAT in Vault → AuthPolicy reads from Vault → sets header
@@ -220,12 +220,12 @@ User credentials are stored as fields on the existing gateway session hash, usin
 | Set | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
 | Get | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
 | Delete (on 401) | `jwt-abc-123` | `usercred:github` | — |
+| Delete (on session invalidation) | `jwt-abc-123` | `usercred:github` | — |
 
-Cached credentials are also removed when the backend MCP session is invalidated, ensuring credentials don't outlive the session they were collected for.
 
 ### URLElicitationRequiredError Response
 
-Returned as an SSE-formatted immediate response (HTTP 200, `text/event-stream`). The `url` field uses `elicitation.url` from the server config if set, otherwise defaults to the broker's `/credentials` page:
+Returned as an SSE-formatted immediate response (HTTP 200, `text/event-stream`). The `url` field uses `credentialURLElicitation.url` from the server config if set, otherwise defaults to the broker's `/credentials` page:
 
 ```json
 {
@@ -266,10 +266,6 @@ The `/credentials` endpoint must be behind the gateway route's OAuth/OIDC policy
 The MCP specification [warns about phishing attacks](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#phishing) where an attacker could trick another user into completing an elicitation on their behalf. The credential page must verify that the user opening the URL is the same user who triggered the elicitation.
 
 Identity verification is handled by the AuthPolicy attached to the gateway route where the credential page is served. The AuthPolicy validates the OIDC token from the request, ensuring the user opening the URL is the same user who triggered the elicitation.
-
-### Token Passthrough
-
-The MCP specification [prohibits token passthrough](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough). This design is distinct from passthrough because credentials are collected out-of-band via the credential page, stored server-side bound to user identity, and never transit through the MCP client or LLM context.
 
 ### Non-Interactive Agents (Service Accounts)
 

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -298,5 +298,6 @@ The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specifi
 - [ ] E2E test with a test server that validates per-user credentials
 - [ ] Update API reference docs for `elicitation` field
 - [ ] User-facing guide for configuring URL mode elicitation
+- [ ] Update security-architecture.md (data boundaries, credential isolation, known risks)
 
 ### Completed

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -1,0 +1,298 @@
+# Gateway-Initiated URL Elicitation for Per-User Credentials
+
+## Problem
+
+Many upstream MCP servers require per-user credentials. Example: a user's own GitHub PAT, not a shared service account token. The gateway currently supports several per-user credential strategies:
+
+1. **Header-based token replacement** — the MCP client sends the user's credential in a custom header and the gateway maps it to the upstream `Authorization` header. The credential passes through the MCP client, making it visible to the LLM context and client-side logging. The MCP specification explicitly [prohibits token passthrough](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough) for this reason.
+2. **Token exchange via OAuth provider** — requires the OAuth provider to support token exchange and be configured per upstream. Requires third party identity federation.
+3. **Vault integration** — requires a Vault instance exposed to external users for credential provisioning.
+
+URL elicitation complements these strategies by offering a server-side credential collection path that doesn't require exposing infrastructure like Vault to external users and keeps credentials out of the MCP client entirely.
+
+## Summary
+
+Enable the MCP Gateway to dynamically request per-user credentials at client tool-call/backend MCP call time if required using [URL mode elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation). The router detects a missing credential and returns a `URLElicitationRequiredError`. The client directs the user to a broker-hosted credential page. The credential is cached per session and re-elicited on upstream 401.
+
+## Goals
+
+- Per-user credential acquisition without exposing credentials to the client configuration
+- Protocol compliant as per [URLElicitationRequiredError flow](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-with-elicitation-required-error-flow) from the MCP specification
+- Cache credentials encrypted in the shared session cache (Redis / in-memory)
+- Invalidate cached credentials on upstream 401 to trigger re-elicitation
+- Maintain capability of using OIDC authentication the main broker gateway route
+
+## Non-Goals
+
+- Replace `credentialRef` (still used by the broker for tool discovery)
+- Form mode elicitation for credentials (prohibited by the MCP spec for sensitive data)
+- Full OAuth client in the broker
+
+## Prerequisites
+
+- MCP client must support URL mode elicitation (MCP spec 2025-11-25)
+- MCP Gateway accessible over HTTPS for the credential page
+
+
+## Design
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant Client as MCP Client
+    participant Gateway as Envoy
+    participant Router as MCP Router (ext_proc)
+    participant Broker as MCP Broker
+    participant Cache as Session Cache
+    participant Upstream as Upstream MCP Server
+
+    Client->>Gateway: POST /mcp tools/call (github_get_me)
+    Gateway->>Router: ext_proc request
+    Router->>Cache: GetUserCredential(sessionID, "github")
+    Cache-->>Router: empty (no credential)
+    Router-->>Client: URLElicitationRequiredError (-32042)
+    Note over Router,Client: includes URL to broker credential page
+
+    Client->>User: Show credential page URL, ask consent
+    User->>Client: Consent
+    Client->>Browser: Open credential page URL
+
+    Browser->>Broker: GET /credentials?server=github&elicitation_id=...
+    Broker-->>Browser: Render credential form
+    User->>Browser: Enter GitHub PAT
+    Browser->>Broker: POST /credentials (PAT)
+    Broker->>Cache: SetUserCredential(sessionID, "github", PAT)
+    Broker-->>Browser: Success page
+
+    Note over Client: User closes browser, retries
+    Client->>Gateway: POST /mcp tools/call (github_get_me) [retry]
+    Gateway->>Router: ext_proc request
+    Router->>Cache: GetUserCredential(sessionID, "github")
+    Cache-->>Router: PAT
+    Router->>Router: Set Authorization: Bearer PAT
+    Router-->>Gateway: Route to upstream
+    Gateway->>Upstream: POST /mcp tools/call (with PAT)
+    Upstream-->>Client: Tool result
+```
+
+### Credential Invalidation on 401
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Router as MCP Router
+    participant Cache as Session Cache
+    participant Upstream as Upstream MCP Server
+
+    Client->>Router: tools/call
+    Router->>Cache: GetUserCredential → expired PAT
+    Router->>Upstream: tools/call (with expired PAT)
+    Upstream-->>Router: 401 Unauthorized
+    Router->>Cache: DeleteUserCredential(sessionID, "github")
+    Note over Client,Router: Next tool call triggers re-elicitation
+```
+
+### Component Responsibilities
+
+| Component | Role |
+|-----------|------|
+| **Router** | Detects missing credential, returns `-32042` with configured or default URL, injects cached credential into `Authorization` header (pattern 1), invalidates on upstream 401 |
+| **Broker** | Hosts `/credentials` page, verifies user identity, writes credential to cache |
+| **Cache** | Shared storage for per-user, per-server credentials |
+| **Controller** | Propagates `elicitation` from CRD to config |
+
+### API Changes
+
+#### MCPServerRegistration
+
+New optional object `elicitation`:
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: github
+  namespace: mcp-test
+spec:
+  toolPrefix: github_
+  targetRef:
+    kind: HTTPRoute
+    name: github-mcp-external
+  credentialRef:           # broker-only: used for tool discovery
+    name: github-token
+    key: token
+  elicitation: {}
+```
+
+`credentialRef` and `elicitation` serve different purposes: `credentialRef` gives the broker a credential for tool discovery, while `elicitation` triggers per-user credential collection at tool-call time.
+
+When present, the router checks the session cache for a per-user credential before routing tool calls. On cache miss, it returns `URLElicitationRequiredError` with a URL to the broker's credential page.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string | Optional. Overrides the default broker credential page URL. Allows operators to direct users to an external UI (e.g., Vault web UI). |
+
+Example with external URL:
+
+```yaml
+spec:
+  elicitation:
+    url: "https://vault.example.com/ui/vault/secrets/mcp/create"
+```
+
+When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. When OAuth fields are added in future (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
+
+#### Config Type
+
+`MCPServer` in `internal/config/types.go` gains:
+- `Elicitation *ElicitationConfig` (optional, nil means no elicitation)
+
+```go
+type ElicitationConfig struct {
+    URL string `json:"url,omitempty"`
+}
+```
+
+### Credential Delivery Patterns
+
+The elicitation URL determines how the credential reaches the upstream request. Two patterns are supported:
+
+#### Pattern 1: Broker Credential Page (default)
+
+When no `elicitation.url` is set, the router generates a URL pointing to the broker's `/credentials` page. The user enters a credential on the broker page, the broker writes it to the session cache, and the router reads from cache on retry to inject the `Authorization` header.
+
+```
+Router → -32042 (broker URL) → User enters PAT → Broker stores in cache → Router reads cache → sets header
+```
+
+The router is responsible for credential injection.
+
+#### Pattern 2: External UI with AuthPolicy
+
+When `elicitation.url` is set to an external UI (e.g., Vault web UI), the user stores their credential there directly. An AuthPolicy on the upstream HTTPRoute reads the credential from the external store and injects it into the `Authorization` header. The router does not need to read from cache — it only needs to detect whether a credential is missing (upstream 401) and re-trigger elicitation.
+
+```
+Router → -32042 (external URL) → User stores PAT in Vault → AuthPolicy reads from Vault → sets header
+```
+
+AuthPolicy handles credential injection. The router's role simplifies to:
+1. If `elicitation` is set and the upstream returns 401, return `-32042` with the configured URL
+2. No cache read/write needed for this server
+
+This pattern is useful when operators already have credential infrastructure (e.g., Vault) and want to avoid duplicating storage in the session cache.
+
+> **Note:** Unlike Pattern 1, there is no completion callback from the external UI, so `notifications/elicitation/complete` cannot be sent. The client retries and either succeeds or gets another 401.
+
+### Credential Storage
+
+Per-user credentials are written by the broker and read by the router. The storage backend is abstracted behind an interface.
+
+| Backend | Description |
+|---------|-------------|
+| **Session cache** (Redis / in-memory) | Initial implementation. Credentials are session-scoped and lost on session expiry or cache eviction. |
+| **Vault** | Stores credentials in Vault keyed by user identity. Provides encrypted storage, audit logging, and credential lifecycle management. See [Vault integration](../guides/vault-integration.md). |
+
+#### Encryption at Rest
+
+Credentials are encrypted within the cache using AES-GCM before storage. The encryption key is derived from the existing session signing key (`--mcp-session-signing-key`) using HKDF (HMAC-based Key Derivation Function, [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869)), so no additional configuration is required. HKDF derives a cryptographically strong key using a context-specific salt, ensuring the encryption key is distinct from the signing key even though both originate from the same secret.
+
+#### Cache Schema
+
+User credentials are stored as fields on the existing gateway session hash, using the prefix `usercred:` to distinguish them from upstream session IDs.
+
+| Operation | Key | Field | Value |
+|-----------|-----|-------|-------|
+| Set | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
+| Get | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
+| Delete (on 401) | `jwt-abc-123` | `usercred:github` | — |
+
+### URLElicitationRequiredError Response
+
+Returned as an SSE-formatted immediate response (HTTP 200, `text/event-stream`). The `url` field uses `elicitation.url` from the server config if set, otherwise defaults to the broker's `/credentials` page:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32042,
+    "message": "User credential required for github",
+    "data": {
+      "elicitations": [
+        {
+          "mode": "url",
+          "elicitationId": "<sessionID>:<serverName>",
+          "url": "https://<gateway-host>/credentials?server=github&elicitation_id=<id>",
+          "message": "Please provide your credential for github"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Credential Page
+
+The broker serves a simple HTML form at `/credentials`:
+
+- **GET** `/credentials?server=<name>&elicitation_id=<id>` — renders credential entry form
+- **POST** `/credentials` — stores credential in cache, keyed by session and server
+
+## Security Considerations
+
+### Identity Verification
+
+The MCP specification [warns about phishing attacks](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#phishing) where an attacker could trick another user into completing an elicitation on their behalf. The credential page must verify that the user opening the URL is the same user who triggered the elicitation.
+
+The initial implementation does not include identity verification. Before production use, the credential page should:
+- Verify the user's OIDC session matches the gateway session that triggered the elicitation
+- Use a signed or encrypted elicitation ID that cannot be forged
+
+### Token Passthrough
+
+The MCP specification [prohibits token passthrough](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough). This design is distinct from passthrough because credentials are collected out-of-band via the credential page, stored server-side bound to user identity, and never transit through the MCP client or LLM context.
+
+## Relationship to Existing Approaches
+
+| Approach | When to Use |
+|----------|-------------|
+| **credentialRef** (static secret) | Broker-only credential for tool discovery and caching |
+| **Header-based token replacement** ([guide](../guides/external-mcp-server-with-token-replacement.md)) | Client supports custom headers, simple setup |
+| **Vault token exchange** ([guide](../guides/vault-token-exchange.md)) | Centralized credential management, admin-provisioned per-user secrets |
+| **URL elicitation + broker page** (this design) | Self-service per-user credentials, no client configuration, no external infrastructure |
+| **URL elicitation + external UI** (this design) | Self-service per-user credentials with existing credential infrastructure (e.g., Vault), AuthPolicy handles injection |
+
+## Future Considerations
+
+### OAuth Callback via Credential Page
+
+The credential page could initiate an OAuth flow instead of rendering a form. The router would construct the OAuth authorize URL dynamically, encoding the elicitation ID in the OAuth `state` parameter. After the user consents, the provider redirects back to a gateway callback endpoint with the authorization code and `state`. The broker extracts the elicitation ID from `state`, exchanges the code for a token, and stores it in the session cache.
+
+This would add OAuth fields to the `elicitation` object (client ID, authorize endpoint, scopes, plus a referenced secret for the client secret). Their presence implies an OAuth flow. The router would compute the authorize URL per-elicitation rather than using the stored `url` verbatim.
+
+The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-elicitation-for-oauth-flows) as a primary use case for URL mode elicitation. The existing abstractions (storage interface, credential page, elicitation ID) would support this without major structural changes.
+
+## Execution
+
+### Todo
+
+- [ ] Add `Elicitation *ElicitationConfig` field to `MCPServer` config type
+- [ ] Add `elicitation` object to MCPServerRegistration CRD and regenerate
+- [ ] Add credential storage interface with cache implementation (set/get/delete + AES-GCM encryption)
+- [ ] Router: check cache for user credential in `HandleToolCall`, return `URLElicitationRequiredError` on miss
+- [ ] Router: inject cached credential into `Authorization` header on cache hit
+- [ ] Router: invalidate cached credential on upstream 401 in `HandleResponseHeaders`
+- [ ] Broker: implement `/credentials` page handler (GET form + POST storage)
+- [ ] Register `/credentials` endpoint in `cmd/mcp-broker-router/main.go`
+- [ ] Controller: propagate `elicitation` from CRD to config
+- [ ] Identity verification on credential page (anti-phishing)
+- [ ] `notifications/elicitation/complete` — broker notifies client after credential stored
+- [ ] Vault storage backend
+- [ ] E2E test with a test server that validates per-user credentials
+- [ ] Update API reference docs for `elicitation` field
+- [ ] User-facing guide for configuring URL mode elicitation
+
+### Completed

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -110,15 +110,15 @@ sequenceDiagram
 | Component | Role |
 |-----------|------|
 | **Router** | Checks for existing `Authorization` header (use as-is), checks client `elicitation.url` capability, falls back to cache, returns `-32042` on miss (if capable), injects cached credential into `Authorization` header (pattern 1), invalidates on upstream 401 |
-| **Broker** | Hosts `/credentials` page, verifies user identity, writes credential to cache |
+| **Broker** | Hosts `/credentials` page, writes credential to cache |
 | **Cache** | Shared storage for per-user, per-server credentials |
-| **Controller** | Propagates `elicitation` from CRD to config |
+| **Controller** | Propagates `credentialURLElicitation` from CRD to config |
 
 ### API Changes
 
 #### MCPServerRegistration
 
-New optional object `elicitation`:
+New optional object `credentialURLElicitation`. When present, it signals that this server requires per-user credentials and that the router should use the URL elicitation flow to collect them from capable clients.
 
 ```yaml
 apiVersion: mcp.kuadrant.io/v1alpha1
@@ -131,15 +131,15 @@ spec:
   targetRef:
     kind: HTTPRoute
     name: github-mcp-external
-  credentialRef:           # broker-only: used for tool discovery
+  credentialRef:                  # broker-only: used for tool discovery
     name: github-token
     key: token
-  elicitation: {}
+  credentialURLElicitation: {}    # enables per-user credential collection
 ```
 
-`credentialRef` and `elicitation` serve different purposes: `credentialRef` gives the broker a credential for tool discovery, while `elicitation` triggers per-user credential collection at tool-call time.
+`credentialRef` and `credentialURLElicitation` serve different purposes: `credentialRef` gives the broker a credential for tool discovery, while `credentialURLElicitation` enables per-user credential collection at tool-call time.
 
-When present, the router checks the session cache for a per-user credential before routing tool calls. On cache miss, it returns `URLElicitationRequiredError` with a URL to the broker's credential page.
+When present, the router checks the session cache for a per-user credential before routing tool calls. On cache miss, it returns `URLElicitationRequiredError` with a URL to the broker's credential page (if the client declares `elicitation.url` capability).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -149,7 +149,7 @@ Example with external URL:
 
 ```yaml
 spec:
-  elicitation:
+  credentialURLElicitation:
     url: "https://vault.example.com/ui/vault/secrets/mcp/create"
 ```
 
@@ -158,10 +158,10 @@ When no `url` is set, the router generates a URL pointing to the broker's built-
 #### Config Type
 
 `MCPServer` in `internal/config/types.go` gains:
-- `Elicitation *ElicitationConfig` (optional, nil means no elicitation)
+- `CredentialURLElicitation *CredentialURLElicitationConfig` (optional, nil means no elicitation)
 
 ```go
-type ElicitationConfig struct {
+type CredentialURLElicitationConfig struct {
     URL string `json:"url,omitempty"`
 }
 ```
@@ -189,7 +189,7 @@ Router → -32042 (external URL) → User stores PAT in Vault → AuthPolicy rea
 ```
 
 AuthPolicy handles credential injection. The router's role simplifies to:
-1. If `elicitation` is set and the upstream returns 401, return `-32042` with the configured URL
+1. If `credentialURLElicitation` is set and the upstream returns 401, return `-32042` with the configured URL
 2. No cache read/write needed for this server
 
 This pattern is useful when operators already have credential infrastructure (e.g., Vault) and want to avoid duplicating storage in the session cache.
@@ -298,7 +298,7 @@ If the upstream MCP server shares the same identity provider as the gateway, onl
 
 The credential page could initiate an OAuth flow instead of rendering a form. The router would construct the OAuth authorize URL dynamically, encoding the elicitation ID in the OAuth `state` parameter. After the user consents, the provider redirects back to a gateway callback endpoint with the authorization code and `state`. The broker extracts the elicitation ID from `state`, exchanges the code for a token, and stores it in the session cache.
 
-This would add OAuth fields to the `elicitation` object (client ID, authorize endpoint, scopes, plus a referenced secret for the client secret). Their presence implies an OAuth flow. The router would compute the authorize URL per-elicitation rather than using the stored `url` verbatim.
+This would add OAuth fields to the `credentialURLElicitation` object (client ID, authorize endpoint, scopes, plus a referenced secret for the client secret). Their presence implies an OAuth flow. The router would compute the authorize URL per-elicitation rather than using the stored `url` verbatim.
 
 The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-elicitation-for-oauth-flows) as a primary use case for URL mode elicitation. The existing abstractions (storage interface, credential page, elicitation ID) would support this without major structural changes.
 
@@ -306,19 +306,19 @@ The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specifi
 
 ### Todo
 
-- [ ] Add `Elicitation *ElicitationConfig` field to `MCPServer` config type
-- [ ] Add `elicitation` object to MCPServerRegistration CRD and regenerate
+- [ ] Add `CredentialURLElicitation *CredentialURLElicitationConfig` field to `MCPServer` config type
+- [ ] Add `credentialURLElicitation` object to MCPServerRegistration CRD and regenerate
 - [ ] Add credential storage interface with cache implementation (set/get/delete + AES-GCM encryption)
 - [ ] Router: credential resolution in `HandleToolCall` — (1) use existing `Authorization` header if present, (2) check cache and inject on hit, (3) return `-32042` on miss if client declares `elicitation.url` capability, otherwise return standard error
 - [ ] Router: invalidate cached credential on upstream 401 in `HandleResponseHeaders`, return `-32042` if client supports elicitation, otherwise standard error
 - [ ] Broker: implement `/credentials` page handler (GET form + POST storage)
 - [ ] Register `/credentials` endpoint in `cmd/mcp-broker-router/main.go`
-- [ ] Controller: propagate `elicitation` from CRD to config
+- [ ] Controller: propagate `credentialURLElicitation` from CRD to config
 - [ ] Document that operators must configure AuthPolicy on the credential page route (identity verification / anti-phishing)
 - [ ] `notifications/elicitation/complete` — broker notifies client after credential stored
 - [ ] Vault storage backend
 - [ ] E2E test with a test server that validates per-user credentials
-- [ ] Update API reference docs for `elicitation` field
+- [ ] Update API reference docs for `credentialURLElicitation` field
 - [ ] User-facing guide for configuring URL mode elicitation
 - [ ] Update security-architecture.md (data boundaries, credential isolation, known risks)
 

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -8,7 +8,7 @@ Many upstream MCP servers require per-user credentials. Example: a user's own Gi
 2. **Token exchange via OAuth provider** — requires the OAuth provider to support token exchange and be configured per upstream. Requires third party identity federation.
 3. **Vault integration** — requires a Vault instance exposed to external users for credential provisioning.
 
-URL elicitation complements these strategies by offering a server-side credential collection path that doesn't require exposing infrastructure like Vault to external users and keeps credentials out of the MCP client entirely.
+URL elicitation complements these strategies by offering a server-side credential collection path that doesn't require exposing infrastructure like Vault to external users and keeps credentials out of the MCP client context and LLM context entirely.
 
 ## Summary
 
@@ -30,7 +30,7 @@ Enable the MCP Gateway to dynamically request per-user credentials at client too
 
 ## Prerequisites
 
-- MCP client must support URL mode elicitation (MCP spec 2025-11-25)
+- MCP client must declare `elicitation.url` capability during the [initialize handshake](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#capabilities) (MCP spec 2025-11-25)
 - MCP Gateway accessible over HTTPS for the credential page
 
 
@@ -212,6 +212,8 @@ User credentials are stored as fields on the existing gateway session hash, usin
 | Get | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
 | Delete (on 401) | `jwt-abc-123` | `usercred:github` | — |
 
+Cached credentials are also removed when the backend MCP session is invalidated, ensuring credentials don't outlive the session they were collected for.
+
 ### URLElicitationRequiredError Response
 
 Returned as an SSE-formatted immediate response (HTTP 200, `text/event-stream`). The `url` field uses `elicitation.url` from the server config if set, otherwise defaults to the broker's `/credentials` page:
@@ -262,21 +264,14 @@ The MCP specification [prohibits token passthrough](https://modelcontextprotocol
 
 ### Non-Interactive Agents (Service Accounts)
 
-Non-interactive agents (CI/CD pipelines, automated MCP clients, agent-to-agent calls) cannot complete browser-based elicitation or OAuth flows. Credential injection for these callers is handled entirely via AuthPolicy — the router's behavior is unchanged.
+Non-interactive agents (CI/CD pipelines, automated MCP clients, agent-to-agent calls) cannot complete browser-based elicitation or OAuth flows. No special configuration is needed — the router uses the client's initialize handshake to determine behavior.
 
-If the upstream MCP server shares the same identity provider as the gateway, only one credential is needed — the gateway's `Authorization` header is valid for both and the router uses it as-is. When the upstream expects a different credential, an AuthPolicy on the MCP's route reads the credential from an additional header or external store (e.g., Vault) and sets the `Authorization` header before the request reaches the upstream.
+If the client does not declare `elicitation.url` in its capabilities, the router never returns `URLElicitationRequiredError` (-32042). Instead:
 
-#### Disabling Elicitation
+1. The `Authorization` header from the request is used as-is for upstream routing
+2. If the upstream returns 401, the router returns a standard error
 
-Non-interactive agents that cannot handle `URLElicitationRequiredError` (-32042) can send a header to opt out:
-
-```
-x-mcp-no-elicitation: true
-```
-
-When this header is present and no credential is available (cache miss or upstream 401), the router returns a standard error instead of `-32042`. This gives the agent an actionable error rather than a URL it cannot open.
-
-The MCP specification's [token passthrough prohibition](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough) guards against credentials being visible to the LLM context. Non-interactive agents have no LLM observing their headers, so header-based credential delivery does not carry the same risk.
+If the upstream MCP server shares the same identity provider as the gateway, only one credential is needed — the gateway's `Authorization` header is valid for both. When the upstream expects a different credential, an AuthPolicy on the MCP's route reads the credential from an additional header or external store (e.g., Vault) and sets the `Authorization` header before the request reaches the upstream.
 
 ## Relationship to Existing Approaches
 

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -5,7 +5,7 @@
 Many upstream MCP servers require per-user credentials. Example: a user's own GitHub PAT, not a shared service account token. The gateway currently supports several per-user credential strategies:
 
 1. **Header-based token replacement** — the MCP client sends the user's credential in a custom header and the gateway maps it to the upstream `Authorization` header. The credential passes through the MCP client, making it visible to the LLM context and client-side logging. The MCP specification explicitly [prohibits token passthrough](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough) for this reason.
-2. **Token exchange via OAuth provider** — requires the OAuth provider to support token exchange and be configured per upstream. Requires third party identity federation.
+2. **Token exchange via OAuth provider** — requires the OAuth provider to support token exchange and be configured per upstream. Requires third-party identity federation.
 3. **Vault integration** — requires a Vault instance exposed to external users for credential provisioning.
 
 URL elicitation complements these strategies by offering a server-side credential collection path that doesn't require exposing infrastructure like Vault to external users and keeps credentials out of the MCP client context and LLM context entirely.
@@ -109,7 +109,7 @@ sequenceDiagram
 
 | Component | Role |
 |-----------|------|
-| **Router** | Checks for existing `Authorization` header (use as-is), checks client `elicitation.url` capability, falls back to cache, returns `-32042` on miss (if capable), injects cached credential into `Authorization` header (pattern 1), invalidates on upstream 401 |
+| **Router** | (1) If `Authorization` header present, use as-is for upstream routing. (2) If absent, check cache — inject cached credential on hit. (3) On cache miss, return `-32042` if client declares `elicitation.url` capability, otherwise return standard error. (4) On upstream 401, invalidate cached credential and re-elicit or error per client capability. |
 | **Broker** | Hosts `/credentials` page, writes credential to cache |
 | **Cache** | Shared storage for per-user, per-server credentials |
 | **Controller** | Propagates `credentialURLElicitation` from CRD to config |
@@ -153,7 +153,7 @@ spec:
     url: "https://vault.example.com/ui/vault/secrets/mcp/create"
 ```
 
-When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. In future, if OAuth fields are added (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
+When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. In the future, if OAuth fields are added (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
 
 #### Config Type
 
@@ -174,7 +174,7 @@ The elicitation URL determines how the credential reaches the upstream request. 
 
 When no `credentialURLElicitation.url` is set, the router generates a URL pointing to the broker's `/credentials` page. The user enters a credential on the broker page, the broker writes it to the session cache, and the router reads from cache on retry to inject the `Authorization` header.
 
-```
+```text
 Router → -32042 (broker URL) → User enters PAT → Broker stores in cache → Router reads cache → sets header
 ```
 
@@ -184,7 +184,7 @@ The router is responsible for credential injection.
 
 When `credentialURLElicitation.url` is set to an external UI (e.g., Vault web UI), the user stores their credential there directly. An AuthPolicy on the upstream HTTPRoute reads the credential from the external store and injects it into the `Authorization` header. The router does not need to read from cache — it only needs to detect whether a credential is missing (upstream 401) and re-trigger elicitation.
 
-```
+```text
 Router → -32042 (external URL) → User stores PAT in Vault → AuthPolicy reads from Vault → sets header
 ```
 
@@ -209,7 +209,7 @@ Per-user credentials are written by the broker and read by the router. The stora
 
 When an external cache is configured, credentials are encrypted using AES-GCM before storage. The encryption key is derived from the existing session signing key (`--mcp-session-signing-key`) using HKDF (HMAC-based Key Derivation Function, [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869)), so no additional configuration is required. HKDF derives a cryptographically strong key using a context-specific salt, ensuring the encryption key is distinct from the signing key even though both originate from the same secret.
 
-Encryption is only applied when using an external cache store as the storage backend — it protects credentials in an external store that may be shared or persisted to disk. For the in-memory backend, encryption adds no value since a process memory dump would reveal the encryption key alongside the ciphertext and in order to be used to call a backend the token credential has to be in plain text in memory.
+Encryption is only applied when using an external cache store as the storage backend — it protects credentials in an external store that may be shared or persisted to disk. For the in-memory backend, encryption adds no value since a process memory dump would reveal the encryption key alongside the ciphertext and to be used to call a backend the token credential has to be in plain text in memory.
 
 #### Cache Schema
 

--- a/docs/design/gateway-initiated-url-elicitation.md
+++ b/docs/design/gateway-initiated-url-elicitation.md
@@ -30,7 +30,7 @@ Enable the MCP Gateway to dynamically request per-user credentials at client too
 
 ## Prerequisites
 
-- MCP client must declare `elicitation.url` capability during the [initialize handshake](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#capabilities) (MCP spec 2025-11-25)
+- MCP client must declare `elicitation.url` capability during the [initialize handshake](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#capabilities) (MCP spec 2025-11-25). Clients without this capability can still use elicitation-configured servers — the router uses the `Authorization` header as-is and returns standard errors on 401 instead of triggering elicitation (see [Non-Interactive Agents](#non-interactive-agents-service-accounts)).
 - MCP Gateway accessible over HTTPS for the credential page
 
 
@@ -51,6 +51,8 @@ sequenceDiagram
 
     Client->>Gateway: POST /mcp tools/call (github_get_me)
     Gateway->>Router: ext_proc request
+    Router->>Router: Check Authorization header → none
+    Router->>Router: Check client elicitation.url capability → supported
     Router->>Cache: GetUserCredential(sessionID, "github")
     Cache-->>Router: empty (no credential)
     Router-->>Client: URLElicitationRequiredError (-32042)
@@ -70,6 +72,7 @@ sequenceDiagram
     Note over Client: User closes browser, retries
     Client->>Gateway: POST /mcp tools/call (github_get_me) [retry]
     Gateway->>Router: ext_proc request
+    Router->>Router: Check Authorization header → none
     Router->>Cache: GetUserCredential(sessionID, "github")
     Cache-->>Router: PAT
     Router->>Router: Set Authorization: Bearer PAT
@@ -83,14 +86,20 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant Client as MCP Client
-    participant Router as MCP Router
+    participant Gateway as Envoy
+    participant Router as MCP Router (ext_proc)
     participant Cache as Session Cache
     participant Upstream as Upstream MCP Server
 
-    Client->>Router: tools/call
+    Client->>Gateway: POST /mcp tools/call
+    Gateway->>Router: ext_proc request
+    Router->>Router: Check Authorization header → none
     Router->>Cache: GetUserCredential → expired PAT
-    Router->>Upstream: tools/call (with expired PAT)
-    Upstream-->>Router: 401 Unauthorized
+    Router->>Router: Set Authorization: Bearer PAT
+    Router-->>Gateway: Route to upstream
+    Gateway->>Upstream: POST /mcp tools/call (with expired PAT)
+    Upstream-->>Gateway: 401 Unauthorized
+    Gateway->>Router: ext_proc response (401)
     Router->>Cache: DeleteUserCredential(sessionID, "github")
     Router-->>Client: URLElicitationRequiredError (-32042)
     Note over Client,Router: Client prompts user to re-enter credential
@@ -100,7 +109,7 @@ sequenceDiagram
 
 | Component | Role |
 |-----------|------|
-| **Router** | Detects missing credential, returns `-32042` with configured or default URL, injects cached credential into `Authorization` header (pattern 1), invalidates on upstream 401 |
+| **Router** | Checks for existing `Authorization` header (use as-is), checks client `elicitation.url` capability, falls back to cache, returns `-32042` on miss (if capable), injects cached credential into `Authorization` header (pattern 1), invalidates on upstream 401 |
 | **Broker** | Hosts `/credentials` page, verifies user identity, writes credential to cache |
 | **Cache** | Shared storage for per-user, per-server credentials |
 | **Controller** | Propagates `elicitation` from CRD to config |
@@ -300,9 +309,8 @@ The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specifi
 - [ ] Add `Elicitation *ElicitationConfig` field to `MCPServer` config type
 - [ ] Add `elicitation` object to MCPServerRegistration CRD and regenerate
 - [ ] Add credential storage interface with cache implementation (set/get/delete + AES-GCM encryption)
-- [ ] Router: check cache for user credential in `HandleToolCall`, return `URLElicitationRequiredError` on miss
-- [ ] Router: inject cached credential into `Authorization` header on cache hit
-- [ ] Router: invalidate cached credential on upstream 401 in `HandleResponseHeaders`
+- [ ] Router: credential resolution in `HandleToolCall` — (1) use existing `Authorization` header if present, (2) check cache and inject on hit, (3) return `-32042` on miss if client declares `elicitation.url` capability, otherwise return standard error
+- [ ] Router: invalidate cached credential on upstream 401 in `HandleResponseHeaders`, return `-32042` if client supports elicitation, otherwise standard error
 - [ ] Broker: implement `/credentials` page handler (GET form + POST storage)
 - [ ] Register `/credentials` endpoint in `cmd/mcp-broker-router/main.go`
 - [ ] Controller: propagate `elicitation` from CRD to config

--- a/docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md
+++ b/docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md
@@ -1,0 +1,339 @@
+# Gateway-Initiated URL Elicitation for Per-User Credentials
+
+## Problem
+
+Many upstream MCP servers require per-user credentials. Example: a user's own GitHub PAT, not a shared service account token. The gateway currently supports several per-user credential strategies:
+
+1. **Header-based token replacement** — the MCP client sends the user's credential in a custom header and the gateway maps it to the upstream `Authorization` header. The credential passes through the MCP client, making it visible to the LLM context and client-side logging. The MCP specification explicitly [prohibits token passthrough](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#token-passthrough) for this reason.
+2. **Token exchange via OAuth provider** — requires the OAuth provider to support token exchange and be configured per upstream. Requires third-party identity federation.
+3. **Vault integration** — requires a Vault instance exposed to external users for credential provisioning.
+
+URL elicitation complements these strategies by offering a server-side credential collection path that doesn't require exposing infrastructure like Vault to external users and keeps credentials out of the MCP client context and LLM context entirely.
+
+## Summary
+
+Enable the MCP Gateway to dynamically request per-user credentials at client tool-call/backend MCP call time if required using [URL mode elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation). The router detects a missing credential and returns a `URLElicitationRequiredError`. The client directs the user to a broker-hosted credential page. The credential is cached per session and re-elicited on upstream 401.
+
+## Goals
+
+- Per-user credential acquisition without exposing credentials to the client or LLM
+- Protocol compliant as per [URLElicitationRequiredError flow](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-with-elicitation-required-error-flow) from the MCP specification
+- Cache credentials encrypted in the shared session cache (Redis / in-memory)
+- Invalidate cached credentials on upstream 401 to trigger re-elicitation
+- Maintain capability of using OIDC authentication on the main broker gateway route
+
+## Non-Goals
+
+- Replace `credentialRef` (still used by the broker for tool discovery)
+- Replace the value of AuthPolicy use with the Gateway
+- Form mode elicitation for credentials (prohibited by the MCP spec for sensitive data)
+- Full OAuth client in the broker
+
+## Job Stories
+
+### When I need per-user upstream tokens without exposing them to the LLM
+
+When a platform operator registers an upstream MCP server that requires per-user tokens (e.g., GitHub PATs), they want the gateway to securely collect tokens at runtime so that tokens never pass through the MCP client or appear in LLM context.
+
+### When a user calls a tool that requires a token they haven't provided yet
+
+When an MCP client user calls a tool on an elicitation-configured server and no token is cached for their session, they want to be directed to a browser-based page where the gateway can securely collect their token, so that the tool call succeeds on retry without any client-side configuration.
+
+### When a cached token expires or is revoked
+
+When an upstream server rejects a cached token with a 401, the user wants the gateway to automatically clear the stale token and prompt them to provide a new one, so that they can recover without restarting their session.
+
+### When I have existing credential infrastructure
+
+When a platform operator already has credential infrastructure (e.g., Vault), they want to point the elicitation URL at their own UI instead of the broker's built-in page, so that tokens are stored in their existing system and an AuthPolicy handles injection.
+
+### When a non-interactive agent calls a tool on an elicitation-configured server
+
+When a CI/CD pipeline or automated agent calls a tool on a server that requires per-user tokens, but the agent cannot complete browser-based flows, the gateway should use the Authorization header from the request as-is and return standard errors on 401, so that agents are not blocked by elicitation prompts.
+
+### When I want to gate the token page behind authentication
+
+When a platform operator deploys the gateway with URL elicitation, they want the `/credentials` page to be protected by the same OIDC AuthPolicy as the gateway route, so that only the authenticated user who triggered the elicitation can provide a token for their session.
+
+## Design
+
+### Prerequisites
+
+- MCP client must declare `elicitation.url` capability during the [initialize handshake](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#capabilities) (MCP spec 2025-11-25). Clients without this capability can still use elicitation-configured servers — the router uses the `Authorization` header as-is and returns standard errors on 401 instead of triggering elicitation (see [Non-Interactive Agents](#non-interactive-agents-service-accounts)).
+- MCP Gateway accessible over HTTPS for the credential page
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant Client as MCP Client
+    participant Gateway as Envoy
+    participant Router as MCP Router (ext_proc)
+    participant Broker as MCP Broker
+    participant Cache as Session Cache
+    participant Upstream as Upstream MCP Server
+
+    Client->>Gateway: POST /mcp tools/call (github_get_me)
+    Gateway->>Router: ext_proc request
+    Router->>Router: Check Authorization header → none
+    Router->>Router: Check client elicitation.url capability → supported
+    Router->>Cache: GetUserCredential(sessionID, "github")
+    Cache-->>Router: empty (no credential)
+    Router-->>Client: URLElicitationRequiredError (-32042)
+    Note over Router,Client: includes URL to broker credential page
+
+    Client->>User: Show credential page URL, ask consent
+    User->>Client: Consent
+    Client->>Browser: Open credential page URL
+
+    Browser->>Broker: GET /credentials?server=github&elicitation_id=...
+    Broker-->>Browser: Render credential form
+    User->>Browser: Enter GitHub PAT
+    Browser->>Broker: POST /credentials (PAT)
+    Broker->>Cache: SetUserCredential(sessionID, "github", PAT)
+    Broker-->>Browser: Success page
+
+    Note over Client: User closes browser, retries
+    Client->>Gateway: POST /mcp tools/call (github_get_me) [retry]
+    Gateway->>Router: ext_proc request
+    Router->>Router: Check Authorization header → none
+    Router->>Cache: GetUserCredential(sessionID, "github")
+    Cache-->>Router: PAT
+    Router->>Router: Set Authorization: Bearer PAT
+    Router-->>Gateway: Route to upstream
+    Gateway->>Upstream: POST /mcp tools/call (with PAT)
+    Upstream-->>Client: Tool result
+```
+
+### Credential Invalidation on 401
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Gateway as Envoy
+    participant Router as MCP Router (ext_proc)
+    participant Cache as Session Cache
+    participant Upstream as Upstream MCP Server
+
+    Client->>Gateway: POST /mcp tools/call
+    Gateway->>Router: ext_proc request
+    Router->>Router: Check Authorization header → none
+    Router->>Cache: GetUserCredential → expired PAT
+    Router->>Router: Set Authorization: Bearer PAT
+    Router-->>Gateway: Route to upstream
+    Gateway->>Upstream: POST /mcp tools/call (with expired PAT)
+    Upstream-->>Gateway: 401 Unauthorized
+    Gateway->>Router: ext_proc response (401)
+    Router->>Cache: DeleteUserCredential(sessionID, "github")
+    Router-->>Client: URLElicitationRequiredError (-32042)
+    Note over Client,Router: Client prompts user to re-enter credential
+```
+
+### Component Responsibilities
+
+| Component | Role |
+|-----------|------|
+| **Router** | (1) If `Authorization` header present, use as-is for upstream routing. (2) If absent, check cache — inject cached credential on hit. (3) On cache miss, return `-32042` if client declares `elicitation.url` capability, otherwise return standard error. (4) On upstream 401, invalidate cached credential and re-elicit or error per client capability. |
+| **Broker** | Hosts `/credentials` page, writes credential to cache |
+| **Cache** | Shared storage for per-user, per-server credentials |
+| **Controller** | Propagates `credentialURLElicitation` from CRD to config |
+
+### API Changes
+
+#### MCPServerRegistration
+
+New optional object `credentialURLElicitation`. When present, it signals that this server requires per-user credentials and that the router should use the URL elicitation flow to collect them from capable clients.
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: github
+  namespace: mcp-test
+spec:
+  toolPrefix: github_
+  targetRef:
+    kind: HTTPRoute
+    name: github-mcp-external
+  credentialRef:                  # broker-only: used for tool discovery
+    name: github-token
+    key: token
+  credentialURLElicitation: {}    # enables per-user credential collection
+```
+
+`credentialRef` and `credentialURLElicitation` serve different purposes: `credentialRef` gives the broker a credential for tool discovery, while `credentialURLElicitation` enables per-user credential collection at tool-call time.
+
+When present, the router checks the session cache for a per-user credential before routing tool calls. On cache miss, it returns `URLElicitationRequiredError` with a URL to the broker's credential page (if the client declares `elicitation.url` capability).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string | Optional. Overrides the default broker credential page URL. Allows operators to direct users to an external UI (e.g., Vault web UI). |
+
+Example with external URL:
+
+```yaml
+spec:
+  credentialURLElicitation:
+    url: "https://vault.example.com/ui/vault/secrets/mcp/create"
+```
+
+When no `url` is set, the router generates a URL pointing to the broker's built-in credential page. In the future, if OAuth fields are added (client ID, authorize endpoint, etc.), their presence on the object will imply an OAuth flow.
+
+#### Config Type
+
+`MCPServer` in `internal/config/types.go` gains:
+- `CredentialURLElicitation *CredentialURLElicitationConfig` (optional, nil means no elicitation)
+
+```go
+type CredentialURLElicitationConfig struct {
+    URL string `json:"url,omitempty"`
+}
+```
+
+### Credential Delivery Patterns
+
+The elicitation URL determines how the credential reaches the upstream request. Two patterns are supported:
+
+#### Pattern 1: Broker Credential Page (default)
+
+When no `credentialURLElicitation.url` is set, the router generates a URL pointing to the broker's `/credentials` page. The user enters a credential on the broker page, the broker writes it to the session cache, and the router reads from cache on retry to inject the `Authorization` header.
+
+```text
+Router → -32042 (broker URL) → User enters PAT → Broker stores in cache → Router reads cache → sets header
+```
+
+The router is responsible for credential injection.
+
+#### Pattern 2: External UI with AuthPolicy
+
+When `credentialURLElicitation.url` is set to an external UI (e.g., Vault web UI), the user stores their credential there directly. An AuthPolicy on the upstream HTTPRoute can then be configured to read the credential from the external store and injects it into the `Authorization` header. The router does not need to read from cache — it only needs to detect whether a credential is missing (upstream 401) and re-trigger elicitation.
+
+```text
+Router → -32042 (external URL) → User stores PAT in Vault → AuthPolicy reads from Vault → sets header
+```
+
+AuthPolicy handles credential injection. The router's role simplifies to:
+1. If `credentialURLElicitation` is set and the upstream returns 401, return `-32042` with the configured URL
+2. No cache read/write needed for this server
+
+This pattern is useful when operators already have credential infrastructure (e.g., Vault) and want to avoid duplicating storage in the session cache.
+
+> **Note:** Unlike Pattern 1, there is no completion callback from the external UI, so `notifications/elicitation/complete` cannot be sent. The client retries and either succeeds or gets another 401.
+
+### Credential Storage
+
+Per-user credentials are written by the broker and read by the router. The storage backend is abstracted behind an interface.
+
+| Backend | Description |
+|---------|-------------|
+| **Session cache** (Redis / in-memory) | Initial implementation. Credentials are session-scoped and lost on session expiry or cache eviction. |
+| **Vault** (Recommended) | Stores credentials in Vault keyed by user identity. Provides encrypted storage, audit logging, and credential lifecycle management. See [Vault integration](../../guides/vault-integration.md). |
+
+#### Encryption at Rest
+
+When an external cache is configured, credentials are encrypted using AES-GCM before storage. The encryption key is derived from the existing session signing key (`--mcp-session-signing-key`) using HKDF (HMAC-based Key Derivation Function, [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869)), so no additional configuration is required. HKDF derives a cryptographically strong key using a context-specific salt, ensuring the encryption key is distinct from the signing key even though both originate from the same secret.
+
+Encryption is only applied when using an external cache store as the storage backend — it protects credentials in an external store that may be shared or persisted to disk. For the in-memory backend, encryption adds no value since a process memory dump would reveal the encryption key alongside the ciphertext and to be used to call a backend the token credential has to be in plain text in memory.
+
+#### Cache Schema
+
+User credentials are stored as fields on the existing gateway session hash, using the prefix `usercred:` to distinguish them from upstream session IDs.
+
+| Operation | Key | Field | Value |
+|-----------|-----|-------|-------|
+| Set | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
+| Get | `jwt-abc-123` | `usercred:github` | AES-GCM encrypted credential |
+| Delete (on 401) | `jwt-abc-123` | `usercred:github` | — |
+| Delete (on session invalidation) | `jwt-abc-123` | `usercred:github` | — |
+
+
+### URLElicitationRequiredError Response
+
+Returned as an SSE-formatted immediate response (HTTP 200, `text/event-stream`). The `url` field uses `credentialURLElicitation.url` from the server config if set, otherwise defaults to the broker's `/credentials` page:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32042,
+    "message": "User credential required for github",
+    "data": {
+      "elicitations": [
+        {
+          "mode": "url",
+          "elicitationId": "<sessionID>:<serverName>",
+          "url": "https://<gateway-host>/credentials?server=github&elicitation_id=<id>",
+          "message": "Please provide your credential for MCP <serverName>"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Credential Page
+
+The broker serves a simple HTML form at `/credentials`:
+
+- **GET** `/credentials?server=<name>&elicitation_id=<id>` — renders credential entry form
+- **POST** `/credentials` — stores credential in cache, keyed by session and server
+
+## Security Considerations
+
+### Credential Page Protection
+
+The `/credentials` endpoint is served behind the same gateway route as MCP traffic. Each client receives a unique, signed JWT session from the gateway, which prevents attackers from injecting credentials into another user's session — the session JWT is signed and unique and the broker verifies that the session JWT on the credential page request matches the session ID embedded in the elicitation ID (`<sessionID>:<serverName>`).
+
+
+Adding an AuthPolicy to the gateway route provides an extra layer of protection by ensuring only authenticated and authorized individuals can access the endpoint. This is recommended for production deployments.
+
+### Identity Verification
+
+The MCP specification [warns about phishing attacks](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#phishing) where an attacker could trick another user into completing an elicitation on their behalf. The spec requires that the server verify the user who opens the elicitation URL is the same user who triggered it.
+
+In the gateway architecture, the gateway session JWT serves as the identity binding. The session JWT is unique per client and is only issued after authentication via the gateway's AuthPolicy. Both requests — the tool call that triggers elicitation and the browser request to the credential page — pass through the same gateway route and carry the same session JWT.
+
+The broker verifies that the session ID from the credential page request matches the session ID encoded in the elicitation ID. Since the session JWT is a signed token that can only be obtained by authenticating through the gateway's AuthPolicy, possession of the JWT proves the holder is the same authenticated user. An attacker who intercepts the elicitation URL cannot complete it without the victim's session JWT, and an attacker who has the victim's session JWT already has equivalent access to make authenticated requests directly.
+
+The spec recommends comparing `sub` claims from an authorization server for architectures where session identifiers might be shared independently of auth tokens. This is unnecessary here — the gateway session JWT is the auth proof itself, so session identity and user identity are the same thing.
+
+### Non-Interactive Agents (Service Accounts)
+
+Non-interactive agents (CI/CD pipelines, automated MCP clients, agent-to-agent calls) cannot complete browser-based elicitation or OAuth flows. No special configuration is needed — the router uses the client's initialize handshake to determine behavior.
+
+If the client does not declare `elicitation.url` in its capabilities, the router never returns `URLElicitationRequiredError` (-32042). Instead:
+
+1. The `Authorization` header from the request is used as-is for upstream routing
+2. If the upstream returns 401, the router returns a standard error
+
+If the upstream MCP server shares the same identity provider as the gateway, only one credential is needed — the gateway's `Authorization` header is valid for both. When the upstream expects a different credential, an AuthPolicy on the MCP's route reads the credential from an additional header or external store (e.g., Vault) and sets the `Authorization` header before the request reaches the upstream.
+
+## Relationship to Existing Approaches
+
+| Approach | When to Use |
+|----------|-------------|
+| **credentialRef** (static secret) | Broker-only credential for tool discovery and caching |
+| **Header-based token replacement** ([guide](../../guides/external-mcp-server-with-token-replacement.md)) | Client supports custom headers, simple setup |
+| **Vault token exchange** ([guide](../../guides/vault-token-exchange.md)) | Centralized credential management, admin-provisioned per-user secrets |
+| **URL elicitation + broker page** (this design) | Self-service per-user credentials, no client configuration, no external infrastructure |
+| **URL elicitation + external UI** (this design) | Self-service per-user credentials with existing credential infrastructure (e.g., Vault), AuthPolicy handles injection |
+
+## Future Considerations
+
+### OAuth Callback via Credential Page
+
+The credential page could initiate an OAuth flow instead of rendering a form. The router would construct the OAuth authorize URL dynamically, encoding the elicitation ID in the OAuth `state` parameter. After the user consents, the provider redirects back to a gateway callback endpoint with the authorization code and `state`. The broker extracts the elicitation ID from `state`, exchanges the code for a token, and stores it in the session cache.
+
+This would add OAuth fields to the `credentialURLElicitation` object (client ID, authorize endpoint, scopes, plus a referenced secret for the client secret). Their presence implies an OAuth flow. The router would compute the authorize URL per-elicitation rather than using the stored `url` verbatim.
+
+The MCP spec [calls this out explicitly](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-elicitation-for-oauth-flows) as a primary use case for URL mode elicitation. The existing abstractions (storage interface, credential page, elicitation ID) would support this without major structural changes.
+
+## Execution
+
+See: 
+- [tasks/tasks.md](tasks/tasks.md) for the implementation plan  
+- [tasks/e2e_test_cases.md](tasks/e2e_test_cases.md) for E2E test cases.
+- [tasks/documentation.md](tasks/documentation.md) for documentation outline

--- a/docs/design/gateway-url-token-elicitation/tasks/documentation.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/documentation.md
@@ -1,0 +1,77 @@
+# URL Elicitation Documentation Plan
+
+Documentation for URL elicitation, organized by user goals. Each section maps to a guide or doc update.
+
+## User-Facing Guide (`docs/guides/url-elicitation.md`)
+
+### When I want to securely collect per-user tokens for an upstream MCP server
+
+When a platform operator has an upstream MCP server that requires each user to authenticate with their own token, they want to enable URL elicitation so that the gateway collects tokens at runtime without exposing them to the MCP client or LLM context.
+
+**Cover:**
+- Adding `credentialURLElicitation: {}` to an MCPServerRegistration
+- Enabling the feature with `--enable-elicitation`
+- What the user experience looks like (tool call → prompt → browser → retry)
+- Prerequisites (HTTPS, client capability)
+
+### When I want to use my own credential UI instead of the built-in page
+
+When a platform operator already has credential infrastructure (e.g., Vault web UI), they want to direct users there instead of the broker's built-in page so that tokens are managed in their existing system.
+
+**Cover:**
+- Setting `credentialURLElicitation.url` to an external URL
+- How AuthPolicy on the upstream route handles token injection
+- Differences from the default flow (no cache write, no completion notification)
+
+### When I want to protect the token page from unauthorized access
+
+When a platform operator deploys URL elicitation, they want to ensure only the authenticated user who triggered the elicitation can submit a token, so that attackers cannot inject credentials into other users' sessions.
+
+**Cover:**
+- How session JWT binding prevents cross-session token injection (broker verifies session JWT matches elicitation ID)
+- Why `mcp-session-id` as a custom header prevents browser-based forgery (CORS blocks cross-origin header setting)
+- AuthPolicy as an additional layer restricting access to authenticated and authorized users
+- Link to the MCP spec's phishing warning
+
+### When I have automated agents that can't use a browser
+
+When a platform operator has both interactive users and automated agents (CI/CD, agent-to-agent) calling the same MCP servers, they want agents to work without being blocked by elicitation prompts.
+
+**Cover:**
+- No configuration needed — behavior is automatic based on client capabilities
+- How agents should pass tokens via the Authorization header
+- What happens when the upstream returns 401 for an agent (standard error, not -32042)
+
+### When a user's token expires and they need to provide a new one
+
+When a user's cached token is rejected by the upstream server, they want to be prompted to provide a new one without restarting their session.
+
+**Cover:**
+- How 401 invalidation works (automatic cache clear + re-elicitation)
+- JWT expiry detection (pre-emptive cache miss before hitting upstream)
+- What the user sees (same flow as initial elicitation)
+
+## Security Architecture Update (`docs/design/security-architecture.md`)
+
+### When I need to understand how user tokens are isolated and protected
+
+When a security reviewer or contributor needs to assess the token handling in URL elicitation, they want to understand data boundaries and protection mechanisms.
+
+**Cover:**
+- Token data flow: broker writes → cache stores (encrypted) → router reads → upstream receives
+- Encryption at rest: AES-GCM with HKDF-derived key, only for external cache backends
+- Session scoping: tokens bound to gateway session, lost on session expiry
+- Identity verification: session JWT binding (broker verifies match), custom header prevents browser forgery, AuthPolicy as additional hardening
+- Known risks: no completion callback for external URL pattern, cache eviction loses tokens
+
+## API Reference Update (`docs/reference/mcpserverregistration.md`)
+
+### When I need to know the exact field names and types for URL elicitation
+
+When a platform operator is writing MCPServerRegistration YAML, they want to know the exact API surface for `credentialURLElicitation`.
+
+**Cover:**
+- `credentialURLElicitation` object (optional)
+- `credentialURLElicitation.url` field (optional string, overrides default broker page)
+- Relationship to `credentialRef` (they serve different purposes)
+- Examples: minimal config, external URL config

--- a/docs/design/gateway-url-token-elicitation/tasks/documentation.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/documentation.md
@@ -6,7 +6,7 @@ Documentation for URL elicitation, organized by user goals. Each section maps to
 
 ### When I want to securely collect per-user tokens for an upstream MCP server
 
-When a platform operator has an upstream MCP server that requires each user to authenticate with their own token, they want to enable URL elicitation so that the gateway collects tokens at runtime without exposing them to the MCP client or LLM context.
+When a platform engineer has an upstream MCP server that requires each user to authenticate with their own token, they want to enable URL elicitation so that the gateway collects tokens at runtime without exposing them to the MCP client or LLM context.
 
 **Cover:**
 - Adding `credentialURLElicitation: {}` to an MCPServerRegistration

--- a/docs/design/gateway-url-token-elicitation/tasks/e2e_test_cases.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/e2e_test_cases.md
@@ -1,0 +1,85 @@
+## URL Elicitation E2E Test Cases
+
+---
+test_suite: elicitation_test.go
+tags: Happy,URLElicitation,Security
+---
+
+### [Happy,URLElicitation] URL elicitation triggers on missing token for elicitation-capable client
+
+- When an MCPServerRegistration is configured with `credentialURLElicitation: {}` and `--enable-elicitation` is true, and a client that declares `elicitation.url` capability during initialize calls a tool on that server without an Authorization header, the gateway should return a URLElicitationRequiredError (-32042) as an SSE response. The error should contain an `elicitations` array with a single entry containing `mode: "url"`, an `elicitationId`, a `url` pointing to the broker's `/credentials` page with the correct server name and elicitation ID as query parameters, and a `message` describing what token is needed.
+
+
+### [Happy,URLElicitation] Token provided via broker page is used for upstream auth
+
+- When a client receives a -32042 error and the user provides a token via the broker's `/credentials` page (POST with the correct elicitation ID and server name), the token should be stored in the session cache. When the client retries the same tool call, the gateway should read the token from cache, set the Authorization header with the token value, and forward the request to the upstream MCP server. The upstream server should receive the token and return a successful tool result.
+
+
+### [Happy,URLElicitation] Full elicitation round-trip with token validation
+
+- When an MCPServerRegistration targets a backend MCP server that validates Bearer tokens (e.g. api-key-server), and the server is configured with `credentialURLElicitation: {}`, a client that declares `elicitation.url` capability should be able to complete the full flow: call a tool → receive -32042 → provide the correct token via the broker page → retry the tool call → receive a successful result from the upstream server. The upstream server should see the correct Authorization header.
+
+
+### [URLElicitation] Cached token reused across multiple tool calls
+
+- When a client has already provided a token via elicitation for a given server, subsequent tool calls to the same server should reuse the cached token without triggering another -32042 error. The Authorization header should be set from the cached token on each call, and the upstream server should return successful results.
+
+
+### [URLElicitation] Elicitation with external URL returns configured URL
+
+- When an MCPServerRegistration is configured with `credentialURLElicitation: { url: "https://vault.example.com/ui" }`, the -32042 error returned to the client should contain the external URL verbatim instead of the broker's `/credentials` page URL. The gateway should not generate a broker page URL when an external URL is configured.
+
+
+### [Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation
+
+- When the upstream MCP server returns a 401 Unauthorized response (e.g. because the cached token has expired or been revoked), the gateway should delete the cached token for that server and session, and return a -32042 URLElicitationRequiredError to the client. The client should be able to provide a new token via the broker page and retry successfully.
+
+
+### [URLElicitation] Non-elicitation-capable client gets standard error on missing token
+
+- When a client does not declare `elicitation.url` capability during initialize, and calls a tool on a server configured with `credentialURLElicitation: {}` without an Authorization header, the gateway should return a standard error (not -32042). The client should not be directed to a credential page.
+
+
+### [Happy,URLElicitation] Non-elicitation-capable client with Authorization header succeeds
+
+- When a client does not declare `elicitation.url` capability but sends an Authorization header with its request, the gateway should use the Authorization header as-is for upstream routing, regardless of the server's `credentialURLElicitation` configuration. The tool call should succeed if the token is valid.
+
+
+### [URLElicitation] Elicitation-capable client with Authorization header bypasses cache
+
+- When a client declares `elicitation.url` capability and sends an Authorization header with its tool call request, the gateway should use the provided Authorization header as-is without checking the token cache. No -32042 error should be returned.
+
+
+### [URLElicitation] Elicitation disabled via feature flag has no effect
+
+- When `--enable-elicitation` is false, even if an MCPServerRegistration has `credentialURLElicitation` configured, the gateway should not return -32042 errors and should not check the token cache. Tool calls should behave as if `credentialURLElicitation` is not set. The Authorization header from the client request should be used as-is.
+
+
+### [URLElicitation] Broker credential page rejects invalid elicitation ID
+
+- When a user navigates to the broker's `/credentials` page with an invalid or missing `elicitation_id` parameter, the page should return an error and not store any token. A missing `server` parameter should also result in an error.
+
+
+### [URLElicitation,Security] Broker credential page rejects session mismatch
+
+- When a user submits a token to the broker's `/credentials` page but the session JWT on the request does not match the session ID embedded in the elicitation ID, the broker should reject the request and not store the token. This prevents an attacker from submitting a token into another user's session using a stolen elicitation URL.
+
+
+### [URLElicitation,Security] Credential page rejects mismatched session (phishing prevention)
+
+- When client Alice triggers elicitation and receives a -32042 with an elicitation URL containing her session ID, a direct HTTP request to the broker's `/credentials` POST endpoint with a different `mcp-session-id` header (emulating a different user) should be rejected. The broker should not store the token. This emulates the MCP spec's phishing scenario where an attacker forwards an elicitation URL to a victim — in practice browsers cannot set the custom header on navigation, but the e2e test verifies the broker's server-side session mismatch check.
+
+
+### [URLElicitation] Expired JWT token treated as cache miss
+
+- When a cached token is a JWT with an expired `exp` claim, the gateway should treat it as a cache miss on the next tool call. The expired token should be deleted from the cache, and a -32042 error should be returned to an elicitation-capable client, prompting the user to provide a new token.
+
+
+### [URLElicitation] Opaque token not subject to expiry check
+
+- When a cached token is not a JWT (e.g. a GitHub PAT like `ghp_abc123`), the gateway should return it from cache without any expiry check. The token should be forwarded to the upstream server as-is.
+
+
+### [Happy,URLElicitation] Server without credentialURLElicitation is unaffected
+
+- When an MCPServerRegistration does not have `credentialURLElicitation` configured, tool calls should behave exactly as before — no token cache lookup, no -32042 errors, no changes to the Authorization header handling. This verifies no regression in existing behavior.

--- a/docs/design/gateway-url-token-elicitation/tasks/tasks.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/tasks.md
@@ -1,0 +1,198 @@
+# URL Elicitation Implementation Plan
+
+## Context
+
+The MCP Gateway needs to support per-user credential collection for upstream MCP servers where credentials are disconnected from the gateway's identity provider (e.g., gateway uses RH-SSO but upstream needs a GitHub PAT). The design uses the MCP spec's URLElicitationRequiredError (-32042) flow: router detects missing credential, returns error with URL, user provides credential on broker-hosted page, client retries.
+
+Jira: CONNLINK-991 (stories: CONNLINK-995 through CONNLINK-999)
+Design: `docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md`
+Branch: `URL-Elicitation-User-Credentials`
+
+## Existing Code to Build On
+
+### Client elicitation capability flow (already implemented)
+1. **Parsed**: `MCPRequest.clientSupportsElicitation()` (`request_handlers.go:134-149`) — checks `capabilities.elicitation` in initialize params
+2. **Stored**: `HandleResponseHeaders` (`response_handlers.go:26-35`) — on initialize response, calls `SessionCache.SetClientElicitation(ctx, sessionID)` to persist the flag
+3. **Read**: `initializeMCPSeverSession` (`request_handlers.go:537-544`) — reads `SessionCache.GetClientElicitation()` and sets `mcpReq.clientElicitation`
+4. **Forwarded**: `clients.Initialize()` (`internal/clients/clients.go:40-42`) — if client declared elicitation, gateway declares it to backend too via `mcp.ElicitationCapability{}`
+5. **Cache impl**: `internal/session/cache.go:96-120` — stores as `clientelicitation:<sessionID>` key
+
+The credential resolution (Task 5) will reuse this flow — call `GetClientElicitation()` to determine whether to return `-32042` or a standard error.
+
+### Other existing code
+- `SessionCache` interface (`internal/mcp-router/server.go:23-31`) — already has `SetClientElicitation`/`GetClientElicitation`
+- `HandleToolCall` (`internal/mcp-router/request_handlers.go:242-425`) — where credential resolution logic will be added
+- `MCPServerRegistrationSpec` (`api/v1alpha1/types.go:38-65`) — CRD spec to extend
+- `config.MCPServer` (`internal/config/types.go:59-67`) — config type to extend
+- `mcpserverregistration_controller.go:386` — where config is built from CRD
+- SSE rewriter + idmap package — existing elicitation infrastructure (for upstream-initiated form-mode elicitation, not URL elicitation)
+- `headers.go` — `WithAuth` method for authorization header injection
+- `MCPRequest.clientElicitation` field (`request_handlers.go:85`) — bool on the request struct, already populated during session init
+
+## Implementation Order
+
+Tasks are ordered by dependency. Each task maps to a Jira story.
+
+### Task 1: Feature flag `--enable-elicitation` (part of CONNLINK-997)
+
+Add the flag early so all subsequent work is gated behind it.
+
+**Files:**
+- `cmd/mcp-broker-router/main.go` — add `--enable-elicitation` flag (default: false), pass to ExtProcServer and Broker
+- `internal/mcp-router/server.go` — add `ElicitationEnabled bool` field to `ExtProcServer`
+- `internal/broker/broker.go` — add `ElicitationEnabled bool` field
+
+**Acceptance criteria:**
+- [ ] Flag parsed and plumbed to router and broker
+- [ ] When disabled, no elicitation behavior changes (verified by existing tests passing)
+
+**Verification:** `make test-unit` passes, `--help` shows the flag
+
+---
+
+### Task 2: CRD + config types (CONNLINK-995)
+
+**Files:**
+- `api/v1alpha1/types.go` — add `CredentialURLElicitation *CredentialURLElicitationConfig` to `MCPServerRegistrationSpec`
+- `api/v1alpha1/types.go` — add `CredentialURLElicitationConfig` struct with `URL string`
+- `internal/config/types.go` — add `CredentialURLElicitation *CredentialURLElicitationConfig` to `MCPServer`
+- `internal/config/types.go` — add `CredentialURLElicitationConfig` struct
+- `internal/controller/mcpserverregistration_controller.go:386` — propagate field from CRD to config
+- Run `make generate-all` to regenerate deepcopy, CRDs, sync Helm
+- `docs/reference/mcpserverregistration.md` — update API reference
+
+**Acceptance criteria:**
+- [ ] CRD accepts `credentialURLElicitation` with optional `url` field
+- [ ] Controller propagates to config Secret
+- [ ] Unit test: controller includes elicitation config when set, omits when not set
+
+**Verification:** `make generate-all && make lint && make test-unit`
+
+---
+
+### Task 3: User token cache with encryption (CONNLINK-996)
+
+**Files:**
+- `internal/mcp-router/user_token_cache.go` (new) — `UserTokenCache` interface:
+  ```go
+  type UserTokenCache interface {
+      SetUserToken(ctx context.Context, sessionID, serverName, token string) error
+      GetUserToken(ctx context.Context, sessionID, serverName string) (string, bool, error)
+      DeleteUserToken(ctx context.Context, sessionID, serverName string) error
+  }
+  ```
+- `internal/mcp-router/user_token_cache_memory.go` (new) — in-memory implementation (no encryption)
+- `internal/mcp-router/user_token_cache_redis.go` (new) — redis protocol compliant backend with AES-GCM encryption
+  - Store as `usercred:<serverName>` field on session hash
+  - Encryption key derived from session signing key via HKDF (RFC 5869)
+  - Reuse existing Redis connection from session cache
+- `internal/mcp-router/user_token_cache_test.go` (new) — unit tests for both backends
+
+**JWT Expiry Check:**
+On `GetUserToken`, attempt to parse the token as a JWT (three dot-separated base64url segments). If it parses successfully, check the `exp` claim — if expired, delete the token and return a cache miss. If the token doesn't parse as a JWT (e.g. opaque PAT like a GitHub token), skip expiry checking and return it as-is for upstream use.
+
+**Acceptance criteria:**
+- [ ] Set/get/delete works for both backends
+- [ ] Redis protocol compliant backend encrypts values (not plaintext in store)
+- [ ] In-memory backend stores plaintext (no encryption overhead)
+- [ ] Token deleted when session hash is deleted
+- [ ] JWT tokens checked for expiry on get — expired tokens deleted and treated as cache miss
+- [ ] Non-JWT tokens (opaque PATs) returned as-is without expiry check
+
+**Verification:** `make test-unit` — tests cover encrypt/decrypt round-trip, set/get/delete, missing key returns false, expired JWT returns miss, opaque token returned without expiry check
+
+---
+
+### Task 4: Broker token page (CONNLINK-998)
+
+**Files:**
+- `internal/broker/credentials.go` (new) — HTTP handler for token page
+  - `GET /credentials?server=<name>&elicitation_id=<id>` — renders HTML form
+  - `POST /credentials` — stores token in cache, returns success
+- `internal/broker/credentials_test.go` (new) — unit tests
+- `cmd/mcp-broker-router/main.go` — register `/credentials` endpoint (gated behind `--enable-elicitation`)
+- `internal/broker/broker.go` — broker needs access to `UserTokenCache`
+
+**Acceptance criteria:**
+- [ ] GET renders form showing server name
+- [ ] POST verifies the session JWT on the request matches the session ID in the elicitation ID before storing
+- [ ] POST stores token in cache keyed by session ID and server name
+- [ ] Invalid/missing elicitation_id returns error
+- [ ] Session mismatch between request JWT and elicitation ID returns error
+- [ ] Endpoint only registered when `--enable-elicitation` is true
+- [ ] E2E: hit `/credentials` endpoint, store a token, verify it's retrievable from cache
+
+**Verification:** `make test-unit && make test-e2e`
+
+---
+
+### Task 5: Router token resolution + elicitation trigger (CONNLINK-997)
+
+**Files:**
+- `internal/mcp-router/request_handlers.go` — modify `HandleToolCall` to add token resolution:
+  1. Check if server has `CredentialURLElicitation` config — if not, skip (existing behavior)
+  2. If `--enable-elicitation` is false, skip (existing behavior)
+  3. Check `Authorization` header from client request — if present, use as-is (no token injection needed)
+  4. Check `UserTokenCache.GetUserToken(sessionID, serverName)` — if hit, inject via `headers.WithAuth()`
+  5. On cache miss, check client elicitation capability via `SessionCache.GetClientElicitation(ctx, gatewaySessionID)` (already stored during initialize handshake in `HandleResponseHeaders`)
+  6. If client supports elicitation → return `-32042` SSE immediate response with token page URL
+  7. If client does not support elicitation → return standard error (non-interactive agent path)
+- `internal/mcp-router/request_handlers.go` — add helper to build `-32042` response with URL (broker page or external URL from config)
+- `internal/mcp-router/request_handlers_test.go` — unit tests for each path
+- `internal/mcp-router/server.go` — add `UserTokenCache` field to `ExtProcServer`
+
+**Acceptance criteria:**
+- [ ] Existing Authorization header used as-is (no regression)
+- [ ] Cached token injected on hit
+- [ ] -32042 returned on miss with elicitation-capable client
+- [ ] Standard error returned on miss without capability
+- [ ] Feature flag disabled → existing behavior unchanged
+- [ ] URL in -32042 uses external URL when `credentialURLElicitation.url` is set
+- [ ] E2E: full flow — call without token → get -32042 → provide token via page → retry succeeds
+
+**Verification:** `make test-unit && make test-e2e`
+
+---
+
+### Task 6: Router 401 invalidation + re-elicitation (CONNLINK-999)
+
+**Files:**
+- `internal/mcp-router/response_handlers.go` — modify `HandleResponseHeaders` to handle 401:
+  1. If status is 401 and server has `CredentialURLElicitation` config and `--enable-elicitation`:
+     - Delete cached token via `UserTokenCache.DeleteUserToken`
+     - Check client capability via `SessionCache.GetClientElicitation(ctx, gatewaySessionID)` (same flow as Task 5)
+     - If client supports elicitation → return `-32042` immediate response (reuse helper from Task 5)
+     - If not → pass 401 through as-is
+- `internal/mcp-router/response_handlers_test.go` — unit tests
+
+**Acceptance criteria:**
+- [ ] 401 from upstream with elicitation-configured server → token deleted + -32042 returned
+- [ ] 401 without elicitation capability → standard 401 pass-through
+- [ ] 401 from non-elicitation server → no change (existing behavior)
+- [ ] Feature flag disabled → 401 passed through as-is
+- [ ] E2E: cached token is invalid → upstream returns 401 → token deleted → re-elicitation triggered
+
+**Verification:** `make test-unit && make test-e2e`
+
+---
+
+### Task 7: Documentation (part of CONNLINK-998)
+
+**Files:**
+- `docs/guides/url-elicitation.md` (new) — user-facing guide
+- `docs/design/security-architecture.md` — update with token data boundaries
+- `docs/reference/mcpserverregistration.md` — update API reference for `credentialURLElicitation` field
+
+**Acceptance criteria:**
+- [ ] Guide covers both broker page and external URL patterns
+- [ ] Security doc covers token isolation and known risks
+- [ ] API reference updated
+
+## Verification (full)
+
+```bash
+make generate-all    # CRD regeneration
+make lint            # Style checks
+make test-unit       # All unit tests
+make test-e2e        # E2E with Kind cluster
+```

--- a/docs/design/gateway-url-token-elicitation/tasks/tasks.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/tasks.md
@@ -66,6 +66,9 @@ Add the flag early so all subsequent work is gated behind it.
 - [ ] Controller propagates to config Secret
 - [ ] Unit test: controller includes elicitation config when set, omits when not set
 
+**Documentation (from `documentation.md`):**
+- API Reference Update: `credentialURLElicitation` object, `url` field, relationship to `credentialRef`, examples
+
 **Verification:** `make generate-all && make lint && make test-unit`
 
 ---
@@ -120,7 +123,14 @@ On `GetUserToken`, attempt to parse the token as a JWT (three dot-separated base
 - [ ] Invalid/missing elicitation_id returns error
 - [ ] Session mismatch between request JWT and elicitation ID returns error
 - [ ] Endpoint only registered when `--enable-elicitation` is true
-- [ ] E2E: hit `/credentials` endpoint, store a token, verify it's retrievable from cache
+
+**E2E test cases (from `e2e_test_cases.md`):**
+- `[URLElicitation] Broker credential page rejects invalid elicitation ID`
+- `[URLElicitation,Security] Broker credential page rejects session mismatch`
+- `[URLElicitation,Security] Credential page rejects mismatched session (phishing prevention)`
+
+**Documentation (from `documentation.md`):**
+- Guide section: "When I want to protect the token page from unauthorized access" — session JWT binding, custom header CORS protection, AuthPolicy as additional layer
 
 **Verification:** `make test-unit && make test-e2e`
 
@@ -148,7 +158,23 @@ On `GetUserToken`, attempt to parse the token as a JWT (three dot-separated base
 - [ ] Standard error returned on miss without capability
 - [ ] Feature flag disabled → existing behavior unchanged
 - [ ] URL in -32042 uses external URL when `credentialURLElicitation.url` is set
-- [ ] E2E: full flow — call without token → get -32042 → provide token via page → retry succeeds
+
+**E2E test cases (from `e2e_test_cases.md`):**
+- `[Happy,URLElicitation] URL elicitation triggers on missing token for elicitation-capable client`
+- `[Happy,URLElicitation] Token provided via broker page is used for upstream auth`
+- `[Happy,URLElicitation] Full elicitation round-trip with token validation`
+- `[URLElicitation] Cached token reused across multiple tool calls`
+- `[URLElicitation] Elicitation with external URL returns configured URL`
+- `[URLElicitation] Non-elicitation-capable client gets standard error on missing token`
+- `[Happy,URLElicitation] Non-elicitation-capable client with Authorization header succeeds`
+- `[URLElicitation] Elicitation-capable client with Authorization header bypasses cache`
+- `[URLElicitation] Elicitation disabled via feature flag has no effect`
+- `[Happy,URLElicitation] Server without credentialURLElicitation is unaffected`
+
+**Documentation (from `documentation.md`):**
+- Guide section: "When I want to securely collect per-user tokens for an upstream MCP server" — adding `credentialURLElicitation`, enabling the feature, user experience flow, prerequisites
+- Guide section: "When I want to use my own credential UI instead of the built-in page" — external URL config, AuthPolicy on upstream route, differences from default flow
+- Guide section: "When I have automated agents that can't use a browser" — automatic capability-based behavior, agents passing Authorization header, 401 handling for agents
 
 **Verification:** `make test-unit && make test-e2e`
 
@@ -170,23 +196,51 @@ On `GetUserToken`, attempt to parse the token as a JWT (three dot-separated base
 - [ ] 401 without elicitation capability → standard 401 pass-through
 - [ ] 401 from non-elicitation server → no change (existing behavior)
 - [ ] Feature flag disabled → 401 passed through as-is
-- [ ] E2E: cached token is invalid → upstream returns 401 → token deleted → re-elicitation triggered
+
+**E2E test cases (from `e2e_test_cases.md`):**
+- `[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation`
+
+**Documentation (from `documentation.md`):**
+- Guide section: "When a user's token expires and they need to provide a new one" — 401 invalidation, JWT expiry detection, user experience
+- Security Architecture Update (`docs/design/security-architecture.md`): token data flow, encryption at rest, session scoping, identity verification, known risks
 
 **Verification:** `make test-unit && make test-e2e`
 
 ---
 
-### Task 7: Documentation (part of CONNLINK-998)
+### Task 7: Documentation review and assembly (part of CONNLINK-998)
+
+Documentation sections are written inline with their implementation tasks (Tasks 2, 4, 5, 6). This task assembles the final `docs/guides/url-elicitation.md` from those sections and does a consistency pass.
 
 **Files:**
-- `docs/guides/url-elicitation.md` (new) — user-facing guide
-- `docs/design/security-architecture.md` — update with token data boundaries
-- `docs/reference/mcpserverregistration.md` — update API reference for `credentialURLElicitation` field
+- `docs/guides/url-elicitation.md` (new) — assemble from sections written in Tasks 4–6
+- `docs/guides/README.md` — add entry for new guide
 
 **Acceptance criteria:**
-- [ ] Guide covers both broker page and external URL patterns
-- [ ] Security doc covers token isolation and known risks
-- [ ] API reference updated
+- [ ] Guide sections from Tasks 4–6 assembled into coherent guide
+- [ ] Guide follows `docs/CLAUDE.md` conventions (numbered steps, prerequisites, next steps)
+- [ ] API reference updated (done in Task 2)
+- [ ] Security architecture updated (done in Task 6)
+- [ ] Guide added to `docs/guides/README.md`
+
+### Task 8: Remaining e2e test cases
+
+Cross-cutting tests that span multiple components and are best added after Tasks 3–6 are complete.
+
+**Files:**
+- `tests/e2e/elicitation_test.go` — add remaining e2e test cases
+
+**E2E test cases (from `e2e_test_cases.md`):**
+- `[URLElicitation] Expired JWT token treated as cache miss`
+- `[URLElicitation] Opaque token not subject to expiry check`
+
+**Acceptance criteria:**
+- [ ] Expired JWT stored in cache → next tool call deletes it, returns -32042
+- [ ] Opaque PAT stored in cache → returned without expiry check, forwarded to upstream
+
+**Verification:** `make test-e2e`
+
+---
 
 ## Verification (full)
 

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -9,6 +9,10 @@
 ## Conformance Tests
 MCP conformance tests verify that the gateway correctly implements the Model Context Protocol specification. These tests are sourced from the official `@modelcontextprotocol/conformance` npm package maintained by Anthropic.
 
+## Useful test servers for inspecting responses
+
+Server1 and Server2 both offer tools for inspecting headers, which is useful for validating what was passed through to the backend MCP.
+
 **Test scenarios currently run in CI** (`.github/workflows/conformance.yaml`):
 - `server-initialize`: Server initialization handshake
 - `tools-list`: Tool listing and discovery


### PR DESCRIPTION
## Summary

  - Design doc for gateway-initiated URL elicitation — a per-user credential strategy that keeps
  credentials server-side, out of the MCP client/LLM context
  - Introduces `elicitation` object on MCPServerRegistration CRD, extensible to OAuth flows
  - Credentials stored encrypted (AES-GCM) on the existing session cache hash, invalidated on upstream
  401

Related #775 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a documentation standard for feature-scoped design docs (structure, required sections, diagrams, task/e2e artifacts, and workflow from design to implementation).
  * Added end-to-end design, task plan, and e2e test specifications for gateway credential URL elicitation, covering UX flow, security, caching/verification behaviors, error flows, and acceptance/verification steps.
  * Added user-facing test server notes to assist response inspection during e2e validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->