### PR TITLE
fix: run spell check on docs-only PRs

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Run lint checks
         run: |
-          npm install -g cspell@9.4.0
-          make lint
+          make lint-go
 
       - name: Check generated resources are synchronized
         run: |

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,0 +1,25 @@
+name: Spelling
+
+on:
+  pull_request:
+    branches: [ 'main',  ]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: spelling-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spelling:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Run spell check
+        run: |
+          npm install -g cspell@9.4.0
+          make spell

--- a/Makefile
+++ b/Makefile
@@ -487,8 +487,12 @@ bin/golangci-lint-kube-api-linter:
 spell:
 	cspell --quiet --config cspell.json .
 
+.PHONY: lint-go
+lint-go: check-gofmt check-goimports check-newlines fmt vet golangci-lint kube-api-linter ## Run Go linting and style checks
+	@echo "All Go lint checks passed!"
+
 .PHONY: lint
-lint: check-gofmt check-goimports check-newlines fmt vet golangci-lint kube-api-linter spell ## Run all linting and style checks
+lint: lint-go spell ## Run all linting and style checks
 	@echo "All lint checks passed!"
 
 # Code style checks


### PR DESCRIPTION
Split cspell into its own workflow so it triggers on all PRs, including docs-only changes.
The code-style workflow keeps its existing path filters and skips docs-only PRs as before.

This fixes an issue where docs only prs didn't have spelling run