### PR TITLE
add A2A task-lifecycle routing infrastructure

### DIFF
--- a/internal/mcp-router/a2a.go
+++ b/internal/mcp-router/a2a.go
@@ -1,0 +1,101 @@
+package mcprouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// a2aTaskExtractor reads A2A message/stream (and message/send) SSE response chunks,
+// extracts the task ID from the first result event, and stores the taskID→serverName
+// mapping in the session cache so that follow-on tasks/get, tasks/cancel, and
+// tasks/resubscribe requests can be routed to the correct backend agent.
+//
+// The body is passed through unmodified; this extractor is read-only.
+type a2aTaskExtractor struct {
+	buf        []byte
+	logger     *slog.Logger
+	serverName string
+	cache      SessionCache
+	done       bool
+}
+
+type a2aResult struct {
+	ID string `json:"id"`
+}
+
+type a2aEnvelope struct {
+	Result *a2aResult `json:"result"`
+}
+
+// Process scans chunk for complete SSE data lines, extracts the first task ID,
+// and stores the taskID→serverName mapping. Returns chunk unchanged.
+// Call Flush at end-of-stream to handle plain-JSON bodies (message/send).
+func (e *a2aTaskExtractor) Process(ctx context.Context, chunk []byte) []byte {
+	if e.done {
+		return chunk
+	}
+	e.buf = append(e.buf, chunk...)
+
+	for {
+		nl := bytes.IndexByte(e.buf, '\n')
+		if nl == -1 {
+			break // incomplete line — wait for more data
+		}
+		line := bytes.TrimSpace(e.buf[:nl+1])
+		e.buf = e.buf[nl+1:]
+
+		var jsonData []byte
+		switch {
+		case bytes.HasPrefix(line, dataPrefix):
+			jsonData = bytes.TrimPrefix(line, dataPrefix)
+			if len(jsonData) > 0 && jsonData[0] == ' ' {
+				jsonData = jsonData[1:]
+			}
+		case len(line) > 0 && line[0] == '{':
+			jsonData = line
+		default:
+			continue
+		}
+
+		if taskID := extractA2ATaskID(jsonData); taskID != "" {
+			e.storeRoute(ctx, taskID)
+			return chunk
+		}
+	}
+
+	return chunk
+}
+
+// Flush handles plain-JSON response bodies (message/send) that may not carry a
+// trailing newline. Call this when EndOfStream is true.
+func (e *a2aTaskExtractor) Flush(ctx context.Context) {
+	if e.done || len(e.buf) == 0 {
+		return
+	}
+	candidate := bytes.TrimSpace(e.buf)
+	e.buf = nil
+	if len(candidate) > 0 && candidate[0] == '{' {
+		if taskID := extractA2ATaskID(candidate); taskID != "" {
+			e.storeRoute(ctx, taskID)
+		}
+	}
+}
+
+func (e *a2aTaskExtractor) storeRoute(ctx context.Context, taskID string) {
+	if err := e.cache.StoreTaskRoute(ctx, taskID, e.serverName); err != nil {
+		e.logger.ErrorContext(ctx, "failed to store a2a task route", "taskID", taskID, "error", err)
+	} else {
+		e.logger.DebugContext(ctx, "stored a2a task route", "taskID", taskID, "server", e.serverName)
+	}
+	e.done = true
+}
+
+func extractA2ATaskID(data []byte) string {
+	var env a2aEnvelope
+	if err := json.Unmarshal(data, &env); err != nil || env.Result == nil {
+		return ""
+	}
+	return env.Result.ID
+}

--- a/internal/mcp-router/a2a_test.go
+++ b/internal/mcp-router/a2a_test.go
@@ -1,0 +1,178 @@
+package mcprouter
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/Kuadrant/mcp-gateway/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger(_ *testing.T) *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, nil))
+}
+
+func TestA2ATaskExtractor_SSEStream(t *testing.T) {
+	ctx := context.Background()
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	ext := &a2aTaskExtractor{
+		logger:     testLogger(t),
+		serverName: "weather-agent",
+		cache:      cache,
+	}
+
+	// first chunk: SSE event with task ID
+	chunk := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":\"task-abc\",\"status\":{\"state\":\"submitted\"}}}\n")
+	out := ext.Process(ctx, chunk)
+	require.Equal(t, chunk, out, "body should pass through unchanged")
+
+	got, err := cache.ResolveTaskRoute(ctx, "task-abc")
+	require.NoError(t, err)
+	require.Equal(t, "weather-agent", got)
+}
+
+func TestA2ATaskExtractor_PlainJSON(t *testing.T) {
+	ctx := context.Background()
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	ext := &a2aTaskExtractor{
+		logger:     testLogger(t),
+		serverName: "code-agent",
+		cache:      cache,
+	}
+
+	// message/send returns a plain JSON response (no SSE framing)
+	chunk := []byte("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":\"task-xyz\",\"status\":{\"state\":\"completed\"}}}\n")
+	out := ext.Process(ctx, chunk)
+	require.Equal(t, chunk, out)
+
+	got, err := cache.ResolveTaskRoute(ctx, "task-xyz")
+	require.NoError(t, err)
+	require.Equal(t, "code-agent", got)
+}
+
+func TestA2ATaskExtractor_MultipleChunks(t *testing.T) {
+	ctx := context.Background()
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	ext := &a2aTaskExtractor{
+		logger:     testLogger(t),
+		serverName: "agent-1",
+		cache:      cache,
+	}
+
+	// SSE event split across two chunks — newline only in second chunk
+	chunk1 := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":")
+	chunk2 := []byte("\"task-split\",\"status\":{\"state\":\"working\"}}}\n")
+
+	ext.Process(ctx, chunk1)  // no newline yet — buffered
+	ext.Process(ctx, chunk2)  // newline arrives — complete line parsed
+
+	got, err := cache.ResolveTaskRoute(ctx, "task-split")
+	require.NoError(t, err)
+	require.Equal(t, "agent-1", got)
+}
+
+func TestA2ATaskExtractor_FlushPlainJSON(t *testing.T) {
+	ctx := context.Background()
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	ext := &a2aTaskExtractor{
+		logger:     testLogger(t),
+		serverName: "sync-agent",
+		cache:      cache,
+	}
+
+	// message/send plain JSON response without a trailing newline
+	chunk := []byte("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":\"task-flush\",\"status\":{\"state\":\"completed\"}}}")
+	ext.Process(ctx, chunk)
+
+	// task ID not stored yet (no newline → stuck in buffer)
+	_, err = cache.ResolveTaskRoute(ctx, "task-flush")
+	require.Error(t, err)
+
+	// Flush triggered at end-of-stream
+	ext.Flush(ctx)
+
+	got, err := cache.ResolveTaskRoute(ctx, "task-flush")
+	require.NoError(t, err)
+	require.Equal(t, "sync-agent", got)
+}
+
+func TestA2ATaskExtractor_DoneAfterFirstID(t *testing.T) {
+	ctx := context.Background()
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	ext := &a2aTaskExtractor{
+		logger:     testLogger(t),
+		serverName: "agent-1",
+		cache:      cache,
+	}
+
+	first := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":\"task-first\",\"status\":{\"state\":\"working\"}}}\n")
+	second := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"id\":\"task-second\",\"status\":{\"state\":\"completed\"}}}\n")
+
+	ext.Process(ctx, first)
+	ext.Process(ctx, second)
+
+	// only the first task ID should be stored
+	_, err = cache.ResolveTaskRoute(ctx, "task-first")
+	require.NoError(t, err)
+	_, err = cache.ResolveTaskRoute(ctx, "task-second")
+	require.Error(t, err, "second task ID should not be stored")
+}
+
+func TestA2ATaskExtractor_NonTaskEvent(t *testing.T) {
+	ctx := context.Background()
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	ext := &a2aTaskExtractor{
+		logger:     testLogger(t),
+		serverName: "agent-1",
+		cache:      cache,
+	}
+
+	// SSE comment / keepalive line followed by real event
+	ext.Process(ctx, []byte(": keepalive\n"))
+	ext.Process(ctx, []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":\"task-real\",\"status\":{\"state\":\"submitted\"}}}\n"))
+
+	got, err := cache.ResolveTaskRoute(ctx, "task-real")
+	require.NoError(t, err)
+	require.Equal(t, "agent-1", got)
+}
+
+func TestMCPRequest_A2AMethods(t *testing.T) {
+	for _, m := range []string{"message/send", "message/stream"} {
+		req := &MCPRequest{Method: m}
+		require.True(t, req.isA2AStreamingMethod(), m)
+		require.False(t, req.isA2ATaskOperation(), m)
+	}
+	for _, m := range []string{"tasks/get", "tasks/cancel", "tasks/resubscribe"} {
+		req := &MCPRequest{Method: m}
+		require.True(t, req.isA2ATaskOperation(), m)
+		require.False(t, req.isA2AStreamingMethod(), m)
+	}
+}
+
+func TestMCPRequest_A2ATaskID(t *testing.T) {
+	req := &MCPRequest{
+		Method: "tasks/get",
+		Params: map[string]any{"id": "task-abc"},
+	}
+	require.Equal(t, "task-abc", req.a2aTaskID())
+
+	req.Params = nil
+	require.Equal(t, "", req.a2aTaskID())
+
+	req.Params = map[string]any{"id": 42} // wrong type
+	require.Equal(t, "", req.a2aTaskID())
+}

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -68,6 +68,10 @@ const (
 	elicitationActionAccept  = "accept"
 	elicitationActionDecline = "decline"
 	elicitationActionCancel  = "cancel"
+
+	// a2aAgentHeader carries the target backend agent name for A2A requests.
+	// Set by the client or injected via an HTTPRoute header filter.
+	a2aAgentHeader = "x-a2a-agent"
 )
 
 // MCPRequest encapsulates a mcp protocol request to the gateway
@@ -129,6 +133,36 @@ func (mr *MCPRequest) isToolCall() bool {
 // isInitializeRequest returns true if the method is initialize or initialized
 func (mr *MCPRequest) isInitializeRequest() bool {
 	return mr.Method == "initialize" || mr.Method == "notifications/initialized"
+}
+
+// isA2AStreamingMethod returns true for A2A methods that produce an SSE response body.
+func (mr *MCPRequest) isA2AStreamingMethod() bool {
+	return mr.Method == "message/send" || mr.Method == "message/stream"
+}
+
+// isA2ATaskOperation returns true for A2A methods that address an existing task by ID.
+func (mr *MCPRequest) isA2ATaskOperation() bool {
+	switch mr.Method {
+	case "tasks/get", "tasks/cancel", "tasks/resubscribe":
+		return true
+	}
+	return false
+}
+
+// a2aTaskID returns the task ID from params.id for A2A task operations.
+func (mr *MCPRequest) a2aTaskID() string {
+	if mr.Params == nil {
+		return ""
+	}
+	id, ok := mr.Params["id"]
+	if !ok {
+		return ""
+	}
+	s, ok := id.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }
 
 // clientSupportsElicitation checks if an initialize request declares elicitation support
@@ -220,6 +254,12 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	case mcpReq.Method == methodToolCall:
 		span.SetAttributes(attribute.String("mcp.route", "tool-call"))
 		return s.HandleToolCall(ctx, mcpReq)
+	case mcpReq.isA2AStreamingMethod():
+		span.SetAttributes(attribute.String("mcp.route", "a2a-stream"))
+		return s.HandleA2AStreamingMethod(ctx, mcpReq)
+	case mcpReq.isA2ATaskOperation():
+		span.SetAttributes(attribute.String("mcp.route", "a2a-task-op"))
+		return s.HandleA2ATaskOperation(ctx, mcpReq)
 	default:
 		span.SetAttributes(attribute.String("mcp.route", "broker"))
 		return s.HandleNoneToolCall(ctx, mcpReq)
@@ -592,6 +632,140 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 	}
 	return remoteSessionID, nil
 
+}
+
+// HandleA2AStreamingMethod routes message/send and message/stream to the backend A2A agent
+// identified by the x-a2a-agent header. The response body is intercepted (via ModeOverride
+// set in HandleResponseHeaders) so the a2aTaskExtractor can capture the task ID.
+func (s *ExtProcServer) HandleA2AStreamingMethod(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
+	ctx, span := tracer().Start(ctx, "mcp-router.a2a-stream",
+		trace.WithAttributes(
+			attribute.String("mcp.method.name", mcpReq.Method),
+			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+		),
+	)
+	defer span.End()
+
+	response := NewResponse()
+	agentName := mcpReq.GetSingleHeaderValue(a2aAgentHeader)
+	if agentName == "" {
+		s.Logger.ErrorContext(ctx, "missing x-a2a-agent header for A2A streaming method", "method", mcpReq.Method)
+		span.SetStatus(codes.Error, "missing agent header")
+		response.WithImmediateResponse(400, "missing x-a2a-agent header")
+		return response.Build()
+	}
+
+	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(agentName)
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "a2a agent not found", "agent", agentName, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "agent not found")
+		response.WithImmediateResponse(404, "a2a agent not found")
+		return response.Build()
+	}
+	// serverName must be set so the response-headers phase can create the a2aTaskExtractor.
+	mcpReq.serverName = mcpServerConfig.Name
+	span.SetAttributes(attribute.String("mcp.server", mcpServerConfig.Name))
+
+	headers := NewHeaders()
+	headers.WithAuthority(mcpServerConfig.Hostname)
+	headers.WithMCPServerName(mcpServerConfig.Name)
+	headers.WithMCPMethod(mcpReq.Method)
+
+	path, err := mcpServerConfig.Path()
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "failed to parse url for a2a backend", "error", err)
+		span.RecordError(err)
+		response.WithImmediateResponse(500, "internal error")
+		return response.Build()
+	}
+	headers.WithPath(path)
+
+	if exists, cacheErr := s.SessionCache.GetSession(ctx, mcpReq.GetSessionID()); cacheErr == nil {
+		if id, ok := exists[mcpServerConfig.Name]; ok {
+			headers.WithMCPSession(id)
+		}
+	}
+
+	body, err := mcpReq.ToBytes()
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "failed to marshal a2a request body", "error", err)
+		response.WithImmediateResponse(500, "internal error")
+		return response.Build()
+	}
+	headers.WithContentLength(len(body))
+	response.WithRequestBodyHeadersAndBodyReponse(headers.Build(), body)
+	return response.Build()
+}
+
+// HandleA2ATaskOperation routes tasks/get, tasks/cancel, and tasks/resubscribe to the
+// backend A2A agent that owns the task, looked up via the session cache task-route index.
+func (s *ExtProcServer) HandleA2ATaskOperation(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
+	ctx, span := tracer().Start(ctx, "mcp-router.a2a-task-op",
+		trace.WithAttributes(
+			attribute.String("mcp.method.name", mcpReq.Method),
+			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+		),
+	)
+	defer span.End()
+
+	response := NewResponse()
+	taskID := mcpReq.a2aTaskID()
+	if taskID == "" {
+		s.Logger.ErrorContext(ctx, "missing task id in A2A task operation", "method", mcpReq.Method)
+		span.SetStatus(codes.Error, "missing task id")
+		response.WithImmediateResponse(400, "missing task id")
+		return response.Build()
+	}
+	span.SetAttributes(attribute.String("a2a.task.id", taskID))
+
+	serverName, err := s.SessionCache.ResolveTaskRoute(ctx, taskID)
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "task route not found", "taskID", taskID, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "task not found")
+		response.WithImmediateResponse(404, "task not found")
+		return response.Build()
+	}
+	span.SetAttributes(attribute.String("mcp.server", serverName))
+
+	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(serverName)
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "server not found for a2a task", "server", serverName, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "server not found")
+		response.WithImmediateResponse(500, "internal error")
+		return response.Build()
+	}
+
+	headers := NewHeaders()
+	headers.WithAuthority(mcpServerConfig.Hostname)
+	headers.WithMCPServerName(mcpServerConfig.Name)
+	headers.WithMCPMethod(mcpReq.Method)
+
+	path, err := mcpServerConfig.Path()
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "failed to parse url for a2a task backend", "error", err)
+		response.WithImmediateResponse(500, "internal error")
+		return response.Build()
+	}
+	headers.WithPath(path)
+
+	if exists, cacheErr := s.SessionCache.GetSession(ctx, mcpReq.GetSessionID()); cacheErr == nil {
+		if id, ok := exists[mcpServerConfig.Name]; ok {
+			headers.WithMCPSession(id)
+		}
+	}
+
+	body, err := mcpReq.ToBytes()
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "failed to marshal a2a task op body", "error", err)
+		response.WithImmediateResponse(500, "internal error")
+		return response.Build()
+	}
+	headers.WithContentLength(len(body))
+	response.WithRequestBodyHeadersAndBodyReponse(headers.Build(), body)
+	return response.Build()
 }
 
 // HandleNoneToolCall handles none tools calls such as initialize. The majority of these requests will be forwarded to the broker

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -47,10 +47,10 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 
 	responses := response.WithResponseHeaderResponse(responseHeaderBuilder.Build()).Build()
 
-	// for tool calls where the client supports elicitation, switch response body
-	// mode to STREAMED so the ext_proc receives each SSE chunk and can rewrite
-	// elicitation request IDs.
-	if req != nil && req.isToolCall() && req.clientElicitation && len(responses) > 0 {
+	// switch response body to STREAMED for tool calls with elicitation (ID rewrite)
+	// and for A2A streaming methods (task ID extraction).
+	if req != nil && len(responses) > 0 &&
+		((req.isToolCall() && req.clientElicitation) || req.isA2AStreamingMethod()) {
 		responses[0].ModeOverride = &extprochttp.ProcessingMode{
 			RequestHeaderMode:   extprochttp.ProcessingMode_SEND,
 			ResponseHeaderMode:  extprochttp.ProcessingMode_SEND,

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -28,6 +28,10 @@ type SessionCache interface {
 	KeyExists(ctx context.Context, key string) (bool, error)
 	SetClientElicitation(ctx context.Context, gatewaySessionID string) error
 	GetClientElicitation(ctx context.Context, gatewaySessionID string) (bool, error)
+	// StoreTaskRoute records which backend server owns the given A2A task ID.
+	StoreTaskRoute(ctx context.Context, taskID, serverName string) error
+	// ResolveTaskRoute returns the backend server name for the given A2A task ID.
+	ResolveTaskRoute(ctx context.Context, taskID string) (string, error)
 }
 
 // InitForClient defines a function for initializing an MCP server for a client
@@ -59,7 +63,8 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 		endOfStream         = false
 		mcpRequest          *MCPRequest
 		ctx                 = stream.Context()
-		rewriter            *sseRewriter // nil until a tool call response arrives
+		rewriter            *sseRewriter      // nil until a tool call response arrives
+		a2aExtractor        *a2aTaskExtractor // nil until an A2A streaming response arrives
 		bodyBuffer          []byte
 	)
 	span := trace.SpanFromContext(ctx)
@@ -259,6 +264,14 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 				}
 			}
 
+			if mcpRequest != nil && mcpRequest.isA2AStreamingMethod() && mcpRequest.serverName != "" {
+				a2aExtractor = &a2aTaskExtractor{
+					logger:     s.Logger,
+					serverName: mcpRequest.serverName,
+					cache:      s.SessionCache,
+				}
+			}
+
 			responses, _ := s.HandleResponseHeaders(ctx, r.ResponseHeaders, localRequestHeaders, mcpRequest)
 			for _, response := range responses {
 				s.Logger.DebugContext(ctx, "sending response header processing instructions to envoy", "response", response)
@@ -268,10 +281,10 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 					return err
 				}
 			}
-			if rewriter != nil {
-				continue // tool call: response body is streamed
+			if rewriter != nil || a2aExtractor != nil {
+				continue // response body is streamed: keep goroutine alive
 			}
-			return nil // non-tool-call: response body is not streamed
+			return nil // non-streaming: response body is not intercepted
 		case *extProcV3.ProcessingRequest_ResponseBody:
 			body := r.ResponseBody.GetBody()
 			endOfStream := r.ResponseBody.GetEndOfStream()
@@ -283,7 +296,11 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 					remaining := rewriter.Flush(ctx)
 					body = append(body, remaining...)
 				}
-
+			} else if a2aExtractor != nil {
+				a2aExtractor.Process(ctx, body) // extracts task ID; body passes through unchanged
+				if endOfStream {
+					a2aExtractor.Flush(ctx)
+				}
 			}
 
 			response := &extProcV3.ProcessingResponse{

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -3,12 +3,16 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	redis "github.com/redis/go-redis/v9"
 )
 
-const clientElicitationPrefix = "clientelicitation:"
+const (
+	clientElicitationPrefix = "clientelicitation:"
+	taskRoutePrefix         = "taskroute:"
+)
 
 // Cache implements a cache
 type Cache struct {
@@ -118,6 +122,33 @@ func (c *Cache) GetClientElicitation(ctx context.Context, gatewaySessionID strin
 		return false, err
 	}
 	return val == "1", nil
+}
+
+// StoreTaskRoute records which backend server owns a given A2A task ID.
+func (c *Cache) StoreTaskRoute(ctx context.Context, taskID, serverName string) error {
+	key := taskRoutePrefix + taskID
+	if c.inmemory != nil {
+		c.inmemory.Store(key, serverName)
+		return nil
+	}
+	return c.extClient.Set(ctx, key, serverName, 0).Err()
+}
+
+// ResolveTaskRoute returns the backend server name that owns the given A2A task ID.
+func (c *Cache) ResolveTaskRoute(ctx context.Context, taskID string) (string, error) {
+	key := taskRoutePrefix + taskID
+	if c.inmemory != nil {
+		val, ok := c.inmemory.Load(key)
+		if !ok {
+			return "", fmt.Errorf("task route not found: %s", taskID)
+		}
+		return val.(string), nil
+	}
+	val, err := c.extClient.Get(ctx, key).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", fmt.Errorf("task route not found: %s", taskID)
+	}
+	return val, err
 }
 
 // NewCache returns a new cache. Pass WithRedisClient to use an external redis

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -289,3 +289,34 @@ func TestInMemoryCache_DeleteSessionsCleansUpElicitation(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, sessions)
 }
+
+func TestInMemoryCache_StoreAndResolveTaskRoute(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	taskID := "task-abc-123"
+	serverName := "weather-agent"
+
+	// missing returns error
+	_, err = cache.ResolveTaskRoute(ctx, taskID)
+	require.Error(t, err)
+
+	// store and resolve
+	require.NoError(t, cache.StoreTaskRoute(ctx, taskID, serverName))
+	got, err := cache.ResolveTaskRoute(ctx, taskID)
+	require.NoError(t, err)
+	require.Equal(t, serverName, got)
+}
+
+func TestInMemoryCache_TaskRouteIsolatedFromSession(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	// storing a task route must not pollute the session namespace
+	require.NoError(t, cache.StoreTaskRoute(ctx, "task-1", "agent-a"))
+	sessions, err := cache.GetSession(ctx, "task-1")
+	require.NoError(t, err)
+	require.Empty(t, sessions)
+}


### PR DESCRIPTION
**Description:**

Right now any JSON-RPC method that isn't tools/call falls through to the broker, which just returns -32601. That's fine for MCP, but it completely blocks A2A; there's no way to route message/stream to the right backend agent, and more critically no way to get tasks/get or tasks/cancel back to whoever owns that task.                                                                                                                                                             
   
  This adds the plumbing needed to make that work:                                                                                                                                                                                               
                                                            
  - Session cache gets a taskID -> serverName index (StoreTaskRoute / ResolveTaskRoute). Kept separate from the existing session hash so nothing existing breaks.                                                                                 
  - Router gets two new dispatch cases before the broker fallthrough: one for message/send / message/stream (routes by x-a2a-agent header), one for tasks/get / tasks/cancel / tasks/resubscribe (routes by task ID lookup).
  - a2aTaskExtractor hooks into the SSE response body of message/stream to grab the task ID from the first result event and populate the cache. Same pattern as the existing elicitation rewriter. Also handles plain-JSON message/send responses
   via Flush() at end-of-stream.                                                                                                                                                                                                                 
  - ModeOverride in HandleResponseHeaders extended to cover A2A streaming methods so the ext_proc goroutine actually stays alive long enough to read the response body. 
  
No existing MCP behaviour is touched. Tests cover the extractor (SSE, plain JSON, multi-chunk split, flush), the cache index, and the new MCPRequest helpers.