### PR TITLE
fix: validate mcp-init-host against registered backends to prevent SSRF

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -42,6 +42,18 @@ func (config *MCPServersConfig) Notify(ctx context.Context) {
 	}
 }
 
+// IsRegisteredHostname returns true if host matches a registered server's Hostname.
+func (config *MCPServersConfig) IsRegisteredHostname(host string) bool {
+	config.lock.RLock()
+	defer config.lock.RUnlock()
+	for _, server := range config.Servers {
+		if server.Hostname == host {
+			return true
+		}
+	}
+	return false
+}
+
 // GetServerConfigByName get the routing config by server name
 func (config *MCPServersConfig) GetServerConfigByName(serverName string) (*MCPServer, error) {
 	config.lock.RLock()

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -615,6 +615,10 @@ func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPReque
 				s.Logger.WarnContext(ctx, "unexpected remote initialize request. Key does not match. Rejecting", "sent headers", mcpReq.Headers)
 				return response.WithImmediateResponse(400, "bad request").Build()
 			}
+			if !s.RoutingConfig.IsRegisteredHostname(remoteInitializeTarget) {
+				s.Logger.WarnContext(ctx, "rejecting init request for unregistered host", "target", remoteInitializeTarget)
+				return response.WithImmediateResponse(400, "bad request").Build()
+			}
 
 			s.Logger.DebugContext(ctx, "HandleMCPBrokerRequest initialize request", "target", remoteInitializeTarget, "call", mcpReq.Method)
 			headers.WithAuthority(remoteInitializeTarget)


### PR DESCRIPTION
## Description:

The router accepts arbitrary hostnames in the `mcp-init-host` header without validation. An attacker with a leaked `RouterAPIKey` can redirect initialize requests to cloud metadata endpoints or internal services.

**Attack:**
```bash
curl -X POST http://gateway/mcp \
  -H "mcp-init-host: 169.254.169.254" \
  -H "x-router-api-key: <leaked-key>" \
  -d '{"jsonrpc":"2.0","method":"initialize","params":{}}'
```

Router sets `:authority` to attacker value, Envoy routes to metadata endpoint.

---

## Fix:
Added hostname allowlist check before setting `:authority`:

```go
// internal/mcp-router/request_handlers.go
if !s.RoutingConfig.IsRegisteredHostname(remoteInitializeTarget) {
    return response.WithImmediateResponse(400, "bad request").Build()
}
```

Helper validates against registered backends:

```go
// internal/config/types.go
func (c *MCPServersConfig) IsRegisteredHostname(hostname string) bool {
    c.mu.RLock()
    defer c.mu.RUnlock()
    for _, server := range c.Servers {
        if server.Hostname == hostname {
            return true
        }
    }
    return false
}
```

---

## Impact:
- SSRF limited to registered backends only
- No breaking changes (broker only sends registered hostnames)
- All tests pass

**Changes:** 2 files, 12 lines

**Severity:** Medium (requires leaked RouterAPIKey, but provides defense-in-depth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote host initialization requests now validate against registered hostnames. Requests from unregistered hosts are rejected with a 400 error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->