### PR TITLE
fix(remote-github): validate AuthPolicy CRD and ensure namespace befo…

### DIFF
--- a/config/samples/remote-github/create_resources.sh
+++ b/config/samples/remote-github/create_resources.sh
@@ -25,8 +25,26 @@ if [[ ! "$GITHUB_PAT" =~ ^ghp_ ]]; then
   fi
 fi
 
+echo ""
+echo "==> Ensuring namespace exists..."
+kubectl create namespace mcp-test --dry-run=client -o yaml | kubectl apply -f -
+
+echo ""
+echo "==> Checking required CRDs..."
+
+if ! kubectl get crd authpolicies.kuadrant.io >/dev/null 2>&1; then
+  echo "Error: AuthPolicy CRD not found."
+  echo ""
+  echo "Kuadrant is required for this example."
+  echo "Please install Kuadrant before running this script."
+  echo ""
+  echo "Refer: https://kuadrant.io/"
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+echo ""
 echo "==> Step 1: Creating ServiceEntry for GitHub MCP API..."
 kubectl apply -f "$SCRIPT_DIR/serviceentry.yaml"
 


### PR DESCRIPTION
## 🐛 Problem

fixes #445

The `config/samples/remote-github/create_resources.sh` script assumes that:

* The `mcp-test` namespace already exists
* Kuadrant (specifically the `AuthPolicy` CRD) is already installed

This leads to:

* Confusing runtime errors such as:

  ```
  no matches for kind "AuthPolicy" in version "kuadrant.io/v1"
  ```
* Partial resource creation before failure
* Poor onboarding experience for new users

---

## ✅ Fix

This PR improves the robustness and usability of the script by:

1. Ensuring the namespace exists (idempotent):

   ```bash
   kubectl create namespace mcp-test --dry-run=client -o yaml | kubectl apply -f -
   ```

2. Validating required CRDs before applying resources:

   * Adds a check for `authpolicies.kuadrant.io`
   * Fails early with a clear and actionable error message if missing

---

## 💡 Result

* Prevents partial resource application
* Provides clear guidance when dependencies are missing
* Makes the script safe to re-run (idempotent)
* Improves developer onboarding experience

---

## 🧪 How to test

1. Run the script without Kuadrant installed → it should fail early with a clear error
2. Install Kuadrant → script should run successfully
3. Re-run the script → no errors, resources remain consistent

---

## 📌 Notes

This change does not modify existing behavior when dependencies are satisfied. It only adds validation and improves reliability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the tool discovery wait so logs are queried from the correct resource form, improving reliability.

* **Chores**
  * Setup script now creates the required namespace up front to ensure resources land in the right place.
  * Added CRD validation with a clear exit message if a required CRD is missing, preventing confusing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->