### PR TITLE
feat(broker): add /readyz endpoint and wire readinessProbe

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -321,6 +321,10 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 		_, _ = fmt.Fprint(w, "Hello, World!  BTW, the MCP server is on /mcp")
 	})
 
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
 	oauthHandler := broker.ProtectedResourceHandler{Logger: logger}
 	mux.HandleFunc("/.well-known/oauth-protected-resource", oauthHandler.Handle)
 	mux.HandleFunc("/.well-known/oauth-protected-resource/", oauthHandler.Handle)

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -322,6 +322,10 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 	})
 
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !mcpBroker.IsReady() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -40,6 +40,12 @@ type MCPBroker interface {
 	// ValidateAllServers performs comprehensive validation of all registered servers and returns status
 	ValidateAllServers() StatusResponse
 
+	// IsReady reports whether the broker can serve traffic.
+	// Returns true when no upstream servers are configured (empty tool list is valid),
+	// or when at least one configured upstream is healthy.
+	// Returns false only when servers are configured but none have connected yet.
+	IsReady() bool
+
 	// HandleStatusRequest handles HTTP status endpoint requests
 	HandleStatusRequest(w http.ResponseWriter, r *http.Request)
 
@@ -326,4 +332,21 @@ func (m *mcpBrokerImpl) ValidateAllServers() StatusResponse {
 		"overallValid", response.OverallValid)
 
 	return response
+}
+
+// IsReady reports whether the broker can serve traffic.
+// Accesses m.mcpServers directly (lock already not held here) rather than
+// calling RegisteredMCPServers to avoid nested RLock under a pending writer.
+func (m *mcpBrokerImpl) IsReady() bool {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+	if len(m.mcpServers) == 0 {
+		return true
+	}
+	for _, mgr := range m.mcpServers {
+		if mgr.GetStatus().Ready {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/tests/server2"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -287,6 +288,58 @@ func TestToolAnnotations(t *testing.T) {
 			require.True(t, exists, "expected annotation to be found")
 			require.Equal(t, tc.readOnly, *annotation.ReadOnlyHint, "readOnly mismatch: %#v", annotation)
 			require.Equal(t, tc.idempotent, *annotation.IdempotentHint, "idempotent mismatch: %#v", annotation)
+		})
+	}
+}
+
+func TestIsReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(b *mcpBrokerImpl)
+		expected bool
+	}{
+		{
+			name:     "no servers configured",
+			setup:    func(_ *mcpBrokerImpl) {},
+			expected: true,
+		},
+		{
+			name: "servers configured, none healthy",
+			setup: func(b *mcpBrokerImpl) {
+				mgr := createTestManager(t, "s1", "", nil)
+				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: false})
+				b.mcpServers["s1"] = mgr
+			},
+			expected: false,
+		},
+		{
+			name: "one unhealthy one healthy",
+			setup: func(b *mcpBrokerImpl) {
+				m1 := createTestManager(t, "s1", "", nil)
+				m1.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: false})
+				b.mcpServers["s1"] = m1
+				m2 := createTestManager(t, "s2", "", nil)
+				m2.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s2", Ready: true})
+				b.mcpServers["s2"] = m2
+			},
+			expected: true,
+		},
+		{
+			name: "all servers healthy",
+			setup: func(b *mcpBrokerImpl) {
+				mgr := createTestManager(t, "s1", "", nil)
+				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
+				b.mcpServers["s1"] = mgr
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBroker(logger).(*mcpBrokerImpl)
+			tt.setup(b)
+			require.Equal(t, tt.expected, b.IsReady())
 		})
 	}
 }

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -166,6 +166,19 @@ func (r *MCPGatewayExtensionReconciler) buildBrokerRouterDeployment(mcpExt *mcpv
 									ReadOnly:  true,
 								},
 							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/readyz",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
+							},
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -331,6 +344,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Contex
 		existingContainer.Ports = desiredContainer.Ports
 		existingContainer.Env = mergeEnvVars(desiredContainer.Env, existingContainer.Env)
 		existingContainer.VolumeMounts = desiredContainer.VolumeMounts
+		existingContainer.ReadinessProbe = desiredContainer.ReadinessProbe
 		existingDeployment.Spec.Template.Spec.Containers[0] = existingContainer
 		existingDeployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes
 		if err := r.Update(ctx, existingDeployment); err != nil {
@@ -444,6 +458,9 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 	}
 	if !equality.Semantic.DeepEqual(desiredContainer.VolumeMounts, existingContainer.VolumeMounts) {
 		return true, fmt.Sprintf("volumeMounts changed: %+v -> %+v", existingContainer.VolumeMounts, desiredContainer.VolumeMounts)
+	}
+	if !equality.Semantic.DeepEqual(desiredContainer.ReadinessProbe, existingContainer.ReadinessProbe) {
+		return true, fmt.Sprintf("readinessProbe changed: %+v -> %+v", existingContainer.ReadinessProbe, desiredContainer.ReadinessProbe)
 	}
 	if !equality.Semantic.DeepEqual(desired.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
 		return true, fmt.Sprintf("volumes changed: %+v -> %+v", existing.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes)

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1512,3 +1512,124 @@ func TestHTTPRouteNeedsUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildBrokerRouterDeployment_ReadinessProbe(t *testing.T) {
+	r := &MCPGatewayExtensionReconciler{
+		BrokerRouterImage: "test-image:v1",
+	}
+	mcpExt := &mcpv1alpha1.MCPGatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ext",
+			Namespace: "test-ns",
+		},
+		Spec: mcpv1alpha1.MCPGatewayExtensionSpec{
+			TargetRef: mcpv1alpha1.MCPGatewayExtensionTargetReference{
+				Name:      "my-gateway",
+				Namespace: "gateway-system",
+			},
+		},
+	}
+
+	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080))
+	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+
+	if probe == nil {
+		t.Fatal("expected ReadinessProbe to be set on broker container, got nil")
+	}
+	if probe.HTTPGet == nil {
+		t.Fatal("expected HTTPGet probe handler, got nil")
+	}
+	if probe.HTTPGet.Path != "/readyz" {
+		t.Errorf("expected probe Path /readyz, got %q", probe.HTTPGet.Path)
+	}
+	wantPort := intstr.FromString("http")
+	if probe.HTTPGet.Port != wantPort {
+		t.Errorf("expected probe Port %v (named http), got %v", wantPort, probe.HTTPGet.Port)
+	}
+}
+
+func TestDeploymentNeedsUpdate_Probe(t *testing.T) {
+	baseDeployment := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    "test-container",
+								Image:   "test-image:v1",
+								Command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+								Ports: []corev1.ContainerPort{
+									{Name: "http", ContainerPort: 8080},
+								},
+								ReadinessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path:   "/readyz",
+											Port:   intstr.FromString("http"),
+											Scheme: corev1.URISchemeHTTP,
+										},
+									},
+									TimeoutSeconds:   1,
+									PeriodSeconds:    10,
+									SuccessThreshold: 1,
+									FailureThreshold: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		modify   func(d *appsv1.Deployment)
+		expected bool
+	}{
+		{
+			name:     "no changes",
+			modify:   func(_ *appsv1.Deployment) {},
+			expected: false,
+		},
+		{
+			name: "probe removed triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
+			},
+			expected: true,
+		},
+		{
+			name: "probe path changed triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path = "/different"
+			},
+			expected: true,
+		},
+		{
+			name: "probe port changed triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromString("grpc")
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := baseDeployment()
+			existing := baseDeployment()
+			tt.modify(existing)
+
+			result, reason := deploymentNeedsUpdate(desired, existing)
+			if result != tt.expected {
+				t.Errorf("deploymentNeedsUpdate() = %v, expected %v, reason: %s", result, tt.expected, reason)
+			}
+		})
+	}
+}

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -532,3 +532,8 @@ func (m *mockBrokerImpl) ToolAnnotations(_ config.UpstreamMCPID, _ string) (mcp.
 func (m *mockBrokerImpl) ValidateAllServers() broker.StatusResponse {
 	panic("unimplemented")
 }
+
+// IsReady implements broker.MCPBroker.
+func (m *mockBrokerImpl) IsReady() bool {
+	return true
+}


### PR DESCRIPTION
Fixes #760

Adds an explicit `/readyz` handler in the broker and wires `ReadinessProbe`
on the controller-built Deployment, mirroring the managed-field pattern from
PR #677 (managed env vars).

## What this PR does

- New `/readyz` handler in `cmd/mcp-broker-router/main.go` returning 200.
- `ReadinessProbe` set on the broker Container in `buildBrokerRouterDeployment`
  (HTTPGet on named port `http`).
- Probe equality added to `deploymentNeedsUpdate` and assignment added to the
  merge block so probe drift is auto-reconciled.
- Tests for the Container shape and drift detection.

## Out of scope (per maintainer guidance in the issue thread)

- No `livenessProbe` — relying on the process running being sufficient.
- No catch-all narrowing — deferred to a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added readiness health check endpoint for broker-router service monitoring
  * Configured Kubernetes readiness probe to automatically detect service availability
  * Improved deployment reliability by preventing traffic routing to unhealthy broker-router instances
<!-- end of auto-generated comment: release notes by coderabbit.ai -->