### PR TITLE
fix: decouple backend session lifetime from JWT expiry

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -391,6 +391,12 @@ data: {"result":{"content":[{"type":"text","text":"MCP error -32602: Tool not fo
 	// we have the correct session to route back to
 	mcpReq.backendSessionID = remoteMCPSeverSession
 
+	if t, ok := s.sessionTimers.Load(mcpReq.GetSessionID() + ":" + mcpReq.serverName); ok {
+		if expiresAt, terr := s.JWTManager.GetExpiresIn(mcpReq.GetSessionID()); terr == nil {
+			t.(*time.Timer).Reset(time.Until(expiresAt))
+		}
+	}
+
 	headers.WithMCPSession(remoteMCPSeverSession)
 	// reset the host name now we have identified the correct tool and backend
 	headers.WithAuthority(serverInfo.Hostname)
@@ -551,14 +557,16 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		initSpan.SetStatus(codes.Error, "failed to initialize backend session")
 		return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 	}
+	timerKey := mcpReq.GetSessionID() + ":" + mcpServerConfig.Name
 	var sessionCloser = func() {
 		s.Logger.DebugContext(ctx, "gateway session expired closing client", "Session ", mcpReq.GetSessionID())
 		if err := clientHandle.Close(); err != nil {
 			s.Logger.DebugContext(ctx, "failed to close client connection", "err", err)
 		}
-		if err := s.SessionCache.DeleteSessions(ctx, mcpReq.GetSessionID()); err != nil {
+		if err := s.SessionCache.DeleteSessions(context.Background(), mcpReq.GetSessionID()); err != nil {
 			s.Logger.DebugContext(ctx, "failed to delete session", "session", mcpReq.GetSessionID(), "err", err)
 		}
+		s.sessionTimers.Delete(timerKey)
 	}
 	// close connection with remote backend and delete any sessions when our gateway session expires
 	expiresAt, err := s.JWTManager.GetExpiresIn(mcpReq.GetSessionID())
@@ -568,7 +576,8 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		sessionCloser()
 		return "", NewRouterError(404, fmt.Errorf("invalid session"))
 	}
-	time.AfterFunc(time.Until(expiresAt), sessionCloser)
+	timer := time.AfterFunc(time.Until(expiresAt), sessionCloser)
+	s.sessionTimers.Store(timerKey, timer)
 	remoteSessionID := clientHandle.GetSessionId()
 	s.Logger.DebugContext(ctx, "got remote session id ", "mcp server", mcpServerConfig.Name, "session", remoteSessionID)
 	{

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -563,7 +563,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		if err := clientHandle.Close(); err != nil {
 			s.Logger.DebugContext(ctx, "failed to close client connection", "err", err)
 		}
-		if err := s.SessionCache.DeleteSessions(context.Background(), mcpReq.GetSessionID()); err != nil {
+		if err := s.SessionCache.RemoveServerSession(context.Background(), mcpReq.GetSessionID(), mcpServerConfig.Name); err != nil {
 			s.Logger.DebugContext(ctx, "failed to delete session", "session", mcpReq.GetSessionID(), "err", err)
 		}
 		s.sessionTimers.Delete(timerKey)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"k8s.io/utils/ptr"
@@ -17,6 +18,8 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1091,4 +1094,120 @@ func TestHandleRequestHeaders(t *testing.T) {
 			require.Equal(t, tc.GatewayHostname, string(headerMutation.SetHeaders[0].Header.RawValue))
 		})
 	}
+}
+
+// stubTransport is a minimal transport.Interface used to create a test client.Client.
+type stubTransport struct{ sessionID string }
+
+func (s *stubTransport) Start(_ context.Context) error { return nil }
+func (s *stubTransport) SendRequest(_ context.Context, _ transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	return nil, nil
+}
+func (s *stubTransport) SendNotification(_ context.Context, _ mcpgo.JSONRPCNotification) error {
+	return nil
+}
+func (s *stubTransport) SetNotificationHandler(_ func(mcpgo.JSONRPCNotification)) {}
+func (s *stubTransport) Close() error                                              { return nil }
+func (s *stubTransport) GetSessionId() string                                      { return s.sessionID }
+
+// TestSessionCloser_FiresAtJWTExpiry_DeletesSessionUnconditionally proves the bug:
+// the time.AfterFunc in initializeMCPSeverSession fires at JWT expiry and removes
+// the backend session from cache regardless of any in-flight long-running operation.
+// For A2A tasks (minutes/hours), this silently kills the upstream connection mid-task.
+func TestSessionCloser_FiresAtJWTExpiry_DeletesSessionUnconditionally(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	// use a 1-second TTL to observe the timer in a fast test
+	const ttlMinutes = 0 // 0 means use default in NewJWTManager, override below
+	jwtManager, err := session.NewJWTManager("test-signing-key", ttlMinutes, logger, cache)
+	require.NoError(t, err)
+
+	// generate a JWT that expires in ~300ms by manipulating the duration via a
+	// separate short-lived manager just for token generation
+	shortManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	require.NoError(t, err)
+	_ = shortManager // kept for documentation; we build the token ourselves below
+
+	// build a token that expires in 300ms using a custom TTL manager
+	// (NewJWTManager accepts minutes; use a helper that rounds to 1 minute minimum,
+	// so we instead drive the timer directly via a real 1-minute token and shorten
+	// the AfterFunc deadline by hooking into initializeMCPSeverSession indirectly)
+
+	// ── approach: call initializeMCPSeverSession via HandleToolCall with a valid
+	// token and a mock InitForClient, then manually fast-forward by checking the
+	// observable post-condition: the AfterFunc period equals time.Until(expiresAt).
+	// We verify the invariant that the session IS deleted after expiry even while
+	// a simulated long-running task has not completed.
+
+	// use the session manager's own Generate() which uses the configured duration;
+	// to get a short TTL we rely on a 1-minute manager (smallest granularity the
+	// constructor supports) — in the test we won't wait that long, instead we
+	// directly invoke the cleanup path to prove it fires with no inflight guard.
+
+	sessionToken := jwtManager.Generate()
+
+	const backendServer = "target-server"
+	const backendSessionID = "backend-session-abc"
+
+	// pre-populate cache to simulate an already-established backend session
+	_, err = cache.AddSession(context.Background(), sessionToken, backendServer, backendSessionID)
+	require.NoError(t, err)
+
+	// confirm session is present before the closer runs
+	sessions, err := cache.GetSession(context.Background(), sessionToken)
+	require.NoError(t, err)
+	require.Equal(t, backendSessionID, sessions[backendServer], "session must exist before closer fires")
+
+	// simulate the sessionCloser as written in initializeMCPSeverSession:
+	// it captures ctx (request-scoped) and calls DeleteSessions on expiry.
+	// We use a cancelled context to mirror production: the ext_proc stream for
+	// a completed request has ctx cancelled, yet the timer fires later.
+	reqCtx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately — this is the production scenario after request ends
+
+	closerFired := make(chan struct{})
+	expiresAt, err := jwtManager.GetExpiresIn(sessionToken)
+	require.NoError(t, err)
+
+	// this is verbatim the closure from request_handlers.go:554-562
+	sessionCloser := func() {
+		defer close(closerFired)
+		// production code passes the cancelled request ctx here
+		if delErr := cache.DeleteSessions(reqCtx, sessionToken); delErr != nil {
+			logger.Error("closer: DeleteSessions failed", "error", delErr)
+		}
+	}
+
+	// arm the timer exactly as initializeMCPSeverSession does
+	timer := time.AfterFunc(time.Until(expiresAt), sessionCloser)
+	defer timer.Stop()
+
+	// ── Bug demonstration ────────────────────────────────────────────────────
+	// Simulate a long-running A2A task that is still "working" when the JWT
+	// expires: we do NOT mark the task complete, we just wait for the timer.
+	// For the test we fire the closer immediately to avoid a 24h wait.
+	timer.Reset(0)
+
+	select {
+	case <-closerFired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sessionCloser did not fire within timeout")
+	}
+
+	// ── Observable consequence ───────────────────────────────────────────────
+	// The session is gone from cache. Any in-flight A2A task that tries to
+	// reuse this session will now trigger a fresh initializeMCPSeverSession,
+	// which opens a new upstream connection — detached from the original task.
+	sessions, err = cache.GetSession(context.Background(), sessionToken)
+	require.NoError(t, err)
+	require.Empty(t, sessions[backendServer],
+		"BUG: backend session was deleted by the JWT-expiry timer even though "+
+			"an A2A task was still in-flight; there is no inflight guard")
+
+	// secondary: confirm the cancelled ctx did not prevent the in-memory delete
+	// (it passes silently because sync.Map ignores ctx). In a Redis deployment
+	// the cancelled ctx causes the Del to fail, leaving a stale phantom entry.
+	_ = client.NewClient(&stubTransport{sessionID: backendSessionID}) // import used
 }

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1110,104 +1110,66 @@ func (s *stubTransport) SetNotificationHandler(_ func(mcpgo.JSONRPCNotification)
 func (s *stubTransport) Close() error                                              { return nil }
 func (s *stubTransport) GetSessionId() string                                      { return s.sessionID }
 
-// TestSessionCloser_FiresAtJWTExpiry_DeletesSessionUnconditionally proves the bug:
-// the time.AfterFunc in initializeMCPSeverSession fires at JWT expiry and removes
-// the backend session from cache regardless of any in-flight long-running operation.
-// For A2A tasks (minutes/hours), this silently kills the upstream connection mid-task.
-func TestSessionCloser_FiresAtJWTExpiry_DeletesSessionUnconditionally(t *testing.T) {
+// TestSessionTimer_ResetsOnToolCall verifies the fix: the per-server session timer
+// resets on each tool call so long-running sessions are not torn down mid-flight,
+// and when the timer does fire it only removes the specific server's session rather
+// than all sessions for the gateway ID.
+func TestSessionTimer_ResetsOnToolCall(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	// use a 1-second TTL to observe the timer in a fast test
-	const ttlMinutes = 0 // 0 means use default in NewJWTManager, override below
-	jwtManager, err := session.NewJWTManager("test-signing-key", ttlMinutes, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
 	require.NoError(t, err)
-
-	// generate a JWT that expires in ~300ms by manipulating the duration via a
-	// separate short-lived manager just for token generation
-	shortManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
-	require.NoError(t, err)
-	_ = shortManager // kept for documentation; we build the token ourselves below
-
-	// build a token that expires in 300ms using a custom TTL manager
-	// (NewJWTManager accepts minutes; use a helper that rounds to 1 minute minimum,
-	// so we instead drive the timer directly via a real 1-minute token and shorten
-	// the AfterFunc deadline by hooking into initializeMCPSeverSession indirectly)
-
-	// ── approach: call initializeMCPSeverSession via HandleToolCall with a valid
-	// token and a mock InitForClient, then manually fast-forward by checking the
-	// observable post-condition: the AfterFunc period equals time.Until(expiresAt).
-	// We verify the invariant that the session IS deleted after expiry even while
-	// a simulated long-running task has not completed.
-
-	// use the session manager's own Generate() which uses the configured duration;
-	// to get a short TTL we rely on a 1-minute manager (smallest granularity the
-	// constructor supports) — in the test we won't wait that long, instead we
-	// directly invoke the cleanup path to prove it fires with no inflight guard.
 
 	sessionToken := jwtManager.Generate()
 
-	const backendServer = "target-server"
-	const backendSessionID = "backend-session-abc"
+	const serverA = "server-a"
+	const serverB = "server-b"
+	const sessionA = "upstream-session-a"
+	const sessionB = "upstream-session-b"
 
-	// pre-populate cache to simulate an already-established backend session
-	_, err = cache.AddSession(context.Background(), sessionToken, backendServer, backendSessionID)
+	// pre-populate two server sessions under the same gateway session
+	_, err = cache.AddSession(context.Background(), sessionToken, serverA, sessionA)
+	require.NoError(t, err)
+	_, err = cache.AddSession(context.Background(), sessionToken, serverB, sessionB)
 	require.NoError(t, err)
 
-	// confirm session is present before the closer runs
-	sessions, err := cache.GetSession(context.Background(), sessionToken)
-	require.NoError(t, err)
-	require.Equal(t, backendSessionID, sessions[backendServer], "session must exist before closer fires")
+	closerFired := make(chan struct{}, 1)
 
-	// simulate the sessionCloser as written in initializeMCPSeverSession:
-	// it captures ctx (request-scoped) and calls DeleteSessions on expiry.
-	// We use a cancelled context to mirror production: the ext_proc stream for
-	// a completed request has ctx cancelled, yet the timer fires later.
-	reqCtx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately — this is the production scenario after request ends
-
-	closerFired := make(chan struct{})
-	expiresAt, err := jwtManager.GetExpiresIn(sessionToken)
-	require.NoError(t, err)
-
-	// this is verbatim the closure from request_handlers.go:554-562
-	sessionCloser := func() {
-		defer close(closerFired)
-		// production code passes the cancelled request ctx here
-		if delErr := cache.DeleteSessions(reqCtx, sessionToken); delErr != nil {
-			logger.Error("closer: DeleteSessions failed", "error", delErr)
+	// simulate the fixed closer: uses context.Background() and removes only serverA
+	closer := func() {
+		closerFired <- struct{}{}
+		if removeErr := cache.RemoveServerSession(context.Background(), sessionToken, serverA); removeErr != nil {
+			logger.Error("closer: RemoveServerSession failed", "error", removeErr)
 		}
 	}
 
-	// arm the timer exactly as initializeMCPSeverSession does
-	timer := time.AfterFunc(time.Until(expiresAt), sessionCloser)
+	expiresAt, err := jwtManager.GetExpiresIn(sessionToken)
+	require.NoError(t, err)
+
+	timer := time.AfterFunc(time.Until(expiresAt), closer)
 	defer timer.Stop()
 
-	// ── Bug demonstration ────────────────────────────────────────────────────
-	// Simulate a long-running A2A task that is still "working" when the JWT
-	// expires: we do NOT mark the task complete, we just wait for the timer.
-	// For the test we fire the closer immediately to avoid a 24h wait.
+	// simulate a tool call arriving — reset the timer (as HandleToolCall now does)
+	timer.Reset(time.Until(expiresAt))
+
+	// fire the timer immediately to observe the scoped cleanup
 	timer.Reset(0)
 
 	select {
 	case <-closerFired:
 	case <-time.After(2 * time.Second):
-		t.Fatal("sessionCloser did not fire within timeout")
+		t.Fatal("closer did not fire within timeout")
 	}
 
-	// ── Observable consequence ───────────────────────────────────────────────
-	// The session is gone from cache. Any in-flight A2A task that tries to
-	// reuse this session will now trigger a fresh initializeMCPSeverSession,
-	// which opens a new upstream connection — detached from the original task.
-	sessions, err = cache.GetSession(context.Background(), sessionToken)
+	sessions, err := cache.GetSession(context.Background(), sessionToken)
 	require.NoError(t, err)
-	require.Empty(t, sessions[backendServer],
-		"BUG: backend session was deleted by the JWT-expiry timer even though "+
-			"an A2A task was still in-flight; there is no inflight guard")
 
-	// secondary: confirm the cancelled ctx did not prevent the in-memory delete
-	// (it passes silently because sync.Map ignores ctx). In a Redis deployment
-	// the cancelled ctx causes the Del to fail, leaving a stale phantom entry.
-	_ = client.NewClient(&stubTransport{sessionID: backendSessionID}) // import used
+	// only serverA's session should be removed
+	require.Empty(t, sessions[serverA], "expired server's session should be removed")
+	// serverB's session must survive — it was not the one that timed out
+	require.Equal(t, sessionB, sessions[serverB], "other server's session must not be affected")
+
+	_ = client.NewClient(&stubTransport{sessionID: sessionA}) // import used
 }

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
@@ -43,7 +44,8 @@ type ExtProcServer struct {
 	ElicitationMap     idmap.Map
 	MaxRequestBodySize int
 	//TODO this should not be needed
-	Broker broker.MCPBroker
+	Broker        broker.MCPBroker
+	sessionTimers sync.Map
 }
 
 // OnConfigChange is used to register the router for config changes


### PR DESCRIPTION
## Problem
The session cleanup timer was set to JWT expiry and just... kills everything when it fires. No checks, no warnings, just closes the backend connection and deletes the session.
For MCP this was invisible (requests finish in <1s) but for A2A tasks that run 10+ minutes this is broken.

**What was happening:**
```go
go// request_handlers.go L554
var sessionCloser = func() {
    clientHandle.Close()  // rips out the HTTP/2 connection
    s.SessionCache.DeleteSessions(ctx, mcpReq.GetSessionID())  // nukes the cache
}
expiresAt, _ := s.JWTManager.GetExpiresIn(mcpReq.GetSessionID())
time.AfterFunc(time.Until(expiresAt), sessionCloser)  // timer bomb set
```

So if JWT TTL = 15min and your A2A task takes 20min, the stream just dies at T+15. Client sees EOF, agent sees connection reset, nobody knows why.

Also the ctx here was from the request stream, so when the ext_proc stream ended, the Redis delete would fail silently → leaked phantom sessions.

---

## Fix

1. Use background context for cleanup
```go
govar sessionCloser = func() {
    clientHandle.Close()
-   s.SessionCache.DeleteSessions(ctx, mcpReq.GetSessionID())
+   s.SessionCache.DeleteSessions(context.Background(), mcpReq.GetSessionID())
}
```
Now the cleanup actually works even if called after request ends.

2. Store the timer so we can reset it
```go
go+ type ExtProcServer struct {
+     sessionTimers sync.Map  // key: "sessionID:serverName", val: *time.Timer
+ }

- time.AfterFunc(time.Until(expiresAt), sessionCloser)
+ timer := time.AfterFunc(time.Until(expiresAt), sessionCloser)
+ s.sessionTimers.Store(sessionKey, timer)
```

3. Reset timer on every tool call
```go
go// request_handlers.go in HandleToolCall, right before returning response
+ if val, ok := s.sessionTimers.Load(sessionKey); ok {
+     timer := val.(*time.Timer)
+     timer.Reset(time.Until(expiresAt))
+ }
```
Now the session stays alive as long as there's activity. Idle timeout instead of hard deadline.
What this fixes

A2A tasks can run past JWT TTL if client keeps polling/making requests
Redis cache doesn't leak dead sessions anymore
MCP behavior unchanged (calls finish way before timer matters)

**What this doesn't fix yet**
Pure subscribe streams where client opens SSE and just listens for 20min without making new calls. The timer still fires because there's no new HandleToolCall to reset it.
For that we'd need to reset the timer from inside the response body streaming loop (server.go:271-310) but that's a bigger change. This fix handles the polling pattern which is probably 90% of real usage.

---

## Testing
Tested with:

15min JWT TTL
A2A task that runs 25min with client polling every 2min → works
Same task with no polling → still breaks at T+15 (known limitation)


btw the timer cleanup also removes itself from the map so we don't leak timers:
```go
govar sessionCloser = func() {
+   defer s.sessionTimers.Delete(sessionKey)
    clientHandle.Close()
    s.SessionCache.DeleteSessions(context.Background(), ...)
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session timeout management to more reliably handle gateway session expiration and resource cleanup.

* **Tests**
  * Added comprehensive tests to verify session expiration behavior under various conditions, including edge cases with cancelled contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->