### PR TITLE
docs: document dev environment Make targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,63 @@ is centered around milestones:
 ### Code of conduct
 
 Participation in the Kuadrant community is governed by the [Kuadrant Community Code of Conduct](https://github.com/Kuadrant/governance/blob/main/CODE_OF_CONDUCT.md).
+
+## Development Environment
+
+The project uses a top-level `Makefile` with additional include files in `build/*.mk`. Run `make help` for a categorised summary of the most common targets.
+
+> **Note:** `make help` only lists targets documented with `## ` (double-hash). Targets in `build/*.mk` that use `# ` (single-hash) are valid but intentionally hidden from the help output to keep the quick-reference list focused. The most useful of those are documented below, grouped by purpose.
+
+### Debugging Envoy
+
+Use these targets when you need to inspect or adjust the Istio gateway's Envoy proxy. `make debug-envoy` and `make debug-envoy-off` are visible in `make help`; the remaining targets are in `build/debug.mk` and hidden from help.
+
+| Target | Purpose |
+|---|---|
+| `make debug-envoy` | Enable debug-level logging on every running Istio gateway. |
+| `make debug-envoy-off` | Restore the gateway's log level to info. |
+| `make debug-envoy-config` | Dump the full Envoy configuration for the gateway as JSON. |
+| `make debug-envoy-clusters` | Show the status of all upstream clusters registered in Envoy. |
+| `make debug-envoy-listeners` | List all listeners configured in Envoy. |
+| `make debug-envoy-admin` | Port-forward the Envoy admin interface to `http://localhost:15000`. |
+| `make debug-ext-proc` | Enable debug-level logging for the `ext_proc` filter only (scoped to the external processor, not the full gateway). |
+
+### Inspecting Istio configuration
+
+Use these targets to query or validate the Istio control-plane configuration of the gateway. `make istio-clusters` and `make istio-config` are visible in `make help`; the remaining targets are in `build/istio-debug.mk` and hidden from help.
+
+| Target | Purpose |
+|---|---|
+| `make istio-clusters` | Show all upstream clusters registered in the gateway's Envoy proxy. |
+| `make istio-listeners` | List all listeners in the gateway's Envoy proxy. |
+| `make istio-routes` | List all routes in the gateway's Envoy proxy. |
+| `make istio-endpoints` | Show all endpoints visible to the gateway. |
+| `make istio-config` | Print all proxy configurations at once (listeners, routes, clusters, endpoints). |
+| `make istio-analyze` | Run `istioctl analyze` against the cluster to surface common misconfiguration issues. |
+| `make istio-dashboard` | Open the Kiali dashboard (requires Kiali to be deployed). |
+| `make istio-external` | Show ServiceEntry and DestinationRule resources used for external MCP server routing. |
+
+### Tailing logs
+
+These targets are in `build/debug.mk`. In addition to `make logs` (gateway logs, visible in `make help`), the following targets cover specific components.
+
+| Target | Purpose |
+|---|---|
+| `make logs-mock` | Tail logs from the mock MCP test servers. |
+| `make logs-istiod` | Tail logs from the Istiod control-plane pod. |
+| `make logs-all` | Print recent logs from every MCP-related component in one view. |
+
+### Local dev loop
+
+These targets are in `build/dev.mk` and support running the broker and router as host processes while the cluster handles everything else. Start with `make dev` (visible in `make help`) to set up the cluster side, then use the targets below to manage the local processes.
+
+| Target | Purpose |
+|---|---|
+| `make dev-setup` | Configure the cluster to route traffic to locally running services (EnvoyFilter and Service resources). |
+| `make dev-reset` | Revert the cluster to use the in-cluster broker and router deployments. |
+| `make dev-envoyfilter` | Apply the EnvoyFilter that points the gateway's ext_proc at the locally running router. |
+| `make dev-broker-service` | Create a Kubernetes Service that forwards to the locally running broker. |
+| `make dev-test` | Send a test MCP request through the gateway to verify end-to-end connectivity. |
+| `make dev-logs-gateway` | Tail logs from the Istio gateway (alias scoped to the dev workflow). |
+| `make dev-stop` | Stop all local dev processes (port-forwards, router, broker). |
+| `make dev-stop-forward` | Stop any `kubectl port-forward` processes started by the dev workflow. |


### PR DESCRIPTION
Fixes #324

Adds a `## Development Environment` section to `CONTRIBUTING.md` documenting
Make targets contributors use during local development.

**What's covered**

Four subsections, each listing targets by purpose:

- **Debugging Envoy** — `debug-envoy`, `debug-envoy-config`, `debug-envoy-admin`,
  and related targets for inspecting and adjusting the gateway's Envoy proxy
- **Inspecting Istio configuration** — `istio-listeners`, `istio-routes`,
  `istio-analyze`, `istio-dashboard`, and the other `istio-*` introspection targets
- **Tailing logs** — `logs-mock`, `logs-istiod`, `logs-all`
- **Local dev loop** — the `dev-*` family in `build/dev.mk` that supports running
  the broker and router as host processes

Also calls out that `make help` only surfaces targets with `## ` (double-hash) and
that several useful targets use `# ` (single-hash) and are intentionally absent from
the help output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contribution documentation with detailed development environment setup instructions, comprehensive guidance on using the Makefile and build system, clear explanation of how the `make help` command filters targets, and organized reference tables for common development tasks including debugging, configuration inspection, component monitoring, and local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->