### PR TITLE
fix : Add an image_tag parameter for custom naming in BuildImage action

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -2,6 +2,11 @@ name: Build Images
 
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Custom image tag (e.g. nightly, dev-branch-name). Leave empty to use default Git-based tags."
+        required: false
+        type: string
   push:
     branches: [ main ]
     tags: [ 'v*' ]
@@ -80,6 +85,7 @@ jobs:
             type=sha,format=long
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ inputs.image_tag }},enable=${{inputs.image_tag != ''}}
 
       - name: Print Docker metadata for debugging
         run: |
@@ -163,7 +169,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }} \
             REGISTRY=${{ env.REGISTRY }} \
             ORG=${{ steps.owner.outputs.name }} \
-            IMAGE_TAG=${{ github.ref_name }}
+            IMAGE_TAG=${{ inputs.image_tag || github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -177,7 +183,7 @@ jobs:
           push: true
           provenance: false
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/mcp-controller-bundle:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/mcp-controller-bundle:${{ inputs.image_tag || github.ref_name }}
 
   build-catalog:
     name: Build Catalog Image
@@ -215,7 +221,7 @@ jobs:
           make catalog \
             REGISTRY=${{ env.REGISTRY }} \
             ORG=${{ steps.owner.outputs.name }} \
-            IMAGE_TAG=${{ github.ref_name }}
+            IMAGE_TAG=${{ inputs.image_tag || github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -229,4 +235,4 @@ jobs:
           push: true
           provenance: false
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/mcp-controller-catalog:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/mcp-controller-catalog:${{ inputs.image_tag || github.ref_name }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -54,6 +54,24 @@ jobs:
             dockerfile: Dockerfile.controller
 
     steps:
+      - name: Validate custom tag
+        if: github.event_name == 'workflow_dispatch' && inputs.image_tag != ''
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          if [[ "$TAG" =~ ^v[0-9] ]]; then
+            echo "::error::Custom tag '$TAG' matches release tag format (vX.Y.Z). Use git tags for releases instead."
+            exit 1
+          fi
+          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Custom tag '$TAG' matches semver format. Use git tags for releases instead."
+            exit 1
+          fi
+          if [[ "$TAG" == "latest" || "$TAG" == "main" ]]; then
+            echo "::error::Custom tag '$TAG' is reserved and cannot be used."
+            exit 1
+          fi
+          echo "Custom tag '$TAG' is valid"
+
       - name: Check out code
         uses: actions/checkout@v4
 

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -164,12 +164,14 @@ jobs:
         run: make olm-tools
 
       - name: Generate bundle
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag || github.ref_name }}
         run: |
           make bundle \
             VERSION=${{ steps.version.outputs.version }} \
             REGISTRY=${{ env.REGISTRY }} \
             ORG=${{ steps.owner.outputs.name }} \
-            IMAGE_TAG=${{ inputs.image_tag || github.ref_name }}
+            IMAGE_TAG="${IMAGE_TAG}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -217,11 +219,13 @@ jobs:
         run: make olm-tools
 
       - name: Generate catalog
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag || github.ref_name }}
         run: |
           make catalog \
             REGISTRY=${{ env.REGISTRY }} \
             ORG=${{ steps.owner.outputs.name }} \
-            IMAGE_TAG=${{ inputs.image_tag || github.ref_name }}
+            IMAGE_TAG="${IMAGE_TAG}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary 

- Fixes #158 
- Added an optional input parameter for to the BuildImage action for custom naming of the image that doesn't necessarily need to follow the `vXYZ` tag format.

Wanted to ask that Should we have some check that the custom name is not of the `vXYZ` or some other common name formats as there could be a problem of overwriting an existing version as GCHR doesn't have tag immutability 
@david-martin 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual image tag input for workflow triggers so you can supply a custom Docker tag (falls back to branch/ref when empty).
  * Validation prevents release-like/semver patterns and reserved values (e.g., "latest", "main") from being used.
  * Custom tag is applied to image metadata and used for bundle/catalog builds and pushed image tags when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->