### PR TITLE
fixed the link of getting started

### DIFF
--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -21,4 +21,4 @@ The MCP Gateway is an early preview feature. This early preview feature is not c
 ## Get started
 
 Information and links to get you started:
-    - [Getting Started](https://docs.kuadrant.io/1.4.x/mcp-gateway/docs/guides/getting-started/)
+    - [Getting Started](./getting-started.md)

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -21,4 +21,4 @@ The MCP Gateway is an early preview feature. This early preview feature is not c
 ## Get started
 
 Information and links to get you started:
-    - [Documentation links](./README.md)
+    - [Getting Started](https://docs.kuadrant.io/1.4.x/mcp-gateway/docs/guides/getting-started/)

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -21,4 +21,4 @@ The MCP Gateway is an early preview feature. This early preview feature is not c
 ## Get started
 
 Information and links to get you started:
-    - [Getting Started](./getting-started.md)
+ - [Getting Started](./getting-started.md)


### PR DESCRIPTION
in this pr, I  have just changed the link. Can we add a simple link checker in CI ??  that would be really beneficial 
i have done discusions on the other possible ways in the issue's page 
https://github.com/Kuadrant/mcp-gateway/issues/791

KIndly check !!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Get started" link to point to the local "Getting Started" guide instead of the previous README reference.
  * Clarified this change only updates the link destination; no other documentation content, behavior, or public interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->