### PR TITLE
Expose tool annotation hints for policy checks

### DIFF
--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -118,7 +118,22 @@ For `tools/call` requests, the router also exposes selected MCP tool annotation 
 | `x-mcp-tool-destructive` | `destructiveHint` |
 | `x-mcp-tool-idempotent` | `idempotentHint` |
 | `x-mcp-tool-open-world` | `openWorldHint` |
-| `x-mcp-annotation-hints` | comma-separated summary of the hints above |
+| `x-mcp-annotation-hints` | comma-separated `name=value` summary of the hints above |
+
+Each individual annotation header is only present when the upstream tool metadata includes that annotation. The value is the string `"true"` or `"false"`, matching the upstream annotation's boolean value. The combined `x-mcp-annotation-hints` header is only present when at least one annotation hint is present. Its value uses the same camel-case names as MCP annotations, has no spaces, and preserves the router order `readOnly`, `destructive`, `idempotent`, `openWorld`, for example `readOnly=true,destructive=false,idempotent=true`.
+
+For CEL predicates, check the header presence before treating an omitted hint as a decision:
+
+```yaml
+authorization:
+  'destructive-check':
+    patternMatching:
+      patterns:
+      - predicate: |
+          !has(request.headers['x-mcp-tool-destructive']) ||
+          request.headers['x-mcp-tool-destructive'] == 'false' ||
+          'admin' in (has(auth.identity.roles) ? auth.identity.roles : [])
+```
 
 These values are copied from the upstream MCP server's tool metadata. Treat them as policy hints, not gateway-verified facts. They are most useful when the platform trusts the upstream MCP server that published the annotations.
 

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -108,6 +108,20 @@ EOF
   - `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed tool the user can access, grouped by MCP server
 - **Response Handling**: Custom 401 and 403 responses for unauthenticated and unauthorized access attempts
 
+### Tool annotation hints
+
+For `tools/call` requests, the router also exposes selected MCP tool annotation hints as request headers when the upstream tool declared them:
+
+| Header | Source annotation |
+| --- | --- |
+| `x-mcp-tool-readonly` | `readOnlyHint` |
+| `x-mcp-tool-destructive` | `destructiveHint` |
+| `x-mcp-tool-idempotent` | `idempotentHint` |
+| `x-mcp-tool-open-world` | `openWorldHint` |
+| `x-mcp-annotation-hints` | comma-separated summary of the hints above |
+
+These values are copied from the upstream MCP server's tool metadata. Treat them as policy hints, not gateway-verified facts. They are most useful when the platform trusts the upstream MCP server that published the annotations.
+
 ## Step 3: Test Authorization
 
 **Note**: The authentication guide already created the `accounting` group, added the `mcp` user to it, and configured group claims in JWT tokens. No additional Keycloak configuration is needed.

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -22,7 +23,7 @@ func TestStatusHandlerNotGet(t *testing.T) {
 	sh := NewStatusHandler(mcpBroker, *logger)
 
 	w := httptest.NewRecorder()
-	sh.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/status", nil))
+	sh.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/status", nil))
 	res := w.Result()
 	require.Equal(t, 405, res.StatusCode)
 }
@@ -50,7 +51,7 @@ func TestStatusHandlerGetSingleServer(t *testing.T) {
 
 	// At first, no server known for this name
 	w := httptest.NewRecorder()
-	sh.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/status/dummyServer", nil))
+	sh.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/status/dummyServer", nil))
 	res := w.Result()
 	require.Equal(t, 404, res.StatusCode)
 
@@ -63,7 +64,7 @@ func TestStatusHandlerGetSingleServer(t *testing.T) {
 	)
 
 	w = httptest.NewRecorder()
-	sh.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/status/dummyServer", nil))
+	sh.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/status/dummyServer", nil))
 	res = w.Result()
 	require.Equal(t, 200, res.StatusCode)
 }
@@ -82,7 +83,7 @@ func TestStatusHandlerGetAll(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	sh.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/status", nil))
+	sh.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/status", nil))
 	res := w.Result()
 	require.Equal(t, 200, res.StatusCode)
 	data, err := io.ReadAll(res.Body)
@@ -90,4 +91,47 @@ func TestStatusHandlerGetAll(t *testing.T) {
 	m := make(map[string]interface{})
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
+}
+
+func TestStatusHandlerReturnsAnnotatedTools(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mcpBroker := NewBroker(logger)
+	sh := NewStatusHandler(mcpBroker, *logger)
+
+	readOnly := true
+	destructive := false
+
+	manager := createTestManagerForStatus(t,
+		"dummyServer",
+		[]mcp.Tool{{Name: "dummyTool"}},
+	)
+	manager.SetStatusForTesting(upstream.ServerValidationStatus{
+		Name:  "dummyServer",
+		Ready: true,
+		AnnotatedTools: []upstream.ToolHints{
+			{
+				Name:            "dummyTool",
+				ReadOnlyHint:    &readOnly,
+				DestructiveHint: &destructive,
+			},
+		},
+	})
+
+	brokerImpl, ok := mcpBroker.(*mcpBrokerImpl)
+	require.True(t, ok)
+	brokerImpl.mcpServers["dummyServer:test_:http://test.local/mcp"] = manager
+
+	w := httptest.NewRecorder()
+	sh.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/status", nil))
+	res := w.Result()
+	require.Equal(t, 200, res.StatusCode)
+
+	var status StatusResponse
+	err := json.NewDecoder(res.Body).Decode(&status)
+	require.NoError(t, err)
+	require.Len(t, status.Servers, 1)
+	require.Len(t, status.Servers[0].AnnotatedTools, 1)
+	require.Equal(t, "dummyTool", status.Servers[0].AnnotatedTools[0].Name)
+	require.True(t, *status.Servers[0].AnnotatedTools[0].ReadOnlyHint)
+	require.False(t, *status.Servers[0].AnnotatedTools[0].DestructiveHint)
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -52,6 +52,16 @@ type ServerValidationStatus struct {
 	TotalTools      int               `json:"totalTools"`
 	InvalidTools    int               `json:"invalidTools"`
 	InvalidToolList []InvalidToolInfo `json:"invalidToolList,omitempty"`
+	AnnotatedTools  []ToolHints       `json:"annotatedTools,omitempty"`
+}
+
+// ToolHints captures the MCP tool annotations the gateway can expose to policy.
+type ToolHints struct {
+	Name            string `json:"name"`
+	ReadOnlyHint    *bool  `json:"readOnlyHint,omitempty"`
+	DestructiveHint *bool  `json:"destructiveHint,omitempty"`
+	IdempotentHint  *bool  `json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool  `json:"openWorldHint,omitempty"`
 }
 
 // MCP defines the interface for the manager to interact with an MCP server
@@ -301,6 +311,7 @@ func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []Invali
 	man.status.Name = man.MCPName()
 	man.status.InvalidTools = len(invalidTools)
 	man.status.InvalidToolList = invalidTools
+	man.status.AnnotatedTools = man.annotationHintsForStatus()
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
@@ -356,6 +367,37 @@ func (man *MCPManager) getTools(ctx context.Context) ([]mcp.Tool, []mcp.Tool, er
 		return tools, tools, fmt.Errorf("failed to get tools: %w", err)
 	}
 	return tools, res.Tools, nil
+}
+
+func (man *MCPManager) annotationHintsForStatus() []ToolHints {
+	man.toolsLock.RLock()
+	defer man.toolsLock.RUnlock()
+
+	hints := make([]ToolHints, 0)
+	for _, tool := range man.tools {
+		if hint, ok := toolHints(tool); ok {
+			hints = append(hints, hint)
+		}
+	}
+	return hints
+}
+
+func toolHints(tool mcp.Tool) (ToolHints, bool) {
+	annotation := tool.Annotations
+	if annotation.ReadOnlyHint == nil &&
+		annotation.DestructiveHint == nil &&
+		annotation.IdempotentHint == nil &&
+		annotation.OpenWorldHint == nil {
+		return ToolHints{}, false
+	}
+
+	return ToolHints{
+		Name:            tool.Name,
+		ReadOnlyHint:    annotation.ReadOnlyHint,
+		DestructiveHint: annotation.DestructiveHint,
+		IdempotentHint:  annotation.IdempotentHint,
+		OpenWorldHint:   annotation.OpenWorldHint,
+	}, true
 }
 
 // GetManagedTools returns a copy of all tools discovered from the upstream server.

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -55,7 +55,8 @@ type ServerValidationStatus struct {
 	AnnotatedTools  []ToolHints       `json:"annotatedTools,omitempty"`
 }
 
-// ToolHints captures the MCP tool annotations the gateway can expose to policy.
+// ToolHints captures upstream-provided MCP tool annotations in the status API.
+// These values are advisory metadata, not gateway-verified or enforced facts.
 type ToolHints struct {
 	Name            string `json:"name"`
 	ReadOnlyHint    *bool  `json:"readOnlyHint,omitempty"`
@@ -373,9 +374,9 @@ func (man *MCPManager) annotationHintsForStatus() []ToolHints {
 	man.toolsLock.RLock()
 	defer man.toolsLock.RUnlock()
 
-	hints := make([]ToolHints, 0)
-	for _, tool := range man.tools {
-		if hint, ok := toolHints(tool); ok {
+	hints := make([]ToolHints, 0, len(man.tools))
+	for i := range man.tools {
+		if hint, ok := toolHints(man.tools[i]); ok {
 			hints = append(hints, hint)
 		}
 	}

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -209,6 +209,38 @@ func TestMCPManager_GetStatus(t *testing.T) {
 	assert.Equal(t, expectedStatus.TotalTools, status.TotalTools)
 }
 
+func TestMCPManager_StatusIncludesToolAnnotationHints(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test-server", "test_")
+	mock.hasToolsCap = false
+	mock.tools = []mcp.Tool{
+		{
+			Name:        "read_status",
+			InputSchema: mcp.ToolInputSchema{Type: "object"},
+			Annotations: mcp.ToolAnnotation{
+				ReadOnlyHint:    mcp.ToBoolPtr(true),
+				DestructiveHint: mcp.ToBoolPtr(false),
+				IdempotentHint:  mcp.ToBoolPtr(true),
+			},
+		},
+		validTool("plain_tool"),
+	}
+
+	gateway := newMockToolsAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager.manage(context.Background(), eventTypeTimer)
+
+	status := manager.GetStatus()
+	assert.True(t, status.Ready)
+	assert.Equal(t, 2, status.TotalTools)
+	assert.Len(t, status.AnnotatedTools, 1)
+	assert.Equal(t, "read_status", status.AnnotatedTools[0].Name)
+	assert.True(t, *status.AnnotatedTools[0].ReadOnlyHint)
+	assert.False(t, *status.AnnotatedTools[0].DestructiveHint)
+	assert.True(t, *status.AnnotatedTools[0].IdempotentHint)
+	assert.Nil(t, status.AnnotatedTools[0].OpenWorldHint)
+}
+
 func TestMCPManager_GetManagedTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -9,6 +9,10 @@ import (
 const (
 	mcpServerNameHeader   = "x-mcp-servername"
 	toolAnnotationsHeader = "x-mcp-annotation-hints"
+	toolReadOnlyHeader    = "x-mcp-tool-readonly"
+	toolDestructiveHeader = "x-mcp-tool-destructive"
+	toolIdempotentHeader  = "x-mcp-tool-idempotent"
+	toolOpenWorldHeader   = "x-mcp-tool-open-world"
 	toolHeader            = "x-mcp-toolname"
 	methodHeader          = "x-mcp-method"
 	sessionHeader         = "mcp-session-id"
@@ -131,6 +135,17 @@ func (hb *HeadersBuilder) WithToolAnnotations(annotations string) *HeadersBuilde
 		Header: &basepb.HeaderValue{
 			Key:      toolAnnotationsHeader,
 			RawValue: []byte(annotations),
+		},
+	})
+	return hb
+}
+
+// WithToolAnnotationHint sets one policy header for a known tool annotation hint.
+func (hb *HeadersBuilder) WithToolAnnotationHint(header, value string) *HeadersBuilder {
+	hb.headers = append(hb.headers, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{
+			Key:      header,
+			RawValue: []byte(value),
 		},
 	})
 	return hb

--- a/internal/mcp-router/headers_test.go
+++ b/internal/mcp-router/headers_test.go
@@ -10,6 +10,10 @@ func Test_Headers(t *testing.T) {
 	expected := map[string]string{
 		toolHeader:            "test_tool",
 		toolAnnotationsHeader: "destructive=true,idempotent=true,readOnly=false",
+		toolReadOnlyHeader:    "false",
+		toolDestructiveHeader: "true",
+		toolIdempotentHeader:  "true",
+		toolOpenWorldHeader:   "false",
 		authorityHeader:       "mcp1.mcp.local",
 		"authorization":       "auth",
 		methodHeader:          "tools/call",
@@ -26,6 +30,10 @@ func Test_Headers(t *testing.T) {
 		WithMCPSession(expected[sessionHeader]).
 		WithMCPToolName(expected[toolHeader]).
 		WithToolAnnotations(expected[toolAnnotationsHeader]).
+		WithToolAnnotationHint(toolReadOnlyHeader, expected[toolReadOnlyHeader]).
+		WithToolAnnotationHint(toolDestructiveHeader, expected[toolDestructiveHeader]).
+		WithToolAnnotationHint(toolIdempotentHeader, expected[toolIdempotentHeader]).
+		WithToolAnnotationHint(toolOpenWorldHeader, expected[toolOpenWorldHeader]).
 		WithPath("/mcp1").
 		Build()
 

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -408,14 +409,14 @@ data: {"result":{"content":[{"type":"text","text":"MCP error -32602: Tool not fo
 }
 
 func addToolAnnotationHeaders(headers *HeadersBuilder, annotations mcp.ToolAnnotation) {
-	var parts []string
+	parts := make([]string, 0, 4)
 	addHint := func(name, header string, val *bool) {
 		if val == nil {
 			return
 		}
 
-		value := fmt.Sprintf("%t", *val)
-		parts = append(parts, fmt.Sprintf("%s=%s", name, value))
+		value := strconv.FormatBool(*val)
+		parts = append(parts, name+"="+value)
 		headers.WithToolAnnotationHint(header, value)
 	}
 

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/mark3labs/mcp-go/mcp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -312,25 +313,7 @@ data: {"result":{"content":[{"type":"text","text":"MCP error -32602: Tool not fo
 		attribute.String("mcp.server.hostname", serverInfo.Hostname),
 	)
 	if annotations, hasAnnotations := s.Broker.ToolAnnotations(serverInfo.ID(), toolName); hasAnnotations {
-		// build header value (e.g. readOnly=true,destructive=false,openWorld=true)
-		var parts []string
-		push := func(key string, val *bool) {
-			if val == nil {
-				parts = append(parts, fmt.Sprintf("%s=unspecified", key))
-			} else if *val {
-				parts = append(parts, fmt.Sprintf("%s=true", key))
-			} else {
-				parts = append(parts, fmt.Sprintf("%s=false", key))
-			}
-		}
-
-		push("readOnly", annotations.ReadOnlyHint)
-		push("destructive", annotations.DestructiveHint)
-		push("idempotent", annotations.IdempotentHint)
-		push("openWorld", annotations.OpenWorldHint)
-
-		hintsHeader := strings.Join(parts, ",")
-		headers.WithToolAnnotations(hintsHeader)
+		addToolAnnotationHeaders(headers, annotations)
 	}
 
 	headers.WithMCPMethod(mcpReq.Method)
@@ -422,6 +405,28 @@ data: {"result":{"content":[{"type":"text","text":"MCP error -32602: Tool not fo
 	}
 	calculatedResponse.WithRequestBodyHeadersAndBodyReponse(headers.Build(), body)
 	return calculatedResponse.Build()
+}
+
+func addToolAnnotationHeaders(headers *HeadersBuilder, annotations mcp.ToolAnnotation) {
+	var parts []string
+	addHint := func(name, header string, val *bool) {
+		if val == nil {
+			return
+		}
+
+		value := fmt.Sprintf("%t", *val)
+		parts = append(parts, fmt.Sprintf("%s=%s", name, value))
+		headers.WithToolAnnotationHint(header, value)
+	}
+
+	addHint("readOnly", toolReadOnlyHeader, annotations.ReadOnlyHint)
+	addHint("destructive", toolDestructiveHeader, annotations.DestructiveHint)
+	addHint("idempotent", toolIdempotentHeader, annotations.IdempotentHint)
+	addHint("openWorld", toolOpenWorldHeader, annotations.OpenWorldHint)
+
+	if len(parts) > 0 {
+		headers.WithToolAnnotations(strings.Join(parts, ","))
+	}
 }
 
 // HandleElicitationResponse routes an elicitation response from the client to the correct backend server

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -247,6 +248,90 @@ func TestHandleRequestBody(t *testing.T) {
 	require.Equal(t,
 		`{"id":0,"jsonrpc":"2.0","method":"tools/call","params":{"name":"mytool","other":"other"}}`,
 		string(rb.RequestBody.Response.BodyMutation.GetBody()))
+}
+
+func TestHandleRequestBodyAddsToolAnnotationHeaders(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	require.NoError(t, err)
+
+	validToken := jwtManager.Generate()
+	sessionAdded, err := cache.AddSession(context.Background(), validToken, "dummy", "mock-upstream-session-id")
+	require.NoError(t, err)
+	require.True(t, sessionAdded)
+
+	serverConfigs := []*config.MCPServer{
+		{
+			Name:       "dummy",
+			URL:        "http://localhost:8080/mcp",
+			ToolPrefix: "s_",
+			Enabled:    true,
+			Hostname:   "localhost",
+		},
+	}
+
+	server := &ExtProcServer{
+		RoutingConfig: &config.MCPServersConfig{
+			Servers: serverConfigs,
+		},
+		JWTManager:   jwtManager,
+		Logger:       logger,
+		SessionCache: cache,
+		InitForClient: func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+			return nil, fmt.Errorf("InitForClient should not be called when session exists")
+		},
+		Broker: newMockBrokerWithAnnotations(serverConfigs, map[string]string{
+			"s_status": "dummy",
+		}, map[string]mcp.ToolAnnotation{
+			"s_status": {
+				ReadOnlyHint:    mcp.ToBoolPtr(true),
+				DestructiveHint: mcp.ToBoolPtr(false),
+				IdempotentHint:  mcp.ToBoolPtr(true),
+			},
+		}),
+	}
+
+	data := &MCPRequest{
+		ID:      ptr.To(0),
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "s_status",
+		},
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{
+					Key:      "mcp-session-id",
+					RawValue: []byte(validToken),
+				},
+			},
+		},
+	}
+
+	resp := server.RouteMCPRequest(context.Background(), data)
+	require.Len(t, resp, 1)
+	require.IsType(t, &eppb.ProcessingResponse_RequestBody{}, resp[0].Response)
+
+	rb := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+	headers := responseHeadersByName(rb.RequestBody.Response.HeaderMutation.SetHeaders)
+
+	require.Equal(t, "readOnly=true,destructive=false,idempotent=true", headers[toolAnnotationsHeader])
+	require.Equal(t, "true", headers[toolReadOnlyHeader])
+	require.Equal(t, "false", headers[toolDestructiveHeader])
+	require.Equal(t, "true", headers[toolIdempotentHeader])
+	require.NotContains(t, headers, toolOpenWorldHeader)
+}
+
+func responseHeadersByName(headers []*corev3.HeaderValueOption) map[string]string {
+	result := make(map[string]string, len(headers))
+	for _, header := range headers {
+		result[header.Header.Key] = string(header.Header.RawValue)
+	}
+	return result
 }
 
 func TestMCPRequest_isNotificationRequest(t *testing.T) {

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -24,7 +24,8 @@ type mockBrokerImpl struct {
 	svrConfigs []*config.MCPServer
 
 	// Map of tool name to server name
-	tool2svr map[string]string
+	tool2svr        map[string]string
+	toolAnnotations map[string]mcp.ToolAnnotation
 }
 
 func TestHandleResponseHeaders_ReturnsGatewaySessionID(t *testing.T) {
@@ -477,6 +478,14 @@ func newMockBroker(svrConfigs []*config.MCPServer, tool2svr map[string]string) b
 	}
 }
 
+func newMockBrokerWithAnnotations(svrConfigs []*config.MCPServer, tool2svr map[string]string, annotations map[string]mcp.ToolAnnotation) broker.MCPBroker {
+	return &mockBrokerImpl{
+		svrConfigs:      svrConfigs,
+		tool2svr:        tool2svr,
+		toolAnnotations: annotations,
+	}
+}
+
 // GetServerInfo implements broker.MCPBroker.
 func (m *mockBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 	svrName, ok := m.tool2svr[tool]
@@ -524,8 +533,9 @@ func (m *mockBrokerImpl) Shutdown(_ context.Context) error {
 }
 
 // ToolAnnotations implements broker.MCPBroker.
-func (m *mockBrokerImpl) ToolAnnotations(_ config.UpstreamMCPID, _ string) (mcp.ToolAnnotation, bool) {
-	return mcp.ToolAnnotation{}, false
+func (m *mockBrokerImpl) ToolAnnotations(_ config.UpstreamMCPID, tool string) (mcp.ToolAnnotation, bool) {
+	annotation, ok := m.toolAnnotations[tool]
+	return annotation, ok
 }
 
 // ValidateAllServers implements broker.MCPBroker.


### PR DESCRIPTION
## summary

This adds policy-facing headers for MCP tool annotation hints on tools/call requests. The router now forwards read only, destructive, idempotent, and open world hints when the upstream tool metadata includes them.

The broker status response also includes annotated tool metadata so operators can see which hints were discovered from upstream servers.

Closes #820

## testing

- go test ./internal/...
- make lint, still reports existing unrelated findings in config, controller, and oauth protected resource handler tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added authorization guide for MCP tool annotation hints forwarded as HTTP headers.

* **New Features**
  * Tool policy hints (read-only, destructive, idempotent, open-world) now sent via HTTP headers for MCP tool calls.
  * Annotation hints exposed in gateway status responses for managed tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->