### PR TITLE
fix(openshift): add EnvoyFilter CRD stub for OCP ingress without Service Mesh

### DIFF
--- a/config/openshift/kustomize/ocp-ingress/base/envoyfilter-crd.yaml
+++ b/config/openshift/kustomize/ocp-ingress/base/envoyfilter-crd.yaml
@@ -1,0 +1,23 @@
+# EnvoyFilter CRD stub - the MCP Gateway controller watches this Istio CRD.
+# On clusters without Service Mesh (USE_OCP_INGRESS=true), we install a minimal
+# CRD so the controller cache can sync without crashing.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: envoyfilters.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    kind: EnvoyFilter
+    listKind: EnvoyFilterList
+    plural: envoyfilters
+    singular: envoyfilter
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/config/openshift/kustomize/ocp-ingress/base/kustomization.yaml
+++ b/config/openshift/kustomize/ocp-ingress/base/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - gatewayclass.yaml
+  - envoyfilter-crd.yaml


### PR DESCRIPTION
The `mcp-gateway` controller watches the `EnvoyFilter` CRD from `networking.istio.io/v1alpha3` at startup. When deploying with `USE_OCP_INGRESS=true` (no Service Mesh), this CRD does not exist and the controller crashes in a loop:

```
no matches for kind "EnvoyFilter" in version "networking.istio.io/v1alpha3"
```

This adds a minimal stub CRD to the ocp-ingress kustomize overlay so the controller cache can sync without requiring a full Service Mesh install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced EnvoyFilter Custom Resource Definition for OpenShift clusters, enabling traffic routing and networking configuration through Envoy proxies. Now available on clusters with or without Service Mesh installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->