### PR TITLE
lint: enable golangci-lint for e2e tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,12 +94,14 @@ linters:
           - revive
           - staticcheck
         text: "dot.imports|ST1001"
-      # gosec false-positives in e2e test code: self-signed Kind certs (G402),
-      # kubectl shell-outs with controlled inputs (G204), trusted int constants
-      # (G109/G115), and a test-only EC signing key (G101).
+      # gosec false-positives in e2e test code: G101 test-only EC signing
+      # key, G109/G115 trusted int conversions in builders, G204 kubectl
+      # shell-outs with controlled inputs, G402 self-signed Kind certs.
+      # Other gosec rules still apply.
       - path: 'tests/e2e/.*\.go$'
         linters:
           - gosec
+        text: "G(101|109|115|204|402):"
       # Suite-level context for the entire Ginkgo run is intentional.
       - path: 'tests/e2e/suite_test\.go$'
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,11 @@ version: 2
 run:
   timeout: 10m
   modules-download-mode: readonly
+  build-tags:
+    - e2e
   exclude-files:
     - "zz_generated.*\\.go$"
-    
+
 linters:
   enable:
     - errcheck
@@ -84,6 +86,24 @@ linters:
     - usetesting # reports uses of functions with replacement inside the testing package
     - wastedassign # finds wasted assignment statements
     # - whitespace # detects leading and trailing whitespace
+  exclusions:
+    rules:
+      # Ginkgo/Gomega dot-imports are idiomatic in BDD test code
+      - path: 'tests/e2e/.*\.go$'
+        linters:
+          - revive
+          - staticcheck
+        text: "dot.imports|ST1001"
+      # gosec false-positives in e2e test code: self-signed Kind certs (G402),
+      # kubectl shell-outs with controlled inputs (G204), trusted int constants
+      # (G109/G115), and a test-only EC signing key (G101).
+      - path: 'tests/e2e/.*\.go$'
+        linters:
+          - gosec
+      # Suite-level context for the entire Ginkgo run is intentional.
+      - path: 'tests/e2e/suite_test\.go$'
+        linters:
+          - fatcontext
 
 issues:
   max-issues-per-linter: 0

--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -42,7 +42,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 			Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
 
 			By("Waiting for gateway to roll out with trusted headers")
-			Expect(WaitForDeploymentReady(ctx, SystemNamespace, "mcp-gateway", 1)).To(Succeed())
+			Expect(WaitForDeploymentReady(ctx, SystemNamespace, "mcp-gateway")).To(Succeed())
 		}
 
 		By("Creating MCPServerRegistrations matching Keycloak client IDs")

--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -1,5 +1,6 @@
 //go:build e2e
 
+// Package e2e contains end-to-end tests that exercise the gateway against a running cluster.
 package e2e
 
 import (
@@ -25,7 +26,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 	var authResources []client.Object
 
 	BeforeAll(func() {
-		if !IsAuthPolicyConfigured() {
+		if !IsAuthPolicyConfigured(ctx) {
 			Skip("auth not configured - skipping AuthPolicy tests")
 		}
 
@@ -41,7 +42,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 			Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
 
 			By("Waiting for gateway to roll out with trusted headers")
-			Expect(WaitForDeploymentReady(SystemNamespace, "mcp-gateway", 1)).To(Succeed())
+			Expect(WaitForDeploymentReady(ctx, SystemNamespace, "mcp-gateway", 1)).To(Succeed())
 		}
 
 		By("Creating MCPServerRegistrations matching Keycloak client IDs")
@@ -72,7 +73,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 
 		By("Waiting for Authorino to start enforcing auth (polling for 401)")
 		Eventually(func(g Gomega) {
-			status, _, _, err := mcpRawPost(authGatewayURL, "", authInitBody(), nil)
+			status, _, _, err := mcpRawPost(ctx, authGatewayURL, "", authInitBody(), nil)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(status).To(Equal(http.StatusUnauthorized))
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
@@ -86,7 +87,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 
 	It("[Auth] should return 401 for unauthenticated requests", func() {
 		By("Sending an initialize request without Authorization header")
-		status, respBody, respHeaders, err := mcpRawPost(authGatewayURL, "", authInitBody(), nil)
+		status, respBody, respHeaders, err := mcpRawPost(ctx, authGatewayURL, "", authInitBody(), nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal(http.StatusUnauthorized))
 		Expect(respBody).To(ContainSubstring("Authentication required"))
@@ -97,24 +98,24 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		By("Sending an initialize request with an invalid bearer token")
 		headers := map[string]string{"Authorization": "Bearer not-a-real-jwt"}
 
-		status, _, _, err := mcpRawPost(authGatewayURL, "", authInitBody(), headers)
+		status, _, _, err := mcpRawPost(ctx, authGatewayURL, "", authInitBody(), headers)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal(http.StatusUnauthorized))
 	})
 
 	It("[Auth] should allow initialize and tools/list with valid JWT, filtered by user roles", func() {
 		By("Obtaining a token from Keycloak")
-		token, err := GetKeycloakUserToken("mcp", "mcp")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
 		Expect(err).NotTo(HaveOccurred())
 		headers := map[string]string{"Authorization": "Bearer " + token}
 
 		By("Sending initialize request")
-		sessionID, err := mcpInitialize(authGatewayURL, headers)
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sessionID).NotTo(BeEmpty())
 
 		By("Sending notifications/initialized")
-		Expect(mcpNotifyInitialized(authGatewayURL, sessionID, headers)).To(Succeed())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
 
 		By("Listing tools and checking role-based filtering")
 		// mcp user is in accounting group:
@@ -123,7 +124,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		var tools []string
 		Eventually(func(g Gomega) {
 			var listErr error
-			_, tools, listErr = mcpListTools(authGatewayURL, sessionID, headers)
+			_, tools, listErr = mcpListTools(ctx, authGatewayURL, sessionID, headers)
 			g.Expect(listErr).NotTo(HaveOccurred())
 			g.Expect(tools).NotTo(BeEmpty())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
@@ -136,16 +137,16 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 
 	It("[Auth] should allow authorised tool call", func() {
 		By("Obtaining a token and initialising a session")
-		token, err := GetKeycloakUserToken("mcp", "mcp")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
 		Expect(err).NotTo(HaveOccurred())
 		headers := map[string]string{"Authorization": "Bearer " + token}
 
-		sessionID, err := mcpInitialize(authGatewayURL, headers)
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mcpNotifyInitialized(authGatewayURL, sessionID, headers)).To(Succeed())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
 
 		By("Calling test1_greet which is in the accounting role")
-		status, content, err := mcpCallTool(authGatewayURL, sessionID, "test1_greet", map[string]any{"name": "e2e"}, headers)
+		status, content, err := mcpCallTool(ctx, authGatewayURL, sessionID, "test1_greet", map[string]any{"name": "e2e"}, headers)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal(http.StatusOK))
 		Expect(content).NotTo(BeEmpty())
@@ -153,16 +154,16 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 
 	It("[Auth] should reject unauthorised tool call", func() {
 		By("Obtaining a token and initialising a session")
-		token, err := GetKeycloakUserToken("mcp", "mcp")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
 		Expect(err).NotTo(HaveOccurred())
 		headers := map[string]string{"Authorization": "Bearer " + token}
 
-		sessionID, err := mcpInitialize(authGatewayURL, headers)
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mcpNotifyInitialized(authGatewayURL, sessionID, headers)).To(Succeed())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
 
 		By("Calling test1_time which is NOT in the accounting role")
-		status, _, callErr := mcpCallTool(authGatewayURL, sessionID, "test1_time", nil, headers)
+		status, _, callErr := mcpCallTool(ctx, authGatewayURL, sessionID, "test1_time", nil, headers)
 		Expect(callErr).To(HaveOccurred())
 		Expect(status).NotTo(Equal(http.StatusOK), "unauthorised tool call must not succeed")
 	})

--- a/tests/e2e/builders.go
+++ b/tests/e2e/builders.go
@@ -131,7 +131,7 @@ func (b *TestResourcesBuilder) WithBackendNamespace(namespace string) *TestResou
 	return b
 }
 
-// overrides the auto-generated registration name for external references (e.g. keycloak client IDs)
+// WithRegistrationName overrides the auto-generated registration name for external references (e.g. keycloak client IDs).
 func (b *TestResourcesBuilder) WithRegistrationName(name string) *TestResourcesBuilder {
 	b.registrationName = name
 	return b
@@ -188,7 +188,7 @@ func (b *TestResourcesBuilder) Build() *TestResourcesBuilder {
 func (b *TestResourcesBuilder) buildInternalResources(routeName string) {
 	backendRef := gatewayapiv1.BackendObjectReference{
 		Name: gatewayapiv1.ObjectName(b.serviceName),
-		Port: (*gatewayapiv1.PortNumber)(&b.port),
+		Port: &b.port,
 	}
 
 	// add namespace if cross-namespace backend reference
@@ -258,7 +258,7 @@ func (b *TestResourcesBuilder) buildExternalResources(routeName string) {
 	externalHost := b.serviceName
 	istioGroup := gatewayapiv1.Group("networking.istio.io")
 	hostnameKind := gatewayapiv1.Kind("Hostname")
-	portNum := gatewayapiv1.PortNumber(b.port)
+	portNum := b.port
 
 	b.serviceEntry = &istionetv1beta1.ServiceEntry{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tests/e2e/elicitation_test.go
+++ b/tests/e2e/elicitation_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Elicitation", func() {
 			elicitClient, err = NewMCPGatewayClientWithElicitation(ctx, gatewayURL, handler)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-		defer elicitClient.Close()
+		defer func() { _ = elicitClient.Close() }()
 
 		By("Verifying the trigger-elicitation-request tool is visible")
 		Eventually(func(g Gomega) {
@@ -124,7 +124,7 @@ var _ = Describe("Elicitation", func() {
 			elicitClient, err = NewMCPGatewayClientWithElicitation(ctx, gatewayURL, handler)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-		defer elicitClient.Close()
+		defer func() { _ = elicitClient.Close() }()
 
 		By("Verifying the trigger-elicitation-request tool is visible")
 		Eventually(func(g Gomega) {
@@ -164,7 +164,7 @@ var _ = Describe("Elicitation", func() {
 			standardClient, err = NewMCPGatewayClient(ctx, gatewayURL)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-		defer standardClient.Close()
+		defer func() { _ = standardClient.Close() }()
 
 		By("Verifying the trigger-elicitation-request tool is visible in tools/list")
 		toolFound := false

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -283,7 +283,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 				ext.Spec.SessionStore = nil
 				g.Expect(k8sClient.Update(ctx, ext)).To(Succeed())
 			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-			Expect(WaitForDeploymentReady(ctx, SystemNamespace, deploymentName, 1)).To(Succeed())
+			Expect(WaitForDeploymentReady(ctx, SystemNamespace, deploymentName)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, redisSecret)).To(Succeed())
 		})
 
@@ -601,7 +601,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 		By("Waiting for deployment to be ready")
 		Eventually(func(g Gomega) {
-			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
+			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, scaledMCPTestServer)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Ensuring the gateway has registered the server")
@@ -656,7 +656,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 		By("Waiting for deployment to be ready")
 		Eventually(func(g Gomega) {
-			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
+			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, scaledMCPTestServer)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Verifying tools are restored in tools/list")

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -31,7 +31,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 	BeforeEach(func() {
 		// we don't use defers for this so if a test fails ensure this server that gets scaled down and up is up and running
-		_ = ScaleDeployment(TestServerNameSpace, scaledMCPTestServer, 1)
+		_ = ScaleDeployment(ctx, TestServerNameSpace, scaledMCPTestServer, 1)
 
 		// Create MCP client for this test
 		Eventually(func(g Gomega) {
@@ -44,7 +44,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 	AfterEach(func() {
 		// Close MCP client
 		if mcpGatewayClient != nil {
-			mcpGatewayClient.Close()
+			_ = mcpGatewayClient.Close()
 			mcpGatewayClient = nil
 		}
 
@@ -283,7 +283,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 				ext.Spec.SessionStore = nil
 				g.Expect(k8sClient.Update(ctx, ext)).To(Succeed())
 			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-			Expect(WaitForDeploymentReady(SystemNamespace, deploymentName, 1)).To(Succeed())
+			Expect(WaitForDeploymentReady(ctx, SystemNamespace, deploymentName, 1)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, redisSecret)).To(Succeed())
 		})
 
@@ -300,7 +300,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		By("Ensuring the gateway has the tools")
 		WaitForToolsWithPrefix(ctx, mcpGatewayClient, registeredServer.Spec.ToolPrefix)
 
-		gen, err := GetDeploymentGeneration(SystemNamespace, deploymentName)
+		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, deploymentName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Enabling Redis session cache via sessionStore on MCPGatewayExtension")
@@ -312,24 +312,24 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 		By("Waiting for gateway rollout after enabling Redis")
-		Expect(WaitForDeploymentReplicas(SystemNamespace, deploymentName, 1, gen)).To(Succeed())
+		Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, deploymentName, 1, gen)).To(Succeed())
 
 		By("Initializing a raw HTTP session with the gateway")
 		var sessionID string
 		Eventually(func(g Gomega) {
 			var initErr error
-			sessionID, initErr = mcpInitialize(gatewayURL, nil)
+			sessionID, initErr = mcpInitialize(ctx, gatewayURL, nil)
 			g.Expect(initErr).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 		GinkgoWriter.Println("client session ID:", sessionID)
 
-		Expect(mcpNotifyInitialized(gatewayURL, sessionID, nil)).To(Succeed())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
 
 		By("Calling headers tool to establish a backend session")
 		toolName := fmt.Sprintf("%s%s", registeredServer.Spec.ToolPrefix, "headers")
 		var backendSessionID string
 		Eventually(func(g Gomega) {
-			_, content, callErr := mcpCallTool(gatewayURL, sessionID, toolName, nil, nil)
+			_, content, callErr := mcpCallTool(ctx, gatewayURL, sessionID, toolName, nil, nil)
 			g.Expect(callErr).NotTo(HaveOccurred())
 			backendSessionID = extractBackendSession(content)
 			g.Expect(backendSessionID).NotTo(BeEmpty(), "expected backend Mcp-Session-Id in tool response")
@@ -337,12 +337,12 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		GinkgoWriter.Println("backend session before restart:", backendSessionID)
 
 		By("Restarting the mcp-gateway deployment and waiting for rollout")
-		Expect(RestartDeploymentAndWait(SystemNamespace, deploymentName)).To(Succeed())
+		Expect(RestartDeploymentAndWait(ctx, SystemNamespace, deploymentName)).To(Succeed())
 
 		By("Calling headers tool with same session ID to verify Redis restored the backend session")
 		var restoredSessionID string
 		Eventually(func(g Gomega) {
-			_, content, callErr := mcpCallTool(gatewayURL, sessionID, toolName, nil, nil)
+			_, content, callErr := mcpCallTool(ctx, gatewayURL, sessionID, toolName, nil, nil)
 			g.Expect(callErr).NotTo(HaveOccurred())
 			restoredSessionID = extractBackendSession(content)
 			g.Expect(restoredSessionID).NotTo(BeEmpty(), "expected backend Mcp-Session-Id in tool response")
@@ -357,15 +357,15 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		By("Creating multiple clients concurrently")
 		client1, err := NewMCPGatewayClient(ctx, gatewayURL)
 		Expect(err).NotTo(HaveOccurred())
-		defer client1.Close()
+		defer func() { _ = client1.Close() }()
 
 		client2, err := NewMCPGatewayClient(ctx, gatewayURL)
 		Expect(err).NotTo(HaveOccurred())
-		defer client2.Close()
+		defer func() { _ = client2.Close() }()
 
 		client3, err := NewMCPGatewayClient(ctx, gatewayURL)
 		Expect(err).NotTo(HaveOccurred())
-		defer client3.Close()
+		defer func() { _ = client3.Close() }()
 
 		By("Verifying all clients have unique session IDs")
 		session1 := client1.GetSessionId()
@@ -385,7 +385,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 		reconnectedClient, err := NewMCPGatewayClient(ctx, gatewayURL)
 		Expect(err).NotTo(HaveOccurred())
-		defer reconnectedClient.Close()
+		defer func() { _ = reconnectedClient.Close() }()
 
 		newSession := reconnectedClient.GetSessionId()
 		Expect(newSession).NotTo(BeEmpty(), "reconnected client should have a session ID")
@@ -425,7 +425,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			"X-Mcp-Virtualserver": virtualServerHeader,
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer virtualServerClient.Close()
+		defer func() { _ = virtualServerClient.Close() }()
 
 		By("Verifying only the tools from MCPVirtualServer are returned")
 		Eventually(func(g Gomega) {
@@ -453,7 +453,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			client1Notification = true
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer client1.Close()
+		defer func() { _ = client1.Close() }()
 
 		client2Notification := false
 		client2, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
@@ -461,7 +461,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			client2Notification = true
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer client2.Close()
+		defer func() { _ = client2.Close() }()
 		Expect(mcpGatewayClient.sessionID).NotTo(BeEmpty())
 		Expect(client2.sessionID).NotTo(BeEmpty())
 		Expect(client1.sessionID).NotTo(Equal(client2.sessionID))
@@ -525,7 +525,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			}
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer client1.Close()
+		defer func() { _ = client1.Close() }()
 
 		client2Notification := false
 		client2, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
@@ -535,7 +535,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			}
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer client2.Close()
+		defer func() { _ = client2.Close() }()
 
 		By("Calling add_tool on the backend server to trigger notifications/tools/list_changed")
 		dynamicToolName := fmt.Sprintf("dynamic_tool_%s", UniqueName(""))
@@ -581,7 +581,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 	// consider moving to separate suite
 	It("[Full] should gracefully handle an MCP Server becoming unavailable", func() {
 		By("Scaling down the MCP server3 deployment to 0")
-		Expect(ScaleDeployment(TestServerNameSpace, scaledMCPTestServer, 0)).To(Succeed())
+		Expect(ScaleDeployment(ctx, TestServerNameSpace, scaledMCPTestServer, 0)).To(Succeed())
 
 		By("Registering an MCPServerRegistration pointing to server3")
 		registration := NewMCPServerResourcesWithDefaults("unavailable-test", k8sClient).
@@ -597,11 +597,11 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Scaling up the MCP server3 deployment to 1")
-		Expect(ScaleDeployment(TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
+		Expect(ScaleDeployment(ctx, TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
 
 		By("Waiting for deployment to be ready")
 		Eventually(func(g Gomega) {
-			g.Expect(WaitForDeploymentReady(TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
+			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Ensuring the gateway has registered the server")
@@ -626,10 +626,10 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			}
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer notifyClient.Close()
+		defer func() { _ = notifyClient.Close() }()
 
 		By("Scaling back down the MCP server3 deployment to 0")
-		Expect(ScaleDeployment(TestServerNameSpace, scaledMCPTestServer, 0)).To(Succeed())
+		Expect(ScaleDeployment(ctx, TestServerNameSpace, scaledMCPTestServer, 0)).To(Succeed())
 
 		By("Verifying tools are removed from tools/list within timeout")
 		Eventually(func(g Gomega) {
@@ -649,13 +649,14 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		_, err = mcpGatewayClient.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{Name: toolName},
 		})
+		Expect(err).To(HaveOccurred())
 
 		By("Scaling the MCP server deployment back up")
-		Expect(ScaleDeployment(TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
+		Expect(ScaleDeployment(ctx, TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
 
 		By("Waiting for deployment to be ready")
 		Eventually(func(g Gomega) {
-			g.Expect(WaitForDeploymentReady(TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
+			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, scaledMCPTestServer, 1)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Verifying tools are restored in tools/list")
@@ -675,7 +676,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 	})
 
 	It("[Happy] should filter tools based on x-mcp-authorized JWT header", func() {
-		if !IsTrustedHeadersEnabled() {
+		if !IsTrustedHeadersEnabled(ctx) {
 			Skip("trusted headers public key not configured - skipping x-mcp-authorized test")
 		}
 
@@ -712,7 +713,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			"X-Mcp-Authorized": jwtToken,
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer authorizedClient.Close()
+		defer func() { _ = authorizedClient.Close() }()
 
 		By("Verifying only the tools from the JWT are returned")
 		Eventually(func(g Gomega) {

--- a/tests/e2e/keycloak_helpers.go
+++ b/tests/e2e/keycloak_helpers.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -17,8 +18,8 @@ import (
 
 var keycloakTokenURL = goenv.GetDefault("KEYCLOAK_TOKEN_URL", "https://keycloak."+e2eDomain+":8002/realms/mcp/protocol/openid-connect/token")
 
-// obtains an access token via ROPC grant (test automation only)
-func GetKeycloakUserToken(username, password string) (string, error) {
+// GetKeycloakUserToken obtains an access token via ROPC grant (test automation only).
+func GetKeycloakUserToken(ctx context.Context, username, password string) (string, error) {
 	data := url.Values{
 		"grant_type":    {"password"},
 		"client_id":     {"mcp-gateway"},
@@ -28,7 +29,7 @@ func GetKeycloakUserToken(username, password string) (string, error) {
 		"scope":         {"openid groups roles"},
 	}
 
-	req, err := http.NewRequest("POST", keycloakTokenURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, keycloakTokenURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create token request: %w", err)
 	}
@@ -44,7 +45,7 @@ func GetKeycloakUserToken(username, password string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("token request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/tests/e2e/kubectl_helpers.go
+++ b/tests/e2e/kubectl_helpers.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -24,7 +23,7 @@ func ScaleDeployment(ctx context.Context, namespace, name string, replicas int) 
 }
 
 // WaitForDeploymentReady waits for a deployment to be ready
-func WaitForDeploymentReady(ctx context.Context, namespace, name string, _ int) error {
+func WaitForDeploymentReady(ctx context.Context, namespace, name string) error {
 	cmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "deployment", name,
 		"-n", namespace, "--timeout=60s")
 	output, err := cmd.CombinedOutput()
@@ -92,51 +91,6 @@ func RestartDeploymentAndWait(ctx context.Context, namespace, deploymentName str
 	output, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("deployment %s not ready after restart: %s: %w", deploymentName, string(output), err)
-	}
-	return nil
-}
-
-// AddDeploymentCommandFlag appends a flag to a deployment's container command array.
-// The flag is not reverted by the controller if it is in the ignoredCommandFlags list.
-func AddDeploymentCommandFlag(ctx context.Context, namespace, deploymentName, flag string) error {
-	patch := fmt.Sprintf(`[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"%s"}]`, flag)
-	cmd := exec.CommandContext(ctx, "kubectl", "patch", "deployment", deploymentName,
-		"-n", namespace, "--type=json", "-p", patch)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to add command flag on deployment %s: %s: %w", deploymentName, string(output), err)
-	}
-	return nil
-}
-
-// RemoveDeploymentCommandFlag removes a flag from a deployment's container command array by value.
-func RemoveDeploymentCommandFlag(ctx context.Context, namespace, deploymentName, flag string) error {
-	cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment", deploymentName,
-		"-n", namespace, "-o", "jsonpath={.spec.template.spec.containers[0].command}")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get command array: %s: %w", string(output), err)
-	}
-	var command []string
-	if err := json.Unmarshal(output, &command); err != nil {
-		return fmt.Errorf("failed to parse command array: %w: %s", err, string(output))
-	}
-	idx := -1
-	for i, c := range command {
-		if c == flag {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		return nil // flag not present, nothing to do
-	}
-	patch := fmt.Sprintf(`[{"op":"remove","path":"/spec/template/spec/containers/0/command/%d"}]`, idx)
-	cmd = exec.CommandContext(ctx, "kubectl", "patch", "deployment", deploymentName,
-		"-n", namespace, "--type=json", "-p", patch)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to remove command flag on deployment %s: %s: %w", deploymentName, string(output), err)
 	}
 	return nil
 }

--- a/tests/e2e/kubectl_helpers.go
+++ b/tests/e2e/kubectl_helpers.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -12,8 +13,8 @@ import (
 )
 
 // ScaleDeployment scales a deployment to the specified replicas
-func ScaleDeployment(namespace, name string, replicas int) error {
-	cmd := exec.Command("kubectl", "scale", "deployment", name,
+func ScaleDeployment(ctx context.Context, namespace, name string, replicas int) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "scale", "deployment", name,
 		"-n", namespace, fmt.Sprintf("--replicas=%d", replicas))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -23,8 +24,8 @@ func ScaleDeployment(namespace, name string, replicas int) error {
 }
 
 // WaitForDeploymentReady waits for a deployment to be ready
-func WaitForDeploymentReady(namespace, name string, _ int) error {
-	cmd := exec.Command("kubectl", "rollout", "status", "deployment", name,
+func WaitForDeploymentReady(ctx context.Context, namespace, name string, _ int) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "deployment", name,
 		"-n", namespace, "--timeout=60s")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -34,8 +35,8 @@ func WaitForDeploymentReady(namespace, name string, _ int) error {
 }
 
 // GetDeploymentGeneration returns the current metadata.generation of a deployment
-func GetDeploymentGeneration(namespace, name string) (string, error) {
-	cmd := exec.Command("kubectl", "get", "deployment", name,
+func GetDeploymentGeneration(ctx context.Context, namespace, name string) (string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment", name,
 		"-n", namespace, "-o", "jsonpath={.metadata.generation}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -48,23 +49,23 @@ func GetDeploymentGeneration(namespace, name string) (string, error) {
 // with the expected number of ready replicas. It requires the caller to pass
 // the generation from before any changes, so it can detect when the rollout
 // has actually started (generation changes) then wait for it to complete.
-func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGeneration string) error {
+func WaitForDeploymentReplicas(ctx context.Context, namespace, name string, replicas int, prevGeneration string) error {
 	// wait for generation to change (confirming the spec mutation was picked up)
 	Eventually(func() string {
-		gen, _ := GetDeploymentGeneration(namespace, name)
+		gen, _ := GetDeploymentGeneration(ctx, namespace, name)
 		return gen
 	}, "30s", "1s").ShouldNot(Equal(prevGeneration),
 		fmt.Sprintf("deployment %s generation did not change from %s", name, prevGeneration))
 
 	// now rollout status will correctly block on the new rollout
-	cmd := exec.Command("kubectl", "rollout", "status", "deployment", name,
+	cmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "deployment", name,
 		"-n", namespace, "--timeout=120s")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("deployment %s rollout not complete: %s: %w", name, string(output), err)
 	}
 
 	// confirm exact ready replica count
-	cmd = exec.Command("kubectl", "wait", "deployment", name,
+	cmd = exec.CommandContext(ctx, "kubectl", "wait", "deployment", name,
 		"-n", namespace,
 		fmt.Sprintf("--for=jsonpath={.status.readyReplicas}=%d", replicas),
 		"--timeout=120s")
@@ -78,15 +79,15 @@ func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGenerat
 // RestartDeploymentAndWait triggers a rollout restart on a deployment and waits
 // for the new rollout to complete. Unlike deleting pods directly, rollout restart
 // changes the deployment generation so rollout status correctly blocks.
-func RestartDeploymentAndWait(namespace, deploymentName string) error {
-	cmd := exec.Command("kubectl", "rollout", "restart", "deployment", deploymentName,
+func RestartDeploymentAndWait(ctx context.Context, namespace, deploymentName string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "rollout", "restart", "deployment", deploymentName,
 		"-n", namespace)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to restart deployment %s: %s: %w", deploymentName, string(output), err)
 	}
 
-	cmd = exec.Command("kubectl", "rollout", "status", "deployment", deploymentName,
+	cmd = exec.CommandContext(ctx, "kubectl", "rollout", "status", "deployment", deploymentName,
 		"-n", namespace, "--timeout=120s")
 	output, err = cmd.CombinedOutput()
 	if err != nil {
@@ -97,9 +98,9 @@ func RestartDeploymentAndWait(namespace, deploymentName string) error {
 
 // AddDeploymentCommandFlag appends a flag to a deployment's container command array.
 // The flag is not reverted by the controller if it is in the ignoredCommandFlags list.
-func AddDeploymentCommandFlag(namespace, deploymentName, flag string) error {
+func AddDeploymentCommandFlag(ctx context.Context, namespace, deploymentName, flag string) error {
 	patch := fmt.Sprintf(`[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"%s"}]`, flag)
-	cmd := exec.Command("kubectl", "patch", "deployment", deploymentName,
+	cmd := exec.CommandContext(ctx, "kubectl", "patch", "deployment", deploymentName,
 		"-n", namespace, "--type=json", "-p", patch)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -109,8 +110,8 @@ func AddDeploymentCommandFlag(namespace, deploymentName, flag string) error {
 }
 
 // RemoveDeploymentCommandFlag removes a flag from a deployment's container command array by value.
-func RemoveDeploymentCommandFlag(namespace, deploymentName, flag string) error {
-	cmd := exec.Command("kubectl", "get", "deployment", deploymentName,
+func RemoveDeploymentCommandFlag(ctx context.Context, namespace, deploymentName, flag string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment", deploymentName,
 		"-n", namespace, "-o", "jsonpath={.spec.template.spec.containers[0].command}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -131,7 +132,7 @@ func RemoveDeploymentCommandFlag(namespace, deploymentName, flag string) error {
 		return nil // flag not present, nothing to do
 	}
 	patch := fmt.Sprintf(`[{"op":"remove","path":"/spec/template/spec/containers/0/command/%d"}]`, idx)
-	cmd = exec.Command("kubectl", "patch", "deployment", deploymentName,
+	cmd = exec.CommandContext(ctx, "kubectl", "patch", "deployment", deploymentName,
 		"-n", namespace, "--type=json", "-p", patch)
 	output, err = cmd.CombinedOutput()
 	if err != nil {
@@ -141,8 +142,8 @@ func RemoveDeploymentCommandFlag(namespace, deploymentName, flag string) error {
 }
 
 // IsTrustedHeadersEnabled checks if the gateway has trusted headers public key configured
-func IsTrustedHeadersEnabled() bool {
-	cmd := exec.Command("kubectl", "get", "deployment", "-n", SystemNamespace,
+func IsTrustedHeadersEnabled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment", "-n", SystemNamespace,
 		"mcp-gateway", "-o", "jsonpath={.spec.template.spec.containers[0].env[?(@.name=='TRUSTED_HEADER_PUBLIC_KEY')].valueFrom.secretKeyRef.name}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -152,8 +153,8 @@ func IsTrustedHeadersEnabled() bool {
 }
 
 // IsAuthPolicyConfigured checks if AuthPolicy resources exist in the gateway namespace
-func IsAuthPolicyConfigured() bool {
-	cmd := exec.Command("kubectl", "get", "authpolicy", "-n", GatewayNamespace,
+func IsAuthPolicyConfigured(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "authpolicy", "-n", GatewayNamespace,
 		"-o", "jsonpath={.items[*].metadata.name}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/tests/e2e/multi_gateway_test.go
+++ b/tests/e2e/multi_gateway_test.go
@@ -196,8 +196,8 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 			e2e1Client *NotifyingMCPClient
 			clientErr  error
 		)
-		Eventually(func(g Gomega) {
-			e2e1Client, clientErr = NewMCPGatewayClientWithNotifications(ctx, E2E1GatewayURL, func(j mcp.JSONRPCNotification) {})
+		Eventually(func(_ Gomega) {
+			e2e1Client, clientErr = NewMCPGatewayClientWithNotifications(ctx, E2E1GatewayURL, func(_ mcp.JSONRPCNotification) {})
 			Expect(clientErr).Error().NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
 
@@ -210,7 +210,7 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Closing the MCP client before deleting MCPGatewayExtension")
-		e2e1Client.Close()
+		_ = e2e1Client.Close()
 
 		By("Deleting the MCPGatewayExtension")
 		ext := e2e1Setup.GetExtension()
@@ -254,9 +254,9 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Re-establishing MCP client connection")
-		e2e1Client, clientErr = NewMCPGatewayClientWithNotifications(ctx, E2E1GatewayURL, func(j mcp.JSONRPCNotification) {})
+		e2e1Client, clientErr = NewMCPGatewayClientWithNotifications(ctx, E2E1GatewayURL, func(_ mcp.JSONRPCNotification) {})
 		Expect(clientErr).Error().NotTo(HaveOccurred())
-		defer e2e1Client.Close()
+		defer func() { _ = e2e1Client.Close() }()
 
 		By("Verifying gateway is accessible again")
 		Eventually(func(g Gomega) {
@@ -341,19 +341,19 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		var mainGatewayClient *NotifyingMCPClient
 		Eventually(func(g Gomega) {
 			var clientErr error
-			mainGatewayClient, clientErr = NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {})
+			mainGatewayClient, clientErr = NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(_ mcp.JSONRPCNotification) {})
 			g.Expect(clientErr).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
-		defer mainGatewayClient.Close()
+		defer func() { _ = mainGatewayClient.Close() }()
 
 		By("Connecting to e2e-1 gateway (team B)")
 		var e2e1Client *NotifyingMCPClient
 		Eventually(func(g Gomega) {
 			var clientErr error
-			e2e1Client, clientErr = NewMCPGatewayClientWithNotifications(ctx, E2E1GatewayURL, func(j mcp.JSONRPCNotification) {})
+			e2e1Client, clientErr = NewMCPGatewayClientWithNotifications(ctx, E2E1GatewayURL, func(_ mcp.JSONRPCNotification) {})
 			g.Expect(clientErr).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
-		defer e2e1Client.Close()
+		defer func() { _ = e2e1Client.Close() }()
 
 		By("Verifying main gateway sees team_a_ tools and NOT team_b_ tools")
 		Eventually(func(g Gomega) {
@@ -538,19 +538,19 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		var teamAClient *NotifyingMCPClient
 		Eventually(func(g Gomega) {
 			var clientErr error
-			teamAClient, clientErr = NewMCPGatewayClientWithNotifications(ctx, TeamAGatewayURL, func(j mcp.JSONRPCNotification) {})
+			teamAClient, clientErr = NewMCPGatewayClientWithNotifications(ctx, TeamAGatewayURL, func(_ mcp.JSONRPCNotification) {})
 			g.Expect(clientErr).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
-		defer teamAClient.Close()
+		defer func() { _ = teamAClient.Close() }()
 
 		By("Connecting to Team B gateway")
 		var teamBClient *NotifyingMCPClient
 		Eventually(func(g Gomega) {
 			var clientErr error
-			teamBClient, clientErr = NewMCPGatewayClientWithNotifications(ctx, TeamBGatewayURL, func(j mcp.JSONRPCNotification) {})
+			teamBClient, clientErr = NewMCPGatewayClientWithNotifications(ctx, TeamBGatewayURL, func(_ mcp.JSONRPCNotification) {})
 			g.Expect(clientErr).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
-		defer teamBClient.Close()
+		defer func() { _ = teamBClient.Close() }()
 
 		By("Verifying Team A gateway sees only team_a_ tools")
 		Eventually(func(g Gomega) {

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -36,8 +37,8 @@ func getMCPHTTPClient() *http.Client {
 
 // mcpPost sends a raw HTTP POST to the MCP gateway and returns the response.
 // Caller is responsible for closing the response body.
-func mcpPost(url, sessionID string, body []byte, headers map[string]string) (*http.Response, error) {
-	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+func mcpPost(ctx context.Context, url, sessionID string, body []byte, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +54,14 @@ func mcpPost(url, sessionID string, body []byte, headers map[string]string) (*ht
 }
 
 // mcpInitialize sends an initialize request and returns the session ID from the response header
-func mcpInitialize(url string, headers map[string]string) (string, error) {
+func mcpInitialize(ctx context.Context, url string, headers map[string]string) (string, error) {
 	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-raw","version":"0.0.1"}}}`
-	resp, err := mcpPost(url, "", []byte(body), headers)
+	resp, err := mcpPost(ctx, url, "", []byte(body), headers)
 	if err != nil {
 		return "", fmt.Errorf("initialize request failed: %w", err)
 	}
-	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("initialize returned status %d", resp.StatusCode)
@@ -72,13 +73,13 @@ func mcpInitialize(url string, headers map[string]string) (string, error) {
 	return sessionID, nil
 }
 
-func mcpNotifyInitialized(url, sessionID string, headers map[string]string) error {
+func mcpNotifyInitialized(ctx context.Context, url, sessionID string, headers map[string]string) error {
 	body := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
-	resp, err := mcpPost(url, sessionID, []byte(body), headers)
+	resp, err := mcpPost(ctx, url, sessionID, []byte(body), headers)
 	if err != nil {
 		return fmt.Errorf("notifications/initialized failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("reading notifications/initialized response: %w", err)
@@ -89,13 +90,13 @@ func mcpNotifyInitialized(url, sessionID string, headers map[string]string) erro
 	return nil
 }
 
-func mcpListTools(url, sessionID string, headers map[string]string) (int, []string, error) {
+func mcpListTools(ctx context.Context, url, sessionID string, headers map[string]string) (int, []string, error) {
 	body := `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`
-	resp, err := mcpPost(url, sessionID, []byte(body), headers)
+	resp, err := mcpPost(ctx, url, sessionID, []byte(body), headers)
 	if err != nil {
 		return 0, nil, fmt.Errorf("tools/list failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, readErr := io.ReadAll(resp.Body)
@@ -125,7 +126,7 @@ func mcpListTools(url, sessionID string, headers map[string]string) (int, []stri
 	return resp.StatusCode, names, nil
 }
 
-func mcpCallTool(url, sessionID, toolName string, args map[string]any, headers map[string]string) (int, []toolContent, error) {
+func mcpCallTool(ctx context.Context, url, sessionID, toolName string, args map[string]any, headers map[string]string) (int, []toolContent, error) {
 	params := map[string]any{"name": toolName}
 	if len(args) > 0 {
 		params["arguments"] = args
@@ -141,11 +142,11 @@ func mcpCallTool(url, sessionID, toolName string, args map[string]any, headers m
 		return 0, nil, fmt.Errorf("failed to marshal tools/call: %w", err)
 	}
 
-	resp, err := mcpPost(url, sessionID, body, headers)
+	resp, err := mcpPost(ctx, url, sessionID, body, headers)
 	if err != nil {
 		return 0, nil, fmt.Errorf("tools/call failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, readErr := io.ReadAll(resp.Body)
@@ -169,12 +170,12 @@ func mcpCallTool(url, sessionID, toolName string, args map[string]any, headers m
 	return resp.StatusCode, callResult.Content, nil
 }
 
-func mcpRawPost(url, sessionID string, body []byte, headers map[string]string) (int, string, http.Header, error) {
-	resp, err := mcpPost(url, sessionID, body, headers)
+func mcpRawPost(ctx context.Context, url, sessionID string, body []byte, headers map[string]string) (int, string, http.Header, error) {
+	resp, err := mcpPost(ctx, url, sessionID, body, headers)
 	if err != nil {
 		return 0, "", nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resp.StatusCode, "", resp.Header, fmt.Errorf("reading response body: %w", err)

--- a/tests/e2e/tool_validation_test.go
+++ b/tests/e2e/tool_validation_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Tool Schema Validation", func() {
 
 	AfterEach(func() {
 		if mcpGatewayClient != nil {
-			mcpGatewayClient.Close()
+			_ = mcpGatewayClient.Close()
 			mcpGatewayClient = nil
 		}
 		for _, to := range testResources {

--- a/tests/e2e/verifiers.go
+++ b/tests/e2e/verifiers.go
@@ -253,6 +253,7 @@ func (v *Verifier) HTTPRouteNotFound(name, namespace string) error {
 
 // Legacy function wrappers for backwards compatibility during migration
 // TODO: Remove these after updating all tests to use Verifier
+//revive:disable:exported
 
 func VerifyMCPServerRegistrationReady(ctx context.Context, k8sClient client.Client, name, namespace string) error {
 	return NewVerifier(ctx, k8sClient).MCPServerRegistrationReady(name, namespace)
@@ -282,16 +283,7 @@ func VerifyHTTPRouteNoProgrammedCondition(ctx context.Context, k8sClient client.
 	return NewVerifier(ctx, k8sClient).HTTPRouteNoProgrammedCondition(name, namespace)
 }
 
-// extractBackendSessionID returns the Mcp-Session-Id value from a tool call response
-func extractBackendSessionID(res *mcp.CallToolResult) string {
-	for _, cont := range res.Content {
-		textContent, ok := cont.(mcp.TextContent)
-		if ok && strings.HasPrefix(textContent.Text, "Mcp-Session-Id") {
-			return textContent.Text
-		}
-	}
-	return ""
-}
+//revive:enable:exported
 
 // Legacy unexported functions for backwards compatibility
 func verifyMCPServerRegistrationToolsPresent(serverPrefix string, toolsList *mcp.ListToolsResult) bool {
@@ -382,6 +374,7 @@ func (v *Verifier) MCPGatewayExtensionStatusMessage(name, namespace string) (str
 }
 
 // Legacy function wrappers for MCPGatewayExtension
+//revive:disable:exported
 
 func VerifyMCPGatewayExtensionReady(ctx context.Context, k8sClient client.Client, name, namespace string) error {
 	return NewVerifier(ctx, k8sClient).MCPGatewayExtensionReady(name, namespace)
@@ -398,6 +391,8 @@ func VerifyMCPGatewayExtensionNotReadyWithReason(ctx context.Context, k8sClient 
 func GetMCPGatewayExtensionStatusMessage(ctx context.Context, k8sClient client.Client, name, namespace string) (string, error) {
 	return NewVerifier(ctx, k8sClient).MCPGatewayExtensionStatusMessage(name, namespace)
 }
+
+//revive:enable:exported
 
 // getGateway fetches a Gateway by name and namespace
 func (v *Verifier) getGateway(name, namespace string) (*gatewayapiv1.Gateway, error) {
@@ -471,6 +466,7 @@ func (v *Verifier) GatewayListenerMCPConditionMessage(gatewayName, gatewayNamesp
 }
 
 // Legacy function wrappers for Gateway listener status
+//revive:disable:exported
 
 func VerifyGatewayListenerHasMCPCondition(ctx context.Context, k8sClient client.Client, gatewayName, gatewayNamespace, listenerName string) error {
 	return NewVerifier(ctx, k8sClient).GatewayListenerHasMCPCondition(gatewayName, gatewayNamespace, listenerName)
@@ -483,3 +479,5 @@ func VerifyGatewayListenerNoMCPCondition(ctx context.Context, k8sClient client.C
 func GetGatewayListenerMCPConditionMessage(ctx context.Context, k8sClient client.Client, gatewayName, gatewayNamespace, listenerName string) (string, error) {
 	return NewVerifier(ctx, k8sClient).GatewayListenerMCPConditionMessage(gatewayName, gatewayNamespace, listenerName)
 }
+
+//revive:enable:exported


### PR DESCRIPTION
Closes #475.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled end-to-end linting tag and added targeted linter exclusions to reduce noisy warnings.

* **Tests**
  * Improved e2e reliability by passing context through helpers to support timeouts/cancellation.
  * Made teardown/cleanup more robust by explicitly handling close return values and strengthening failure assertions.
  * Updated helper APIs and test plumbing to propagate context consistently.

* **Documentation**
  * Clarified test package and builder comments for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->