### PR TITLE
fix(controller): include oauth protected-resource route in managed ht…

### DIFF
--- a/config/mcp-gateway/base/mcpgatewayextension.yaml
+++ b/config/mcp-gateway/base/mcpgatewayextension.yaml
@@ -3,6 +3,7 @@ kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway-extension
 spec:
+  httpRouteManagement: Disabled
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway

--- a/config/mcp-gateway/base/mcpgatewayextension.yaml
+++ b/config/mcp-gateway/base/mcpgatewayextension.yaml
@@ -3,7 +3,6 @@ kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway-extension
 spec:
-  httpRouteManagement: Disabled
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -516,7 +516,8 @@ func mergeEnvVars(desired, existing []corev1.EnvVar) []corev1.EnvVar {
 func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1alpha1.MCPGatewayExtension, publicHost string) *gatewayv1.HTTPRoute {
 	labels := brokerRouterLabels()
 	pathType := gatewayv1.PathMatchPathPrefix
-	pathValue := "/mcp"
+	mcpPathValue := "/mcp"
+	oauthProtectedResourcePathValue := "/.well-known/oauth-protected-resource"
 	port := gatewayv1.PortNumber(brokerHTTPPort)
 	gatewayNamespace := gatewayv1.Namespace(mcpExt.Spec.TargetRef.Namespace)
 	sectionName := gatewayv1.SectionName(mcpExt.Spec.TargetRef.SectionName)
@@ -548,7 +549,27 @@ func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1alpha
 						{
 							Path: &gatewayv1.HTTPPathMatch{
 								Type:  &pathType,
-								Value: &pathValue,
+								Value: &mcpPathValue,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(brokerRouterName),
+									Port: &port,
+								},
+							},
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &oauthProtectedResourcePathValue,
 							},
 						},
 					},

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -1237,6 +1238,22 @@ func TestBuildGatewayHTTPRoute(t *testing.T) {
 			}
 			if parentRef.SectionName == nil || string(*parentRef.SectionName) != tt.mcpExt.Spec.TargetRef.SectionName {
 				t.Errorf("parentRef sectionName = %v, want %q", parentRef.SectionName, tt.mcpExt.Spec.TargetRef.SectionName)
+			}
+			if len(route.Spec.Rules) != 2 {
+				t.Fatalf("expected 2 rules, got %d", len(route.Spec.Rules))
+			}
+			gotPaths := []string{}
+			for _, rule := range route.Spec.Rules {
+				if len(rule.Matches) == 0 || rule.Matches[0].Path == nil || rule.Matches[0].Path.Value == nil {
+					t.Fatalf("expected rule with path match, got %#v", rule)
+				}
+				gotPaths = append(gotPaths, *rule.Matches[0].Path.Value)
+			}
+			if !slices.Contains(gotPaths, "/mcp") {
+				t.Errorf("expected /mcp rule, got paths %v", gotPaths)
+			}
+			if !slices.Contains(gotPaths, "/.well-known/oauth-protected-resource") {
+				t.Errorf("expected /.well-known/oauth-protected-resource rule, got paths %v", gotPaths)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes [#776](https://github.com/Kuadrant/mcp-gateway/issues/776) 
by updating controller-managed HTTPRoute generation to include both `/mcp `and `/.well-known/oauth-protected-resource`, so OAuth protected-resource discovery works when httpRouteManagement is enabled. Also sets `httpRouteManagement`: Disabled in the base MCP Gateway extension overlay to prevent the static route (which already includes both paths) from being overwritten, and adds unit test coverage for both route rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Disabled HTTP route management in gateway extension configuration.

* **New Features / Bug Fixes**
  * Routing updated to handle MCP and OAuth-protected-resource paths as distinct routes.

* **Tests**
  * Strengthened tests to validate presence of both MCP and OAuth-protected-resource routes and related match criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->