### PR TITLE
Update vision to include non goal on transforming tools

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,8 @@ MCP Gateway composes MCP support out of Envoy’s routing and extension mechanis
 ## Non-Goals
 
 * Not replacing Envoy AI Gateway or its broader AI gateway capabilities
+* Not transforming or masking tool inputs/outputs — the gateway federates and aggregates tools as they are; reshaping tool schemas, filtering fields, or creating derived tools from existing ones is the responsibility of the MCP server itself or dedicated tooling (e.g. camel, toolhive proxy, custom MCP servers)
+* Not automatically mapping non-MCP APIs (OpenAPI, REST, gRPC) to MCP tools — converting existing APIs into MCP tool definitions is out of scope; use purpose-built tooling at the MCP server layer for that
 
 ## Approach
 


### PR DESCRIPTION
Adds two new Non-Goals to VISION.md clarifying that MCP Gateway does not transform/mask tool inputs/outputs and does not auto-map non-MCP APIs (OpenAPI, REST, gRPC) to MCP tools

MCP Gateway's focus is federation (tool discovery, virtual servers, aggregation) and policy, not reshaping tool schemas or converting existing APIs into MCP tool definitions. That work belongs at the MCP server layer or with dedicated tooling (e.g. Camel, ToolHive proxy, custom MCP servers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vision documentation to clarify MCP Gateway's non-goals, including constraints around MCP tool I/O manipulation and automatic API specification conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->