### PR TITLE
move to streamed mode for the ext_proc body

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -70,6 +70,7 @@ var (
 	logFormat                 string
 	enforceToolFilteringFlag  bool
 	invalidToolPolicyFlag     string
+	maxRequestBodySize        int
 )
 
 func main() {
@@ -136,6 +137,7 @@ func main() {
 	flag.Int64Var(&managerTickerIntervalSecs, "mcp-check-interval", 60, "interval in seconds for MCP manager backend health checks. Default 60 seconds.")
 	flag.BoolVar(&enforceToolFilteringFlag, "enforce-tool-filtering", false, "when enabled an x-authorized-tools header will be needed to return any tools")
 	flag.StringVar(&invalidToolPolicyFlag, "invalid-tool-policy", "FilterOut", "policy for upstream tools with invalid schemas: FilterOut (default) or RejectServer")
+	flag.IntVar(&maxRequestBodySize, "max-request-body-size", 5242880, "max request body size in bytes for the ext_proc router. Default 5MB.")
 	flag.Parse()
 
 	loggerOpts := &slog.HandlerOptions{}
@@ -357,13 +359,14 @@ func setUpRouter(broker broker.MCPBroker, logger *slog.Logger, jwtManager *sessi
 
 	grpcSrv := grpc.NewServer()
 	server := &mcpRouter.ExtProcServer{
-		RoutingConfig:  mcpConfig,
-		Logger:         logger.With("component", "router"),
-		JWTManager:     jwtManager,
-		InitForClient:  clients.Initialize,
-		SessionCache:   sessionCache,
-		ElicitationMap: elicitationMap,
-		Broker:         broker, // TODO we shouldn't need a handle to broker in the router
+		RoutingConfig:      mcpConfig,
+		Logger:             logger.With("component", "router"),
+		JWTManager:         jwtManager,
+		InitForClient:      clients.Initialize,
+		SessionCache:       sessionCache,
+		ElicitationMap:     elicitationMap,
+		Broker:             broker, // TODO we shouldn't need a handle to broker in the router
+		MaxRequestBodySize: maxRequestBodySize,
 	}
 
 	extProcV3.RegisterExternalProcessorServer(grpcSrv, server)

--- a/config/istio/envoyfilter.yaml
+++ b/config/istio/envoyfilter.yaml
@@ -32,7 +32,7 @@ spec:
             processing_mode:
               request_header_mode: 'SEND'
               response_header_mode: 'SEND'
-              request_body_mode: 'BUFFERED'
+              request_body_mode: 'STREAMED'
               response_body_mode: 'NONE'
               request_trailer_mode: 'SKIP'
               response_trailer_mode: 'SKIP'

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -731,7 +731,7 @@ func (r *MCPGatewayExtensionReconciler) buildEnvoyFilter(mcpExt *mcpv1alpha1.MCP
 			"processing_mode": map[string]any{
 				"request_header_mode":   "SEND",
 				"response_header_mode":  "SEND",
-				"request_body_mode":     "BUFFERED",
+				"request_body_mode":     "STREAMED",
 				"response_body_mode":    "NONE",
 				"request_trailer_mode":  "SKIP",
 				"response_trailer_mode": "SKIP",

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -54,7 +54,7 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 		responses[0].ModeOverride = &extprochttp.ProcessingMode{
 			RequestHeaderMode:   extprochttp.ProcessingMode_SEND,
 			ResponseHeaderMode:  extprochttp.ProcessingMode_SEND,
-			RequestBodyMode:     extprochttp.ProcessingMode_BUFFERED,
+			RequestBodyMode:     extprochttp.ProcessingMode_STREAMED,
 			ResponseBodyMode:    extprochttp.ProcessingMode_STREAMED,
 			RequestTrailerMode:  extprochttp.ProcessingMode_SKIP,
 			ResponseTrailerMode: extprochttp.ProcessingMode_SKIP,

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -35,12 +35,13 @@ type InitForClient func(ctx context.Context, gatewayHost, routerKey string, conf
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {
-	RoutingConfig  *config.MCPServersConfig
-	JWTManager     *session.JWTManager
-	Logger         *slog.Logger
-	InitForClient  InitForClient
-	SessionCache   SessionCache
-	ElicitationMap idmap.Map
+	RoutingConfig      *config.MCPServersConfig
+	JWTManager         *session.JWTManager
+	Logger             *slog.Logger
+	InitForClient      InitForClient
+	SessionCache       SessionCache
+	ElicitationMap     idmap.Map
+	MaxRequestBodySize int
 	//TODO this should not be needed
 	Broker broker.MCPBroker
 }
@@ -59,6 +60,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 		mcpRequest          *MCPRequest
 		ctx                 = stream.Context()
 		rewriter            *sseRewriter // nil until a tool call response arrives
+		bodyBuffer          []byte
 	)
 	span := trace.SpanFromContext(ctx)
 	defer func() { span.End() }()
@@ -140,8 +142,39 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 				return err
 			}
 			s.Logger.DebugContext(ctx, "[ext_proc ] Process: ProcessingRequest_RequestBody", "request id:", requestID)
-			// It is highly unlikely we would hit this situation as envoy skips this step if no body present. However it doesn't hurt to be defensive here just in case
-			if len(r.RequestBody.Body) == 0 {
+
+			// enforce max body size before allocating memory for the chunk
+			if s.MaxRequestBodySize > 0 && len(bodyBuffer)+len(r.RequestBody.Body) > s.MaxRequestBodySize {
+				err := fmt.Errorf("request body too large: %d bytes exceeds limit of %d", len(bodyBuffer)+len(r.RequestBody.Body), s.MaxRequestBodySize)
+				s.Logger.ErrorContext(ctx, err.Error(), "request id", requestID)
+				recordError(span, err, 413)
+				resp := responseBuilder.WithImmediateResponse(413, "request body too large").Build()
+				for _, res := range resp {
+					if sendErr := stream.Send(res); sendErr != nil {
+						s.Logger.ErrorContext(ctx, fmt.Sprintf("Error sending response: %v", sendErr))
+					}
+				}
+				return err
+			}
+
+			// accumulate streamed body chunk
+			bodyBuffer = append(bodyBuffer, r.RequestBody.Body...)
+
+			if !r.RequestBody.EndOfStream {
+				// intermediate chunk: acknowledge and wait for more data
+				s.Logger.DebugContext(ctx, "received body chunk, waiting for more", "request id", requestID, "buffer_size", len(bodyBuffer))
+				resp := responseBuilder.WithDoNothingResponse(false).Build()
+				for _, res := range resp {
+					if err := stream.Send(res); err != nil {
+						s.Logger.ErrorContext(ctx, fmt.Sprintf("Error sending response: %v", err))
+						return err
+					}
+				}
+				continue
+			}
+
+			// EndOfStream: all chunks received, process complete body
+			if len(bodyBuffer) == 0 {
 				s.Logger.DebugContext(ctx, "empty request body, skipping", "request id", requestID)
 				resp := responseBuilder.WithDoNothingResponse(false).Build()
 				for _, res := range resp {
@@ -152,7 +185,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 				}
 				continue
 			}
-			if err := json.Unmarshal(r.RequestBody.Body, &mcpRequest); err != nil {
+			if err := json.Unmarshal(bodyBuffer, &mcpRequest); err != nil {
 				s.Logger.ErrorContext(ctx, "error unmarshalling request body", "error", err)
 				recordError(span, err, 400)
 				resp := responseBuilder.WithImmediateResponse(400, "invalid request body").Build()

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -67,7 +67,8 @@ func TestProcess_InvalidBody(t *testing.T) {
 			msg: &extProcV3.ProcessingRequest{
 				Request: &extProcV3.ProcessingRequest_RequestBody{
 					RequestBody: &extProcV3.HttpBody{
-						Body: []byte("{}"),
+						Body:        []byte("{}"),
+						EndOfStream: true,
 					},
 				},
 			},
@@ -102,7 +103,8 @@ func TestProcess_HappyPath(t *testing.T) {
 			msg: &extProcV3.ProcessingRequest{
 				Request: &extProcV3.ProcessingRequest_RequestBody{
 					RequestBody: &extProcV3.HttpBody{
-						Body: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+						Body:        []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+						EndOfStream: true,
 					},
 				},
 			},
@@ -140,7 +142,8 @@ func TestProcess_EmptyBody(t *testing.T) {
 			msg: &extProcV3.ProcessingRequest{
 				Request: &extProcV3.ProcessingRequest_RequestBody{
 					RequestBody: &extProcV3.HttpBody{
-						Body: []byte{},
+						Body:        []byte{},
+						EndOfStream: true,
 					},
 				},
 			},
@@ -171,7 +174,8 @@ func TestProcess_UnmarshalError(t *testing.T) {
 			msg: &extProcV3.ProcessingRequest{
 				Request: &extProcV3.ProcessingRequest_RequestBody{
 					RequestBody: &extProcV3.HttpBody{
-						Body: []byte("not json at all"),
+						Body:        []byte("not json at all"),
+						EndOfStream: true,
 					},
 				},
 			},
@@ -334,6 +338,187 @@ func TestProcessSpanEnded(t *testing.T) {
 		}
 	}
 	require.True(t, found, "expected mcp-router.process span to be recorded")
+}
+
+func TestProcess_StreamedBodyMultipleChunks(t *testing.T) {
+	srv := newTestServer(t)
+
+	// do-nothing body response for intermediate chunks
+	doNothingBody := &extProcV3.ProcessingResponse{
+		Response: &extProcV3.ProcessingResponse_RequestBody{
+			RequestBody: &extProcV3.BodyResponse{
+				Response: &extProcV3.CommonResponse{},
+			},
+		},
+	}
+
+	mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+		requestHeadersStep(),
+		// chunk 1: partial body, EndOfStream=false
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`{"jsonrpc":"2.0",`),
+						EndOfStream: false,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{doNothingBody},
+		},
+		// chunk 2: partial body, EndOfStream=false
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`"method":"initialize",`),
+						EndOfStream: false,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{doNothingBody},
+		},
+		// chunk 3: final body, EndOfStream=true — triggers routing
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`"id":1}`),
+						EndOfStream: true,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{
+				{
+					Response: &extProcV3.ProcessingResponse_RequestBody{
+						RequestBody: &extProcV3.BodyResponse{
+							Response: &extProcV3.CommonResponse{
+								HeaderMutation: &extProcV3.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										{Header: &corev3.HeaderValue{Key: "x-mcp-method", RawValue: []byte("initialize")}},
+										{Header: &corev3.HeaderValue{Key: "x-mcp-servername", RawValue: []byte("mcpBroker")}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		responseHeadersStep(),
+	})
+
+	err := srv.Process(mock)
+	require.NoError(t, err)
+	mock.verifyAllResponsesConsumed()
+}
+
+func TestProcess_StreamedBodyExceedsMaxSize(t *testing.T) {
+	srv := newTestServer(t)
+	srv.MaxRequestBodySize = 50
+
+	mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+		requestHeadersStep(),
+		// chunk 1: 30 bytes, under the limit
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`{"jsonrpc":"2.0","method":"in`),
+						EndOfStream: false,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{
+				{
+					Response: &extProcV3.ProcessingResponse_RequestBody{
+						RequestBody: &extProcV3.BodyResponse{
+							Response: &extProcV3.CommonResponse{},
+						},
+					},
+				},
+			},
+		},
+		// chunk 2: pushes total over 50 bytes, expect 413
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`itialize","id":1,"params":{"extra":"data"}}`),
+						EndOfStream: true,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{
+				immediateResponse(413),
+			},
+		},
+	})
+
+	err := srv.Process(mock)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "request body too large")
+	mock.verifyAllResponsesConsumed()
+}
+
+func TestProcess_StreamedBodyEmptyFinalChunk(t *testing.T) {
+	srv := newTestServer(t)
+
+	doNothingBody := &extProcV3.ProcessingResponse{
+		Response: &extProcV3.ProcessingResponse_RequestBody{
+			RequestBody: &extProcV3.BodyResponse{
+				Response: &extProcV3.CommonResponse{},
+			},
+		},
+	}
+
+	mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+		requestHeadersStep(),
+		// chunk 1: full body in intermediate chunk
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`{"jsonrpc":"2.0","method":"initialize","id":1}`),
+						EndOfStream: false,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{doNothingBody},
+		},
+		// chunk 2: empty final chunk, EndOfStream=true — should process accumulated data
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte{},
+						EndOfStream: true,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{
+				{
+					Response: &extProcV3.ProcessingResponse_RequestBody{
+						RequestBody: &extProcV3.BodyResponse{
+							Response: &extProcV3.CommonResponse{
+								HeaderMutation: &extProcV3.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										{Header: &corev3.HeaderValue{Key: "x-mcp-method", RawValue: []byte("initialize")}},
+										{Header: &corev3.HeaderValue{Key: "x-mcp-servername", RawValue: []byte("mcpBroker")}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		responseHeadersStep(),
+	})
+
+	err := srv.Process(mock)
+	require.NoError(t, err)
+	mock.verifyAllResponsesConsumed()
 }
 
 func newTestServer(t *testing.T) *ExtProcServer {

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -444,7 +444,7 @@ func TestProcess_StreamedBodyExceedsMaxSize(t *testing.T) {
 			msg: &extProcV3.ProcessingRequest{
 				Request: &extProcV3.ProcessingRequest_RequestBody{
 					RequestBody: &extProcV3.HttpBody{
-						Body:        []byte(`itialize","id":1,"params":{"extra":"data"}}`),
+						Body:        []byte(`initialize","id":1,"params":{"extra":"data"}}`),
 						EndOfStream: true,
 					},
 				},


### PR DESCRIPTION
  Switches the Envoy ext_proc request body mode from BUFFERED to STREAMED. Instead of Envoy buffering the entire
  request body (constrained by Envoy's internal buffer limits), the ext_proc now receives and reassembles body chunks
  itself. Small requests — which covers most MCP calls — arrive as a single chunk, so there's no impact on existing
  performance. For larger payloads, this removes the dependency on Envoy's buffer size and gives the gateway direct
  control. Adds a configurable max request body size (--max-request-body-size, default 5MB) — requests exceeding this
  limit are rejected with 413.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CLI parameter to set maximum request body size limit
  * Migrated from buffered to streamed request body processing for improved handling of large payloads
  * Implemented request body size validation with 413 error response for oversized requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->