### PR TITLE
refactor allowed-tools to allowedCapabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ local-env-teardown: ## Tear down the local Kind cluster
 
 
 .PHONY: add-jwt-key
-add-jwt-key: #add the public key needed to validate any incoming jwt based headers such as x-allowed-tools
+add-jwt-key: #add the public key needed to validate any incoming jwt based headers such as x-mcp-authorized
 	@for i in 1 2 3 4 5; do \
 		kubectl get deployment/$(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) -o yaml | \
 		bin/yq '.spec.template.spec.containers[0].env += [{"name":"TRUSTED_HEADER_PUBLIC_KEY","valueFrom":{"secretKeyRef":{"name":"trusted-headers-public-key","key":"key"}}}] | .spec.template.spec.containers[0].env |= unique_by(.name)' | \

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -55,22 +55,22 @@ func init() {
 }
 
 var (
-	mcpRouterAddrFlag         string
-	mcpBrokerAddrFlag         string
-	mcpRoutePublicHost        string
-	mcpRoutePrivateHost       string
-	mcpRouterKey              string
-	cacheConnectionStringFlag string
-	mcpConfigFile             string
-	jwtSigningKeyFlag         string
-	sessionDurationInMins     int64
-	brokerWriteTimeoutSecs    int64
-	managerTickerIntervalSecs int64
-	loglevel                  int
-	logFormat                 string
-	enforceToolFilteringFlag  bool
-	invalidToolPolicyFlag     string
-	maxRequestBodySize        int
+	mcpRouterAddrFlag              string
+	mcpBrokerAddrFlag              string
+	mcpRoutePublicHost             string
+	mcpRoutePrivateHost            string
+	mcpRouterKey                   string
+	cacheConnectionStringFlag      string
+	mcpConfigFile                  string
+	jwtSigningKeyFlag              string
+	sessionDurationInMins          int64
+	brokerWriteTimeoutSecs         int64
+	managerTickerIntervalSecs      int64
+	loglevel                       int
+	logFormat                      string
+	enforceCapabilityFilteringFlag bool
+	invalidToolPolicyFlag          string
+	maxRequestBodySize             int
 )
 
 func main() {
@@ -135,7 +135,7 @@ func main() {
 	flag.Int64Var(&sessionDurationInMins, "session-length", 60*24, "default session length with the gateway in minutes. Default 24h")
 	flag.Int64Var(&brokerWriteTimeoutSecs, "mcp-broker-write-timeout", 0, "HTTP write timeout in seconds for the broker. Default 0 (disabled) for SSE notification support. Set > 0 to enable timeout.")
 	flag.Int64Var(&managerTickerIntervalSecs, "mcp-check-interval", 60, "interval in seconds for MCP manager backend health checks. Default 60 seconds.")
-	flag.BoolVar(&enforceToolFilteringFlag, "enforce-tool-filtering", false, "when enabled an x-authorized-tools header will be needed to return any tools")
+	flag.BoolVar(&enforceCapabilityFilteringFlag, "enforce-capability-filtering", false, "when enabled an x-mcp-authorized header will be needed to return any capabilities (tools, prompts)")
 	flag.StringVar(&invalidToolPolicyFlag, "invalid-tool-policy", "FilterOut", "policy for upstream tools with invalid schemas: FilterOut (default) or RejectServer")
 	flag.IntVar(&maxRequestBodySize, "max-request-body-size", 5242880, "max request body size in bytes for the ext_proc router. Default 5MB.")
 	flag.Parse()
@@ -215,7 +215,7 @@ func main() {
 		panic("flag mcp-check-interval cannot be 0 or less seconds")
 	}
 	mcpBroker := broker.NewBroker(logger.With("component", "broker"),
-		broker.WithEnforceToolFilter(enforceToolFilteringFlag),
+		broker.WithEnforceCapabilityFilter(enforceCapabilityFilteringFlag),
 		broker.WithTrustedHeadersPublicKey(os.Getenv("TRUSTED_HEADER_PUBLIC_KEY")),
 		broker.WithManagerTickerInterval(managerTickerInterval),
 		broker.WithInvalidToolPolicy(invalidToolPolicy),

--- a/config/keycloak/realm-import.yaml
+++ b/config/keycloak/realm-import.yaml
@@ -68,120 +68,120 @@ data:
           ],
           "mcp-test/test-server1": [
             {
-              "name": "greet"
+              "name": "tool:greet"
             },
             {
-              "name": "headers"
+              "name": "tool:headers"
             },
             {
-              "name": "slow"
+              "name": "tool:slow"
             },
             {
-              "name": "time"
+              "name": "tool:time"
             }
           ],
           "mcp-test/test-server2": [
             {
-              "name": "auth1234"
+              "name": "tool:auth1234"
             },
             {
-              "name": "headers"
+              "name": "tool:headers"
             },
             {
-              "name": "hello_world"
+              "name": "tool:hello_world"
             },
             {
-              "name": "slow"
+              "name": "tool:slow"
             },
             {
-              "name": "time"
+              "name": "tool:time"
             }
           ],
           "mcp-test/test-server3": [
             {
-              "name": "time"
+              "name": "tool:time"
             },
             {
-              "name": "add"
+              "name": "tool:add"
             },
             {
-              "name": "dozen"
+              "name": "tool:dozen"
             },
             {
-              "name": "pi"
+              "name": "tool:pi"
             }
           ],
           "mcp-test/oidc-server": [
             {
-              "name": "hello_world"
+              "name": "tool:hello_world"
             }
           ],
           "mcp-test/kubernetes-mcp-server": [
             {
-              "name": "configuration_contexts_list"
+              "name": "tool:configuration_contexts_list"
             },
             {
-              "name": "configuration_view"
+              "name": "tool:configuration_view"
             },
             {
-              "name": "events_list"
+              "name": "tool:events_list"
             },
             {
-              "name": "helm_install"
+              "name": "tool:helm_install"
             },
             {
-              "name": "helm_list"
+              "name": "tool:helm_list"
             },
             {
-              "name": "helm_uninstall"
+              "name": "tool:helm_uninstall"
             },
             {
-              "name": "namespaces_list"
+              "name": "tool:namespaces_list"
             },
             {
-              "name": "nodes_log"
+              "name": "tool:nodes_log"
             },
             {
-              "name": "nodes_stats_summary"
+              "name": "tool:nodes_stats_summary"
             },
             {
-              "name": "nodes_top"
+              "name": "tool:nodes_top"
             },
             {
-              "name": "pods_delete"
+              "name": "tool:pods_delete"
             },
             {
-              "name": "pods_exec"
+              "name": "tool:pods_exec"
             },
             {
-              "name": "pods_get"
+              "name": "tool:pods_get"
             },
             {
-              "name": "pods_list"
+              "name": "tool:pods_list"
             },
             {
-              "name": "pods_list_in_namespace"
+              "name": "tool:pods_list_in_namespace"
             },
             {
-              "name": "pods_log"
+              "name": "tool:pods_log"
             },
             {
-              "name": "pods_run"
+              "name": "tool:pods_run"
             },
             {
-              "name": "pods_top"
+              "name": "tool:pods_top"
             },
             {
-              "name": "resources_create_or_update"
+              "name": "tool:resources_create_or_update"
             },
             {
-              "name": "resources_delete"
+              "name": "tool:resources_delete"
             },
             {
-              "name": "resources_get"
+              "name": "tool:resources_get"
             },
             {
-              "name": "resources_list"
+              "name": "tool:resources_list"
             }
           ]
         }
@@ -199,16 +199,16 @@ data:
           "name": "accounting",
           "clientRoles": {
             "mcp-test/test-server1": [
-              "greet"
+              "tool:greet"
             ],
             "mcp-test/test-server2": [
-              "headers"
+              "tool:headers"
             ],
             "mcp-test/test-server3": [
-              "add"
+              "tool:add"
             ],
             "mcp-test/oidc-server": [
-              "hello_world"
+              "tool:hello_world"
             ]
           }
         },
@@ -216,28 +216,28 @@ data:
           "name": "engineering",
           "clientRoles": {
             "mcp-test/kubernetes-mcp-server": [
-              "configuration_contexts_list",
-              "configuration_view",
-              "events_list",
-              "helm_install",
-              "helm_list",
-              "helm_uninstall",
-              "namespaces_list",
-              "nodes_log",
-              "nodes_stats_summary",
-              "nodes_top",
-              "pods_delete",
-              "pods_exec",
-              "pods_get",
-              "pods_list",
-              "pods_list_in_namespace",
-              "pods_log",
-              "pods_run",
-              "pods_top",
-              "resources_create_or_update",
-              "resources_delete",
-              "resources_get",
-              "resources_list"
+              "tool:configuration_contexts_list",
+              "tool:configuration_view",
+              "tool:events_list",
+              "tool:helm_install",
+              "tool:helm_list",
+              "tool:helm_uninstall",
+              "tool:namespaces_list",
+              "tool:nodes_log",
+              "tool:nodes_stats_summary",
+              "tool:nodes_top",
+              "tool:pods_delete",
+              "tool:pods_exec",
+              "tool:pods_get",
+              "tool:pods_list",
+              "tool:pods_list_in_namespace",
+              "tool:pods_log",
+              "tool:pods_run",
+              "tool:pods_top",
+              "tool:resources_create_or_update",
+              "tool:resources_delete",
+              "tool:resources_get",
+              "tool:resources_list"
             ]
           }
         }

--- a/config/samples/oauth-token-exchange/tools-call-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-call-auth.yaml
@@ -74,7 +74,7 @@ spec:
         patternMatching:
           patterns:
             - predicate: |
-                request.headers['x-mcp-toolname'] in (has(auth.authorization.token.claims.resource_access) && auth.authorization.token.claims.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.authorization.token.claims.resource_access[request.headers['x-mcp-servername']].roles : [])
+                ('tool:' + request.headers['x-mcp-toolname']) in (has(auth.authorization.token.claims.resource_access) && auth.authorization.token.claims.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.authorization.token.claims.resource_access[request.headers['x-mcp-servername']].roles : [])
         priority: 1
     response:
       success:

--- a/config/samples/oauth-token-exchange/tools-list-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-list-auth.yaml
@@ -22,21 +22,21 @@ spec:
           patterns:
           - predicate: |
               !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
-      'authorized-tools':
+      'authorized-capabilities':
         opa:
           rego: |
             allow = true
-            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+            capabilities = {"tools": { server: tools | server := object.keys(input.auth.identity.resource_access)[_]; tools := [substring(r, count("tool:"), -1) | r := input.auth.identity.resource_access[server].roles[_]; startswith(r, "tool:")] }}
           allValues: true
     response:
       success:
         headers:
-          x-authorized-tools:
+          x-mcp-authorized:
             wristband:
               issuer: 'authorino'
               customClaims:
-                'allowed-tools':
-                  selector: auth.authorization.authorized-tools.tools.@tostr
+                'allowed-capabilities':
+                  selector: auth.authorization.authorized-capabilities.capabilities.@tostr
               tokenDuration: 300
               signingKeyRefs:
                 - name: trusted-headers-private-key

--- a/config/samples/oauth-token-exchange/tools-list-auth.yaml
+++ b/config/samples/oauth-token-exchange/tools-list-auth.yaml
@@ -22,21 +22,29 @@ spec:
           patterns:
           - predicate: |
               !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
-      'authorized-tools':
+      'authorized-capabilities':
         opa:
           rego: |
             allow = true
-            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+            capabilities = {
+              "tools": { server: tools |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                tools := [substring(r, count("tool:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "tool:")
+                ]
+              }
+            }
           allValues: true
     response:
       success:
         headers:
-          x-authorized-tools:
+          x-mcp-authorized:
             wristband:
               issuer: 'authorino'
               customClaims:
-                'allowed-tools':
-                  selector: auth.authorization.authorized-tools.tools.@tostr
+                'allowed-capabilities':
+                  selector: auth.authorization.authorized-capabilities.capabilities.@tostr
               tokenDuration: 300
               signingKeyRefs:
                 - name: trusted-headers-private-key

--- a/cspell.json
+++ b/cspell.json
@@ -9,6 +9,6 @@
         }
     ],
     "dictionaries": ["project-words"],
-    "ignorePaths": ["tests/**", "/project-words.txt", "/config/crd/istio/**", "go.mod","realm-import.yaml", "docs/plans/**", "catalog/mcp-gateway-catalog/**"]
+    "ignorePaths": ["tests/**", "/project-words.txt", "/config/crd/istio/**", "go.mod","realm-import.yaml", "docs/plans/**", "docs/superpowers/**", "catalog/mcp-gateway-catalog/**"]
 
 }

--- a/docs/design/auth-phase-2.md
+++ b/docs/design/auth-phase-2.md
@@ -22,13 +22,13 @@ Following on from [Auth Phase 1](./auth-phase-1.md), we will now also show how t
 
 ![](./images/tools-list.jpg)
 
-In order to filter down the available tools, either generally or within the context of a virtual MCP, based on the auth integration, a trusted source can set a header `x-allowed-tools`. This header is expected to be in JWT format signed by a trusted key pair, with the public element being shared with the broker via env var `TRUSTED_HEADER_PUBLIC_KEY`. The list of tools has to be a claim within this JWT with a key `allowed-tools` and a value as shown below. The broker will look for this header during a `tools/list` call. If set, it will validate the JWT, extract the allowed tools and ensure the returned tools are matched against this list. If it fails to validate the header, it will return an empty list.
+In order to filter down the available capabilities (tools, and in future prompts and resources), either generally or within the context of a virtual MCP, based on the auth integration, a trusted source can set a header `x-mcp-authorized`. This header is expected to be in JWT format signed by a trusted key pair, with the public element being shared with the broker via env var `TRUSTED_HEADER_PUBLIC_KEY`. The JWT must contain a claim with key `allowed-capabilities` whose value is a JSON-encoded capabilities map, keyed by capability type (e.g. `"tools"`) with each entry mapping server names to allowed item names. The broker will look for this header during a `tools/list` call, validate the JWT, extract `capabilities["tools"]`, and filter the returned tools accordingly. If validation fails, it will return an empty list.
 
 Example JWT payload:
 
 ```json
 {
-  "allowed-tools": "{\"mcp-test/mcp-server1-route\":[\"greet\"],\"mcp-test/mcp-server2-route\":[\"headers\"],\"mcp-test/mcp-server3-route\":[\"add\"]}",
+  "allowed-capabilities": "{\"tools\":{\"mcp-test/mcp-server1-route\":[\"greet\"],\"mcp-test/mcp-server2-route\":[\"headers\"],\"mcp-test/mcp-server3-route\":[\"add\"]}}",
   "exp": 1760004918,
   "iat": 1760004618,
   "iss": "Authorino",
@@ -44,7 +44,7 @@ We have provided an [example AuthPolicy](../../config/samples/oauth-token-exchan
 
 There are multiple ways to configure a Keycloak realm for storing permissions to control access to the MCP tools. The method employed in the [example provided](../../config/keycloak/realm-import.yaml) consists of:
 - An OAuth "resource server" client for each MCP server, identified by the MCP server's internal host name for convenience
-- Each tool of an MCP server defined as a role of the resource server client
+- Each tool of an MCP server defined as a role of the resource server client, prefixed with `tool:` (e.g. `tool:greet`)
 - Groups representing aggregations of permissions, to which MCP tool client roles are assigned
 - Users added as members of the groups whose assigned tools the user can access
 - An OpenId Connect client for each MCP client (e.g. agent) that requests access to the MCP system, created by the [OAuth2 Dynamic Client Registration Protocol](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#dynamic-client-registration), with **Full scopes allowed** and the `roles` client scope set by default

--- a/docs/design/auth-phase-2.md
+++ b/docs/design/auth-phase-2.md
@@ -22,13 +22,13 @@ Following on from [Auth Phase 1](./auth-phase-1.md), we will now also show how t
 
 ![](./images/tools-list.jpg)
 
-In order to filter down the available tools, either generally or within the context of a virtual MCP, based on the auth integration, a trusted source can set a header `x-allowed-tools`. This header is expected to be in JWT format signed by a trusted key pair, with the public element being shared with the broker via env var `TRUSTED_HEADER_PUBLIC_KEY`. The list of tools has to be a claim within this JWT with a key `allowed-tools` and a value as shown below. The broker will look for this header during a `tools/list` call. If set, it will validate the JWT, extract the allowed tools and ensure the returned tools are matched against this list. If it fails to validate the header, it will return an empty list.
+In order to filter down the available tools, either generally or within the context of a virtual MCP, based on the auth integration, a trusted source can set a header `x-mcp-authorized`. This header is expected to be in JWT format signed by a trusted key pair, with the public element being shared with the broker via env var `TRUSTED_HEADER_PUBLIC_KEY`. The list of tools has to be a claim within this JWT with a key `allowed-capabilities` and a value as shown below. The broker will look for this header during a `tools/list` call. If set, it will validate the JWT, extract the allowed tools and ensure the returned tools are matched against this list. If it fails to validate the header, it will return an empty list.
 
 Example JWT payload:
 
 ```json
 {
-  "allowed-tools": "{\"mcp-test/mcp-server1-route\":[\"greet\"],\"mcp-test/mcp-server2-route\":[\"headers\"],\"mcp-test/mcp-server3-route\":[\"add\"]}",
+  "allowed-capabilities": "{\"tools\":{\"mcp-test/mcp-server1-route\":[\"greet\"],\"mcp-test/mcp-server2-route\":[\"headers\"],\"mcp-test/mcp-server3-route\":[\"add\"]}}",
   "exp": 1760004918,
   "iat": 1760004618,
   "iss": "Authorino",
@@ -44,7 +44,7 @@ We have provided an [example AuthPolicy](../../config/samples/oauth-token-exchan
 
 There are multiple ways to configure a Keycloak realm for storing permissions to control access to the MCP tools. The method employed in the [example provided](../../config/keycloak/realm-import.yaml) consists of:
 - An OAuth "resource server" client for each MCP server, identified by the MCP server's internal host name for convenience
-- Each tool of an MCP server defined as a role of the resource server client
+- Each tool of an MCP server defined as a role of the resource server client, prefixed with `tool:` (e.g. `tool:greet`)
 - Groups representing aggregations of permissions, to which MCP tool client roles are assigned
 - Users added as members of the groups whose assigned tools the user can access
 - An OpenId Connect client for each MCP client (e.g. agent) that requests access to the MCP system, created by the [OAuth2 Dynamic Client Registration Protocol](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#dynamic-client-registration), with **Full scopes allowed** and the `roles` client scope set by default

--- a/docs/design/security-architecture.md
+++ b/docs/design/security-architecture.md
@@ -26,7 +26,7 @@ MCP Client
 │  │  - JWT validation (Keycloak OIDC)      │  │
 │  │  - Token exchange (RFC 8693)           │  │
 │  │  - Tool-level RBAC                     │  │
-│  │  - x-authorized-tools header (signed)  │  │
+│  │  - x-mcp-authorized header (signed)  │  │
 │  └────────────────────────────────────────┘  │
 │                                              │
 │  ┌────────────────────────────────────────┐  │
@@ -54,7 +54,7 @@ MCP Client
 | Client → Gateway | Bearer token, MCP JSON-RPC body, custom headers |
 | Gateway → Router (ext_proc) | Request headers, buffered body |
 | Gateway → Upstream MCP Server | All client headers, MCP JSON-RPC body |
-| Gateway → Broker | MCP JSON-RPC body, gateway session JWT, `x-authorized-tools` signed header |
+| Gateway → Broker | MCP JSON-RPC body, gateway session JWT, `x-mcp-authorized` signed header |
 | Upstream MCP Server → Client | MCP JSON-RPC response body (streamed as-is), backend session IDs (rewritten to gateway session IDs) |
 
 ### Information shared with upstream MCP servers (model providers)
@@ -97,7 +97,7 @@ The client's Authorization header is always forwarded to upstream servers, allow
 
 ### Tool-level RBAC
 
-AuthPolicy can enforce per-tool access control using the `x-mcp-toolname` and `x-mcp-servername` headers set by the router. JWT claims (e.g., `resource_access`) are matched against the requested tool to produce an `x-authorized-tools` JWT signed header via Authorino. The broker verifies this signature and filters tool lists accordingly.  
+AuthPolicy can enforce per-tool access control using the `x-mcp-toolname` and `x-mcp-servername` headers set by the router. JWT claims (e.g., `resource_access`) are matched against the requested tool to produce an `x-mcp-authorized` JWT signed header via Authorino. The broker verifies this signature and filters tool lists accordingly.  
 
 ## Session Isolation
 

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -38,10 +38,10 @@ The issued OAuth token should include claims similar to:
 {
   "resource_access": {
     "mcp-ns/arithmetic-mcp-server": { // matches the namespaced name of the MCPServerRegistration CR
-      "roles": ["add", "sum", "multiply", "divide"] // roles representing the allowed tools
+      "roles": ["tool:add", "tool:sum", "tool:multiply", "tool:divide"] // roles prefixed with capability type
     },
     "mcp-ns/geometry-mcp-server": {
-      "roles": ["area", "distance", "volume"]
+      "roles": ["tool:area", "tool:distance", "tool:volume"]
     }
   }
 }
@@ -76,7 +76,7 @@ spec:
         patternMatching:
           patterns:
             - predicate: |
-                request.headers['x-mcp-toolname'] in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
+                ('tool:' + request.headers['x-mcp-toolname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
     response:
       unauthenticated:
         headers:
@@ -105,7 +105,7 @@ EOF
 - **CEL Breakdown**:
   - `request.headers['x-mcp-toolname']`: The name of the requested MCP tool (stripped from prefix)
   - `request.headers['x-mcp-servername']`: The namespaced name of the MCP server matching the MCPServerRegistration resource
-  - `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed tool the user can access, grouped by MCP server
+  - `auth.identity.resource_access`: The JWT claim containing roles prefixed by capability type (e.g. `tool:greet`), grouped by MCP server
 - **Response Handling**: Custom 401 and 403 responses for unauthenticated and unauthorized access attempts
 
 ## Step 3: Test Authorization
@@ -138,7 +138,7 @@ open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-
    - `test1_greet`
    - `test2_headers`
 3. **Try restricted tools**:
-   - `test1_time` - Should return 403 Forbidden (accounting group only has the `greet` role for test-server1)
+   - `test1_time` - Should return 403 Forbidden (accounting group only has the `tool:greet` role for test-server1)
 
 ## Alternative Authorization Mechanisms
 

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -9,7 +9,7 @@ Tool revocation prevents a user or group from calling specific MCP tools. It bui
 Two enforcement points apply:
 
 - **`tools/call`**: The AuthPolicy's CEL expression checks the `x-mcp-toolname` header against the user's `resource_access` roles. A revoked tool returns 403 Forbidden.
-- **`tools/list`**: The broker filters the tools list using the signed `x-authorized-tools` header. A revoked tool no longer appears in the list.
+- **`tools/list`**: The broker filters the tools list using the signed `x-mcp-authorized` header. A revoked tool no longer appears in the list.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ Two enforcement points apply:
 
 Remove the tool role from the user or group in your identity provider.
 
-In Keycloak, this is done by removing a client role mapping. The client name corresponds to the namespaced MCPServerRegistration (e.g., `mcp-test/server1-route`), and each role represents a tool name (e.g., `greet`, `headers`).
+In Keycloak, this is done by removing a client role mapping. The client name corresponds to the namespaced MCPServerRegistration (e.g., `mcp-test/server1-route`), and each role represents a tool name prefixed with `tool:` (e.g., `tool:greet`, `tool:headers`).
 
 To revoke a tool for a group:
 1. Go to **Groups** > select the group (e.g., `accounting`)
@@ -79,7 +79,7 @@ kubectl create secret generic trusted-headers-private-key \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-### Update the AuthPolicy to generate the x-authorized-tools header
+### Update the AuthPolicy to generate the x-mcp-authorized header
 
 Delete the existing `mcp-auth-policy` and create a new version that adds authorization rules and a wristband response. The policy must be deleted first because the original uses `defaults.rules` while this version uses `rules`, and `kubectl apply` would merge both instead of replacing:
 
@@ -110,21 +110,21 @@ spec:
           patterns:
           - predicate: |
               !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
-      'authorized-tools':
+      'authorized-capabilities':
         opa:
           rego: |
             allow = true
-            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+            capabilities = {"tools": { server: tools | server := object.keys(input.auth.identity.resource_access)[_]; tools := [substring(r, count("tool:"), -1) | r := input.auth.identity.resource_access[server].roles[_]; startswith(r, "tool:")] }}
           allValues: true
     response:
       success:
         headers:
-          x-authorized-tools:
+          x-mcp-authorized:
             wristband:
               issuer: 'authorino'
               customClaims:
-                'allowed-tools':
-                  selector: auth.authorization.authorized-tools.tools.@tostr
+                'allowed-capabilities':
+                  selector: auth.authorization.authorized-capabilities.capabilities.@tostr
               tokenDuration: 300
               signingKeyRefs:
                 - name: trusted-headers-private-key

--- a/docs/guides/tool-revocation.md
+++ b/docs/guides/tool-revocation.md
@@ -9,7 +9,7 @@ Tool revocation prevents a user or group from calling specific MCP tools. It bui
 Two enforcement points apply:
 
 - **`tools/call`**: The AuthPolicy's CEL expression checks the `x-mcp-toolname` header against the user's `resource_access` roles. A revoked tool returns 403 Forbidden.
-- **`tools/list`**: The broker filters the tools list using the signed `x-authorized-tools` header. A revoked tool no longer appears in the list.
+- **`tools/list`**: The broker filters the tools list using the signed `x-mcp-authorized` header. A revoked tool no longer appears in the list.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ Two enforcement points apply:
 
 Remove the tool role from the user or group in your identity provider.
 
-In Keycloak, this is done by removing a client role mapping. The client name corresponds to the namespaced MCPServerRegistration (e.g., `mcp-test/server1-route`), and each role represents a tool name (e.g., `greet`, `headers`).
+In Keycloak, this is done by removing a client role mapping. The client name corresponds to the namespaced MCPServerRegistration (e.g., `mcp-test/server1-route`), and each role represents a tool name prefixed with `tool:` (e.g., `tool:greet`, `tool:headers`).
 
 To revoke a tool for a group:
 1. Go to **Groups** > select the group (e.g., `accounting`)
@@ -79,7 +79,7 @@ kubectl create secret generic trusted-headers-private-key \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-### Update the AuthPolicy to generate the x-authorized-tools header
+### Update the AuthPolicy to generate the x-mcp-authorized header
 
 Delete the existing `mcp-auth-policy` and create a new version that adds authorization rules and a wristband response. The policy must be deleted first because the original uses `defaults.rules` while this version uses `rules`, and `kubectl apply` would merge both instead of replacing:
 
@@ -110,21 +110,29 @@ spec:
           patterns:
           - predicate: |
               !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
-      'authorized-tools':
+      'authorized-capabilities':
         opa:
           rego: |
             allow = true
-            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+            capabilities = {
+              "tools": { server: tools |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                tools := [substring(r, count("tool:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "tool:")
+                ]
+              }
+            }
           allValues: true
     response:
       success:
         headers:
-          x-authorized-tools:
+          x-mcp-authorized:
             wristband:
               issuer: 'authorino'
               customClaims:
-                'allowed-tools':
-                  selector: auth.authorization.authorized-tools.tools.@tostr
+                'allowed-capabilities':
+                  selector: auth.authorization.authorized-capabilities.capabilities.@tostr
               tokenDuration: 300
               signingKeyRefs:
                 - name: trusted-headers-private-key

--- a/docs/guides/user-based-tool-filter.md
+++ b/docs/guides/user-based-tool-filter.md
@@ -1,25 +1,27 @@
 ## Trusted Header Public Key Configuration
 
-The MCP Broker can filter tools based on a signed JWT in the `x-authorized-tools` header. This enables identity-based tool filtering when integrated with an external authorization system.
+The MCP Broker can filter tools based on a signed JWT in the `x-mcp-authorized` header. This enables identity-based tool filtering when integrated with an external authorization system.
 
 ### How It Works
 
 1. An upstream authorization system validates the user's identity
-2. It creates a signed JWT containing the user's allowed tools in an `allowed-tools` claim
-3. This JWT is passed to the broker via the `x-authorized-tools` header
+2. It creates a signed JWT containing the user's allowed tools in an `allowed-capabilities` claim
+3. This JWT is passed to the broker via the `x-mcp-authorized` header
 4. The broker validates the JWT signature and filters `tools/list` responses accordingly
 
 ### JWT Payload Format
 
-The `allowed-tools` claim should contain a JSON object mapping server routes to tool arrays:
+The `allowed-capabilities` claim is a JSON-encoded string containing a capabilities map. The top-level key is the capability type (e.g. `"tools"`), and each entry maps server names to allowed item names:
 
 ```json
 {
-  "allowed-tools": "{\"mcp-test/server1-route\":[\"tool_a\",\"tool_b\"],\"mcp-test/server2-route\":[\"tool_c\"]}",
+  "allowed-capabilities": "{\"tools\":{\"mcp-test/server1-route\":[\"tool_a\",\"tool_b\"],\"mcp-test/server2-route\":[\"tool_c\"]}}",
   "exp": 1760004918,
   "iat": 1760004618
 }
 ```
+
+The value of `allowed-capabilities` is a **string**, not a nested JSON object. The broker deserializes this string to extract the `"tools"` map for filtering. This structure supports additional capability types (e.g. `"prompts"`, `"resources"`) in the same claim.
 
 ### Example Key Pair Generation
 
@@ -54,9 +56,9 @@ env:
         key: key
 ```
 
-When this environment variable is set, the broker will validate any `x-authorized-tools` header using ES256 and filter the tools list accordingly. If validation fails, an empty tools list is returned.
+When this environment variable is set, the broker will validate any `x-mcp-authorized` header using ES256 and filter the tools list accordingly. If validation fails, an empty tools list is returned.
 
 
 ### Example AuthPolicy that uses this method
 
-An example AuthPolicy that implements the `x-authorized-tools` can be found at [Sample Tool Filtering](../../config/samples/oauth-token-exchange/tools-list-auth.yaml)
+An example AuthPolicy that implements the `x-mcp-authorized` can be found at [Sample Tool Filtering](../../config/samples/oauth-token-exchange/tools-list-auth.yaml)

--- a/docs/guides/user-based-tool-filter.md
+++ b/docs/guides/user-based-tool-filter.md
@@ -1,21 +1,21 @@
 ## Trusted Header Public Key Configuration
 
-The MCP Broker can filter tools based on a signed JWT in the `x-authorized-tools` header. This enables identity-based tool filtering when integrated with an external authorization system.
+The MCP Broker can filter tools based on a signed JWT in the `x-mcp-authorized` header. This enables identity-based tool filtering when integrated with an external authorization system.
 
 ### How It Works
 
 1. An upstream authorization system validates the user's identity
-2. It creates a signed JWT containing the user's allowed tools in an `allowed-tools` claim
-3. This JWT is passed to the broker via the `x-authorized-tools` header
+2. It creates a signed JWT containing the user's allowed tools in an `allowed-capabilities` claim
+3. This JWT is passed to the broker via the `x-mcp-authorized` header
 4. The broker validates the JWT signature and filters `tools/list` responses accordingly
 
 ### JWT Payload Format
 
-The `allowed-tools` claim should contain a JSON object mapping server routes to tool arrays:
+The `allowed-capabilities` claim should contain a JSON object mapping server routes to tool arrays:
 
 ```json
 {
-  "allowed-tools": "{\"mcp-test/server1-route\":[\"tool_a\",\"tool_b\"],\"mcp-test/server2-route\":[\"tool_c\"]}",
+  "allowed-capabilities": "{\"tools\":{\"mcp-test/server1-route\":[\"tool_a\",\"tool_b\"],\"mcp-test/server2-route\":[\"tool_c\"]}}",
   "exp": 1760004918,
   "iat": 1760004618
 }
@@ -54,9 +54,9 @@ env:
         key: key
 ```
 
-When this environment variable is set, the broker will validate any `x-authorized-tools` header using ES256 and filter the tools list accordingly. If validation fails, an empty tools list is returned.
+When this environment variable is set, the broker will validate any `x-mcp-authorized` header using ES256 and filter the tools list accordingly. If validation fails, an empty tools list is returned.
 
 
 ### Example AuthPolicy that uses this method
 
-An example AuthPolicy that implements the `x-authorized-tools` can be found at [Sample Tool Filtering](../../config/samples/oauth-token-exchange/tools-list-auth.yaml)
+An example AuthPolicy that implements the `x-mcp-authorized` can be found at [Sample Tool Filtering](../../config/samples/oauth-token-exchange/tools-list-auth.yaml)

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -166,7 +166,7 @@ Virtual MCP servers are a `tools/list` concept only. They filter which tools a c
 
 If you have [authentication](./authentication.md) and [user-based tool filtering](./user-based-tool-filter.md) configured, the broker applies two filters sequentially when handling a `tools/list` request with a virtual server header:
 
-1. **Identity-based filtering** -- the `x-authorized-tools` reduces the tool list to only tools the user has `resource_access` roles for
+1. **Identity-based filtering** -- the `x-mcp-authorized` reduces the tool list to only tools the user has `resource_access` roles for
 2. **Virtual server filtering** -- the `X-Mcp-Virtualserver` header further reduces the list to only tools defined in the MCPVirtualServer resource
 
 The result is the intersection of both filters. For example, if the `accounting` virtual server lists `test1_greet` and `test3_add`, but the user only has the `greet` role on `mcp-test/test-server1`, they will only see `test1_greet`.

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -64,8 +64,8 @@ type mcpBrokerImpl struct {
 
 	logger *slog.Logger
 
-	// enforceToolFilter if set will ensure only a filtered list of tools is returned this list is based on the x-authorized-tools trusted header
-	enforceToolFilter bool
+	// enforceCapabilityFilter if set will ensure only filtered capabilities are returned based on the x-mcp-authorized trusted header
+	enforceCapabilityFilter bool
 
 	// trustedHeadersPublicKey this is the key to verify that a trusted header came from the trusted source (the owner of the private key)
 	trustedHeadersPublicKey string
@@ -83,10 +83,10 @@ var _ MCPBroker = &mcpBrokerImpl{}
 // Option configures a broker instance
 type Option func(mb *mcpBrokerImpl)
 
-// WithEnforceToolFilter defines enforceToolFilter setting and is intended for use with the NewBroker function
-func WithEnforceToolFilter(enforce bool) Option {
+// WithEnforceCapabilityFilter defines enforceCapabilityFilter setting and is intended for use with the NewBroker function
+func WithEnforceCapabilityFilter(enforce bool) Option {
 	return func(mb *mcpBrokerImpl) {
-		mb.enforceToolFilter = enforce
+		mb.enforceCapabilityFilter = enforce
 	}
 }
 
@@ -111,7 +111,7 @@ func WithInvalidToolPolicy(policy mcpv1alpha1.InvalidToolPolicy) Option {
 	}
 }
 
-// NewBroker creates a new MCPBroker accepts optional config functions such as WithEnforceToolFilter
+// NewBroker creates a new MCPBroker accepts optional config functions such as WithEnforceCapabilityFilter
 func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	mcpBkr := &mcpBrokerImpl{
 		mcpServers:            map[config.UpstreamMCPID]*upstream.MCPManager{},

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -219,7 +219,7 @@ func TestGetServerInfo(t *testing.T) {
 
 func TestToolAnnotations(t *testing.T) {
 	b := NewBroker(logger,
-		WithEnforceToolFilter(true),
+		WithEnforceCapabilityFilter(true),
 		WithManagerTickerInterval(time.Microsecond),
 		WithTrustedHeadersPublicKey("abc"))
 	require.NotNil(t, b)

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -15,15 +15,15 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-var authorizedToolsHeader = http.CanonicalHeaderKey("x-authorized-tools")
+var authorizedCapabilitiesHeader = http.CanonicalHeaderKey("x-mcp-authorized")
 var virtualMCPHeader = http.CanonicalHeaderKey("x-mcp-virtualserver")
 
-const allowedToolsClaimKey = "allowed-tools"
+const allowedCapabilitiesClaimKey = "allowed-capabilities"
 
 // FilterTools reduces the tool set based on authorization headers.
-// Priority: x-authorized-tools JWT filtering, then x-mcp-virtualserver filtering.
+// Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
 func (broker *mcpBrokerImpl) FilterTools(_ context.Context, _ any, mcpReq *mcp.ListToolsRequest, mcpRes *mcp.ListToolsResult) {
-	broker.logger.Info("FilterTools called", "input_tools_count", len(mcpRes.Tools))
+	broker.logger.Debug("FilterTools called", "input_tools_count", len(mcpRes.Tools))
 	tools := mcpRes.Tools
 	emptyTools := []mcp.Tool{}
 	if len(mcpRes.Tools) == 0 {
@@ -31,9 +31,9 @@ func (broker *mcpBrokerImpl) FilterTools(_ context.Context, _ any, mcpReq *mcp.L
 		return
 	}
 
-	// step 1: apply x-authorized-tools filtering (JWT-based)
-	tools = broker.applyAuthorizedToolsFilter(mcpReq.Header, tools)
-	broker.logger.Debug("FilterTools authorized tools result", "output_tools_count", len(tools))
+	// step 1: apply x-mcp-authorized filtering (JWT-based)
+	tools = broker.applyAuthorizedCapabilitiesFilter(mcpReq.Header, tools)
+	broker.logger.Debug("FilterTools authorized capabilities result", "output_tools_count", len(tools))
 
 	// step 2: apply virtual server filtering
 	tools = broker.applyVirtualServerFilter(mcpReq.Header, tools)
@@ -58,31 +58,40 @@ func (broker *mcpBrokerImpl) removeGatewayMeta(tools []mcp.Tool) []mcp.Tool {
 	return tools
 }
 
-// applyAuthorizedToolsFilter filters tools based on x-authorized-tools JWT header.
+// applyAuthorizedCapabilitiesFilter filters tools based on x-mcp-authorized JWT header.
 // Returns original tools if header not present and enforcement is off.
 // Returns empty slice if header validation fails or enforcement is on without header.
-func (broker *mcpBrokerImpl) applyAuthorizedToolsFilter(headers http.Header, tools []mcp.Tool) []mcp.Tool {
-	headerValues, present := headers[authorizedToolsHeader]
+func (broker *mcpBrokerImpl) applyAuthorizedCapabilitiesFilter(headers http.Header, tools []mcp.Tool) []mcp.Tool {
+	headerValues, present := headers[authorizedCapabilitiesHeader]
 
 	if !present {
-		broker.logger.Debug("no x-authorized-tools header", "enforced", broker.enforceToolFilter)
-		if broker.enforceToolFilter {
+		broker.logger.Debug("no x-mcp-authorized header", "enforced", broker.enforceCapabilityFilter)
+		if broker.enforceCapabilityFilter {
 			return []mcp.Tool{}
 		}
 		return tools
 	}
 
-	allowedTools, err := broker.parseAuthorizedToolsJWT(headerValues)
+	capabilities, err := broker.parseAuthorizedCapabilitiesJWT(headerValues)
 	if err != nil {
-		broker.logger.Error("failed to parse x-authorized-tools header", "error", err)
+		broker.logger.Error("failed to parse x-mcp-authorized header", "error", err)
 		return []mcp.Tool{}
+	}
+
+	allowedTools, hasTools := capabilities["tools"]
+	if !hasTools {
+		broker.logger.Debug("no tools key in capabilities")
+		if broker.enforceCapabilityFilter {
+			return []mcp.Tool{}
+		}
+		return tools
 	}
 
 	return broker.filterToolsByServerMap(allowedTools)
 }
 
-// parseAuthorizedToolsJWT validates and extracts allowed tools from the JWT header.
-func (broker *mcpBrokerImpl) parseAuthorizedToolsJWT(headerValues []string) (map[string][]string, error) {
+// parseAuthorizedCapabilitiesJWT validates and extracts allowed capabilities from the JWT header.
+func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []string) (map[string]map[string][]string, error) {
 	if len(headerValues) != 1 {
 		return nil, fmt.Errorf("expected exactly 1 header value, got %d", len(headerValues))
 	}
@@ -106,23 +115,23 @@ func (broker *mcpBrokerImpl) parseAuthorizedToolsJWT(headerValues []string) (map
 		return nil, fmt.Errorf("failed to extract claims from JWT")
 	}
 
-	toolsClaim, ok := claims[allowedToolsClaimKey]
+	capabilitiesClaim, ok := claims[allowedCapabilitiesClaimKey]
 	if !ok {
-		return nil, fmt.Errorf("missing %s claim in JWT", allowedToolsClaimKey)
+		return nil, fmt.Errorf("missing %s claim in JWT", allowedCapabilitiesClaimKey)
 	}
 
-	toolsJSON, ok := toolsClaim.(string)
+	capabilitiesJSON, ok := capabilitiesClaim.(string)
 	if !ok {
-		return nil, fmt.Errorf("%s claim is not a string", allowedToolsClaimKey)
+		return nil, fmt.Errorf("%s claim is not a string", allowedCapabilitiesClaimKey)
 	}
 
-	var allowedTools map[string][]string
-	if err := json.Unmarshal([]byte(toolsJSON), &allowedTools); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal allowed-tools JSON: %w", err)
+	var capabilities map[string]map[string][]string
+	if err := json.Unmarshal([]byte(capabilitiesJSON), &capabilities); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal allowed-capabilities JSON: %w", err)
 	}
 
-	broker.logger.Debug("parsed authorized tools", "tools", allowedTools)
-	return allowedTools, nil
+	broker.logger.Debug("parsed authorized capabilities", "capabilities", capabilities)
+	return capabilities, nil
 }
 
 func (broker *mcpBrokerImpl) findServerByName(name string) *upstream.MCPManager {

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -15,13 +15,13 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-var authorizedToolsHeader = http.CanonicalHeaderKey("x-authorized-tools")
+var authorizedCapabilitiesHeader = http.CanonicalHeaderKey("x-mcp-authorized")
 var virtualMCPHeader = http.CanonicalHeaderKey("x-mcp-virtualserver")
 
-const allowedToolsClaimKey = "allowed-tools"
+const allowedCapabilitiesClaimKey = "allowed-capabilities"
 
 // FilterTools reduces the tool set based on authorization headers.
-// Priority: x-authorized-tools JWT filtering, then x-mcp-virtualserver filtering.
+// Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
 func (broker *mcpBrokerImpl) FilterTools(_ context.Context, _ any, mcpReq *mcp.ListToolsRequest, mcpRes *mcp.ListToolsResult) {
 	broker.logger.Info("FilterTools called", "input_tools_count", len(mcpRes.Tools))
 	tools := mcpRes.Tools
@@ -31,9 +31,9 @@ func (broker *mcpBrokerImpl) FilterTools(_ context.Context, _ any, mcpReq *mcp.L
 		return
 	}
 
-	// step 1: apply x-authorized-tools filtering (JWT-based)
-	tools = broker.applyAuthorizedToolsFilter(mcpReq.Header, tools)
-	broker.logger.Debug("FilterTools authorized tools result", "output_tools_count", len(tools))
+	// step 1: apply x-mcp-authorized filtering (JWT-based)
+	tools = broker.applyAuthorizedCapabilitiesFilter(mcpReq.Header, tools)
+	broker.logger.Debug("FilterTools authorized capabilities result", "output_tools_count", len(tools))
 
 	// step 2: apply virtual server filtering
 	tools = broker.applyVirtualServerFilter(mcpReq.Header, tools)
@@ -58,31 +58,40 @@ func (broker *mcpBrokerImpl) removeGatewayMeta(tools []mcp.Tool) []mcp.Tool {
 	return tools
 }
 
-// applyAuthorizedToolsFilter filters tools based on x-authorized-tools JWT header.
+// applyAuthorizedCapabilitiesFilter filters tools based on x-mcp-authorized JWT header.
 // Returns original tools if header not present and enforcement is off.
 // Returns empty slice if header validation fails or enforcement is on without header.
-func (broker *mcpBrokerImpl) applyAuthorizedToolsFilter(headers http.Header, tools []mcp.Tool) []mcp.Tool {
-	headerValues, present := headers[authorizedToolsHeader]
+func (broker *mcpBrokerImpl) applyAuthorizedCapabilitiesFilter(headers http.Header, tools []mcp.Tool) []mcp.Tool {
+	headerValues, present := headers[authorizedCapabilitiesHeader]
 
 	if !present {
-		broker.logger.Debug("no x-authorized-tools header", "enforced", broker.enforceToolFilter)
-		if broker.enforceToolFilter {
+		broker.logger.Debug("no x-mcp-authorized header", "enforced", broker.enforceCapabilityFilter)
+		if broker.enforceCapabilityFilter {
 			return []mcp.Tool{}
 		}
 		return tools
 	}
 
-	allowedTools, err := broker.parseAuthorizedToolsJWT(headerValues)
+	capabilities, err := broker.parseAuthorizedCapabilitiesJWT(headerValues)
 	if err != nil {
-		broker.logger.Error("failed to parse x-authorized-tools header", "error", err)
+		broker.logger.Error("failed to parse x-mcp-authorized header", "error", err)
 		return []mcp.Tool{}
+	}
+
+	allowedTools, hasTools := capabilities["tools"]
+	if !hasTools {
+		broker.logger.Debug("no tools key in capabilities")
+		if broker.enforceCapabilityFilter {
+			return []mcp.Tool{}
+		}
+		return tools
 	}
 
 	return broker.filterToolsByServerMap(allowedTools)
 }
 
-// parseAuthorizedToolsJWT validates and extracts allowed tools from the JWT header.
-func (broker *mcpBrokerImpl) parseAuthorizedToolsJWT(headerValues []string) (map[string][]string, error) {
+// parseAuthorizedCapabilitiesJWT validates and extracts allowed capabilities from the JWT header.
+func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []string) (map[string]map[string][]string, error) {
 	if len(headerValues) != 1 {
 		return nil, fmt.Errorf("expected exactly 1 header value, got %d", len(headerValues))
 	}
@@ -106,23 +115,23 @@ func (broker *mcpBrokerImpl) parseAuthorizedToolsJWT(headerValues []string) (map
 		return nil, fmt.Errorf("failed to extract claims from JWT")
 	}
 
-	toolsClaim, ok := claims[allowedToolsClaimKey]
+	capabilitiesClaim, ok := claims[allowedCapabilitiesClaimKey]
 	if !ok {
-		return nil, fmt.Errorf("missing %s claim in JWT", allowedToolsClaimKey)
+		return nil, fmt.Errorf("missing %s claim in JWT", allowedCapabilitiesClaimKey)
 	}
 
-	toolsJSON, ok := toolsClaim.(string)
+	capabilitiesJSON, ok := capabilitiesClaim.(string)
 	if !ok {
-		return nil, fmt.Errorf("%s claim is not a string", allowedToolsClaimKey)
+		return nil, fmt.Errorf("%s claim is not a string", allowedCapabilitiesClaimKey)
 	}
 
-	var allowedTools map[string][]string
-	if err := json.Unmarshal([]byte(toolsJSON), &allowedTools); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal allowed-tools JSON: %w", err)
+	var capabilities map[string]map[string][]string
+	if err := json.Unmarshal([]byte(capabilitiesJSON), &capabilities); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal allowed-capabilities JSON: %w", err)
 	}
 
-	broker.logger.Debug("parsed authorized tools", "tools", allowedTools)
-	return allowedTools, nil
+	broker.logger.Debug("parsed authorized capabilities", "capabilities", capabilities)
+	return capabilities, nil
 }
 
 func (broker *mcpBrokerImpl) findServerByName(name string) *upstream.MCPManager {

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -25,13 +25,16 @@ VEiyi/nozagw7BaWXmzbOWyy95gZLirTkhUb1P4Z4lgKLU2rD5NCbGPHAA==
 
 func createTestJWT(t *testing.T, allowedTools map[string][]string) string {
 	t.Helper()
-	claimPayload, _ := json.Marshal(allowedTools)
+	capabilities := map[string]map[string][]string{
+		"tools": allowedTools,
+	}
+	claimPayload, _ := json.Marshal(capabilities)
 	block, _ := pem.Decode([]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIEY3QeiP9B9Bm3NHG3SgyiDHcbckwsGsQLKgv4fJxjJWoAoGCCqGSM49
 AwEHoUQDQgAE7WdMdvC8hviEAL4wcebqaYbLEtVOVEiyi/nozagw7BaWXmzbOWyy
 95gZLirTkhUb1P4Z4lgKLU2rD5NCbGPHAA==
 -----END EC PRIVATE KEY-----`))
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{"allowed-tools": string(claimPayload)})
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{"allowed-capabilities": string(claimPayload)})
 	parsedKey, err := x509.ParseECPrivateKey(block.Bytes)
 	if err != nil {
 		t.Fatalf("error parsing key for jwt %s", err)
@@ -163,7 +166,7 @@ func TestFilteredTools(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			mcpBroker := &mcpBrokerImpl{
-				enforceToolFilter:       tc.enforceFilterList,
+				enforceCapabilityFilter: tc.enforceFilterList,
 				trustedHeadersPublicKey: testPublicKey,
 				logger:                  slog.Default(),
 				mcpServers:              tc.RegisteredMCPServers,
@@ -173,7 +176,7 @@ func TestFilteredTools(t *testing.T) {
 			if tc.AllowedToolsList != nil {
 				headerValue := createTestJWT(t, tc.AllowedToolsList)
 				request.Header = http.Header{
-					authorizedToolsHeader: {headerValue},
+					authorizedCapabilitiesHeader: {headerValue},
 				}
 			}
 			mcpBroker.FilterTools(context.TODO(), 1, request, tc.FullToolList)
@@ -266,9 +269,9 @@ func TestVirtualServerFiltering(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			mcpBroker := &mcpBrokerImpl{
-				enforceToolFilter: false,
-				virtualServers:    tc.VirtualServers,
-				logger:            slog.Default(),
+				enforceCapabilityFilter: false,
+				virtualServers:          tc.VirtualServers,
+				logger:                  slog.Default(),
 			}
 
 			request := &mcp.ListToolsRequest{Header: http.Header{}}
@@ -300,8 +303,8 @@ func TestVirtualServerFiltering(t *testing.T) {
 
 func TestFilterToolsSerializesAsEmptyArray(t *testing.T) {
 	mcpBroker := &mcpBrokerImpl{
-		enforceToolFilter: true, // will return empty when no header
-		logger:            slog.Default(),
+		enforceCapabilityFilter: true, // will return empty when no header
+		logger:                  slog.Default(),
 	}
 
 	// nil tools input
@@ -350,7 +353,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 		ExpectedTools    []string
 	}{
 		{
-			Name: "x-authorized-tools filtered first then virtual server filters further",
+			Name: "x-mcp-authorized filtered first then virtual server filters further",
 			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
 				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
 					"mcp-test/server1",
@@ -374,7 +377,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 			ExpectedTools: []string{"s1_tool1"},
 		},
 		{
-			Name: "x-authorized-tools only when no virtual server header",
+			Name: "x-mcp-authorized only when no virtual server header",
 			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
 				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
 					"mcp-test/server1",
@@ -395,7 +398,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 			ExpectedTools:   []string{"s1_tool1", "s1_tool2"},
 		},
 		{
-			Name: "virtual server only when no x-authorized-tools header",
+			Name: "virtual server only when no x-mcp-authorized header",
 			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
 				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
 					"mcp-test/server1",
@@ -442,7 +445,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			mcpBroker := &mcpBrokerImpl{
-				enforceToolFilter:       false,
+				enforceCapabilityFilter: false,
 				trustedHeadersPublicKey: testPublicKey,
 				mcpServers:              tc.MCPServers,
 				virtualServers:          tc.VirtualServers,
@@ -461,7 +464,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 
 			request := &mcp.ListToolsRequest{Header: http.Header{}}
 			if tc.AllowedToolsList != nil {
-				request.Header[authorizedToolsHeader] = []string{createTestJWT(t, tc.AllowedToolsList)}
+				request.Header[authorizedCapabilitiesHeader] = []string{createTestJWT(t, tc.AllowedToolsList)}
 			}
 			if tc.VirtualServerID != "" {
 				request.Header[virtualMCPHeader] = []string{tc.VirtualServerID}

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -23,11 +23,8 @@ VEiyi/nozagw7BaWXmzbOWyy95gZLirTkhUb1P4Z4lgKLU2rD5NCbGPHAA==
 -----END PUBLIC KEY-----`
 )
 
-func createTestJWT(t *testing.T, allowedTools map[string][]string) string {
+func createTestJWTWithCapabilities(t *testing.T, capabilities map[string]map[string][]string) string {
 	t.Helper()
-	capabilities := map[string]map[string][]string{
-		"tools": allowedTools,
-	}
 	claimPayload, _ := json.Marshal(capabilities)
 	block, _ := pem.Decode([]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIEY3QeiP9B9Bm3NHG3SgyiDHcbckwsGsQLKgv4fJxjJWoAoGCCqGSM49
@@ -44,6 +41,13 @@ AwEHoUQDQgAE7WdMdvC8hviEAL4wcebqaYbLEtVOVEiyi/nozagw7BaWXmzbOWyy
 		t.Fatalf("error signing jwt %s", err)
 	}
 	return jwtToken
+}
+
+func createTestJWT(t *testing.T, allowedTools map[string][]string) string {
+	t.Helper()
+	return createTestJWTWithCapabilities(t, map[string]map[string][]string{
+		"tools": allowedTools,
+	})
 }
 
 // createTestManager creates a test MCPManager with pre-populated tools
@@ -161,6 +165,115 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool2"},
 			},
 		},
+	}
+
+	promptsOnlyJWT := createTestJWTWithCapabilities(t, map[string]map[string][]string{
+		"prompts": {"mcp-test/test-server1": {"prompt1"}},
+	})
+	toolsAndPromptsJWT := createTestJWTWithCapabilities(t, map[string]map[string][]string{
+		"tools":   {"mcp-test/test-server1": {"tool"}},
+		"prompts": {"mcp-test/test-server1": {"prompt1", "prompt2"}},
+	})
+	promptsOnlyCases := []struct {
+		Name                 string
+		FullToolList         *mcp.ListToolsResult
+		AllowedToolsList     map[string][]string
+		RegisteredMCPServers map[config.UpstreamMCPID]*upstream.MCPManager
+		enforceFilterList    bool
+		ExpectedTools        []mcp.Tool
+		jwtOverride          string
+	}{
+		{
+			Name: "prompts-only JWT returns all tools when enforce is false",
+			FullToolList: &mcp.ListToolsResult{Tools: []mcp.Tool{
+				{Name: "test1_tool"},
+				{Name: "test1_tool2"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+					"mcp-test/test-server1",
+					"test1_",
+					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
+				),
+			},
+			enforceFilterList: false,
+			jwtOverride:       promptsOnlyJWT,
+			ExpectedTools: []mcp.Tool{
+				{Name: "test1_tool"},
+				{Name: "test1_tool2"},
+			},
+		},
+		{
+			Name: "prompts-only JWT returns empty tools when enforce is true",
+			FullToolList: &mcp.ListToolsResult{Tools: []mcp.Tool{
+				{Name: "test1_tool"},
+				{Name: "test1_tool2"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+					"mcp-test/test-server1",
+					"test1_",
+					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
+				),
+			},
+			enforceFilterList: true,
+			jwtOverride:       promptsOnlyJWT,
+			ExpectedTools:     []mcp.Tool{},
+		},
+		{
+			Name: "tools and prompts JWT filters tools only, prompts ignored",
+			FullToolList: &mcp.ListToolsResult{Tools: []mcp.Tool{
+				{Name: "test1_tool"},
+				{Name: "test1_tool2"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+					"mcp-test/test-server1",
+					"test1_",
+					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
+				),
+			},
+			enforceFilterList: true,
+			jwtOverride:       toolsAndPromptsJWT,
+			ExpectedTools: []mcp.Tool{
+				{Name: "test1_tool"},
+			},
+		},
+	}
+
+	for _, tc := range promptsOnlyCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mcpBroker := &mcpBrokerImpl{
+				enforceCapabilityFilter: tc.enforceFilterList,
+				trustedHeadersPublicKey: testPublicKey,
+				logger:                  slog.Default(),
+				mcpServers:              tc.RegisteredMCPServers,
+			}
+
+			request := &mcp.ListToolsRequest{
+				Header: http.Header{
+					authorizedCapabilitiesHeader: {tc.jwtOverride},
+				},
+			}
+			mcpBroker.FilterTools(context.TODO(), 1, request, tc.FullToolList)
+
+			if len(tc.ExpectedTools) != len(tc.FullToolList.Tools) {
+				t.Fatalf("expected %d tools but got %d: %v", len(tc.ExpectedTools), len(tc.FullToolList.Tools), tc.FullToolList.Tools)
+			}
+
+			for _, exp := range tc.ExpectedTools {
+				found := false
+				for _, actual := range tc.FullToolList.Tools {
+					if exp.Name == actual.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected to find tool %s but it was not in returned tools %v", exp.Name, tc.FullToolList.Tools)
+				}
+			}
+		})
 	}
 
 	for _, tc := range testCases {

--- a/project-words.txt
+++ b/project-words.txt
@@ -397,3 +397,5 @@ ZDRQ
 Znet
 Zscifu
 ztunnels
+startswith
+unmarshals

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -674,13 +674,13 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(err).NotTo(HaveOccurred(), "tool calls should work once the server is back and ready")
 	})
 
-	It("[Happy] should filter tools based on x-authorized-tools JWT header", func() {
+	It("[Happy] should filter tools based on x-mcp-authorized JWT header", func() {
 		if !IsTrustedHeadersEnabled() {
-			Skip("trusted headers public key not configured - skipping x-authorized-tools test")
+			Skip("trusted headers public key not configured - skipping x-mcp-authorized test")
 		}
 
 		By("Creating an MCPServerRegistration with tools")
-		registration := NewMCPServerResourcesWithDefaults("authorized-tools-test", k8sClient).Build()
+		registration := NewMCPServerResourcesWithDefaults("authorized-capabilities-test", k8sClient).Build()
 		testResources = append(testResources, registration.GetObjects()...)
 		registeredServer := registration.Register(ctx)
 
@@ -704,12 +704,12 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		allowedTools := map[string][]string{
 			fmt.Sprintf("%s/%s", registeredServer.Namespace, registeredServer.Name): {"hello_world"},
 		}
-		jwtToken, err := CreateAuthorizedToolsJWT(allowedTools)
+		jwtToken, err := CreateAuthorizedCapabilitiesJWT(allowedTools)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Creating a client with x-authorized-tools header")
+		By("Creating a client with x-mcp-authorized header")
 		authorizedClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"X-Authorized-Tools": jwtToken,
+			"X-Mcp-Authorized": jwtToken,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer authorizedClient.Close()
@@ -719,7 +719,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			filteredTools, err := authorizedClient.ListTools(ctx, mcp.ListToolsRequest{})
 			g.Expect(err).Error().NotTo(HaveOccurred())
 			g.Expect(filteredTools).NotTo(BeNil())
-			g.Expect(len(filteredTools.Tools)).To(Equal(1), "expected exactly 1 tool from authorized tools header")
+			g.Expect(len(filteredTools.Tools)).To(Equal(1), "expected exactly 1 tool from authorized capabilities header")
 			expectedToolName := fmt.Sprintf("%s%s", registeredServer.Spec.ToolPrefix, "hello_world")
 			g.Expect(filteredTools.Tools[0].Name).To(Equal(expectedToolName))
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -674,9 +674,9 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(err).NotTo(HaveOccurred(), "tool calls should work once the server is back and ready")
 	})
 
-	It("[Happy] should filter tools based on x-authorized-tools JWT header", func() {
+	It("[Happy] should filter tools based on x-mcp-authorized JWT header", func() {
 		if !IsTrustedHeadersEnabled() {
-			Skip("trusted headers public key not configured - skipping x-authorized-tools test")
+			Skip("trusted headers public key not configured - skipping x-mcp-authorized test")
 		}
 
 		By("Creating an MCPServerRegistration with tools")
@@ -704,12 +704,12 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		allowedTools := map[string][]string{
 			fmt.Sprintf("%s/%s", registeredServer.Namespace, registeredServer.Name): {"hello_world"},
 		}
-		jwtToken, err := CreateAuthorizedToolsJWT(allowedTools)
+		jwtToken, err := CreateAuthorizedCapabilitiesJWT(allowedTools)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Creating a client with x-authorized-tools header")
+		By("Creating a client with x-mcp-authorized header")
 		authorizedClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"X-Authorized-Tools": jwtToken,
+			"X-Mcp-Authorized": jwtToken,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer authorizedClient.Close()
@@ -719,7 +719,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			filteredTools, err := authorizedClient.ListTools(ctx, mcp.ListToolsRequest{})
 			g.Expect(err).Error().NotTo(HaveOccurred())
 			g.Expect(filteredTools).NotTo(BeNil())
-			g.Expect(len(filteredTools.Tools)).To(Equal(1), "expected exactly 1 tool from authorized tools header")
+			g.Expect(len(filteredTools.Tools)).To(Equal(1), "expected exactly 1 tool from authorized capabilities header")
 			expectedToolName := fmt.Sprintf("%s%s", registeredServer.Spec.ToolPrefix, "hello_world")
 			g.Expect(filteredTools.Tools[0].Name).To(Equal(expectedToolName))
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())

--- a/tests/e2e/jwt_helpers.go
+++ b/tests/e2e/jwt_helpers.go
@@ -23,13 +23,16 @@ func GetTestHeaderSigningKey() string {
 	return testHeaderSigningKey
 }
 
-// CreateAuthorizedToolsJWT creates a signed JWT for the x-authorized-tools header
+// CreateAuthorizedCapabilitiesJWT creates a signed JWT for the x-mcp-authorized header
 // allowedTools is a map of server namespace/name to list of tool names
-func CreateAuthorizedToolsJWT(allowedTools map[string][]string) (string, error) {
+func CreateAuthorizedCapabilitiesJWT(allowedTools map[string][]string) (string, error) {
 	keyBytes := []byte(testHeaderSigningKey)
-	claimPayload, err := json.Marshal(allowedTools)
+	capabilities := map[string]map[string][]string{
+		"tools": allowedTools,
+	}
+	claimPayload, err := json.Marshal(capabilities)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal allowed tools: %w", err)
+		return "", fmt.Errorf("failed to marshal allowed capabilities: %w", err)
 	}
 
 	block, _ := pem.Decode(keyBytes)
@@ -43,7 +46,7 @@ func CreateAuthorizedToolsJWT(allowedTools map[string][]string) (string, error) 
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"allowed-tools": string(claimPayload),
+		"allowed-capabilities": string(claimPayload),
 	})
 
 	jwtToken, err := token.SignedString(parsedKey)

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -31,9 +31,9 @@
 - When a developer defines an MCPVirtualServer resource and specifies the value of the `X-Mcp-Virtualserver` header as the name in the format `namespace/name`, where the namespace and name come from the created MCPVirtualServer resource, they should only get the tools specified in the MCPVirtualServer resource when they do a tools/list request to the MCP Gateway host.
 
 
-### [Happy] Test tools are filtered down based on x-authorized-tools header
+### [Happy] Test tools are filtered down based on x-mcp-authorized header
 
-- When the value of the `x-authorized-tools` header is set as a JWT signed by a trusted key to a set of tools, the MCP Gateway should respond with only tools in that list.
+- When the value of the `x-mcp-authorized` header is set as a JWT signed by a trusted key to a set of tools, the MCP Gateway should respond with only tools in that list.
 
 
 ### [Happy] Test notifications are received when a notifications/tools/list_changed notification is sent


### PR DESCRIPTION
# Authorization Header Generalization — Verification Guide

This guide walks through verifying the authorization header refactor from `x-authorized-tools` / `allowed-tools` to `x-mcp-authorized` / `allowed-capabilities`, including the `tool:` prefix convention on Keycloak roles.

## Prerequisites

- Kind cluster with MCP Gateway deployed: `make local-env-setup`
- Auth stack deployed: `make auth-example-setup`
- `kubectl`, `curl`, `jq` available locally

## 1. Verify Keycloak roles use `tool:` prefix

Open the Keycloak admin console at `https://keycloak.127-0-0-1.sslip.io:8002` (admin/admin).

1. Select the **mcp** realm from the dropdown
2. Go to **Clients** > **mcp-test/test-server1** > **Roles** tab
3. Confirm roles are named `tool:greet`, `tool:headers`, `tool:slow`, `tool:time`
4. Go to **Groups** > **accounting** > **Role mapping**
5. Confirm the accounting group has `tool:greet` on test-server1, `tool:headers` on test-server2, `tool:add` on test-server3, `tool:hello_world` on oidc-server

The `impersonator` role on the `mcp-gateway` client should NOT have a `tool:` prefix — it is not a tool.

## 2. Verify the `tool:` prefix appears in the OAuth token

Get a token and decode it:

```bash
TOKEN=$(curl -sk -X POST "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token" \
  -d "grant_type=password" \
  -d "client_id=mcp-gateway" \
  -d "client_secret=secret" \
  -d "username=mcp" \
  -d "password=mcp" \
  -d "scope=openid roles" | jq -r '.access_token')

echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '.resource_access | del(.account)'
```

Expected output should show `tool:`-prefixed roles:

```json
{
  "mcp-test/test-server1": { "roles": ["tool:greet"] },
  "mcp-test/test-server2": { "roles": ["tool:headers"] },
  "mcp-test/test-server3": { "roles": ["tool:add"] },
  "mcp-test/oidc-server": { "roles": ["tool:hello_world"] },
  "mcp-gateway": { "roles": ["impersonator"] },
  "mcp-test/kubernetes-mcp-server": { "roles": ["tool:configuration_contexts_list", "..."] }
}
```

## 3. Verify the AuthPolicy uses the new header and Rego

Check the deployed AuthPolicy:

```bash
kubectl get authpolicy mcp-auth-policy -n gateway-system -o yaml
```

Confirm:
- The authorization rule is named `authorized-capabilities` (not `authorized-tools`)
- The Rego policy builds a `capabilities` variable wrapping tools in `{"tools": {...}}`
- The Rego filters roles by `startswith(r, "tool:")` and strips the prefix with `substring`
- The response header is `x-mcp-authorized` (not `x-authorized-tools`)
- The custom claim is `allowed-capabilities` (not `allowed-tools`)
- The selector references `auth.authorization.authorized-capabilities.capabilities.@tostr`

Also check the tools/call policy:

```bash
kubectl get authpolicy mcps-auth-policy -n gateway-system -o yaml
```

Confirm the `tool-access-check` predicate prepends `tool:` when checking roles:

```
('tool:' + request.headers['x-mcp-toolname']) in ...resource_access[...].roles
```

## 4. Enable broker debug logging

The broker's filter and capabilities logs are at DEBUG level. Enable them before testing:

```bash
kubectl patch deployment mcp-gateway -n mcp-system --type='json' \
  -p='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--log-level=-4"}]'
kubectl rollout status deployment/mcp-gateway -n mcp-system --timeout=60s
```

Open a second terminal and tail the logs:

```bash
kubectl logs -f deployment/mcp-gateway -n mcp-system | grep -i "capabilities\|filter"
```

Leave this running while you perform the next steps.

## 5. Verify `tools/list` filtering works end-to-end

The pod restarted in step 4, so get a fresh token and session:

```bash
TOKEN=$(curl -sk -X POST "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token" \
  -d "grant_type=password" \
  -d "client_id=mcp-gateway" \
  -d "client_secret=secret" \
  -d "username=mcp" \
  -d "password=mcp" \
  -d "scope=openid roles" | jq -r '.access_token')
```

Initialize a session:

```bash
HEADERS=$(mktemp)
curl -sk -D "$HEADERS" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

SESSION_ID=$(grep -i "mcp-session-id:" "$HEADERS" | tr -d '\r' | awk '{print $2}')
```

List tools:

```bash
curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | jq '.result.tools[].name'
```

Expected: exactly 4 tools — `test1_greet`, `test2_headers`, `test3_add`, `oidc_hello_world`. These correspond to the accounting group's `tool:` roles.

In the log tail from step 4 you should see:

```
FilterTools called input_tools_count=...
parsed authorized capabilities capabilities=map[tools:map[mcp-test/test-server1:[greet] ...]]
FilterTools authorized capabilities result output_tools_count=4
```

This confirms:
- The broker received the `x-mcp-authorized` header
- It parsed the `allowed-capabilities` JWT claim
- The capabilities map contains `tools` -> server -> tool names (with `tool:` prefix already stripped by the Rego)
- Filtering reduced the tool list to 4

## 6. Verify `tools/call` authorization with `tool:` prefix

Using the same token and session from step 5:

**Allowed tool** — accounting group has `tool:greet` on test-server1:

```bash
curl -sk -o /dev/null -w "%{http_code}" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test1_greet","arguments":{"name":"reviewer"}}}'
```

Expected: `200`

**Denied tool** — accounting group does NOT have `tool:time` on test-server1:

```bash
curl -sk -o /dev/null -w "%{http_code}" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"test1_time","arguments":{}}}'
```

Expected: `403`

## 7. Verify unit tests pass

```bash
make test-unit
```

All tests should pass, including `TestFilteredTools`, `TestCombinedAuthorizedToolsAndVirtualServer`, etc.


## Summary of what changed

| Before | After |
|--------|-------|
| `x-authorized-tools` header | `x-mcp-authorized` header |
| `allowed-tools` JWT claim | `allowed-capabilities` JWT claim |
| Claim value: `map[string][]string` | Claim value: `map[string]map[string][]string` |
| `enforceToolFilter` / `--enforce-tool-filtering` | `enforceCapabilityFilter` / `--enforce-capability-filtering` |
| Keycloak roles: `greet`, `headers` | Keycloak roles: `tool:greet`, `tool:headers` |
| Rego passes roles through directly | Rego filters by `tool:` prefix and strips it |
| CEL checks `x-mcp-toolname in roles` | CEL checks `('tool:' + x-mcp-toolname) in roles` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched to capability-based filtering (broader capability model vs. tool-only).
  * Authorization header changed to x-mcp-authorized carrying allowed-capabilities.

* **Documentation**
  * Updated guides, design docs, and examples to describe the new header, claim shape, and role naming.

* **Chores**
  * Keycloak role names updated to use tool: prefixes.
  * Tests and test helpers updated to the new capability-based JWT format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->