### PR TITLE
broker: surface viper errors and document inotify requirement

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -239,6 +239,9 @@ func main() {
 	mutex.Unlock()
 	mcpConfig.Notify(ctx)
 
+	// wire viper's logger so fsnotify errors (e.g. EMFILE from Kind's inotify
+	// limit) surface instead of being dropped before WatchConfig's os.Exit(1).
+	viper.SetOptions(viper.WithLogger(logger))
 	viper.WatchConfig()
 	// set up our change event handler
 	viper.OnConfigChange(func(in fsnotify.Event) {

--- a/docs/guides/kind-cluster-setup.md
+++ b/docs/guides/kind-cluster-setup.md
@@ -9,7 +9,13 @@ This guide walks through setting up a local Kind cluster with the essential prer
 - [Helm](https://helm.sh/docs/intro/install/) installed
 - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) installed
 
-> **Note:** On Linux hosts the broker uses fsnotify, which consumes inotify instances. Kind defaults to `fs.inotify.max_user_instances=128`, and Kubernetes system components consume most of those slots, which can cause the broker pod to exit on startup with `EMFILE` ("too many open files"). After creating the cluster, raise the limit on the Kind node: `docker exec <kind-node-name> sysctl fs.inotify.max_user_instances=1024`. See [Troubleshooting: Broker Crashes on Startup](./troubleshooting.md#broker-crashes-on-startup-with-exit-code-1-inotify-limit-on-kind) for details.
+> **Note:** On Linux hosts the broker uses fsnotify, which consumes inotify instances. Kind defaults to `fs.inotify.max_user_instances=128`, and Kubernetes system components consume most of those slots, which can cause the broker pod to exit on startup with `EMFILE` ("too many open files"). After creating the cluster, raise the limit on the Kind node:
+>
+> ```shell
+> <container-runtime> exec <kind-node-name> sysctl fs.inotify.max_user_instances=1024
+> ```
+>
+> See [Troubleshooting: Broker Crashes on Startup](./troubleshooting.md#broker-crashes-on-startup-with-exit-code-1-inotify-limit-on-kind) for details.
 
 ## Step 1: Create Kind Cluster
 

--- a/docs/guides/kind-cluster-setup.md
+++ b/docs/guides/kind-cluster-setup.md
@@ -9,6 +9,8 @@ This guide walks through setting up a local Kind cluster with the essential prer
 - [Helm](https://helm.sh/docs/intro/install/) installed
 - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) installed
 
+> **Note:** On Linux hosts the broker uses fsnotify, which consumes inotify instances. Kind defaults to `fs.inotify.max_user_instances=128`, and Kubernetes system components consume most of those slots, which can cause the broker pod to exit on startup with `EMFILE` ("too many open files"). After creating the cluster, raise the limit on the Kind node: `docker exec <kind-node-name> sysctl fs.inotify.max_user_instances=1024`. See [Troubleshooting: Broker Crashes on Startup](./troubleshooting.md#broker-crashes-on-startup-with-exit-code-1-inotify-limit-on-kind) for details.
+
 ## Step 1: Create Kind Cluster
 
 ```bash

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -67,7 +67,7 @@ kubectl logs -n mcp-system <pod-name>
 
 **Symptom**: The `mcp-gateway` broker pod is in `CrashLoopBackOff`. Logs end after a single line and there is no error message:
 
-```
+```text
 time=... level=INFO msg="jwt session manager configured"
 ```
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -63,6 +63,33 @@ kubectl logs -n mcp-system <pod-name>
 - **Pending**: Check resource availability and node capacity
 - **Init Container Failures**: Check RBAC permissions
 
+### Broker Crashes on Startup with Exit Code 1 (inotify limit on Kind)
+
+**Symptom**: The `mcp-gateway` broker pod is in `CrashLoopBackOff`. Logs end after a single line and there is no error message:
+
+```
+time=... level=INFO msg="jwt session manager configured"
+```
+
+The pod exits with code 1 and the next line of context is missing.
+
+**Cause**: On Linux hosts, every fsnotify watcher consumes one inotify instance. Kind clusters default to `fs.inotify.max_user_instances=128`, and Kubernetes system components (kubelet, containerd-shim, kube-apiserver, kube-controller, istiod, and so on) collectively consume most of those slots. When the broker calls viper's `WatchConfig`, `fsnotify.NewWatcher` can fail with `EMFILE` ("too many open files") and viper exits the process. As of #790 the broker wires viper's logger to its own slog logger so the underlying error becomes visible in the pod logs, but the underlying limit still needs to be raised.
+
+**Fix**: Raise the inotify instance limit on the Kind node:
+
+```bash
+docker exec <kind-node-name> sysctl fs.inotify.max_user_instances=1024
+kubectl delete pods -n mcp-system -l app.kubernetes.io/name=mcp-gateway
+```
+
+For the standard local-env-setup, the node name is usually `kuadrant-local-control-plane`:
+
+```bash
+docker exec kuadrant-local-control-plane sysctl fs.inotify.max_user_instances=1024
+```
+
+To make the change persist across host reboots, set it in the Kind cluster config or the host's sysctl configuration. See the [Kind cluster setup guide](./kind-cluster-setup.md) for the prerequisite section.
+
 ## Gateway Routing Issues
 
 ### Gateway Listener Not Working

--- a/project-words.txt
+++ b/project-words.txt
@@ -72,6 +72,7 @@ Elicitations
 elif
 emceepea
 emicklei
+EMFILE
 EMKAB
 endpointslices
 envoyfilter
@@ -150,6 +151,7 @@ infobip
 ingester
 ingressgateway
 inmemory
+inotify
 installplan
 integration
 intialise
@@ -348,6 +350,7 @@ SPIFFE
 SQAY
 Srbu
 sslip
+startswith
 statefulness
 stdr
 streamable
@@ -378,6 +381,7 @@ typev
 uninimically
 unmarshal
 Unmarshal
+unmarshals
 unmarshalling
 Unregistration
 upserted


### PR DESCRIPTION
Fixes #790

Configures viper's internal logger so the underlying `fsnotify.NewWatcher` failure (e.g. EMFILE when the host's inotify-instance limit is exhausted on Kind) is visible in pod logs instead of being dropped silently before viper calls `os.Exit(1)`.

Also adds a troubleshooting section describing the symptom and the `docker exec sysctl` fix, plus a prerequisites note in the Kind cluster setup guide so users raise the limit before deploying.

Note: the cspell CI failure is pre-existing and unrelated to this PR — it originates from `docs/design/prompts-federation.md` which was merged upstream before this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility when configuration watching encounters failures.

* **Documentation**
  * Added setup guidance for Kind clusters regarding file watcher resource limits.
  * Added troubleshooting section for broker pod startup issues in Kind environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->