### PR TITLE
fix : Adding a informational get endpoint and catch all route 

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -12,6 +12,7 @@ import (
 	_ "net/http/pprof" //nolint:gosec // G108: intentional pprof endpoint for performance profiling
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"time"
 
@@ -352,6 +353,15 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 	mux.HandleFunc("OPTIONS /mcp", func(w http.ResponseWriter, r *http.Request) {
 		logger.Debug("Handling OPTIONS", "Mcp-Session-Id", r.Header.Get("Mcp-Session-Id"))
 		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("GET /mcp", func(w http.ResponseWriter, r *http.Request) {
+		accept := r.Header.Get("Accept")
+		if strings.Contains(accept, "text/event-stream") {
+			streamableHTTPServer.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "GET /mcp requires Accept: text/event-stream header for SSE streaming", http.StatusNotAcceptable)
 	})
 
 	mux.HandleFunc("/status", mcpBroker.HandleStatusRequest)

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -7,14 +7,11 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"mime"
 	"net"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec // G108: intentional pprof endpoint for performance profiling
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -357,15 +354,6 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mux.HandleFunc("GET /mcp", func(w http.ResponseWriter, r *http.Request) {
-		accept := r.Header.Get("Accept")
-		if acceptSSE(accept) {
-			streamableHTTPServer.ServeHTTP(w, r)
-			return
-		}
-		http.Error(w, "GET /mcp requires Accept: text/event-stream header for SSE streaming", http.StatusNotAcceptable)
-	})
-
 	mux.HandleFunc("/status", mcpBroker.HandleStatusRequest)
 	mux.HandleFunc("/status/", mcpBroker.HandleStatusRequest)
 	mux.Handle("/mcp", streamableHTTPServer)
@@ -434,35 +422,4 @@ func LoadConfig(path string) {
 			s.Hostname,
 		)
 	}
-}
-
-// acceptSSE checks if the Accept header includes text/event-stream with non-zero q
-
-func acceptSSE(accept string) bool {
-	accepts := strings.Split(accept, ",")
-	for _, a := range accepts {
-		a = strings.TrimSpace(a)
-		if a == "" {
-			continue
-		}
-		mediaType, params, err := mime.ParseMediaType(a)
-		if err != nil {
-			continue
-		}
-		if mediaType != "text/event-stream" {
-			continue
-		}
-		if qStr, ok := params["q"]; ok {
-			q, err := strconv.ParseFloat(qStr, 64)
-			if err != nil {
-				continue
-			}
-			if q > 0 {
-				return true
-			}
-		} else {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"mime"
 	"net"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec // G108: intentional pprof endpoint for performance profiling
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -357,7 +359,7 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 
 	mux.HandleFunc("GET /mcp", func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
-		if strings.Contains(accept, "text/event-stream") {
+		if acceptSSE(accept) {
 			streamableHTTPServer.ServeHTTP(w, r)
 			return
 		}
@@ -432,4 +434,35 @@ func LoadConfig(path string) {
 			s.Hostname,
 		)
 	}
+}
+
+// acceptSSE checks if the Accept header includes text/event-stream with non-zero q
+
+func acceptSSE(accept string) bool {
+	accepts := strings.Split(accept, ",")
+	for _, a := range accepts {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		mediaType, params, err := mime.ParseMediaType(a)
+		if err != nil {
+			continue
+		}
+		if mediaType != "text/event-stream" {
+			continue
+		}
+		if qStr, ok := params["q"]; ok {
+			q, err := strconv.ParseFloat(qStr, 64)
+			if err != nil {
+				continue
+			}
+			if q > 0 {
+				return true
+			}
+		} else {
+			return true
+		}
+	}
+	return false
 }

--- a/config/mcp-gateway/base/httproute.yaml
+++ b/config/mcp-gateway/base/httproute.yaml
@@ -44,4 +44,3 @@ spec:
       backendRefs:
         - name: mcp-gateway
           port: 8080
-          

--- a/config/mcp-gateway/base/httproute.yaml
+++ b/config/mcp-gateway/base/httproute.yaml
@@ -37,3 +37,10 @@ spec:
       backendRefs:
         - name: mcp-gateway
           port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mcp-gateway
+          port: 8080

--- a/config/mcp-gateway/base/httproute.yaml
+++ b/config/mcp-gateway/base/httproute.yaml
@@ -44,3 +44,4 @@ spec:
       backendRefs:
         - name: mcp-gateway
           port: 8080
+          

--- a/config/mcp-system/httproute.yaml
+++ b/config/mcp-system/httproute.yaml
@@ -37,3 +37,10 @@ spec:
       backendRefs:
         - name: mcp-gateway
           port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mcp-gateway
+          port: 8080


### PR DESCRIPTION
## Summary 

- Fixes #402 
- Added a `GET /mcp` handler that validates the `Accept` header. Requests
  without `Accept: text/event-stream` now return `406 Not Acceptable` with a
  helpful message instead of silently blocking on an SSE stream.
- Added a catch-all `PathPrefix: /` route to the HTTPRoute so unmatched paths
  (e.g. `/`) are forwarded to the broker instead of returning an Envoy 404.
  The broker already responds with an informational message on unmatched paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE streaming on /mcp now requires and validates Accept: text/event-stream; requests that do not match receive a clear HTTP 406 Not Acceptable response.
* **Chores**
  * Added broad HTTP routing rules to forward general traffic to the existing gateway/backend on port 8080, ensuring wider request coverage alongside the existing routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/832)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->