### PR TITLE
docs: clarify Kuadrant namespace when installed via OLM

### DIFF
--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -54,6 +54,10 @@ make local-env-setup-olm
 
 This builds the bundle and catalog images locally, loads them into the Kind cluster, deploys the Kuadrant OLM catalog, and lets OLM resolve Kuadrant as a dependency automatically.
 
+> **Note:**
+> When using `make local-env-setup-olm`, Kuadrant is installed in the same namespace as MCP Gateway (e.g. `mcp-system`), rather than the default `kuadrant-system` namespace used by the Helm-based installation.  
+> This may be relevant when inspecting resources or debugging installation issues.
+
 ## Available Make Targets
 
 | Target | Description |

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -28,6 +28,10 @@ kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system=""
 
 If the command returns "no matching resources found", wait a few seconds and retry -- the CSV has not been created yet.
 
+> **Note:**
+> When installing MCP Gateway via OLM, Kuadrant is installed in the same namespace as MCP Gateway (e.g. `mcp-system`), rather than the default `kuadrant-system` namespace used by the Helm-based installation.  
+> This applies regardless of whether you are installing locally (e.g. via `make local-env-setup-olm`) or on a cluster.
+
 ## Next Steps
 
 Installing via OLM deploys the operator only. To deploy the MCP Gateway itself, create an `MCPGatewayExtension` resource. See [Manual Resource Creation](./isolated-gateway-deployment.md#manual-resource-creation) for details.
@@ -53,10 +57,6 @@ make local-env-setup-olm
 ```
 
 This builds the bundle and catalog images locally, loads them into the Kind cluster, deploys the Kuadrant OLM catalog, and lets OLM resolve Kuadrant as a dependency automatically.
-
-> **Note:**
-> When using `make local-env-setup-olm`, Kuadrant is installed in the same namespace as MCP Gateway (e.g. `mcp-system`), rather than the default `kuadrant-system` namespace used by the Helm-based installation.  
-> This may be relevant when inspecting resources or debugging installation issues.
 
 ## Available Make Targets
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -28,7 +28,7 @@ kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system=""
 
 If the command returns "no matching resources found", wait a few seconds and retry -- the CSV has not been created yet.
 
-> **Note:**
+> [!NOTE]
 > When installing MCP Gateway via OLM, Kuadrant is installed in the same namespace as MCP Gateway (e.g. `mcp-system`), rather than the default `kuadrant-system` namespace used by the Helm-based installation.  
 > This applies regardless of whether you are installing locally (e.g. via `make local-env-setup-olm`) or on a cluster.
 


### PR DESCRIPTION
Clarifies that when installing MCP Gateway via OLM (e.g. using `make local-env-setup-olm`), Kuadrant is installed in the same namespace as MCP Gateway (e.g. `mcp-system`), rather than the default `kuadrant-system` used in Helm-based installs.

This helps avoid confusion when users look for Kuadrant resources after installation.

fixes : #794 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation note: when MCP Gateway is installed via OLM, Kuadrant is deployed into MCP Gateway’s namespace (for example, mcp-system) rather than the Helm default kuadrant-system. This clarification applies to both local setups (e.g., Kind) and non-local cluster installations, helping avoid namespace-related confusion during installation and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->