### PR TITLE
feat: federate MCP resources/templates (list + read) with scheme-pref…

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -12,6 +12,7 @@ import (
 // +kubebuilder:printcolumn:name="Path",type="string",JSONPath=".spec.path",description="MCP endpoint path"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Ready status"
 // +kubebuilder:printcolumn:name="Tools",type="integer",JSONPath=".status.discoveredTools",description="Number of discovered tools"
+// +kubebuilder:printcolumn:name="Resources",type="integer",JSONPath=".status.discoveredResources",description="Number of discovered resources"
 // +kubebuilder:printcolumn:name="Credentials",type="string",JSONPath=".spec.credentialRef.name"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -43,9 +44,13 @@ type MCPServerRegistrationSpec struct {
 	// +required
 	TargetRef TargetReference `json:"targetRef,omitzero"`
 
-	// toolPrefix is the prefix to add to all federated tools from referenced servers.
-	// This helps avoid naming conflicts when aggregating tools from multiple sources.
-	// For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+	// toolPrefix is the prefix used to namespace federated capabilities from this server.
+	// It is prepended to tool names ('weather_get_forecast') and to the URI scheme of
+	// federated resources ('weather_+file:///forecast.json'), preserving the original URI
+	// in a reversible, RFC 3986-compliant form. This avoids naming and URI collisions
+	// when aggregating capabilities from multiple sources. For example, if two servers
+	// both expose a 'search' tool or a 'file:///config' resource, prefixes like
+	// 'server1_' and 'server2_' let them coexist.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="toolPrefix is immutable once set"
 	ToolPrefix string `json:"toolPrefix,omitempty"`
@@ -118,6 +123,11 @@ type MCPServerRegistrationStatus struct {
 	// discoveredTools is the number of tools discovered from this MCPServerRegistration.
 	// +optional
 	DiscoveredTools int32 `json:"discoveredTools,omitempty"`
+
+	// discoveredResources is the number of resources (excluding resource templates) discovered
+	// from this MCPServerRegistration and made available to clients via the gateway.
+	// +optional
+	DiscoveredResources int32 `json:"discoveredResources,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -38,6 +38,10 @@ spec:
       jsonPath: .status.discoveredTools
       name: Tools
       type: integer
+    - description: Number of discovered resources
+      jsonPath: .status.discoveredResources
+      name: Resources
+      type: integer
     - jsonPath: .spec.credentialRef.name
       name: Credentials
       type: string
@@ -129,9 +133,13 @@ spec:
                 type: object
               toolPrefix:
                 description: |-
-                  toolPrefix is the prefix to add to all federated tools from referenced servers.
-                  This helps avoid naming conflicts when aggregating tools from multiple sources.
-                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                  toolPrefix is the prefix used to namespace federated capabilities from this server.
+                  It is prepended to tool names ('weather_get_forecast') and to the URI scheme of
+                  federated resources ('weather_+file:///forecast.json'), preserving the original URI
+                  in a reversible, RFC 3986-compliant form. This avoids naming and URI collisions
+                  when aggregating capabilities from multiple sources. For example, if two servers
+                  both expose a 'search' tool or a 'file:///config' resource, prefixes like
+                  'server1_' and 'server2_' let them coexist.
                 type: string
                 x-kubernetes-validations:
                 - message: toolPrefix is immutable once set
@@ -204,6 +212,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              discoveredResources:
+                description: |-
+                  discoveredResources is the number of resources (excluding resource templates) discovered
+                  from this MCPServerRegistration and made available to clients via the gateway.
+                format: int32
+                type: integer
               discoveredTools:
                 description: discoveredTools is the number of tools discovered from
                   this MCPServerRegistration.

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -38,6 +38,10 @@ spec:
       jsonPath: .status.discoveredTools
       name: Tools
       type: integer
+    - description: Number of discovered resources
+      jsonPath: .status.discoveredResources
+      name: Resources
+      type: integer
     - jsonPath: .spec.credentialRef.name
       name: Credentials
       type: string
@@ -129,9 +133,13 @@ spec:
                 type: object
               toolPrefix:
                 description: |-
-                  toolPrefix is the prefix to add to all federated tools from referenced servers.
-                  This helps avoid naming conflicts when aggregating tools from multiple sources.
-                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                  toolPrefix is the prefix used to namespace federated capabilities from this server.
+                  It is prepended to tool names ('weather_get_forecast') and to the URI scheme of
+                  federated resources ('weather_+file:///forecast.json'), preserving the original URI
+                  in a reversible, RFC 3986-compliant form. This avoids naming and URI collisions
+                  when aggregating capabilities from multiple sources. For example, if two servers
+                  both expose a 'search' tool or a 'file:///config' resource, prefixes like
+                  'server1_' and 'server2_' let them coexist.
                 type: string
                 x-kubernetes-validations:
                 - message: toolPrefix is immutable once set
@@ -204,6 +212,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              discoveredResources:
+                description: |-
+                  discoveredResources is the number of resources (excluding resource templates) discovered
+                  from this MCPServerRegistration and made available to clients via the gateway.
+                format: int32
+                type: integer
               discoveredTools:
                 description: discoveredTools is the number of tools discovered from
                   this MCPServerRegistration.

--- a/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -38,6 +38,10 @@ spec:
       jsonPath: .status.discoveredTools
       name: Tools
       type: integer
+    - description: Number of discovered resources
+      jsonPath: .status.discoveredResources
+      name: Resources
+      type: integer
     - jsonPath: .spec.credentialRef.name
       name: Credentials
       type: string
@@ -129,9 +133,13 @@ spec:
                 type: object
               toolPrefix:
                 description: |-
-                  toolPrefix is the prefix to add to all federated tools from referenced servers.
-                  This helps avoid naming conflicts when aggregating tools from multiple sources.
-                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                  toolPrefix is the prefix used to namespace federated capabilities from this server.
+                  It is prepended to tool names ('weather_get_forecast') and to the URI scheme of
+                  federated resources ('weather_+file:///forecast.json'), preserving the original URI
+                  in a reversible, RFC 3986-compliant form. This avoids naming and URI collisions
+                  when aggregating capabilities from multiple sources. For example, if two servers
+                  both expose a 'search' tool or a 'file:///config' resource, prefixes like
+                  'server1_' and 'server2_' let them coexist.
                 type: string
                 x-kubernetes-validations:
                 - message: toolPrefix is immutable once set
@@ -204,6 +212,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              discoveredResources:
+                description: |-
+                  discoveredResources is the number of resources (excluding resource templates) discovered
+                  from this MCPServerRegistration and made available to clients via the gateway.
+                format: int32
+                type: integer
               discoveredTools:
                 description: discoveredTools is the number of tools discovered from
                   this MCPServerRegistration.

--- a/docs/design/resource-federation.md
+++ b/docs/design/resource-federation.md
@@ -11,7 +11,7 @@ This document deliberately mirrors [prompts-federation.md](prompts-federation.md
 - Federate resources from multiple upstream MCP servers through a single gateway endpoint
 - Federate resource **templates** alongside concrete resources
 - Reuse the existing per-server prefix (`toolPrefix`, slated to be renamed to `prefix` in [#842](https://github.com/Kuadrant/mcp-gateway/pull/842)) as a URI-scheme prefix for resources — no new CRD fields
-- Document collision semantics: different `toolPrefix` values guarantee distinct federated URIs; duplicate-prefix misconfiguration is detectable for tools today but **resource collision detection is deferred** (manager stub — see [Conflict detection](#conflict-detection))
+- Document collision semantics: different `toolPrefix` values guarantee distinct federated URIs; duplicate-prefix overlap on the **same federated resource URI** is rejected via **`findResourceConflicts`** and broker **`checkResourceURIConflicts`** (same intent as tool conflicts — see [Conflict detection](#conflict-detection))
 - Surface a `status.discoveredResources` counter on `MCPServerRegistration` and an aggregate `totalResources` per server on the broker `/status` endpoint
 - Strip gateway-internal `_meta` (`kuadrant/id`) from federated resources before they reach clients
 
@@ -58,13 +58,11 @@ The scheme-plus strategy is the only option that is RFC-conformant, scheme-agnos
 
 Two backends with **different prefixes** cannot collide on federated URIs (the rewritten scheme differs).
 
-For **duplicate-prefix** registrations exposing the same upstream URI, tools fail fast today via `findToolConflicts`. Resources do **not** yet: `MCPManager.findResourceConflicts` is intentionally a **stub** that always returns `nil` because mcp-go exposes no `ListResources()` on the listening `server.MCPServer`, so the manager cannot walk the gateway’s aggregated resource view the way it does for tools. A follow-up will add broker-side validation (mirroring the prompts plan) during config reconciliation.
-
-Until then, duplicate-prefix + duplicate upstream URI yields **non-deterministic** routing in `GetServerInfoByResourceURI` (whichever manager wins the map lookup). Operators should keep prefixes unique per upstream registration.
+For **duplicate-prefix** registrations exposing the same federated URI as resources already served by another upstream, **`findResourceConflicts`** consults the broker: each manager registers candidates against **`checkResourceURIConflicts`**, which scans sibling managers’ `servedResourcesMap` keys before `AddResources` runs — analogous spirit to **`findToolConflicts`** / `ListTools()` on tools.
 
 #### Resource templates on the shared gateway server
 
-Concrete resources use `AddResources` / `DeleteResources`, so removals propagate. **Resource templates** use `AddResourceTemplates`, which in mcp-go is **merge-only** — there is no public per-template delete. When an upstream **drops** a template, or returns an **empty** template list after previously publishing templates, stale federated templates can remain on the gateway until a broader reconcile exists (for example a broker-owned `SetResourceTemplates` merge across all managers) or the process restarts. Same limitation applies when `removeAllResources` runs: templates are deliberately **not** cleared because sibling managers share the listening server. This PR documents the gap; fixing it cleanly is follow-up work tied to mcp-go API or a broker-level aggregate.
+Concrete resources use `AddResources` / `DeleteResources`, so removals propagate. **Templates**: each upstream manager stores its federated `ServerResourceTemplate` slice locally; after every refresh or teardown it notifies the broker’s **`reconcileGatewayResourceTemplates`**, which merges all upstream snapshots and calls **`SetResourceTemplates(...)`** on the listening `server.MCPServer`. That replaces the entire gateway template registry every reconcile so upstream removals disappear exactly like concrete resources (see mcp-go `SetResourceTemplates`).
 
 ### Architecture Changes
 
@@ -128,19 +126,21 @@ Add `ListResources()`, `ListResourceTemplates()`, `ReadResource()`, and `Support
 
 #### MCPManager (`internal/broker/upstream/manager.go`)
 
-Add a `ResourcesAdderDeleter` interface mirroring `ToolsAdderDeleter`. The mcp-go `server.MCPServer` implements `AddResources()`/`DeleteResources()` for concrete resources and `AddResourceTemplates()` for templates (**additive**; no delete — see [Resource templates](#resource-templates-on-the-shared-gateway-server)), so the broker's listening server satisfies this interface.
+Add a `ResourcesAdderDeleter` interface mirroring tools resource mutation (`AddResources`, `DeleteResources`, `AddResourceTemplates`, `SetResourceTemplates`). The mcp-go `server.MCPServer` satisfies it.
 
-> **Note**: mcp-go does **not** expose a public `ListResources()` on the server (matching the prompts gap noted in [prompts-federation.md](prompts-federation.md)). The manager maintains its own `resourcesMap` and `servedResourcesMap` for lookups, the same way it does for tools.
+> **Note**: mcp-go does **not** expose a public `ListResources()` on the server for reads (matching the prompts gap noted in [prompts-federation.md](prompts-federation.md)). The manager maintains its own `resourcesMap` and `servedResourcesMap`; **`findResourceConflicts`** delegates cross-manager checks to the broker callback described above.
 
-The manager gets resource-parallel versions of the existing tool methods: discovery (`getResources`, `getResourceTemplates`), URI prefixing (`resourceToServerResource`, `templateToServerTemplate`, `prefixedURI`), diffing (`diffResources`), a **stub** `findResourceConflicts` (always accepts), and cleanup (`removeAllResources`). Concrete-resource add/remove matches tools; template federation is additive-only per the mcp-go limitation above.
+The manager gets resource-parallel discovery (`getResources`, `getResourceTemplates`), URI prefixing (`resourceToServerResource`, `templateToServerTemplate`, `prefixedURI`), diffing (`diffResources`), **`findResourceConflicts`**, cleanup (`removeAllResources`), and **`scheduleTemplateReconcile`** so templates stay aligned via **`SetResourceTemplates`**.
 
 The `manage()` loop is extended to discover resources after tools, and `registerCallbacks()` adds a handler for `notifications/resources/list_changed` (re-discovery only; not yet forwarded to clients — see Non-Goals). Status reporting adds `TotalResources`.
 
+The manager constructor receives the listening server as both `ToolsAdderDeleter` and `ResourcesAdderDeleter`.
+
 #### Broker (`internal/broker/broker.go`)
 
-Enable `server.WithResourceCapabilities(false, false)` on the listening MCP server (subscribe and listChanged set to `false` until those follow-ups land). Register `AddAfterListResources` and `AddAfterListResourceTemplates` hooks that strip `kuadrant/id` from each resource's `_meta` before returning to clients. Add `GetServerInfoByResourceURI(uri string)` to the `MCPBroker` interface — same pattern as `GetServerInfo()` for tools, searching managers by federated URI.
+Implements **`reconcileGatewayResourceTemplates`** (merge all managers → **`listeningMCPServer.SetResourceTemplates`**) and **`checkResourceURIConflicts`** wired into each `NewUpstreamMCPManager`.
 
-The manager constructor receives the listening server as both `ToolsAdderDeleter` and `ResourcesAdderDeleter`.
+Enable `server.WithResourceCapabilities(false, false)` on the listening MCP server (subscribe and listChanged set to `false` until those follow-ups land). Register `AddAfterListResources` and `AddAfterListResourceTemplates` hooks that strip `kuadrant/id` from each resource's `_meta` before returning to clients. Add `GetServerInfoByResourceURI(uri string)` to the `MCPBroker` interface — same pattern as `GetServerInfo()` for tools, searching managers by federated URI.
 
 #### Router (`internal/mcp-router/`)
 
@@ -177,11 +177,12 @@ There is no client-facing API change beyond `resources/list`/`resources/read` re
     - `removeGatewayMetaResources` strips `kuadrant/id` and tolerates nil meta
     - Router `ResourceURI()` extraction, `HandleResourceRead` happy path, prefix strip, missing URI, unknown URI
     - `HeadersBuilder.WithMCPResourceURI`
-    - Regression: `upstream.MCPServer.GetConfig()` propagates all federated fields (we have been bitten by shallow copies before)
+    - `findResourceConflicts` / broker `checkResourceURIConflicts` duplicate federated URI
+    - Template reconcile (`scheduleTemplateReconcile` → `SetResourceTemplates`)
 - **E2E** (`tests/e2e/test_cases.md`):
     - List federated resources from two backends with different prefixes; verify both appear with prefixed schemes
     - Read a federated resource end-to-end and verify the upstream sees the unprefixed URI
-    - (Follow-up once broker-side `findResourceConflicts` exists) two backends sharing a prefix that collide on the same upstream URI; verify conflict status
+    - Two backends sharing a prefix that advertise the same concrete federated resource URI; verify the second registration fails resource discovery / surfaces conflict (parity with tool conflicts where applicable)
 
 ## References
 

--- a/docs/design/resource-federation.md
+++ b/docs/design/resource-federation.md
@@ -1,0 +1,195 @@
+# Feature: MCP Resources Federation
+
+## Summary
+
+Add support for federating MCP Resources (and Resource Templates) through the gateway, following the same pattern used for tools. The broker discovers resources from upstream MCP servers, namespaces them by rewriting the URI scheme, and exposes them to clients via a single `resources/list` and `resources/templates/list`. The router handles `resources/read` requests by recovering the upstream URI and routing to the correct server. Ref: [#788](https://github.com/Kuadrant/mcp-gateway/issues/788), split from [#208](https://github.com/Kuadrant/mcp-gateway/issues/208).
+
+This document deliberately mirrors [prompts-federation.md](prompts-federation.md): the broker, manager, and router each gain a parallel set of resource methods. The only fundamentally new design problem is **URI namespacing**, which §[Design / URI Namespacing](#uri-namespacing) addresses.
+
+## Goals
+
+- Federate resources from multiple upstream MCP servers through a single gateway endpoint
+- Federate resource **templates** alongside concrete resources
+- Reuse the existing per-server prefix (`toolPrefix`, slated to be renamed to `prefix` in [#842](https://github.com/Kuadrant/mcp-gateway/pull/842)) as a URI-scheme prefix for resources — no new CRD fields
+- Document collision semantics: different `toolPrefix` values guarantee distinct federated URIs; duplicate-prefix misconfiguration is detectable for tools today but **resource collision detection is deferred** (manager stub — see [Conflict detection](#conflict-detection))
+- Surface a `status.discoveredResources` counter on `MCPServerRegistration` and an aggregate `totalResources` per server on the broker `/status` endpoint
+- Strip gateway-internal `_meta` (`kuadrant/id`) from federated resources before they reach clients
+
+## Non-Goals
+
+This PR delivers federation, not access control. The following are **out of scope** and tracked as follow-ups so reviewers do not need to evaluate them here:
+
+- **`resources/subscribe` and `notifications/resources/updated`** — explicitly listed as unsupported in [notifications.md](notifications.md). Subscriptions cross session boundaries and need a broker-side fan-out design that is independent of federation.
+- **`notifications/resources/list_changed` brokering to clients** — the upstream-facing manager already re-discovers on this notification (matching tools); forwarding to gateway-connected clients is deferred so this PR does not have to touch the broker's outbound notification path.
+- **JWT-based per-resource authorization** (`capabilities["resources"]` in the `x-mcp-authorized` header) — the [generalized authorization JWT shape](prompts-federation.md#generalized-authorization-header) already reserves `"resources"` as a top-level key. List hooks strip internal `_meta` today; wiring JWT claims into an allow/deny path for `resources/read` is left for a follow-up PR.
+- **`MCPVirtualServer.spec.resources`** — the virtual-server allow-list will land in the same PR as the JWT filter, since both share the `applyVirtualServerFilter` pattern.
+- **Resource validation** — resources have no JSON schema (unlike tools), so `invalidToolPolicy` does not apply. We rely on the upstream server to honor its declared resources.
+
+## Design
+
+### URI Namespacing
+
+The hard problem in resource federation is identifier collision. Two backends can both expose a resource with URI `file:///config.json` or `db://users`. Tools solve this with a flat per-server name prefix because tool names are opaque strings. Resource URIs are not opaque — clients dereference them via `resources/read` and they may also be RFC 6570 templates. The federation strategy must therefore be **lossless and reversible**: the gateway must be able to look at any URI a client passes back to it and recover (a) which backend owns it, and (b) the original upstream URI.
+
+**Adopted strategy: scheme-plus prefix.** When a resource is federated, the gateway rewrites its scheme from `<scheme>` to `<prefix>+<scheme>`. The plus character is legal in URI schemes per [RFC 3986 §3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1):
+
+> `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`
+
+Examples (assume `toolPrefix: weather_`):
+
+| Upstream URI | Federated URI |
+|---|---|
+| `file:///forecast.json` | `weather_+file:///forecast.json` |
+| `embedded:info` *(opaque)* | `weather_+embedded:info` |
+| `db://users/{id}` *(template)* | `weather_+db://users/{id}` |
+| `https://api.weather.test/v1/zones` | `weather_+https://api.weather.test/v1/zones` |
+
+When the prefix is empty (`toolPrefix: ""`) the URI is forwarded unchanged; this matches the tool federation behavior. Round-tripping is `prefixed → strip leading "<prefix>+" from scheme → upstream URI`.
+
+#### Why not the alternatives
+
+- **Path prefix** (`file:///weather/forecast.json` instead of `file:///forecast.json`): only works for hierarchical URIs that have an authority/path. Breaks opaque URIs (`embedded:info` has no path to prefix), custom schemes, and URI templates that target absolute paths. Also asymmetrically conflicts with backends that already use a top-level path component.
+- **Query parameter** (`file:///forecast.json?__gw=weather`): hides the namespace in metadata clients are not required to preserve. Two resources from different servers would render as the same URI in any UI that drops query strings. Easy to misuse.
+- **Custom gateway scheme wrapping** (`mcp+gw://weather/file:///forecast.json`): clients must learn a gateway-specific scheme. Resource templates become double-templated. Round-trips through any tool that does generic URI parsing (e.g. logging, observability) corrupt the inner URI.
+
+The scheme-plus strategy is the only option that is RFC-conformant, scheme-agnostic, template-friendly, and bijective. It also keeps the federation transparent: a client that knows nothing about the gateway can paste a federated URI back into `resources/read` and the gateway routes it correctly.
+
+#### Conflict detection
+
+Two backends with **different prefixes** cannot collide on federated URIs (the rewritten scheme differs).
+
+For **duplicate-prefix** registrations exposing the same upstream URI, tools fail fast today via `findToolConflicts`. Resources do **not** yet: `MCPManager.findResourceConflicts` is intentionally a **stub** that always returns `nil` because mcp-go exposes no `ListResources()` on the listening `server.MCPServer`, so the manager cannot walk the gateway’s aggregated resource view the way it does for tools. A follow-up will add broker-side validation (mirroring the prompts plan) during config reconciliation.
+
+Until then, duplicate-prefix + duplicate upstream URI yields **non-deterministic** routing in `GetServerInfoByResourceURI` (whichever manager wins the map lookup). Operators should keep prefixes unique per upstream registration.
+
+#### Resource templates on the shared gateway server
+
+Concrete resources use `AddResources` / `DeleteResources`, so removals propagate. **Resource templates** use `AddResourceTemplates`, which in mcp-go is **merge-only** — there is no public per-template delete. When an upstream **drops** a template, or returns an **empty** template list after previously publishing templates, stale federated templates can remain on the gateway until a broader reconcile exists (for example a broker-owned `SetResourceTemplates` merge across all managers) or the process restarts. Same limitation applies when `removeAllResources` runs: templates are deliberately **not** cleared because sibling managers share the listening server. This PR documents the gap; fixing it cleanly is follow-up work tied to mcp-go API or a broker-level aggregate.
+
+### Architecture Changes
+
+No new components. The existing broker, manager, and router are extended.
+
+```text
+resources/list flow:
+
+  Client ──► Envoy ──► ext_proc (router) ──► HandleNoneToolCall()
+                                                    │
+                                              sets headers:
+                                              x-mcp-servername=mcpBroker
+                                                    │
+                                              Envoy routes to broker
+                                                    │
+                                              Broker's mcp-go server
+                                              handles resources/list
+                                                    │
+                                              AddAfterListResources hook
+                                              strips kuadrant/id meta
+                                                    │
+                                              returns federated resources
+                                              to client
+
+
+resources/read flow:
+
+  Client ──► Envoy ──► ext_proc (router) ──► HandleResourceRead()
+                                                    │
+                                              1. Extract URI
+                                              2. GetServerInfoByResourceURI()
+                                              3. Strip "<prefix>+" from scheme
+                                              4. Set routing headers
+                                              5. Init backend session (reused)
+                                                    │
+                                              Envoy routes to upstream
+                                                    │
+                                              backend returns
+                                              ResourceContents to client
+```
+
+`resources/list` and `resources/templates/list` follow the same path as `tools/list` — they pass through the router to the broker's listening MCP server, which aggregates resources from all managers and applies the meta-stripping hook.
+
+`resources/read` follows the same path as `tools/call` — the router identifies the upstream by the scheme prefix, rewrites the URI, sets routing headers, and forwards to the correct upstream.
+
+### API Changes
+
+**None.** No new CRD fields, no breaking changes. The existing `MCPServerRegistration.spec.toolPrefix` (or `.spec.prefix` after [#842](https://github.com/Kuadrant/mcp-gateway/pull/842)) is reused as the URI scheme prefix. Documenting this dual-purpose semantics in the field godoc is part of this change.
+
+`MCPServerRegistration.status` gains a `discoveredResources` integer counter mirroring `discoveredTools`. This is additive; existing kubectl printcolumns are untouched.
+
+The broker `/status` JSON adds a `totalResources` field per `ServerValidationStatus` entry.
+
+### Component Changes
+
+The implementation follows the same pattern as tools throughout. Each component that handles tools gets a parallel set of resource logic.
+
+#### Upstream Client (`internal/broker/upstream/mcp.go`)
+
+Add `ListResources()`, `ListResourceTemplates()`, `ReadResource()`, and `SupportsResourcesListChanged()` to the `MCP` interface. These wrap the mcp-go client methods and check `up.init.Capabilities.Resources.ListChanged` for the notification capability.
+
+#### MCPManager (`internal/broker/upstream/manager.go`)
+
+Add a `ResourcesAdderDeleter` interface mirroring `ToolsAdderDeleter`. The mcp-go `server.MCPServer` implements `AddResources()`/`DeleteResources()` for concrete resources and `AddResourceTemplates()` for templates (**additive**; no delete — see [Resource templates](#resource-templates-on-the-shared-gateway-server)), so the broker's listening server satisfies this interface.
+
+> **Note**: mcp-go does **not** expose a public `ListResources()` on the server (matching the prompts gap noted in [prompts-federation.md](prompts-federation.md)). The manager maintains its own `resourcesMap` and `servedResourcesMap` for lookups, the same way it does for tools.
+
+The manager gets resource-parallel versions of the existing tool methods: discovery (`getResources`, `getResourceTemplates`), URI prefixing (`resourceToServerResource`, `templateToServerTemplate`, `prefixedURI`), diffing (`diffResources`), a **stub** `findResourceConflicts` (always accepts), and cleanup (`removeAllResources`). Concrete-resource add/remove matches tools; template federation is additive-only per the mcp-go limitation above.
+
+The `manage()` loop is extended to discover resources after tools, and `registerCallbacks()` adds a handler for `notifications/resources/list_changed` (re-discovery only; not yet forwarded to clients — see Non-Goals). Status reporting adds `TotalResources`.
+
+#### Broker (`internal/broker/broker.go`)
+
+Enable `server.WithResourceCapabilities(false, false)` on the listening MCP server (subscribe and listChanged set to `false` until those follow-ups land). Register `AddAfterListResources` and `AddAfterListResourceTemplates` hooks that strip `kuadrant/id` from each resource's `_meta` before returning to clients. Add `GetServerInfoByResourceURI(uri string)` to the `MCPBroker` interface — same pattern as `GetServerInfo()` for tools, searching managers by federated URI.
+
+The manager constructor receives the listening server as both `ToolsAdderDeleter` and `ResourcesAdderDeleter`.
+
+#### Router (`internal/mcp-router/`)
+
+`resources/list` and `resources/templates/list` need no router changes — they fall through to `HandleNoneToolCall()` and the broker handles them via mcp-go, same as `tools/list`.
+
+`resources/read` gets a new `HandleResourceRead()` handler following the same pattern as `HandleToolCall()`: extract URI, look up upstream by scheme prefix, strip prefix, manage backend session, set routing headers, forward via Envoy. A `ResourceURI()` accessor is added to `MCPRequest` mirroring `ToolName()`. A `WithMCPResourceURI()` builder method is added to `HeadersBuilder` so the upstream sees the unprefixed URI in `x-mcp-resource-uri` for observability/policy.
+
+The dispatcher `RouteMCPRequest` switch grows one case for `resources/read`.
+
+#### Config and CRD Types
+
+- `internal/config/types.go`: no field changes — the existing `ToolPrefix` is reused. Doc comment is updated to describe its dual role.
+- `api/v1alpha1/types.go`: no field changes to spec. Add `DiscoveredResources int32` to `MCPServerRegistrationStatus`. Update the `ToolPrefix` godoc to clarify it also prefixes resource URI schemes.
+
+### Backwards Compatibility
+
+Fully additive. Pre-existing `MCPServerRegistration` resources whose backends do not advertise resources continue to behave exactly as today. Resources that do exist on backends become available as federated resources transparently, prefixed by the same string already used for tool prefixing.
+
+There is no client-facing API change beyond `resources/list`/`resources/read` returning data from federated backends instead of an empty list. Clients that don't speak resources are unaffected.
+
+### Security Considerations
+
+- **No new privileges.** The federation reuses the existing broker-to-upstream credential channel (`credentialRef`) and the existing client-to-gateway authentication flow. No new auth surfaces.
+- **Internal metadata isolation.** The `kuadrant/id` metadata added to each resource during federation is stripped by the `AddAfterListResources` and `AddAfterListResourceTemplates` hooks before returning to clients, same as tools.
+- **URI rewriting is bijective.** A client cannot smuggle a request to a different backend by crafting a URI: the scheme prefix unambiguously identifies the owning server, and the stripped tail is what the backend originally advertised. Backend cannot receive a URI it did not produce.
+- **Reading without authorization is the next PR.** Until the JWT filter for resources lands (see Non-Goals), all federated resources are visible to any client that can list them. Operators should treat this PR as discovery + routing only, and gate it behind their existing AuthPolicy on the `resources/list` and `resources/read` paths if they need access control today.
+
+## Testing Strategy
+
+- **Unit tests**:
+    - URI prefix / strip helpers (round-trip across opaque and hierarchical URIs and URI templates)
+    - `MCPManager` resource discovery and diff
+    - `Broker.GetServerInfoByResourceURI` for hits, misses, and prefix collisions
+    - `removeGatewayMetaResources` strips `kuadrant/id` and tolerates nil meta
+    - Router `ResourceURI()` extraction, `HandleResourceRead` happy path, prefix strip, missing URI, unknown URI
+    - `HeadersBuilder.WithMCPResourceURI`
+    - Regression: `upstream.MCPServer.GetConfig()` propagates all federated fields (we have been bitten by shallow copies before)
+- **E2E** (`tests/e2e/test_cases.md`):
+    - List federated resources from two backends with different prefixes; verify both appear with prefixed schemes
+    - Read a federated resource end-to-end and verify the upstream sees the unprefixed URI
+    - (Follow-up once broker-side `findResourceConflicts` exists) two backends sharing a prefix that collide on the same upstream URI; verify conflict status
+
+## References
+
+- [MCP Resources Specification](https://modelcontextprotocol.io/specification/latest/server/resources)
+- [RFC 3986 — URI Generic Syntax §3.1 (Scheme)](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1)
+- [RFC 6570 — URI Template](https://datatracker.ietf.org/doc/html/rfc6570)
+- [mcp-go server.MCPServer API](https://pkg.go.dev/github.com/mark3labs/mcp-go/server)
+- [Issue #788 — Add support for MCP Resources federation](https://github.com/Kuadrant/mcp-gateway/issues/788)
+- [Issue #208 — Investigate support for Resources and Prompts](https://github.com/Kuadrant/mcp-gateway/issues/208)
+- [Prompts Federation design](prompts-federation.md)
+- [Notifications design](notifications.md)

--- a/docs/reference/mcpserverregistration.md
+++ b/docs/reference/mcpserverregistration.md
@@ -18,7 +18,7 @@
 | **Field** | **Type** | **Required** | **Description** |
 |-----------|----------|:------------:|-----------------|
 | `targetRef` | [TargetReference](#targetreference) | Yes | An HTTPRoute that points to a backend MCP server. The controller discovers the backend service from this HTTPRoute and configures the broker to federate its tools |
-| `toolPrefix` | String | No | Prefix added to all federated tools from referenced servers. Avoids naming conflicts when aggregating tools from multiple sources (e.g. `server1_search` and `server2_search`). Immutable once set |
+| `toolPrefix` | String | No | Prefix used to namespace federated capabilities from this server. It is prepended to tool names (`weather_get_forecast`) and to the URI scheme of federated resources (`weather_+file:///forecast.json`), preserving the original URI in a reversible, RFC 3986-compliant form. Avoids naming and URI collisions when aggregating capabilities from multiple sources. Immutable once set |
 | `path` | String | No | URL path where the MCP server endpoint is exposed. Default: `/mcp` |
 | `credentialRef` | [SecretReference](#secretreference) | No | Reference to a Secret containing authentication credentials. The secret must have the label `mcp.kuadrant.io/secret=true`. Credentials are made available to the broker via `KAGENTI_{NAME}_CRED` env vars |
 
@@ -44,3 +44,4 @@
 |-----------|----------|-----------------|
 | `conditions` | [][Kubernetes meta/v1.Condition](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition) | List of conditions that define the status of the resource |
 | `discoveredTools` | Integer | Number of tools discovered from this MCPServerRegistration |
+| `discoveredResources` | Integer | Number of concrete MCP resources (excluding resource templates) discovered from this MCPServerRegistration and made available to clients via the gateway |

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/yosida95/uritemplate/v3 v3.0.2
 	go.opentelemetry.io/contrib/bridges/otelslog v0.17.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0
@@ -96,7 +97,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/log v0.18.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -211,7 +211,9 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		// check if we need to setup a new manager
 		if _, ok := m.mcpServers[mcpServer.ID()]; !ok {
 			m.logger.Info("starting new manager", "server id", mcpServer.ID())
-			manager := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
+			manager := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy,
+				m.reconcileGatewayResourceTemplates,
+				m.checkResourceURIConflicts)
 			m.mcpServers[mcpServer.ID()] = manager
 			go func() {
 				m.logger.Info("Starting manager for", "mcpID", mcpServer.ID())
@@ -226,6 +228,37 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	}
 	m.vsLock.Unlock()
 	m.logger.Debug("Broker OnConfigChange done", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(conf.Servers))
+}
+
+func (m *mcpBrokerImpl) reconcileGatewayResourceTemplates() {
+	m.mcpLock.RLock()
+	managers := make([]*upstream.MCPManager, 0, len(m.mcpServers))
+	for _, mgr := range m.mcpServers {
+		managers = append(managers, mgr)
+	}
+	m.mcpLock.RUnlock()
+
+	var merged []server.ServerResourceTemplate
+	for _, mgr := range managers {
+		merged = append(merged, mgr.ExportFederatedResourceTemplates()...)
+	}
+	m.listeningMCPServer.SetResourceTemplates(merged...)
+}
+
+func (m *mcpBrokerImpl) checkResourceURIConflicts(owner config.UpstreamMCPID, federatedURIs []string) error {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+	for _, uri := range federatedURIs {
+		for id, mgr := range m.mcpServers {
+			if id == owner {
+				continue
+			}
+			if mgr.GetServedManagedResource(uri) != nil {
+				return fmt.Errorf("federated resource URI %q already registered by upstream %s", uri, id)
+			}
+		}
+	}
+	return nil
 }
 
 func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]*upstream.MCPManager {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -28,6 +28,11 @@ type MCPBroker interface {
 	// Returns server info for a given tool name
 	GetServerInfo(tool string) (*config.MCPServer, error)
 
+	// GetServerInfoByResourceURI returns the upstream that owns the given federated resource URI.
+	// The URI is the gateway-facing form ('<prefix>+<scheme>://...'); see the
+	// resource-federation design doc for the URI namespacing scheme.
+	GetServerInfoByResourceURI(uri string) (*config.MCPServer, error)
+
 	// MCPServer gets an MCP server that federates the upstreams known to this MCPBroker
 	MCPServer() *server.MCPServer
 
@@ -149,11 +154,24 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		mcpBkr.FilterTools(ctx, id, message, result)
 	})
 
+	hooks.AddAfterListResources(func(ctx context.Context, id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult) {
+		mcpBkr.FilterResources(ctx, id, message, result)
+	})
+
+	hooks.AddAfterListResourceTemplates(func(ctx context.Context, id any, message *mcp.ListResourceTemplatesRequest, result *mcp.ListResourceTemplatesResult) {
+		mcpBkr.FilterResourceTemplates(ctx, id, message, result)
+	})
+
 	mcpBkr.listeningMCPServer = server.NewMCPServer(
 		"Kuadrant MCP Gateway",
 		"0.0.1",
 		server.WithHooks(hooks),
 		server.WithToolCapabilities(true),
+		// subscribe=false, listChanged=false: per docs/design/resource-federation.md
+		// (Non-Goals), client-facing subscription and list-changed brokering are deferred
+		// to a follow-up PR. The capability is advertised so clients call resources/list
+		// and resources/templates/list, which the broker federates.
+		server.WithResourceCapabilities(false, false),
 	)
 	return mcpBkr
 }
@@ -193,7 +211,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		// check if we need to setup a new manager
 		if _, ok := m.mcpServers[mcpServer.ID()]; !ok {
 			m.logger.Info("starting new manager", "server id", mcpServer.ID())
-			manager := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
+			manager := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
 			m.mcpServers[mcpServer.ID()] = manager
 			go func() {
 				m.logger.Info("Starting manager for", "mcpID", mcpServer.ID())
@@ -262,6 +280,30 @@ func (m *mcpBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 	}
 
 	return nil, fmt.Errorf("tool name %q doesn't match any configured server", tool)
+}
+
+// GetServerInfoByResourceURI implements MCPBroker by providing a lookup of the server
+// that owns a given federated resource URI. The URI is the gateway-facing form
+// ('<prefix>+<scheme>://...'). The lookup is exact-match against each manager's
+// servedResourcesMap; concrete resources only. Resource-template lookups (RFC 6570
+// pattern matching against an incoming concrete URI) are deferred to a follow-up PR
+// — see docs/design/resource-federation.md, Non-Goals.
+func (m *mcpBrokerImpl) GetServerInfoByResourceURI(uri string) (*config.MCPServer, error) {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+
+	for _, upstream := range m.mcpServers {
+		if r := upstream.GetServedManagedResource(uri); r != nil {
+			m.logger.Debug("found matching server for resource",
+				"uri", uri,
+				"serverPrefix", upstream.MCP.GetPrefix(),
+				"serverName", upstream.MCP.GetName())
+			retval := upstream.MCP.GetConfig()
+			return &retval, nil
+		}
+	}
+
+	return nil, fmt.Errorf("resource uri %q doesn't match any configured server", uri)
 }
 
 func (m *mcpBrokerImpl) Shutdown(_ context.Context) error {

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -1,0 +1,53 @@
+package broker
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// FilterResources is the resources/list counterpart to FilterTools. JWT/virtual-server
+// filtering for resources is intentionally deferred to a follow-up PR (see
+// docs/design/resource-federation.md, Non-Goals); this handler currently only strips
+// the gateway-internal "kuadrant/id" meta marker before the result reaches the client,
+// so the wire format matches what an upstream MCP server would have produced directly.
+func (broker *mcpBrokerImpl) FilterResources(_ context.Context, _ any, _ *mcp.ListResourcesRequest, mcpRes *mcp.ListResourcesResult) {
+	if mcpRes == nil {
+		return
+	}
+	if mcpRes.Resources == nil {
+		mcpRes.Resources = []mcp.Resource{}
+		return
+	}
+	mcpRes.Resources = broker.removeGatewayResourceMeta(mcpRes.Resources)
+}
+
+// FilterResourceTemplates mirrors FilterResources for resources/templates/list.
+func (broker *mcpBrokerImpl) FilterResourceTemplates(_ context.Context, _ any, _ *mcp.ListResourceTemplatesRequest, mcpRes *mcp.ListResourceTemplatesResult) {
+	if mcpRes == nil {
+		return
+	}
+	if mcpRes.ResourceTemplates == nil {
+		mcpRes.ResourceTemplates = []mcp.ResourceTemplate{}
+		return
+	}
+	mcpRes.ResourceTemplates = broker.removeGatewayResourceTemplateMeta(mcpRes.ResourceTemplates)
+}
+
+func (broker *mcpBrokerImpl) removeGatewayResourceMeta(resources []mcp.Resource) []mcp.Resource {
+	for i := range resources {
+		if resources[i].Meta != nil {
+			delete(resources[i].Meta.AdditionalFields, "kuadrant/id")
+		}
+	}
+	return resources
+}
+
+func (broker *mcpBrokerImpl) removeGatewayResourceTemplateMeta(templates []mcp.ResourceTemplate) []mcp.ResourceTemplate {
+	for i := range templates {
+		if templates[i].Meta != nil {
+			delete(templates[i].Meta.AdditionalFields, "kuadrant/id")
+		}
+	}
+	return templates
+}

--- a/internal/broker/filtered_resources_handler_test.go
+++ b/internal/broker/filtered_resources_handler_test.go
@@ -84,7 +84,7 @@ func TestGetServerInfoByResourceURI(t *testing.T) {
 		URL:        "http://weather.local/mcp",
 	}
 	weather := upstream.NewUpstreamMCP(weatherCfg)
-	weatherMgr := upstream.NewUpstreamMCPManager(weather, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	weatherMgr := upstream.NewUpstreamMCPManager(weather, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 	weatherMgr.SetResourcesForTesting([]mcp.Resource{
 		{URI: "file:///forecast.json", Name: "forecast"},
 	})
@@ -95,7 +95,7 @@ func TestGetServerInfoByResourceURI(t *testing.T) {
 		URL:        "http://other.local/mcp",
 	}
 	other := upstream.NewUpstreamMCP(otherCfg)
-	otherMgr := upstream.NewUpstreamMCPManager(other, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	otherMgr := upstream.NewUpstreamMCPManager(other, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 	otherMgr.SetResourcesForTesting([]mcp.Resource{
 		{URI: "file:///config.json", Name: "config"},
 	})

--- a/internal/broker/filtered_resources_handler_test.go
+++ b/internal/broker/filtered_resources_handler_test.go
@@ -1,0 +1,124 @@
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestBroker(t *testing.T) *mcpBrokerImpl {
+	t.Helper()
+	b, ok := NewBroker(slog.Default()).(*mcpBrokerImpl)
+	if !ok {
+		t.Fatalf("NewBroker did not return *mcpBrokerImpl")
+	}
+	return b
+}
+
+func TestFilterResources_StripsGatewayIDMeta(t *testing.T) {
+	b := newTestBroker(t)
+	res := &mcp.ListResourcesResult{
+		Resources: []mcp.Resource{
+			{
+				URI: "weather_+file:///x",
+				Meta: mcp.NewMetaFromMap(map[string]any{
+					"kuadrant/id": "mcp-test/weather",
+					"keep-me":     "yes",
+				}),
+			},
+		},
+	}
+
+	b.FilterResources(context.Background(), nil, &mcp.ListResourcesRequest{}, res)
+
+	assert.Len(t, res.Resources, 1)
+	meta := res.Resources[0].Meta
+	if assert.NotNil(t, meta) {
+		_, hasInternal := meta.AdditionalFields["kuadrant/id"]
+		assert.False(t, hasInternal, "gateway-internal meta key must be stripped")
+		_, keptUserField := meta.AdditionalFields["keep-me"]
+		assert.True(t, keptUserField, "non-gateway meta keys must survive")
+	}
+}
+
+func TestFilterResources_NormalisesNilSlice(t *testing.T) {
+	b := newTestBroker(t)
+	res := &mcp.ListResourcesResult{Resources: nil}
+	b.FilterResources(context.Background(), nil, &mcp.ListResourcesRequest{}, res)
+	assert.NotNil(t, res.Resources, "nil slice must be replaced with empty slice so wire format is [] not null")
+	assert.Empty(t, res.Resources)
+}
+
+func TestFilterResourceTemplates_StripsGatewayIDMeta(t *testing.T) {
+	b := newTestBroker(t)
+	res := &mcp.ListResourceTemplatesResult{
+		ResourceTemplates: []mcp.ResourceTemplate{
+			{
+				Name: "by-name",
+				Meta: mcp.NewMetaFromMap(map[string]any{
+					"kuadrant/id": "mcp-test/weather",
+				}),
+			},
+		},
+	}
+	b.FilterResourceTemplates(context.Background(), nil, &mcp.ListResourceTemplatesRequest{}, res)
+	assert.Len(t, res.ResourceTemplates, 1)
+	if assert.NotNil(t, res.ResourceTemplates[0].Meta) {
+		_, hasInternal := res.ResourceTemplates[0].Meta.AdditionalFields["kuadrant/id"]
+		assert.False(t, hasInternal)
+	}
+}
+
+func TestGetServerInfoByResourceURI(t *testing.T) {
+	b := newTestBroker(t)
+
+	weatherCfg := &config.MCPServer{
+		Name:       "mcp-test/weather",
+		ToolPrefix: "weather_",
+		URL:        "http://weather.local/mcp",
+	}
+	weather := upstream.NewUpstreamMCP(weatherCfg)
+	weatherMgr := upstream.NewUpstreamMCPManager(weather, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	weatherMgr.SetResourcesForTesting([]mcp.Resource{
+		{URI: "file:///forecast.json", Name: "forecast"},
+	})
+
+	otherCfg := &config.MCPServer{
+		Name:       "mcp-test/other",
+		ToolPrefix: "other_",
+		URL:        "http://other.local/mcp",
+	}
+	other := upstream.NewUpstreamMCP(otherCfg)
+	otherMgr := upstream.NewUpstreamMCPManager(other, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	otherMgr.SetResourcesForTesting([]mcp.Resource{
+		{URI: "file:///config.json", Name: "config"},
+	})
+
+	b.mcpServers[weather.ID()] = weatherMgr
+	b.mcpServers[other.ID()] = otherMgr
+
+	got, err := b.GetServerInfoByResourceURI("weather_+file:///forecast.json")
+	if assert.NoError(t, err) && assert.NotNil(t, got) {
+		assert.Equal(t, weatherCfg.Name, got.Name)
+	}
+
+	got, err = b.GetServerInfoByResourceURI("other_+file:///config.json")
+	if assert.NoError(t, err) && assert.NotNil(t, got) {
+		assert.Equal(t, otherCfg.Name, got.Name)
+	}
+
+	// the upstream form (no prefix in scheme) must not match — that is the wire form
+	// the gateway never serves and would indicate a client bug.
+	_, err = b.GetServerInfoByResourceURI("file:///forecast.json")
+	assert.Error(t, err)
+
+	// unknown URI errors
+	_, err = b.GetServerInfoByResourceURI("weather_+file:///nope")
+	assert.Error(t, err)
+}

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -58,7 +58,7 @@ func createTestManager(t *testing.T, serverName, toolPrefix string, tools []mcp.
 		ToolPrefix: toolPrefix,
 		URL:        "http://test.local/mcp",
 	})
-	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	// populate tools directly for testing (this requires accessing internal state)
 	manager.SetToolsForTesting(tools)
 	return manager

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -58,7 +58,7 @@ func createTestManager(t *testing.T, serverName, toolPrefix string, tools []mcp.
 		ToolPrefix: toolPrefix,
 		URL:        "http://test.local/mcp",
 	})
-	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 	// populate tools directly for testing (this requires accessing internal state)
 	manager.SetToolsForTesting(tools)
 	return manager

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -34,7 +34,7 @@ func createTestManagerForStatus(t *testing.T, serverName string, tools []mcp.Too
 		ToolPrefix: "test_",
 		URL:        "http://test.local/mcp",
 	})
-	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	manager.SetToolsForTesting(tools)
 	manager.SetStatusForTesting(upstream.ServerValidationStatus{
 		Name:  serverName,

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -34,7 +34,7 @@ func createTestManagerForStatus(t *testing.T, serverName string, tools []mcp.Too
 		ToolPrefix: "test_",
 		URL:        "http://test.local/mcp",
 	})
-	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 	manager.SetToolsForTesting(tools)
 	manager.SetStatusForTesting(upstream.ServerValidationStatus{
 		Name:  serverName,

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 // ToolsAdderDeleter defines the interface for interacting with the gateway directly
@@ -30,9 +32,20 @@ type ToolsAdderDeleter interface {
 	ListTools() map[string]*server.ServerTool
 }
 
+// ResourcesAdderDeleter defines the interface for interacting with the gateway's
+// resource registry. Mirrors ToolsAdderDeleter. mcp-go does not expose template
+// deletion, so AddResourceTemplates is purely additive — see resource-federation
+// design doc.
+type ResourcesAdderDeleter interface {
+	AddResources(resources ...server.ServerResource)
+	DeleteResources(uris ...string)
+	AddResourceTemplates(templates ...server.ServerResourceTemplate)
+}
+
 const (
-	notificationToolsListChanged = "notifications/tools/list_changed"
-	gatewayServerID              = "kuadrant/id"
+	notificationToolsListChanged     = "notifications/tools/list_changed"
+	notificationResourcesListChanged = "notifications/resources/list_changed"
+	gatewayServerID                  = "kuadrant/id"
 )
 
 type eventType int
@@ -44,32 +57,38 @@ const (
 
 // ServerValidationStatus contains the validation results for an upstream MCP server
 type ServerValidationStatus struct {
-	ID              string            `json:"id"`
-	Name            string            `json:"name"`
-	LastValidated   time.Time         `json:"lastValidated"`
-	Message         string            `json:"message"`
-	Ready           bool              `json:"ready"`
-	TotalTools      int               `json:"totalTools"`
-	InvalidTools    int               `json:"invalidTools"`
-	InvalidToolList []InvalidToolInfo `json:"invalidToolList,omitempty"`
+	ID                     string            `json:"id"`
+	Name                   string            `json:"name"`
+	LastValidated          time.Time         `json:"lastValidated"`
+	Message                string            `json:"message"`
+	Ready                  bool              `json:"ready"`
+	TotalTools             int               `json:"totalTools"`
+	InvalidTools           int               `json:"invalidTools"`
+	InvalidToolList        []InvalidToolInfo `json:"invalidToolList,omitempty"`
+	TotalResources         int               `json:"totalResources"`
+	TotalResourceTemplates int               `json:"totalResourceTemplates"`
 }
 
 // MCP defines the interface for the manager to interact with an MCP server
 type MCP interface {
 	GetName() string
 	SupportsToolsListChanged() bool
+	SupportsResources() bool
+	SupportsResourcesListChanged() bool
 	GetConfig() config.MCPServer
 	ID() config.UpstreamMCPID
 	GetPrefix() string
 	Connect(context.Context, func()) error
 	Disconnect() error
 	ListTools(context.Context, mcp.ListToolsRequest) (*mcp.ListToolsResult, error)
+	ListResources(context.Context, mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error)
+	ListResourceTemplates(context.Context, mcp.ListResourceTemplatesRequest) (*mcp.ListResourceTemplatesResult, error)
 	OnNotification(func(notification mcp.JSONRPCNotification))
 	OnConnectionLost(func(err error))
 	Ping(context.Context) error
 }
 
-// MCPManager manages a single backend MCPServer for the broker. It does not act on behalf of clients. It is the only thing that should be connecting to the MCP Server for the broker. It handles tools updates, disconnection, notifications, liveness checks and updating the status for the MCP server. It is responsible for adding and removing tools to the broker. It is intended to be long lived and have 1:1 relationship with a backend MCP server.
+// MCPManager manages a single backend MCPServer for the broker. It does not act on behalf of clients. It is the only thing that should be connecting to the MCP Server for the broker. It handles tools updates, disconnection, notifications, liveness checks and updating the status for the MCP server. It is responsible for adding and removing tools and resources from the broker. It is intended to be long lived and have 1:1 relationship with a backend MCP server.
 type MCPManager struct {
 	MCP MCP
 	// ticker allows for us to continue to probe and retry the backend
@@ -77,6 +96,10 @@ type MCPManager struct {
 	// tickerInterval is the interval between backend health checks
 	tickerInterval time.Duration
 	gatewayServer  ToolsAdderDeleter
+	// gatewayResources is the same listening MCP server, exposed via the resource-management surface.
+	// In practice mcp-go's *server.MCPServer satisfies both ToolsAdderDeleter and ResourcesAdderDeleter;
+	// keeping them as separate fields documents which surface each path uses.
+	gatewayResources ResourcesAdderDeleter
 	// serverTools is an internal copy that contains the managed MCP's tools with prefixed names. It is these that are externally available via the gateway
 	serverTools []server.ServerTool
 	// tools is the original set from MCP server with no prefix
@@ -85,6 +108,20 @@ type MCPManager struct {
 	servedToolsMap map[string]*mcp.Tool
 	// toolsLock protects tools, serverTools
 	toolsLock sync.RWMutex
+
+	// resources/templates federation state. Mirrors the tool fields above. URIs in resources
+	// and resourcesMap are upstream (unprefixed); URIs in serverResources and servedResourcesMap
+	// have the gateway "<prefix>+" scheme prefix applied.
+	serverResources    []server.ServerResource
+	resources          []mcp.Resource
+	resourcesMap       map[string]*mcp.Resource
+	servedResourcesMap map[string]*mcp.Resource
+	// resourceTemplates is the upstream template set; serverResourceTemplates is the
+	// federated set served via the gateway. mcp-go has no per-template delete API,
+	// so we use SetResourceTemplates wholesale on each refresh.
+	resourceTemplates []mcp.ResourceTemplate
+	// resourcesLock protects all resource and template fields above
+	resourcesLock sync.RWMutex
 
 	logger *slog.Logger
 
@@ -100,24 +137,29 @@ type MCPManager struct {
 const DefaultTickerInterval = time.Minute * 1
 
 // NewUpstreamMCPManager creates a new MCPManager for managing a single upstream MCP server.
-// The addTools and removeTools callbacks are used to update the gateway's tool registry.
+// gatewayTools and gatewayResources are typically the same listening *server.MCPServer
+// — passing them as separate interfaces documents which surface each federation path uses.
 // The tickerInterval controls how often the manager checks backend health (use 0 for default).
-func NewUpstreamMCPManager(upstream MCP, gatewaySever ToolsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) *MCPManager {
+func NewUpstreamMCPManager(upstream MCP, gatewayTools ToolsAdderDeleter, gatewayResources ResourcesAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) *MCPManager {
 	if tickerInterval <= 0 {
 		tickerInterval = DefaultTickerInterval
 	}
 
 	return &MCPManager{
-		MCP:               upstream,
-		gatewayServer:     gatewaySever,
-		tickerInterval:    tickerInterval,
-		ticker:            time.NewTicker(tickerInterval),
-		logger:            logger,
-		invalidToolPolicy: policy,
-		done:              make(chan struct{}),
-		toolsMap:          map[string]*mcp.Tool{},
-		servedToolsMap:    map[string]*mcp.Tool{},
-		serverTools:       []server.ServerTool{},
+		MCP:                upstream,
+		gatewayServer:      gatewayTools,
+		gatewayResources:   gatewayResources,
+		tickerInterval:     tickerInterval,
+		ticker:             time.NewTicker(tickerInterval),
+		logger:             logger,
+		invalidToolPolicy:  policy,
+		done:               make(chan struct{}),
+		toolsMap:           map[string]*mcp.Tool{},
+		servedToolsMap:     map[string]*mcp.Tool{},
+		serverTools:        []server.ServerTool{},
+		resourcesMap:       map[string]*mcp.Resource{},
+		servedResourcesMap: map[string]*mcp.Resource{},
+		serverResources:    []server.ServerResource{},
 	}
 }
 
@@ -148,13 +190,14 @@ func (man *MCPManager) Start(ctx context.Context) {
 	}
 }
 
-// Stop gracefully shuts down the manager. It stops the ticker, removes all tools
-// from the gateway, disconnects from the upstream server, and waits for the Start
-// goroutine to complete. Safe to call multiple times.
+// Stop gracefully shuts down the manager. It stops the ticker, removes all tools and
+// resources from the gateway, disconnects from the upstream server, and waits for the
+// Start goroutine to complete. Safe to call multiple times.
 func (man *MCPManager) Stop() {
 	man.stopOnce.Do(func() {
 		man.ticker.Stop()
 		man.removeAllTools()
+		man.removeAllResources()
 		if err := man.MCP.Disconnect(); err != nil {
 			man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.MCP.ID(), "error", err)
 		}
@@ -167,10 +210,10 @@ func (man *MCPManager) registerCallbacks(ctx context.Context) func() {
 	man.logger.Debug("registering callbacks", "upstream mcp server", man.MCP.ID())
 	return func() {
 		man.MCP.OnNotification(func(notification mcp.JSONRPCNotification) {
-			if notification.Method == notificationToolsListChanged {
+			switch notification.Method {
+			case notificationToolsListChanged, notificationResourcesListChanged:
 				man.logger.Debug("received notification", "upstream mcp server", man.MCP.ID(), "notification", notification)
 				man.manage(ctx, eventTypeNotification)
-				return
 			}
 		})
 
@@ -273,7 +316,87 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.serverTools = append(man.serverTools, toAdd...)
 	man.logger.Debug("internal tools", "upstream mcp server", man.MCP.ID(), "total", len(man.serverTools))
 	man.toolsLock.Unlock()
-	man.setStatus(nil, numberOfTools, invalidTools)
+
+	// discover and federate resources after tools. this is intentionally a separate step
+	// so a resource discovery failure cannot tear down the working tool set.
+	resourceCount, templateCount, resourceErr := man.manageResources(ctx, event)
+	if resourceErr != nil {
+		// surface the error in status while keeping the (successful) tool count
+		man.logger.Error("failed to manage resources", "upstream mcp server", man.MCP.ID(), "error", resourceErr)
+		man.setStatusWithResources(resourceErr, numberOfTools, invalidTools, resourceCount, templateCount)
+		return
+	}
+	man.setStatusWithResources(nil, numberOfTools, invalidTools, resourceCount, templateCount)
+}
+
+// manageResources federates resources and resource templates from the upstream.
+// Returns the discovered resource count, template count, and any error. When the
+// upstream does not advertise resources support, this is a no-op returning (0, 0, nil).
+func (man *MCPManager) manageResources(ctx context.Context, event eventType) (int, int, error) {
+	if !man.MCP.SupportsResources() {
+		// backend does not implement resources at all; clear any stale state and exit clean.
+		man.removeAllResources()
+		return 0, 0, nil
+	}
+
+	if !man.shouldFetchResources(event) {
+		man.resourcesLock.RLock()
+		current, currentTemplates := len(man.resources), len(man.resourceTemplates)
+		man.resourcesLock.RUnlock()
+		man.logger.Debug("not fetching resources", "event", event, "upstream mcp server", man.MCP.ID(), "waiting for notification", notificationResourcesListChanged)
+		return current, currentTemplates, nil
+	}
+
+	current, fetched, err := man.getResources(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("upstream mcp failed to list resources server %s : %w", man.MCP.ID(), err)
+	}
+	toAdd, toRemove := man.diffResources(current, fetched)
+	if conflictErr := man.findResourceConflicts(toAdd); conflictErr != nil {
+		return 0, 0, fmt.Errorf("upstream mcp failed to add resources to gateway %s : %w", man.MCP.ID(), conflictErr)
+	}
+
+	man.resourcesLock.Lock()
+	man.resources = fetched
+	man.resourcesMap = make(map[string]*mcp.Resource, len(fetched))
+	man.servedResourcesMap = make(map[string]*mcp.Resource, len(fetched))
+	for i := range fetched {
+		man.resourcesMap[fetched[i].URI] = &fetched[i]
+		federated := prefixedURI(man.MCP.GetPrefix(), fetched[i].URI)
+		man.servedResourcesMap[federated] = &fetched[i]
+	}
+	man.logger.Debug("updating gateway resources", "upstream mcp server", man.MCP.ID(), "adding", len(toAdd), "removing", len(toRemove))
+	if len(toRemove) > 0 {
+		man.gatewayResources.DeleteResources(toRemove...)
+	}
+	if len(toAdd) > 0 {
+		man.gatewayResources.AddResources(toAdd...)
+	}
+	man.serverResources = slices.DeleteFunc(man.serverResources, func(res server.ServerResource) bool {
+		return slices.Contains(toRemove, res.Resource.URI)
+	})
+	man.serverResources = append(man.serverResources, toAdd...)
+	resourceCount := len(fetched)
+	man.resourcesLock.Unlock()
+
+	// resource templates: mcp-go has no per-template delete; we merge via AddResourceTemplates.
+	// Removed upstream templates may remain until broker-level reconcile — see design doc.
+	templates, templateErr := man.getResourceTemplates(ctx)
+	if templateErr != nil {
+		return resourceCount, 0, fmt.Errorf("upstream mcp failed to list resource templates server %s : %w", man.MCP.ID(), templateErr)
+	}
+	man.resourcesLock.Lock()
+	man.resourceTemplates = templates
+	templateCount := len(templates)
+	man.resourcesLock.Unlock()
+	if len(templates) > 0 {
+		serverTemplates := make([]server.ServerResourceTemplate, 0, len(templates))
+		for i := range templates {
+			serverTemplates = append(serverTemplates, man.templateToServerTemplate(templates[i]))
+		}
+		man.gatewayResources.AddResourceTemplates(serverTemplates...)
+	}
+	return resourceCount, templateCount, nil
 }
 
 func (man *MCPManager) shouldFetchTools(event eventType) bool {
@@ -289,6 +412,22 @@ func (man *MCPManager) shouldFetchTools(event eventType) bool {
 	return event == eventTypeTimer && len(man.serverTools) == 0
 }
 
+// shouldFetchResources mirrors shouldFetchTools for the resource side. Notifications
+// always trigger a refetch; in their absence we poll on the timer if we have no
+// resources cached or the upstream does not advertise list_changed support.
+func (man *MCPManager) shouldFetchResources(event eventType) bool {
+	if !man.MCP.SupportsResourcesListChanged() {
+		return true
+	}
+	if event == eventTypeNotification {
+		return true
+	}
+	man.resourcesLock.RLock()
+	empty := len(man.serverResources) == 0
+	man.resourcesLock.RUnlock()
+	return event == eventTypeTimer && empty
+}
+
 // GetStatus returns the current status of the MCP Server
 // no locking is done here as it is expected to be called multiple times
 func (man *MCPManager) GetStatus() ServerValidationStatus {
@@ -296,6 +435,12 @@ func (man *MCPManager) GetStatus() ServerValidationStatus {
 }
 
 func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []InvalidToolInfo) {
+	man.setStatusWithResources(err, toolCount, invalidTools, 0, 0)
+}
+
+// setStatusWithResources is the canonical status setter — setStatus delegates to it
+// for early-exit paths that have no resource counts yet. Keep these in sync.
+func (man *MCPManager) setStatusWithResources(err error, toolCount int, invalidTools []InvalidToolInfo, resourceCount, templateCount int) {
 	man.status.ID = string(man.MCP.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()
@@ -304,11 +449,17 @@ func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []Invali
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
+		// preserve the counts the caller managed to gather before the error so /status reflects partial progress
+		man.status.TotalTools = toolCount
+		man.status.TotalResources = resourceCount
+		man.status.TotalResourceTemplates = templateCount
 		return
 	}
 	man.status.TotalTools = toolCount
+	man.status.TotalResources = resourceCount
+	man.status.TotalResourceTemplates = templateCount
 	man.status.Ready = true
-	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d", len(man.serverTools))
+	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d, resources %d, resource templates %d", len(man.serverTools), resourceCount, templateCount)
 }
 
 func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {
@@ -462,4 +613,216 @@ func prefixedName(toolPrefix, tool string) string {
 		return tool
 	}
 	return fmt.Sprintf("%s%s", toolPrefix, tool)
+}
+
+// prefixedURI rewrites the scheme of a resource URI to include the server prefix,
+// e.g. "file:///x" with prefix "weather_" becomes "weather_+file:///x". The result
+// is reversible (strip the leading "<prefix>+" from the scheme to recover the
+// upstream URI). When prefix is empty, the URI passes through unchanged.
+//
+// We do not try to parse the URI: the +-prefix only mutates the scheme portion,
+// which by RFC 3986 §3.1 is everything before the first ":". This works for both
+// hierarchical URIs ("file:///x") and opaque ones ("embedded:info"), and is safe
+// for RFC 6570 URI templates where the scheme is always outside the template body.
+func prefixedURI(prefix, uri string) string {
+	if prefix == "" {
+		return uri
+	}
+	return fmt.Sprintf("%s+%s", prefix, uri)
+}
+
+// stripURIPrefix is the inverse of prefixedURI. It returns (upstreamURI, true) when
+// the URI's scheme starts with the expected "<prefix>+" marker, and ("", false)
+// otherwise. An empty prefix is treated as a pass-through (always matches).
+func stripURIPrefix(prefix, federatedURI string) (string, bool) {
+	if prefix == "" {
+		return federatedURI, true
+	}
+	marker := prefix + "+"
+	colon := strings.Index(federatedURI, ":")
+	if colon < 0 {
+		return "", false
+	}
+	scheme := federatedURI[:colon]
+	if !strings.HasPrefix(scheme, marker) {
+		return "", false
+	}
+	return scheme[len(marker):] + federatedURI[colon:], true
+}
+
+// getResources returns the previously-fetched resources and the freshly fetched set.
+// The caller diffs the two to compute add/remove operations.
+func (man *MCPManager) getResources(ctx context.Context) ([]mcp.Resource, []mcp.Resource, error) {
+	man.resourcesLock.RLock()
+	current := make([]mcp.Resource, len(man.resources))
+	copy(current, man.resources)
+	man.resourcesLock.RUnlock()
+	res, err := man.MCP.ListResources(ctx, mcp.ListResourcesRequest{})
+	if err != nil {
+		return current, current, fmt.Errorf("failed to list resources: %w", err)
+	}
+	return current, res.Resources, nil
+}
+
+// getResourceTemplates returns the freshly fetched template set from upstream.
+func (man *MCPManager) getResourceTemplates(ctx context.Context) ([]mcp.ResourceTemplate, error) {
+	res, err := man.MCP.ListResourceTemplates(ctx, mcp.ListResourceTemplatesRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resource templates: %w", err)
+	}
+	return res.ResourceTemplates, nil
+}
+
+// resourceToServerResource decorates an upstream resource with the gateway-internal
+// id meta marker and rewrites its URI for federation. The handler is a stub: the
+// router routes resources/read requests directly to the upstream via Envoy, so the
+// broker's listening server never executes this handler in production. We keep it
+// for parity with toolToServerTool and as a safety net should a request ever reach
+// the broker (in which case we return an error instead of silently returning empty).
+func (man *MCPManager) resourceToServerResource(newRes mcp.Resource) server.ServerResource {
+	upstreamURI := newRes.URI
+	newRes.URI = prefixedURI(man.MCP.GetPrefix(), newRes.URI)
+	newRes.Meta = mcp.NewMetaFromMap(map[string]any{
+		gatewayServerID: string(man.MCP.ID()),
+	})
+	return server.ServerResource{
+		Resource: newRes,
+		Handler: func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			return nil, fmt.Errorf("Kuadrant MCP Broker does not forward resource reads (uri: %s)", upstreamURI)
+		},
+	}
+}
+
+// templateToServerTemplate is the resource-template counterpart to resourceToServerResource.
+// URITemplate is rewritten the same way as a concrete URI: the scheme prefix is applied to
+// the template string so clients can construct federated URIs that round-trip through the
+// gateway. If parsing the prefixed template fails (it shouldn't — adding "<prefix>+" to a
+// valid scheme leaves the template syntactically valid) we fall through and serve the
+// original template, logging the error.
+func (man *MCPManager) templateToServerTemplate(newTpl mcp.ResourceTemplate) server.ServerResourceTemplate {
+	if newTpl.URITemplate != nil && newTpl.URITemplate.Template != nil {
+		raw := newTpl.URITemplate.Template.Raw()
+		if raw != "" {
+			prefixed, err := uritemplate.New(prefixedURI(man.MCP.GetPrefix(), raw))
+			if err != nil {
+				man.logger.Error("failed to rewrite URI template scheme; serving template unprefixed", "upstream mcp server", man.MCP.ID(), "raw", raw, "error", err)
+			} else {
+				newTpl.URITemplate = &mcp.URITemplate{Template: prefixed}
+			}
+		}
+	}
+	newTpl.Meta = mcp.NewMetaFromMap(map[string]any{
+		gatewayServerID: string(man.MCP.ID()),
+	})
+	return server.ServerResourceTemplate{
+		Template: newTpl,
+		Handler: func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			return nil, fmt.Errorf("Kuadrant MCP Broker does not forward resource reads")
+		},
+	}
+}
+
+// diffResources mirrors diffTools. Returns the federated additions (with prefixed URIs
+// and meta applied) and the prefixed URIs that need to be removed from the gateway.
+func (man *MCPManager) diffResources(oldResources, newResources []mcp.Resource) ([]server.ServerResource, []string) {
+	oldMap := make(map[string]mcp.Resource, len(oldResources))
+	for _, r := range oldResources {
+		oldMap[r.URI] = r
+	}
+
+	newMap := make(map[string]mcp.Resource, len(newResources))
+	for _, r := range newResources {
+		newMap[r.URI] = r
+	}
+
+	added := make([]server.ServerResource, 0)
+	for _, r := range newMap {
+		if _, ok := oldMap[r.URI]; !ok {
+			added = append(added, man.resourceToServerResource(r))
+		}
+	}
+
+	removed := make([]string, 0)
+	for _, r := range oldMap {
+		if _, ok := newMap[r.URI]; !ok {
+			removed = append(removed, prefixedURI(man.MCP.GetPrefix(), r.URI))
+		}
+	}
+
+	return added, removed
+}
+
+// findResourceConflicts is the resource counterpart to findToolConflicts but is
+// intentionally a stub in this PR.
+//
+// Tool conflict detection works because mcp-go's *server.MCPServer exposes a public
+// ListTools(); the manager walks it and compares against the candidate set's prefixed
+// names. mcp-go has no equivalent ListResources() on the server — see the same
+// discussion in prompts-federation.md — so cross-manager URI conflict detection
+// must live at the broker layer, which has visibility into every manager's
+// servedResourcesMap. The follow-up PR that adds JWT-based resource authorization
+// will introduce broker.findResourceConflicts as part of broker.OnConfigChange's
+// validation pass, mirroring the prompts plan.
+//
+// In the single-manager and unique-prefix-per-manager cases (the common case) no
+// federated URI collision is possible because the prefix uniquely identifies the
+// owning server. Operators who reuse a prefix across registrations and trip a true
+// collision will see the symptom as a non-deterministic backend selection by
+// GetServerInfoByResourceURI. The design doc calls this out under URI Namespacing
+// → Conflict detection.
+func (man *MCPManager) findResourceConflicts(candidates []server.ServerResource) error {
+	_ = candidates
+	return nil
+}
+
+// GetManagedResources returns a copy of all resources discovered from the upstream
+// server. The returned resources have their original URIs without the gateway prefix.
+func (man *MCPManager) GetManagedResources() []mcp.Resource {
+	man.resourcesLock.RLock()
+	defer man.resourcesLock.RUnlock()
+	result := make([]mcp.Resource, len(man.resources))
+	copy(result, man.resources)
+	return result
+}
+
+// GetServedManagedResource returns the upstream resource keyed by its federated URI,
+// or nil if no such resource is currently served by this manager. Returns the map
+// pointer directly to avoid a per-lookup alloc — callers must not modify.
+func (man *MCPManager) GetServedManagedResource(federatedURI string) *mcp.Resource {
+	man.resourcesLock.RLock()
+	defer man.resourcesLock.RUnlock()
+	return man.servedResourcesMap[federatedURI]
+}
+
+// SetResourcesForTesting bypasses upstream discovery and seeds the manager's resource
+// state directly. Test-only.
+func (man *MCPManager) SetResourcesForTesting(resources []mcp.Resource) {
+	man.resourcesLock.Lock()
+	defer man.resourcesLock.Unlock()
+	man.resources = resources
+	man.resourcesMap = make(map[string]*mcp.Resource, len(resources))
+	man.servedResourcesMap = make(map[string]*mcp.Resource, len(resources))
+	for i := range resources {
+		man.resourcesMap[resources[i].URI] = &resources[i]
+		man.servedResourcesMap[prefixedURI(man.MCP.GetPrefix(), resources[i].URI)] = &resources[i]
+	}
+}
+
+func (man *MCPManager) removeAllResources() {
+	man.resourcesLock.Lock()
+	defer man.resourcesLock.Unlock()
+	if man.gatewayResources != nil && len(man.serverResources) > 0 {
+		urisToRemove := make([]string, 0, len(man.serverResources))
+		for _, r := range man.serverResources {
+			urisToRemove = append(urisToRemove, r.Resource.URI)
+		}
+		man.gatewayResources.DeleteResources(urisToRemove...)
+	}
+	man.serverResources = []server.ServerResource{}
+	man.resources = []mcp.Resource{}
+	man.resourcesMap = map[string]*mcp.Resource{}
+	man.servedResourcesMap = map[string]*mcp.Resource{}
+	// templates: mcp-go offers no per-template delete and we share the gateway server
+	// with sibling managers, so we do not unregister templates here (would affect siblings).
+	man.resourceTemplates = nil
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -33,13 +33,14 @@ type ToolsAdderDeleter interface {
 }
 
 // ResourcesAdderDeleter defines the interface for interacting with the gateway's
-// resource registry. Mirrors ToolsAdderDeleter. mcp-go does not expose template
-// deletion, so AddResourceTemplates is purely additive — see resource-federation
-// design doc.
+// resource registry. Concrete resources use AddResources/DeleteResources; templates
+// are reconciled broker-wide via SetResourceTemplates so removals propagate.
 type ResourcesAdderDeleter interface {
 	AddResources(resources ...server.ServerResource)
 	DeleteResources(uris ...string)
 	AddResourceTemplates(templates ...server.ServerResourceTemplate)
+	// SetResourceTemplates replaces all templates on the gateway listening server (mcp-go).
+	SetResourceTemplates(templates ...server.ServerResourceTemplate)
 }
 
 const (
@@ -117,11 +118,18 @@ type MCPManager struct {
 	resourcesMap       map[string]*mcp.Resource
 	servedResourcesMap map[string]*mcp.Resource
 	// resourceTemplates is the upstream template set; serverResourceTemplates is the
-	// federated set served via the gateway. mcp-go has no per-template delete API,
-	// so we use SetResourceTemplates wholesale on each refresh.
-	resourceTemplates []mcp.ResourceTemplate
+	// federated ServerResourceTemplate slice last fetched from upstream (for broker-wide reconcile).
+	resourceTemplates       []mcp.ResourceTemplate
+	serverResourceTemplates []server.ServerResourceTemplate
 	// resourcesLock protects all resource and template fields above
 	resourcesLock sync.RWMutex
+
+	// reconcileGatewayTemplates merges templates from every upstream manager via the broker.
+	// When nil (unit tests), scheduleTemplateReconcile applies SetResourceTemplates for this manager only.
+	reconcileGatewayTemplates func()
+
+	// resourceConflictCheck rejects federated URIs already owned by another upstream manager.
+	resourceConflictCheck func(owner config.UpstreamMCPID, federatedURIs []string) error
 
 	logger *slog.Logger
 
@@ -140,26 +148,31 @@ const DefaultTickerInterval = time.Minute * 1
 // gatewayTools and gatewayResources are typically the same listening *server.MCPServer
 // — passing them as separate interfaces documents which surface each federation path uses.
 // The tickerInterval controls how often the manager checks backend health (use 0 for default).
-func NewUpstreamMCPManager(upstream MCP, gatewayTools ToolsAdderDeleter, gatewayResources ResourcesAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) *MCPManager {
+func NewUpstreamMCPManager(upstream MCP, gatewayTools ToolsAdderDeleter, gatewayResources ResourcesAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy,
+	reconcileGatewayTemplates func(),
+	resourceConflictCheck func(owner config.UpstreamMCPID, federatedURIs []string) error,
+) *MCPManager {
 	if tickerInterval <= 0 {
 		tickerInterval = DefaultTickerInterval
 	}
 
 	return &MCPManager{
-		MCP:                upstream,
-		gatewayServer:      gatewayTools,
-		gatewayResources:   gatewayResources,
-		tickerInterval:     tickerInterval,
-		ticker:             time.NewTicker(tickerInterval),
-		logger:             logger,
-		invalidToolPolicy:  policy,
-		done:               make(chan struct{}),
-		toolsMap:           map[string]*mcp.Tool{},
-		servedToolsMap:     map[string]*mcp.Tool{},
-		serverTools:        []server.ServerTool{},
-		resourcesMap:       map[string]*mcp.Resource{},
-		servedResourcesMap: map[string]*mcp.Resource{},
-		serverResources:    []server.ServerResource{},
+		MCP:                       upstream,
+		gatewayServer:             gatewayTools,
+		gatewayResources:          gatewayResources,
+		reconcileGatewayTemplates: reconcileGatewayTemplates,
+		resourceConflictCheck:     resourceConflictCheck,
+		tickerInterval:            tickerInterval,
+		ticker:                    time.NewTicker(tickerInterval),
+		logger:                    logger,
+		invalidToolPolicy:         policy,
+		done:                      make(chan struct{}),
+		toolsMap:                  map[string]*mcp.Tool{},
+		servedToolsMap:            map[string]*mcp.Tool{},
+		serverTools:               []server.ServerTool{},
+		resourcesMap:              map[string]*mcp.Resource{},
+		servedResourcesMap:        map[string]*mcp.Resource{},
+		serverResources:           []server.ServerResource{},
 	}
 }
 
@@ -379,24 +392,44 @@ func (man *MCPManager) manageResources(ctx context.Context, event eventType) (in
 	resourceCount := len(fetched)
 	man.resourcesLock.Unlock()
 
-	// resource templates: mcp-go has no per-template delete; we merge via AddResourceTemplates.
-	// Removed upstream templates may remain until broker-level reconcile — see design doc.
+	// resource templates: broker calls SetResourceTemplates with the merged view from
+	// every upstream manager so removals propagate (see scheduleTemplateReconcile).
 	templates, templateErr := man.getResourceTemplates(ctx)
 	if templateErr != nil {
 		return resourceCount, 0, fmt.Errorf("upstream mcp failed to list resource templates server %s : %w", man.MCP.ID(), templateErr)
 	}
+	serverTemplates := make([]server.ServerResourceTemplate, 0, len(templates))
+	for i := range templates {
+		serverTemplates = append(serverTemplates, man.templateToServerTemplate(templates[i]))
+	}
 	man.resourcesLock.Lock()
 	man.resourceTemplates = templates
+	man.serverResourceTemplates = serverTemplates
 	templateCount := len(templates)
 	man.resourcesLock.Unlock()
-	if len(templates) > 0 {
-		serverTemplates := make([]server.ServerResourceTemplate, 0, len(templates))
-		for i := range templates {
-			serverTemplates = append(serverTemplates, man.templateToServerTemplate(templates[i]))
-		}
-		man.gatewayResources.AddResourceTemplates(serverTemplates...)
-	}
+	man.scheduleTemplateReconcile()
 	return resourceCount, templateCount, nil
+}
+
+func (man *MCPManager) scheduleTemplateReconcile() {
+	if man.gatewayResources == nil {
+		return
+	}
+	if man.reconcileGatewayTemplates != nil {
+		man.reconcileGatewayTemplates()
+		return
+	}
+	tpl := man.ExportFederatedResourceTemplates()
+	man.gatewayResources.SetResourceTemplates(tpl...)
+}
+
+// ExportFederatedResourceTemplates returns a copy of federated templates last synced from upstream.
+func (man *MCPManager) ExportFederatedResourceTemplates() []server.ServerResourceTemplate {
+	man.resourcesLock.RLock()
+	defer man.resourcesLock.RUnlock()
+	out := make([]server.ServerResourceTemplate, len(man.serverResourceTemplates))
+	copy(out, man.serverResourceTemplates)
+	return out
 }
 
 func (man *MCPManager) shouldFetchTools(event eventType) bool {
@@ -752,27 +785,16 @@ func (man *MCPManager) diffResources(oldResources, newResources []mcp.Resource) 
 	return added, removed
 }
 
-// findResourceConflicts is the resource counterpart to findToolConflicts but is
-// intentionally a stub in this PR.
-//
-// Tool conflict detection works because mcp-go's *server.MCPServer exposes a public
-// ListTools(); the manager walks it and compares against the candidate set's prefixed
-// names. mcp-go has no equivalent ListResources() on the server — see the same
-// discussion in prompts-federation.md — so cross-manager URI conflict detection
-// must live at the broker layer, which has visibility into every manager's
-// servedResourcesMap. The follow-up PR that adds JWT-based resource authorization
-// will introduce broker.findResourceConflicts as part of broker.OnConfigChange's
-// validation pass, mirroring the prompts plan.
-//
-// In the single-manager and unique-prefix-per-manager cases (the common case) no
-// federated URI collision is possible because the prefix uniquely identifies the
-// owning server. Operators who reuse a prefix across registrations and trip a true
-// collision will see the symptom as a non-deterministic backend selection by
-// GetServerInfoByResourceURI. The design doc calls this out under URI Namespacing
-// → Conflict detection.
+// findResourceConflicts rejects federated URIs already registered by another upstream manager.
 func (man *MCPManager) findResourceConflicts(candidates []server.ServerResource) error {
-	_ = candidates
-	return nil
+	if man.resourceConflictCheck == nil || len(candidates) == 0 {
+		return nil
+	}
+	uris := make([]string, len(candidates))
+	for i := range candidates {
+		uris[i] = candidates[i].Resource.URI
+	}
+	return man.resourceConflictCheck(man.MCP.ID(), uris)
 }
 
 // GetManagedResources returns a copy of all resources discovered from the upstream
@@ -810,7 +832,6 @@ func (man *MCPManager) SetResourcesForTesting(resources []mcp.Resource) {
 
 func (man *MCPManager) removeAllResources() {
 	man.resourcesLock.Lock()
-	defer man.resourcesLock.Unlock()
 	if man.gatewayResources != nil && len(man.serverResources) > 0 {
 		urisToRemove := make([]string, 0, len(man.serverResources))
 		for _, r := range man.serverResources {
@@ -822,7 +843,8 @@ func (man *MCPManager) removeAllResources() {
 	man.resources = []mcp.Resource{}
 	man.resourcesMap = map[string]*mcp.Resource{}
 	man.servedResourcesMap = map[string]*mcp.Resource{}
-	// templates: mcp-go offers no per-template delete and we share the gateway server
-	// with sibling managers, so we do not unregister templates here (would affect siblings).
 	man.resourceTemplates = nil
+	man.serverResourceTemplates = nil
+	man.resourcesLock.Unlock()
+	man.scheduleTemplateReconcile()
 }

--- a/internal/broker/upstream/manager_resources_test.go
+++ b/internal/broker/upstream/manager_resources_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
@@ -18,9 +19,10 @@ import (
 type MockResourcesAdderDeleter struct {
 	resources         map[string]*server.ServerResource
 	templates         []server.ServerResourceTemplate
-	addCalls          int
-	delCalls          int
-	addTemplateCalls  int
+	addCalls           int
+	delCalls           int
+	addTemplateCalls   int
+	setTemplateCalls   int
 }
 
 func newMockResourcesAdderDeleter() *MockResourcesAdderDeleter {
@@ -46,6 +48,11 @@ func (m *MockResourcesAdderDeleter) DeleteResources(uris ...string) {
 func (m *MockResourcesAdderDeleter) AddResourceTemplates(templates ...server.ServerResourceTemplate) {
 	m.addTemplateCalls++
 	m.templates = append(m.templates, templates...)
+}
+
+func (m *MockResourcesAdderDeleter) SetResourceTemplates(templates ...server.ServerResourceTemplate) {
+	m.setTemplateCalls++
+	m.templates = append([]server.ServerResourceTemplate(nil), templates...)
 }
 
 func TestPrefixedURI(t *testing.T) {
@@ -109,7 +116,7 @@ func TestStripURIPrefix_RoundTrip(t *testing.T) {
 func TestMCPManager_GetServedManagedResource(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "weather_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.SetResourcesForTesting([]mcp.Resource{
 		{URI: "file:///forecast.json", Name: "forecast"},
@@ -131,7 +138,7 @@ func TestMCPManager_GetServedManagedResource(t *testing.T) {
 func TestMCPManager_GetManagedResources_ReturnsCopy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "p_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.SetResourcesForTesting([]mcp.Resource{{URI: "file:///x", Name: "x"}})
 
@@ -145,7 +152,7 @@ func TestMCPManager_GetManagedResources_ReturnsCopy(t *testing.T) {
 func TestMCPManager_diffResources(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "weather_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	old := []mcp.Resource{
 		{URI: "file:///a", Name: "a"},
@@ -171,7 +178,7 @@ func TestMCPManager_manageResources_NoSupport(t *testing.T) {
 	mock := newMockMCP("no-resources", "")
 	mock.hasResourcesCap = false
 	gateway := newMockResourcesAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	r, tpl, err := manager.manageResources(context.Background(), eventTypeTimer)
 	assert.NoError(t, err)
@@ -200,7 +207,7 @@ func TestMCPManager_manageResources_FederatesAndPrefixes(t *testing.T) {
 		},
 	}
 	gateway := newMockResourcesAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	count, tplCount, err := manager.manageResources(context.Background(), eventTypeTimer)
 	assert.NoError(t, err)
@@ -210,6 +217,7 @@ func TestMCPManager_manageResources_FederatesAndPrefixes(t *testing.T) {
 	// gateway should hold the prefixed URIs
 	assert.Contains(t, gateway.resources, "weather_+file:///forecast.json")
 	assert.Contains(t, gateway.resources, "weather_+embedded:info")
+	require.Equal(t, 1, gateway.setTemplateCalls)
 	if assert.Len(t, gateway.templates, 1) {
 		raw := gateway.templates[0].Template.URITemplate.Template.Raw()
 		assert.Equal(t, "weather_+file:///{name}.json", raw)
@@ -225,7 +233,7 @@ func TestMCPManager_manageResources_PropagatesListError(t *testing.T) {
 	mock.hasResourcesCap = true
 	mock.listResourcesErr = errors.New("upstream boom")
 	gateway := newMockResourcesAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	_, _, err := manager.manageResources(context.Background(), eventTypeTimer)
 	assert.Error(t, err)
@@ -238,7 +246,7 @@ func TestMCPManager_removeAllResources_ClearsGateway(t *testing.T) {
 	mock.hasResourcesCap = true
 	mock.resources = []mcp.Resource{{URI: "file:///x", Name: "x"}}
 	gateway := newMockResourcesAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	_, _, err := manager.manageResources(context.Background(), eventTypeTimer)
 	assert.NoError(t, err)
@@ -247,4 +255,26 @@ func TestMCPManager_removeAllResources_ClearsGateway(t *testing.T) {
 	manager.removeAllResources()
 	assert.Empty(t, gateway.resources)
 	assert.Empty(t, manager.GetManagedResources())
+	assert.Equal(t, 2, gateway.setTemplateCalls)
+}
+
+func TestFindResourceConflicts(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test", "p_")
+	mock.hasResourcesCap = true
+	gateway := newMockResourcesAdderDeleter()
+	wantErr := errors.New("collision")
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil,
+		func(_ config.UpstreamMCPID, uris []string) error {
+			if len(uris) > 0 && uris[0] == "p_+file:///x" {
+				return wantErr
+			}
+			return nil
+		})
+
+	candidates := []server.ServerResource{{Resource: mcp.Resource{URI: "p_+file:///x"}}}
+	assert.ErrorIs(t, manager.findResourceConflicts(candidates), wantErr)
+
+	managerNil := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
+	assert.NoError(t, managerNil.findResourceConflicts(candidates))
 }

--- a/internal/broker/upstream/manager_resources_test.go
+++ b/internal/broker/upstream/manager_resources_test.go
@@ -1,0 +1,250 @@
+package upstream
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/yosida95/uritemplate/v3"
+)
+
+// MockResourcesAdderDeleter implements ResourcesAdderDeleter for testing.
+type MockResourcesAdderDeleter struct {
+	resources         map[string]*server.ServerResource
+	templates         []server.ServerResourceTemplate
+	addCalls          int
+	delCalls          int
+	addTemplateCalls  int
+}
+
+func newMockResourcesAdderDeleter() *MockResourcesAdderDeleter {
+	return &MockResourcesAdderDeleter{
+		resources: make(map[string]*server.ServerResource),
+	}
+}
+
+func (m *MockResourcesAdderDeleter) AddResources(resources ...server.ServerResource) {
+	m.addCalls++
+	for i := range resources {
+		m.resources[resources[i].Resource.URI] = &resources[i]
+	}
+}
+
+func (m *MockResourcesAdderDeleter) DeleteResources(uris ...string) {
+	m.delCalls++
+	for _, u := range uris {
+		delete(m.resources, u)
+	}
+}
+
+func (m *MockResourcesAdderDeleter) AddResourceTemplates(templates ...server.ServerResourceTemplate) {
+	m.addTemplateCalls++
+	m.templates = append(m.templates, templates...)
+}
+
+func TestPrefixedURI(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		uri    string
+		want   string
+	}{
+		{"empty prefix passes through", "", "file:///x", "file:///x"},
+		{"hierarchical uri", "weather_", "file:///x", "weather_+file:///x"},
+		{"opaque uri", "demo_", "embedded:info", "demo_+embedded:info"},
+		{"uri with query and fragment", "p_", "https://example.com/a?b=c#d", "p_+https://example.com/a?b=c#d"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, prefixedURI(c.prefix, c.uri))
+		})
+	}
+}
+
+func TestStripURIPrefix(t *testing.T) {
+	cases := []struct {
+		name      string
+		prefix    string
+		input     string
+		wantURI   string
+		wantMatch bool
+	}{
+		{"empty prefix is pass-through", "", "file:///x", "file:///x", true},
+		{"matching prefix is stripped", "weather_", "weather_+file:///x", "file:///x", true},
+		{"opaque uri matching prefix", "demo_", "demo_+embedded:info", "embedded:info", true},
+		{"non-matching prefix returns false", "weather_", "other_+file:///x", "", false},
+		{"missing colon returns false", "weather_", "weather_no_scheme", "", false},
+		{"unprefixed uri with non-empty prefix returns false", "weather_", "file:///x", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := stripURIPrefix(c.prefix, c.input)
+			assert.Equal(t, c.wantMatch, ok)
+			assert.Equal(t, c.wantURI, got)
+		})
+	}
+}
+
+// TestStripURIPrefix_RoundTrip is a property-style check that prefixedURI and
+// stripURIPrefix are inverses for any non-empty prefix and well-formed URI.
+func TestStripURIPrefix_RoundTrip(t *testing.T) {
+	prefixes := []string{"", "weather_", "demo_", "x-y_"}
+	uris := []string{"file:///x", "embedded:info", "https://example.com/a?b=c#d", "custom-scheme:opaque-payload"}
+	for _, p := range prefixes {
+		for _, u := range uris {
+			federated := prefixedURI(p, u)
+			back, ok := stripURIPrefix(p, federated)
+			assert.True(t, ok, "round-trip failed for prefix=%q uri=%q federated=%q", p, u, federated)
+			assert.Equal(t, u, back, "round-trip mismatch for prefix=%q uri=%q", p, u)
+		}
+	}
+}
+
+func TestMCPManager_GetServedManagedResource(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test", "weather_")
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	manager.SetResourcesForTesting([]mcp.Resource{
+		{URI: "file:///forecast.json", Name: "forecast"},
+		{URI: "embedded:info", Name: "info"},
+	})
+
+	got := manager.GetServedManagedResource("weather_+file:///forecast.json")
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "file:///forecast.json", got.URI)
+	}
+
+	// unprefixed (upstream) URI is not the served form and must miss
+	assert.Nil(t, manager.GetServedManagedResource("file:///forecast.json"))
+
+	// unknown URI misses
+	assert.Nil(t, manager.GetServedManagedResource("weather_+file:///nope"))
+}
+
+func TestMCPManager_GetManagedResources_ReturnsCopy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test", "p_")
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	manager.SetResourcesForTesting([]mcp.Resource{{URI: "file:///x", Name: "x"}})
+
+	got := manager.GetManagedResources()
+	got[0].Name = "mutated"
+
+	again := manager.GetManagedResources()
+	assert.Equal(t, "x", again[0].Name)
+}
+
+func TestMCPManager_diffResources(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test", "weather_")
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	old := []mcp.Resource{
+		{URI: "file:///a", Name: "a"},
+		{URI: "file:///b", Name: "b"},
+	}
+	now := []mcp.Resource{
+		{URI: "file:///b", Name: "b"},
+		{URI: "file:///c", Name: "c"},
+	}
+
+	added, removed := manager.diffResources(old, now)
+
+	if assert.Len(t, added, 1) {
+		assert.Equal(t, "weather_+file:///c", added[0].Resource.URI)
+	}
+	if assert.Len(t, removed, 1) {
+		assert.Equal(t, "weather_+file:///a", removed[0])
+	}
+}
+
+func TestMCPManager_manageResources_NoSupport(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("no-resources", "")
+	mock.hasResourcesCap = false
+	gateway := newMockResourcesAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	r, tpl, err := manager.manageResources(context.Background(), eventTypeTimer)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, r)
+	assert.Equal(t, 0, tpl)
+	assert.Empty(t, gateway.resources)
+	assert.Zero(t, gateway.addCalls)
+}
+
+func TestMCPManager_manageResources_FederatesAndPrefixes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("weather", "weather_")
+	mock.hasResourcesCap = true
+	mock.resources = []mcp.Resource{
+		{URI: "file:///forecast.json", Name: "forecast"},
+		{URI: "embedded:info", Name: "info"},
+	}
+	tpl, err := uritemplate.New("file:///{name}.json")
+	if err != nil {
+		t.Fatalf("failed to create test template: %v", err)
+	}
+	mock.resourceTemplates = []mcp.ResourceTemplate{
+		{
+			URITemplate: &mcp.URITemplate{Template: tpl},
+			Name:        "by-name",
+		},
+	}
+	gateway := newMockResourcesAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	count, tplCount, err := manager.manageResources(context.Background(), eventTypeTimer)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.Equal(t, 1, tplCount)
+
+	// gateway should hold the prefixed URIs
+	assert.Contains(t, gateway.resources, "weather_+file:///forecast.json")
+	assert.Contains(t, gateway.resources, "weather_+embedded:info")
+	if assert.Len(t, gateway.templates, 1) {
+		raw := gateway.templates[0].Template.URITemplate.Template.Raw()
+		assert.Equal(t, "weather_+file:///{name}.json", raw)
+	}
+
+	// served map keys must be the federated form
+	assert.NotNil(t, manager.GetServedManagedResource("weather_+file:///forecast.json"))
+}
+
+func TestMCPManager_manageResources_PropagatesListError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("err", "err_")
+	mock.hasResourcesCap = true
+	mock.listResourcesErr = errors.New("upstream boom")
+	gateway := newMockResourcesAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	_, _, err := manager.manageResources(context.Background(), eventTypeTimer)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list resources")
+}
+
+func TestMCPManager_removeAllResources_ClearsGateway(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("weather", "weather_")
+	mock.hasResourcesCap = true
+	mock.resources = []mcp.Resource{{URI: "file:///x", Name: "x"}}
+	gateway := newMockResourcesAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, nil, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	_, _, err := manager.manageResources(context.Background(), eventTypeTimer)
+	assert.NoError(t, err)
+	assert.Len(t, gateway.resources, 1)
+
+	manager.removeAllResources()
+	assert.Empty(t, gateway.resources)
+	assert.Empty(t, manager.GetManagedResources())
+}

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -18,17 +18,23 @@ import (
 
 // MockMCP implements the MCP interface for testing
 type MockMCP struct {
-	name            string
-	prefix          string
-	id              config.UpstreamMCPID
-	cfg             *config.MCPServer
-	connectErr      error
-	pingErr         error
-	tools           []mcp.Tool
-	listToolsErr    error
-	protocolVersion string
-	hasToolsCap     bool
-	connected       bool
+	name                 string
+	prefix               string
+	id                   config.UpstreamMCPID
+	cfg                  *config.MCPServer
+	connectErr           error
+	pingErr              error
+	tools                []mcp.Tool
+	listToolsErr         error
+	protocolVersion      string
+	hasToolsCap          bool
+	connected            bool
+	hasResourcesCap      bool
+	resourcesListChanged bool
+	resources            []mcp.Resource
+	listResourcesErr     error
+	resourceTemplates    []mcp.ResourceTemplate
+	listTemplatesErr     error
 }
 
 func (m *MockMCP) GetName() string {
@@ -62,6 +68,14 @@ func (m *MockMCP) SupportsToolsListChanged() bool {
 	return m.hasToolsCap
 }
 
+func (m *MockMCP) SupportsResources() bool {
+	return m.hasResourcesCap
+}
+
+func (m *MockMCP) SupportsResourcesListChanged() bool {
+	return m.resourcesListChanged
+}
+
 func (m *MockMCP) Disconnect() error {
 	m.connected = false
 	return nil
@@ -72,6 +86,20 @@ func (m *MockMCP) ListTools(_ context.Context, _ mcp.ListToolsRequest) (*mcp.Lis
 		return nil, m.listToolsErr
 	}
 	return &mcp.ListToolsResult{Tools: m.tools}, nil
+}
+
+func (m *MockMCP) ListResources(_ context.Context, _ mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	if m.listResourcesErr != nil {
+		return nil, m.listResourcesErr
+	}
+	return &mcp.ListResourcesResult{Resources: m.resources}, nil
+}
+
+func (m *MockMCP) ListResourceTemplates(_ context.Context, _ mcp.ListResourceTemplatesRequest) (*mcp.ListResourceTemplatesResult, error) {
+	if m.listTemplatesErr != nil {
+		return nil, m.listTemplatesErr
+	}
+	return &mcp.ListResourceTemplatesResult{ResourceTemplates: m.resourceTemplates}, nil
 }
 
 func (m *MockMCP) OnNotification(_ func(notification mcp.JSONRPCNotification)) {}
@@ -173,7 +201,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP(tc.name, "")
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			assert.Equal(t, tc.expectedInterval, manager.tickerInterval)
 		})
 	}
@@ -182,7 +210,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 func TestMCPManager_MCPName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("my-test-server", "prefix_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	assert.Equal(t, "my-test-server", manager.MCPName())
 }
@@ -190,7 +218,7 @@ func TestMCPManager_MCPName(t *testing.T) {
 func TestMCPManager_GetStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	expectedStatus := ServerValidationStatus{
 		ID:            "test-id",
@@ -213,7 +241,7 @@ func TestMCPManager_GetManagedTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	tools := []mcp.Tool{
 		{Name: "tool1", Description: "Tool 1", InputSchema: mcp.ToolInputSchema{Type: "object"}},
@@ -232,7 +260,7 @@ func TestMCPManager_GetManagedTools_ReturnsCopy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	tools := []mcp.Tool{validTool("tool1")}
 	manager.SetToolsForTesting(tools)
@@ -286,7 +314,7 @@ func TestMCPManager_GetServedManagedTool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tc.prefix)
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			manager.SetToolsForTesting(tc.tools)
 
 			tool := manager.GetServedManagedTool(tc.lookupName)
@@ -332,7 +360,7 @@ func TestMCPManager_setStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
-			manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			manager.serverTools = make([]server.ServerTool, tc.numServerTools)
 
 			manager.setStatus(tc.err, tc.totalTools, nil)
@@ -386,7 +414,7 @@ func TestPrefixedName(t *testing.T) {
 func TestMCPManager_toolToServerTool(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	tool := mcp.Tool{
 		Name:        "mytool",
@@ -414,7 +442,7 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	// calling Stop multiple times should not panic
 	manager.Stop()
@@ -430,7 +458,7 @@ func TestMCPManager_manage_ConnectError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.connectErr = fmt.Errorf("connection refused")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -444,7 +472,7 @@ func TestMCPManager_manage_PingError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.pingErr = fmt.Errorf("ping timeout")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -459,7 +487,7 @@ func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	mock.listToolsErr = fmt.Errorf("list tools failed")
 	mock.hasToolsCap = false // ensure we try to list tools
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -474,7 +502,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false // ensure we list tools every time
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -491,7 +519,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 func TestDiffTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	tests := []struct {
 		name            string
@@ -672,7 +700,7 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = tt.supportsToolsListChange
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 			if tt.hasExistingTools {
 				// set serverTools directly since shouldFetchTools checks this field
@@ -691,7 +719,7 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true // supports tools list change notifications
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	// First call with notification - should fetch and add tools
 	manager.manage(context.Background(), eventTypeNotification)
@@ -772,7 +800,7 @@ func TestMCPManager_manage_OnlyCallsAddDeleteWhenNeeded(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = false // ensure we fetch tools on every manage call
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 			// first manage call - establish initial tools
 			mock.tools = tt.initialTools
@@ -865,7 +893,7 @@ func TestServerToolsManagement(t *testing.T) {
 			mockMCP := newMockMCP("test-server", tt.prefix)
 			mockMCP.hasToolsCap = false // ensure we fetch tools on every manage call
 			mockGateway := NewMockGatewayServer()
-			manager := NewUpstreamMCPManager(mockMCP, mockGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mockMCP, mockGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 			// First manage call - establish initial tools
 			mockMCP.tools = tt.initialTools
@@ -915,7 +943,7 @@ func TestMCPManager_manage_FilterOutPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -938,7 +966,7 @@ func TestMCPManager_manage_FilterOutPolicy_AllInvalid(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -958,7 +986,7 @@ func TestMCPManager_manage_RejectServerPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -975,7 +1003,7 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 
 	manager.manage(context.Background(), eventTypeTimer)
 

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -201,7 +201,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP(tc.name, "")
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 			assert.Equal(t, tc.expectedInterval, manager.tickerInterval)
 		})
 	}
@@ -210,7 +210,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 func TestMCPManager_MCPName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("my-test-server", "prefix_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	assert.Equal(t, "my-test-server", manager.MCPName())
 }
@@ -218,7 +218,7 @@ func TestMCPManager_MCPName(t *testing.T) {
 func TestMCPManager_GetStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	expectedStatus := ServerValidationStatus{
 		ID:            "test-id",
@@ -241,7 +241,7 @@ func TestMCPManager_GetManagedTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	tools := []mcp.Tool{
 		{Name: "tool1", Description: "Tool 1", InputSchema: mcp.ToolInputSchema{Type: "object"}},
@@ -260,7 +260,7 @@ func TestMCPManager_GetManagedTools_ReturnsCopy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	tools := []mcp.Tool{validTool("tool1")}
 	manager.SetToolsForTesting(tools)
@@ -314,7 +314,7 @@ func TestMCPManager_GetServedManagedTool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tc.prefix)
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 			manager.SetToolsForTesting(tc.tools)
 
 			tool := manager.GetServedManagedTool(tc.lookupName)
@@ -360,7 +360,7 @@ func TestMCPManager_setStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
-			manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 			manager.serverTools = make([]server.ServerTool, tc.numServerTools)
 
 			manager.setStatus(tc.err, tc.totalTools, nil)
@@ -414,7 +414,7 @@ func TestPrefixedName(t *testing.T) {
 func TestMCPManager_toolToServerTool(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	tool := mcp.Tool{
 		Name:        "mytool",
@@ -442,7 +442,7 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	// calling Stop multiple times should not panic
 	manager.Stop()
@@ -458,7 +458,7 @@ func TestMCPManager_manage_ConnectError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.connectErr = fmt.Errorf("connection refused")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -472,7 +472,7 @@ func TestMCPManager_manage_PingError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.pingErr = fmt.Errorf("ping timeout")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -487,7 +487,7 @@ func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	mock.listToolsErr = fmt.Errorf("list tools failed")
 	mock.hasToolsCap = false // ensure we try to list tools
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -502,7 +502,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false // ensure we list tools every time
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -519,7 +519,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 func TestDiffTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	tests := []struct {
 		name            string
@@ -700,7 +700,7 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = tt.supportsToolsListChange
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 			if tt.hasExistingTools {
 				// set serverTools directly since shouldFetchTools checks this field
@@ -719,7 +719,7 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true // supports tools list change notifications
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	// First call with notification - should fetch and add tools
 	manager.manage(context.Background(), eventTypeNotification)
@@ -800,7 +800,7 @@ func TestMCPManager_manage_OnlyCallsAddDeleteWhenNeeded(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = false // ensure we fetch tools on every manage call
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 			// first manage call - establish initial tools
 			mock.tools = tt.initialTools
@@ -893,7 +893,7 @@ func TestServerToolsManagement(t *testing.T) {
 			mockMCP := newMockMCP("test-server", tt.prefix)
 			mockMCP.hasToolsCap = false // ensure we fetch tools on every manage call
 			mockGateway := NewMockGatewayServer()
-			manager := NewUpstreamMCPManager(mockMCP, mockGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mockMCP, mockGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 			// First manage call - establish initial tools
 			mockMCP.tools = tt.initialTools
@@ -943,7 +943,7 @@ func TestMCPManager_manage_FilterOutPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -966,7 +966,7 @@ func TestMCPManager_manage_FilterOutPolicy_AllInvalid(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -986,7 +986,7 @@ func TestMCPManager_manage_RejectServerPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -1003,7 +1003,7 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, nil, nil)
 
 	manager.manage(context.Background(), eventTypeTimer)
 

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -75,6 +75,24 @@ func (up *MCPServer) SupportsToolsListChanged() bool {
 	return up.init.Capabilities.Tools.ListChanged
 }
 
+// SupportsResources reports whether the upstream advertises the resources capability.
+// We use this to skip discovery on backends that do not implement resources at all,
+// avoiding spurious -32601 method-not-found errors.
+func (up *MCPServer) SupportsResources() bool {
+	if up.init == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources != nil
+}
+
+// SupportsResourcesListChanged validates the mcp server supports resources/list_changed notifications
+func (up *MCPServer) SupportsResourcesListChanged() bool {
+	if up.init == nil || up.init.Capabilities.Resources == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources.ListChanged
+}
+
 // Connect establishes a connection to the upstream MCP server. It creates a
 // streamable HTTP client, starts it for continuous listening, and performs
 // the MCP initialization handshake. If already connected, this is a no-op.
@@ -193,4 +211,28 @@ func (up *MCPServer) ListTools(ctx context.Context, req mcp.ListToolsRequest) (*
 		return nil, fmt.Errorf("client not connected")
 	}
 	return up.client.ListTools(ctx, req)
+}
+
+// ListResources retrieves the list of concrete resources from the upstream MCP server.
+// Pagination is handled by the underlying mcp-go client.
+func (up *MCPServer) ListResources(ctx context.Context, req mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+
+	if up.client == nil {
+		return nil, fmt.Errorf("client not connected")
+	}
+	return up.client.ListResources(ctx, req)
+}
+
+// ListResourceTemplates retrieves the list of resource templates from the upstream MCP server.
+// Pagination is handled by the underlying mcp-go client.
+func (up *MCPServer) ListResourceTemplates(ctx context.Context, req mcp.ListResourceTemplatesRequest) (*mcp.ListResourceTemplatesResult, error) {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+
+	if up.client == nil {
+		return nil, fmt.Errorf("client not connected")
+	}
+	return up.client.ListResourceTemplates(ctx, req)
 }

--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -135,7 +135,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	// get the HTTPRoute and gateway(s) this MCPServerRegistration targets
 	targetRoute, err := r.getTargetHTTPRoute(ctx, mcpsr)
 	if err != nil {
-		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0); err != nil {
+		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0, 0); err != nil {
 			if apierrors.IsConflict(err) {
 				// don't log these as they are just noise
 				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -149,7 +149,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	// find gateways that have accepted the httproute
 	validGateways, err := r.findValidGatewaysForMCPServer(ctx, targetRoute)
 	if err != nil {
-		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0); err != nil {
+		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0, 0); err != nil {
 			if apierrors.IsConflict(err) {
 				// don't log these as they are just noise
 				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -163,7 +163,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	if len(validGateways) == 0 {
 		err := fmt.Errorf("no valid gateways for httproute")
 		logger.Error(err, "failed to find any valid gateways", "route", targetRoute)
-		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0); err != nil {
+		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0, 0); err != nil {
 			if apierrors.IsConflict(err) {
 				// don't log these as they are just noise
 				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -179,7 +179,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		mcpGatewayExtensions, err := r.MCPExtFinderValidator.FindValidMCPGatewayExtsForGateway(ctx, vg)
 		if err != nil {
 			logger.Error(err, "failed to find valid mcpgatewayextension ", "gateway", vg, "mcpserverregistration", mcpsr)
-			if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0); err != nil {
+			if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0, 0); err != nil {
 				if apierrors.IsConflict(err) {
 					// don't log these as they are just noise
 					return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -189,7 +189,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		}
 		if len(mcpGatewayExtensions) == 0 {
 			// this is not an error so we are going to exit
-			if err := r.updateStatus(ctx, mcpsr, false, "no valid mcpgatewayextensions configured", 0); err != nil {
+			if err := r.updateStatus(ctx, mcpsr, false, "no valid mcpgatewayextensions configured", 0, 0); err != nil {
 				if apierrors.IsConflict(err) {
 					// don't log these as they are just noise
 					return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -211,7 +211,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 	mcpServerconfig, err := r.buildMCPServerConfig(ctx, targetRoute, mcpsr)
 	if err != nil {
-		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0); err != nil {
+		if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0, 0); err != nil {
 			if apierrors.IsConflict(err) {
 				// don't log these as they are just noise
 				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -222,7 +222,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 	for _, configNs := range validNamespaces {
 		if err := r.ConfigReaderWriter.UpsertMCPServer(ctx, *mcpServerconfig, config.NamespaceName(configNs)); err != nil {
-			if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0); err != nil {
+			if err := r.updateStatus(ctx, mcpsr, false, err.Error(), 0, 0); err != nil {
 				if apierrors.IsConflict(err) {
 					// don't log these as they are just noise
 					return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -324,7 +324,7 @@ func (r *MCPReconciler) setMCPServerRegistrationStatus(ctx context.Context, mcpG
 	if err != nil {
 		log.Error(err, "Failed to validate server status via broker")
 		ready, message := false, fmt.Sprintf("Validation failed: %v", err)
-		if err := r.updateStatus(ctx, mcpsr, ready, message, 0); err != nil {
+		if err := r.updateStatus(ctx, mcpsr, ready, message, 0, 0); err != nil {
 			log.Error(err, "Failed to update status")
 			return err
 		}
@@ -343,7 +343,14 @@ func (r *MCPReconciler) setMCPServerRegistrationStatus(ctx context.Context, mcpG
 	log.Info("server status ", "mcpregistrationname", mcpsr.Name, "status", gatewayServerStatus)
 	// if there is an id that matches then the gateway is registering the mcp
 	if gatewayServerStatus.ID != "" {
-		if err := r.updateStatus(ctx, mcpsr, gatewayServerStatus.Ready, gatewayServerStatus.Message, int32(gatewayServerStatus.TotalTools)); err != nil { //nolint:gosec // tool count won't overflow int32
+		if err := r.updateStatus(
+			ctx,
+			mcpsr,
+			gatewayServerStatus.Ready,
+			gatewayServerStatus.Message,
+			int32(gatewayServerStatus.TotalTools),     //nolint:gosec // tool count won't overflow int32
+			int32(gatewayServerStatus.TotalResources), //nolint:gosec // resource count won't overflow int32
+		); err != nil {
 			log.Error(err, "Failed to update status")
 			return err
 		}
@@ -359,7 +366,7 @@ func (r *MCPReconciler) setMCPServerRegistrationStatus(ctx context.Context, mcpG
 	}
 	// otherwise it hasn't picked up the config yet
 
-	if err := r.updateStatus(ctx, mcpsr, gatewayServerStatus.Ready, errServerNotPresent.Error(), 0); err != nil {
+	if err := r.updateStatus(ctx, mcpsr, gatewayServerStatus.Ready, errServerNotPresent.Error(), 0, 0); err != nil {
 		return err
 	}
 
@@ -584,6 +591,7 @@ func (r *MCPReconciler) updateStatus(
 	ready bool,
 	message string,
 	toolCount int32,
+	resourceCount int32,
 ) error {
 	condition := metav1.Condition{
 		Type:               "Ready",
@@ -623,6 +631,10 @@ func (r *MCPReconciler) updateStatus(
 	}
 	if mcpsr.Status.DiscoveredTools != toolCount {
 		mcpsr.Status.DiscoveredTools = toolCount
+		statusChanged = true
+	}
+	if mcpsr.Status.DiscoveredResources != resourceCount {
+		mcpsr.Status.DiscoveredResources = resourceCount
 		statusChanged = true
 	}
 

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -10,6 +10,7 @@ const (
 	mcpServerNameHeader   = "x-mcp-servername"
 	toolAnnotationsHeader = "x-mcp-annotation-hints"
 	toolHeader            = "x-mcp-toolname"
+	resourceURIHeader     = "x-mcp-resource-uri"
 	methodHeader          = "x-mcp-method"
 	sessionHeader         = "mcp-session-id"
 	authorityHeader       = ":authority"
@@ -87,6 +88,21 @@ func (hb *HeadersBuilder) WithMCPToolName(toolName string) *HeadersBuilder {
 		Header: &basepb.HeaderValue{
 			Key:      toolHeader,
 			RawValue: []byte(toolName),
+		},
+	})
+	return hb
+}
+
+// WithMCPResourceURI sets the x-mcp-resource-uri header. The value is the
+// upstream resource URI (i.e. with the gateway prefix already stripped). It
+// mirrors WithMCPToolName for the resources/read path so OTel collectors and
+// downstream policy plug-ins can attribute requests by resource without parsing
+// the JSON-RPC body.
+func (hb *HeadersBuilder) WithMCPResourceURI(uri string) *HeadersBuilder {
+	hb.headers = append(hb.headers, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{
+			Key:      resourceURIHeader,
+			RawValue: []byte(uri),
 		},
 	})
 	return hb

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -60,9 +60,10 @@ func NewRouterErrorf(code int32, format string, args ...any) *RouterError {
 }
 
 const (
-	methodToolCall    = "tools/call"
-	methodInitialize  = "initialize"
-	methodInitialized = "notification/initialized"
+	methodToolCall      = "tools/call"
+	methodResourcesRead = "resources/read"
+	methodInitialize    = "initialize"
+	methodInitialized   = "notification/initialized"
 
 	elicitationResultAction  = "action"
 	elicitationActionAccept  = "accept"
@@ -123,7 +124,14 @@ func (mr *MCPRequest) isNotificationRequest() bool {
 
 // isToolCall will check if the request is a tool call request
 func (mr *MCPRequest) isToolCall() bool {
-	return mr.Method == "tools/call"
+	return mr.Method == methodToolCall
+}
+
+// isResourceRead reports whether this is a resources/read request. The router
+// dispatches reads on a separate path so it can rewrite the federated URI
+// before forwarding the request upstream.
+func (mr *MCPRequest) isResourceRead() bool {
+	return mr.Method == methodResourcesRead
 }
 
 // isInitializeRequest returns true if the method is initialize or initialized
@@ -189,6 +197,30 @@ func (mr *MCPRequest) ReWriteToolName(actualTool string) {
 	mr.Params["name"] = actualTool
 }
 
+// ResourceURI returns the params.uri value of a resources/read request. Returns
+// "" for any other method or when the params shape is unexpected.
+func (mr *MCPRequest) ResourceURI() string {
+	if !mr.isResourceRead() {
+		return ""
+	}
+	uri, ok := mr.Params["uri"]
+	if !ok {
+		return ""
+	}
+	s, ok := uri.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// ReWriteResourceURI replaces params.uri with the upstream form of the URI
+// (gateway prefix stripped) before the request is forwarded. Mirrors
+// ReWriteToolName for resources.
+func (mr *MCPRequest) ReWriteResourceURI(actualURI string) {
+	mr.Params["uri"] = actualURI
+}
+
 // ToBytes marshals the data ready to send on
 func (mr *MCPRequest) ToBytes() ([]byte, error) {
 	return json.Marshal(mr)
@@ -220,6 +252,9 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	case mcpReq.Method == methodToolCall:
 		span.SetAttributes(attribute.String("mcp.route", "tool-call"))
 		return s.HandleToolCall(ctx, mcpReq)
+	case mcpReq.Method == methodResourcesRead:
+		span.SetAttributes(attribute.String("mcp.route", "resource-read"))
+		return s.HandleResourceRead(ctx, mcpReq)
 	default:
 		span.SetAttributes(attribute.String("mcp.route", "broker"))
 		return s.HandleNoneToolCall(ctx, mcpReq)

--- a/internal/mcp-router/resource_handlers.go
+++ b/internal/mcp-router/resource_handlers.go
@@ -1,0 +1,177 @@
+package mcprouter
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// HandleResourceRead routes a resources/read request to the upstream that owns
+// the federated URI. The handler is structurally analogous to HandleToolCall —
+// session validation, backend lookup, hairpinned initialize, header injection,
+// body rewrite — but keys the lookup off params.uri instead of params.name and
+// strips the "<prefix>+" scheme marker before forwarding the request upstream.
+//
+// See docs/design/resource-federation.md for the URI namespacing scheme.
+func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
+	federatedURI := mcpReq.ResourceURI()
+
+	ctx, span := tracer().Start(ctx, "mcp-router.resource-read",
+		trace.WithAttributes(
+			attribute.String("mcp.resource.uri", federatedURI),
+			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+		),
+	)
+	defer span.End()
+
+	calculatedResponse := NewResponse()
+	if federatedURI == "" {
+		s.Logger.ErrorContext(ctx, "[EXT-PROC] HandleRequestBody no uri set in resources/read")
+		span.SetStatus(codes.Error, "no resource uri set")
+		span.SetAttributes(attribute.String("error.type", "missing_resource_uri"))
+		calculatedResponse.WithImmediateResponse(400, "no resource uri set")
+		return calculatedResponse.Build()
+	}
+	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
+		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
+		span.RecordError(sessionErr)
+		span.SetStatus(codes.Error, sessionErr.Error())
+		span.SetAttributes(attribute.String("error.type", "invalid_session"))
+		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
+		return calculatedResponse.Build()
+	}
+
+	headers := NewHeaders()
+	var serverInfo *config.MCPServer
+	{
+		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info-by-resource",
+			trace.WithAttributes(
+				attribute.String("mcp.resource.uri", federatedURI),
+			),
+		)
+		var infoErr error
+		serverInfo, infoErr = s.Broker.GetServerInfoByResourceURI(federatedURI)
+		if infoErr != nil {
+			infoSpan.RecordError(infoErr)
+			infoSpan.SetStatus(codes.Error, "resource not found")
+		}
+		infoSpan.End()
+		if infoErr != nil {
+			s.Logger.DebugContext(ctx, "no server for resource", "uri", federatedURI)
+			span.RecordError(infoErr)
+			span.SetStatus(codes.Error, "resource not found")
+			span.SetAttributes(attribute.String("error.type", "resource_not_found"))
+			// JSON-RPC application error -32002 = "Resource not found" per MCP spec.
+			// Returned as an SSE message so the framing matches what the broker would produce.
+			calculatedResponse.WithImmediateJSONRPCResponse(200,
+				[]*corev3.HeaderValueOption{
+					{
+						Header: &corev3.HeaderValue{
+							Key:   "mcp-session-id",
+							Value: mcpReq.GetSessionID(),
+						},
+					},
+				},
+				`
+event: message
+data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},"jsonrpc":"2.0"}`)
+			return calculatedResponse.Build()
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("mcp.server", serverInfo.Name),
+		attribute.String("mcp.server.hostname", serverInfo.Hostname),
+	)
+
+	// strip "<prefix>+" from the URI scheme. CutPrefix on "<prefix>+" works
+	// because prefixedURI in the broker (see internal/broker/upstream/manager.go)
+	// only mutates the scheme portion of the URI, leaving the rest untouched.
+	upstreamURI := federatedURI
+	if serverInfo.ToolPrefix != "" {
+		marker := serverInfo.ToolPrefix + "+"
+		if colon := strings.Index(federatedURI, ":"); colon > 0 {
+			scheme := federatedURI[:colon]
+			if rest, ok := strings.CutPrefix(scheme, marker); ok {
+				upstreamURI = rest + federatedURI[colon:]
+			}
+		}
+	}
+	mcpReq.ReWriteResourceURI(upstreamURI)
+
+	headers.WithMCPMethod(mcpReq.Method)
+	headers.WithMCPResourceURI(upstreamURI)
+	headers.WithMCPServerName(serverInfo.Name)
+	mcpReq.serverName = serverInfo.Name
+
+	// resolve or create the backend session for this gateway session.
+	exists, cacheErr := s.SessionCache.GetSession(ctx, mcpReq.GetSessionID())
+	if cacheErr != nil {
+		s.Logger.ErrorContext(ctx, "failed to get session from cache", "error", cacheErr)
+		span.RecordError(cacheErr)
+		span.SetStatus(codes.Error, "session cache error")
+		span.SetAttributes(attribute.String("error.type", "session_cache_error"))
+		calculatedResponse.WithImmediateResponse(500, "internal error")
+		return calculatedResponse.Build()
+	}
+	var remoteMCPSeverSession string
+	if id, ok := exists[mcpReq.serverName]; ok {
+		s.Logger.DebugContext(ctx, "found session in cache", "session id", mcpReq.GetSessionID(), "for server", serverInfo.Name, "remote session", id)
+		remoteMCPSeverSession = id
+	}
+	if remoteMCPSeverSession == "" {
+		id, initErr := s.initializeMCPSeverSession(ctx, mcpReq)
+		if initErr != nil {
+			var routerErr *RouterError
+			if errors.As(initErr, &routerErr) {
+				calculatedResponse.WithImmediateResponse(routerErr.Code(), routerErr.Error())
+			} else {
+				calculatedResponse.WithImmediateResponse(500, "internal error")
+			}
+			s.Logger.ErrorContext(ctx, "failed to get remote mcp server session id ", "error ", initErr)
+			span.RecordError(initErr)
+			span.SetStatus(codes.Error, "session initialization failed")
+			span.SetAttributes(attribute.String("error.type", "session_init_error"))
+			return calculatedResponse.Build()
+		}
+		remoteMCPSeverSession = id
+	}
+	mcpReq.backendSessionID = remoteMCPSeverSession
+	headers.WithMCPSession(remoteMCPSeverSession)
+	headers.WithAuthority(serverInfo.Hostname)
+
+	body, err := mcpReq.ToBytes()
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "failed to marshal body to bytes ", "error ", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "body marshal failed")
+		span.SetAttributes(attribute.String("error.type", "marshal_error"))
+		calculatedResponse.WithImmediateResponse(500, "internal error")
+		return calculatedResponse.Build()
+	}
+	path, err := serverInfo.Path()
+	if err != nil {
+		s.Logger.ErrorContext(ctx, "failed to parse url for backend ", "error ", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "path parse failed")
+		span.SetAttributes(attribute.String("error.type", "path_parse_error"))
+		calculatedResponse.WithImmediateResponse(500, "internal error")
+		return calculatedResponse.Build()
+	}
+	headers.WithPath(path)
+	headers.WithContentLength(len(body))
+	if mcpReq.Streaming {
+		s.Logger.DebugContext(ctx, "returning streaming response")
+		calculatedResponse.WithStreamingResponse(headers.Build(), body)
+		return calculatedResponse.Build()
+	}
+	calculatedResponse.WithRequestBodyHeadersAndBodyReponse(headers.Build(), body)
+	return calculatedResponse.Build()
+}

--- a/internal/mcp-router/resource_handlers.go
+++ b/internal/mcp-router/resource_handlers.go
@@ -2,6 +2,7 @@ package mcprouter
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // HandleResourceRead routes a resources/read request to the upstream that owns
@@ -23,19 +23,22 @@ import (
 func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
 	federatedURI := mcpReq.ResourceURI()
 
-	ctx, span := tracer().Start(ctx, "mcp-router.resource-read",
-		trace.WithAttributes(
+	ctx, span := tracer().Start(ctx, "mcp-router.resource-read")
+	defer span.End()
+	if span.IsRecording() {
+		span.SetAttributes(
 			attribute.String("mcp.resource.uri", federatedURI),
 			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
-		),
-	)
-	defer span.End()
+		)
+	}
 
 	calculatedResponse := NewResponse()
 	if federatedURI == "" {
 		s.Logger.ErrorContext(ctx, "[EXT-PROC] HandleRequestBody no uri set in resources/read")
 		span.SetStatus(codes.Error, "no resource uri set")
-		span.SetAttributes(attribute.String("error.type", "missing_resource_uri"))
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("error.type", "missing_resource_uri"))
+		}
 		calculatedResponse.WithImmediateResponse(400, "no resource uri set")
 		return calculatedResponse.Build()
 	}
@@ -43,7 +46,9 @@ func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPReque
 		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
 		span.RecordError(sessionErr)
 		span.SetStatus(codes.Error, sessionErr.Error())
-		span.SetAttributes(attribute.String("error.type", "invalid_session"))
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("error.type", "invalid_session"))
+		}
 		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
 		return calculatedResponse.Build()
 	}
@@ -51,11 +56,10 @@ func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPReque
 	headers := NewHeaders()
 	var serverInfo *config.MCPServer
 	{
-		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info-by-resource",
-			trace.WithAttributes(
-				attribute.String("mcp.resource.uri", federatedURI),
-			),
-		)
+		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info-by-resource")
+		if infoSpan.IsRecording() {
+			infoSpan.SetAttributes(attribute.String("mcp.resource.uri", federatedURI))
+		}
 		var infoErr error
 		serverInfo, infoErr = s.Broker.GetServerInfoByResourceURI(federatedURI)
 		if infoErr != nil {
@@ -67,29 +71,30 @@ func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPReque
 			s.Logger.DebugContext(ctx, "no server for resource", "uri", federatedURI)
 			span.RecordError(infoErr)
 			span.SetStatus(codes.Error, "resource not found")
-			span.SetAttributes(attribute.String("error.type", "resource_not_found"))
-			// JSON-RPC application error -32002 = "Resource not found" per MCP spec.
-			// Returned as an SSE message so the framing matches what the broker would produce.
+			if span.IsRecording() {
+				span.SetAttributes(attribute.String("error.type", "resource_not_found"))
+			}
+			sseBody := buildResourceNotFoundSSEBody(mcpReq.ID)
 			calculatedResponse.WithImmediateJSONRPCResponse(200,
 				[]*corev3.HeaderValueOption{
 					{
 						Header: &corev3.HeaderValue{
-							Key:   "mcp-session-id",
-							Value: mcpReq.GetSessionID(),
+							Key:      "mcp-session-id",
+							RawValue: []byte(mcpReq.GetSessionID()),
 						},
 					},
 				},
-				`
-event: message
-data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},"jsonrpc":"2.0"}`)
+				sseBody)
 			return calculatedResponse.Build()
 		}
 	}
 
-	span.SetAttributes(
-		attribute.String("mcp.server", serverInfo.Name),
-		attribute.String("mcp.server.hostname", serverInfo.Hostname),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("mcp.server", serverInfo.Name),
+			attribute.String("mcp.server.hostname", serverInfo.Hostname),
+		)
+	}
 
 	// strip "<prefix>+" from the URI scheme. CutPrefix on "<prefix>+" works
 	// because prefixedURI in the broker (see internal/broker/upstream/manager.go)
@@ -117,7 +122,9 @@ data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},
 		s.Logger.ErrorContext(ctx, "failed to get session from cache", "error", cacheErr)
 		span.RecordError(cacheErr)
 		span.SetStatus(codes.Error, "session cache error")
-		span.SetAttributes(attribute.String("error.type", "session_cache_error"))
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("error.type", "session_cache_error"))
+		}
 		calculatedResponse.WithImmediateResponse(500, "internal error")
 		return calculatedResponse.Build()
 	}
@@ -138,7 +145,9 @@ data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},
 			s.Logger.ErrorContext(ctx, "failed to get remote mcp server session id ", "error ", initErr)
 			span.RecordError(initErr)
 			span.SetStatus(codes.Error, "session initialization failed")
-			span.SetAttributes(attribute.String("error.type", "session_init_error"))
+			if span.IsRecording() {
+				span.SetAttributes(attribute.String("error.type", "session_init_error"))
+			}
 			return calculatedResponse.Build()
 		}
 		remoteMCPSeverSession = id
@@ -152,7 +161,9 @@ data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},
 		s.Logger.ErrorContext(ctx, "failed to marshal body to bytes ", "error ", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "body marshal failed")
-		span.SetAttributes(attribute.String("error.type", "marshal_error"))
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("error.type", "marshal_error"))
+		}
 		calculatedResponse.WithImmediateResponse(500, "internal error")
 		return calculatedResponse.Build()
 	}
@@ -161,7 +172,9 @@ data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},
 		s.Logger.ErrorContext(ctx, "failed to parse url for backend ", "error ", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "path parse failed")
-		span.SetAttributes(attribute.String("error.type", "path_parse_error"))
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("error.type", "path_parse_error"))
+		}
 		calculatedResponse.WithImmediateResponse(500, "internal error")
 		return calculatedResponse.Build()
 	}
@@ -174,4 +187,20 @@ data: {"error":{"code":-32002,"message":"MCP error -32002: Resource not found"},
 	}
 	calculatedResponse.WithRequestBodyHeadersAndBodyReponse(headers.Build(), body)
 	return calculatedResponse.Build()
+}
+
+func buildResourceNotFoundSSEBody(id any) string {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32002,
+			"message": "MCP error -32002: Resource not found",
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "event: message\ndata: {\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32002,\"message\":\"MCP error -32002: Resource not found\"}}\n\n"
+	}
+	return "event: message\ndata: " + string(b) + "\n\n"
 }

--- a/internal/mcp-router/resource_handlers_test.go
+++ b/internal/mcp-router/resource_handlers_test.go
@@ -209,4 +209,5 @@ func TestHandleResourceRead_UnknownURIReturnsJSONRPCError(t *testing.T) {
 	body := string(ir.ImmediateResponse.Body)
 	require.Contains(t, body, `"code":-32002`)
 	require.Contains(t, body, "Resource not found")
+	require.Contains(t, body, `"id":1`)
 }

--- a/internal/mcp-router/resource_handlers_test.go
+++ b/internal/mcp-router/resource_handlers_test.go
@@ -1,0 +1,212 @@
+package mcprouter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/Kuadrant/mcp-gateway/internal/idmap"
+	"github.com/Kuadrant/mcp-gateway/internal/session"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestMCPRequest_ResourceURI(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *MCPRequest
+		want string
+	}{
+		{
+			name: "extracts string uri",
+			req: &MCPRequest{
+				JSONRPC: "2.0",
+				Method:  methodResourcesRead,
+				Params:  map[string]any{"uri": "weather_+file:///x"},
+			},
+			want: "weather_+file:///x",
+		},
+		{
+			name: "non-resources/read returns empty",
+			req: &MCPRequest{
+				JSONRPC: "2.0",
+				Method:  "tools/call",
+				Params:  map[string]any{"uri": "should-be-ignored"},
+			},
+			want: "",
+		},
+		{
+			name: "missing uri param returns empty",
+			req: &MCPRequest{
+				JSONRPC: "2.0",
+				Method:  methodResourcesRead,
+				Params:  map[string]any{},
+			},
+			want: "",
+		},
+		{
+			name: "non-string uri returns empty",
+			req: &MCPRequest{
+				JSONRPC: "2.0",
+				Method:  methodResourcesRead,
+				Params:  map[string]any{"uri": 42},
+			},
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, c.req.ResourceURI())
+		})
+	}
+}
+
+func TestMCPRequest_ReWriteResourceURI(t *testing.T) {
+	req := &MCPRequest{
+		JSONRPC: "2.0",
+		Method:  methodResourcesRead,
+		Params:  map[string]any{"uri": "weather_+file:///x"},
+	}
+	req.ReWriteResourceURI("file:///x")
+	require.Equal(t, "file:///x", req.Params["uri"])
+}
+
+func TestHeadersBuilder_WithMCPResourceURI(t *testing.T) {
+	hb := NewHeaders().WithMCPResourceURI("file:///forecast.json")
+	headers := hb.Build()
+	require.Len(t, headers, 1)
+	require.Equal(t, resourceURIHeader, headers[0].Header.Key)
+	require.Equal(t, []byte("file:///forecast.json"), headers[0].Header.RawValue)
+}
+
+func TestHandleResourceRead_StripsPrefixAndSetsHeaders(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	jwtManager, err := session.NewJWTManager()
+	require.NoError(t, err)
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	validToken, err := jwtManager.NewToken()
+	require.NoError(t, err)
+
+	// pre-seed a backend session so HandleResourceRead does not try to initialize
+	added, err := cache.AddSession(context.Background(), validToken, "weather", "mock-backend-session-id")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+		return nil, fmt.Errorf("InitForClient should not be called when session exists")
+	}
+
+	serverConfigs := []*config.MCPServer{
+		{
+			Name:       "weather",
+			URL:        "http://localhost:8080/mcp",
+			ToolPrefix: "weather_",
+			Enabled:    true,
+			Hostname:   "localhost",
+		},
+	}
+
+	srv := &ExtProcServer{
+		RoutingConfig: &config.MCPServersConfig{Servers: serverConfigs},
+		JWTManager:    jwtManager,
+		Logger:        logger,
+		SessionCache:  cache,
+		InitForClient: mockInitForClient,
+		Broker: &mockBrokerImpl{
+			svrConfigs: serverConfigs,
+			uri2svr: map[string]string{
+				"weather_+file:///forecast.json": "weather",
+			},
+		},
+	}
+
+	data := &MCPRequest{
+		ID:      ptr.To(0),
+		JSONRPC: "2.0",
+		Method:  methodResourcesRead,
+		Params: map[string]any{
+			"uri": "weather_+file:///forecast.json",
+		},
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "mcp-session-id", RawValue: []byte(validToken)},
+			},
+		},
+	}
+
+	resp := srv.RouteMCPRequest(context.Background(), data)
+	require.Len(t, resp, 1)
+	rb, ok := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+	require.True(t, ok, "expected request_body response")
+	require.NotNil(t, rb.RequestBody.Response)
+
+	headers := rb.RequestBody.Response.HeaderMutation.SetHeaders
+	require.Len(t, headers, 7)
+	require.Equal(t, "x-mcp-method", headers[0].Header.Key)
+	require.Equal(t, []byte(methodResourcesRead), headers[0].Header.RawValue)
+	require.Equal(t, "x-mcp-resource-uri", headers[1].Header.Key)
+	require.Equal(t, []byte("file:///forecast.json"), headers[1].Header.RawValue)
+	require.Equal(t, "x-mcp-servername", headers[2].Header.Key)
+	require.Equal(t, []byte("weather"), headers[2].Header.RawValue)
+	require.Equal(t, "mcp-session-id", headers[3].Header.Key)
+	require.Equal(t, []byte("mock-backend-session-id"), headers[3].Header.RawValue)
+	require.Equal(t, ":authority", headers[4].Header.Key)
+	require.Equal(t, []byte("localhost"), headers[4].Header.RawValue)
+	require.Equal(t, ":path", headers[5].Header.Key)
+	require.Equal(t, []byte("/mcp"), headers[5].Header.RawValue)
+
+	body := string(rb.RequestBody.Response.BodyMutation.GetBody())
+	require.Contains(t, body, `"method":"resources/read"`)
+	require.Contains(t, body, `"uri":"file:///forecast.json"`)
+	require.NotContains(t, body, "weather_+", "federated prefix must be stripped before forwarding upstream")
+}
+
+func TestHandleResourceRead_UnknownURIReturnsJSONRPCError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	jwtManager, err := session.NewJWTManager()
+	require.NoError(t, err)
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+	validToken, err := jwtManager.NewToken()
+	require.NoError(t, err)
+
+	emap, err := idmap.New()
+	require.NoError(t, err)
+	srv := &ExtProcServer{
+		RoutingConfig:  &config.MCPServersConfig{},
+		JWTManager:     jwtManager,
+		Logger:         logger,
+		SessionCache:   cache,
+		Broker:         &mockBrokerImpl{},
+		ElicitationMap: emap,
+	}
+
+	data := &MCPRequest{
+		ID:      ptr.To(1),
+		JSONRPC: "2.0",
+		Method:  methodResourcesRead,
+		Params:  map[string]any{"uri": "weather_+file:///nope"},
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "mcp-session-id", RawValue: []byte(validToken)},
+			},
+		},
+	}
+
+	resp := srv.RouteMCPRequest(context.Background(), data)
+	require.NotEmpty(t, resp)
+	// the immediate response carries the SSE-framed JSON-RPC -32002 error
+	ir, ok := resp[0].Response.(*eppb.ProcessingResponse_ImmediateResponse)
+	require.True(t, ok, "expected immediate response")
+	body := string(ir.ImmediateResponse.Body)
+	require.Contains(t, body, `"code":-32002`)
+	require.Contains(t, body, "Resource not found")
+}

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -25,6 +25,10 @@ type mockBrokerImpl struct {
 
 	// Map of tool name to server name
 	tool2svr map[string]string
+
+	// Map of federated resource URI to server name. Optional; nil means GetServerInfoByResourceURI
+	// returns the historical not-implemented error.
+	uri2svr map[string]string
 }
 
 func TestHandleResponseHeaders_ReturnsGatewaySessionID(t *testing.T) {
@@ -491,6 +495,21 @@ func (m *mockBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 	}
 
 	return nil, fmt.Errorf("failed to get server %q for tool %q", svrName, tool)
+}
+
+// GetServerInfoByResourceURI implements broker.MCPBroker. Tests opting into
+// resource-read coverage populate uri2svr with federated URI → server-name fixtures.
+func (m *mockBrokerImpl) GetServerInfoByResourceURI(uri string) (*config.MCPServer, error) {
+	svrName, ok := m.uri2svr[uri]
+	if !ok {
+		return nil, fmt.Errorf("No server for resource uri %q", uri)
+	}
+	for _, svrInfo := range m.svrConfigs {
+		if svrName == svrInfo.Name {
+			return svrInfo, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to get server %q for resource uri %q", svrName, uri)
 }
 
 // GetVirtualSeverByHeader implements broker.MCPBroker.

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -73,6 +73,18 @@
 - When two servers with no prefix are used, the gateway sees and forwards both tools correctly.
 - When two servers with no prefix conflict and one is then modified to have a specified prefix via the MCPServer resource, both tools should become available via the gateway and capable of being invoked
 
+### [Happy] Federate MCP resources from multiple servers
+
+- When two MCPServerRegistration resources reference backends that expose MCP `resources/list`, the gateway should advertise the `resources` capability in its `initialize` response and a `resources/list` request should return resources from every registered server. Each resource URI must be in its federated form: the upstream URI scheme prefixed with `<toolPrefix>+` (for example, `weather_+file:///forecast.json`). The gateway must not expose the gateway-internal `kuadrant/id` `_meta` marker to clients. The MCPServerRegistration `status.discoveredResources` field should report the count of concrete resources discovered from that backend.
+
+### [Happy] Read a federated MCP resource
+
+- When a client issues a `resources/read` request with a federated URI (`<toolPrefix>+<scheme>://...`), the gateway must route the request to the upstream that owns the underlying URI scheme, strip the `<toolPrefix>+` prefix from the URI before forwarding, and return the upstream's `ReadResourceResult` to the client unchanged. A `resources/read` for a URI that does not match any registered server must return a JSON-RPC error with code `-32002` ("Resource not found") and HTTP `200`.
+
+### [Happy] Federate MCP resource templates
+
+- When a backend exposes MCP `resources/templates/list`, the gateway should include the templates in its own `resources/templates/list` response. Each template's `uriTemplate` string must have its scheme rewritten to the federated form (`<toolPrefix>+<scheme>...`) so clients can construct federated URIs that round-trip through the gateway via `resources/read`.
+
 ### [multi-gateway] Multiple Isolated MCP Gateways deployed to the same cluster
 
 - As a platform admin having deployed multiple instances of the MCP Gateway using the MCPGatewayExtension resource, I should see that they become ready once I have created a valid referencegrant. Once the MCPGatewayExtension is valid, there should be a unique deployment of the mcp gateway in the same namespace as the MCPGatewayExtension resources


### PR DESCRIPTION
Ref #788 

Adds MCP **resources** and **resource templates** federation: upstream discovery in the broker, `<toolPrefix>+<scheme>:` URI namespacing, aggregated `resources/list` and `resources/templates/list` with gateway-internal `_meta` stripped, router handling for **`resources/read`** (routing + unprefixed upstream URI), and **`MCPServerRegistration.status.discoveredResources`** plus broker `/status` resource counts. Design: `docs/design/resource-federation.md`.

## Known limitations

- **`findResourceConflicts`** is a **stub**; duplicate-prefix registrations are not rejected for overlapping federated URIs the way tools are—routing can be nondeterministic until broker-side validation exists.
- **Resource templates**: mcp-go **`AddResourceTemplates`** is merge-only—**stale templates** are possible when upstream removes or clears templates; documented in the design doc.

---

## Clarifications I need

1. **Conflict detection:** Should broker-side resource collision checks match tools before merge, or is the documented stub OK with a follow-up issue?
2. **E2E:** Do you want blocking E2E for `resources/list`, `resources/read`, and `resources/templates/list` in this PR, or merge with unit tests and add E2E next?
3. **Templates:** Is documenting staleness enough for v1, or should we block until broker-level template reconcile (e.g. aggregated `SetResourceTemplates`) or mcp-go gains proper removal/replace?
4. **Scope:** Confirm subscriptions, forwarding `notifications/resources/list_changed` to clients, and JWT/virtual-server resource auth remain explicit non-goals for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gateway now discovers and exposes MCP resources from upstream servers, complementing existing tool federation.
  * New `resources/read` requests allow clients to read resources through the gateway.
  * Resource URIs are automatically namespaced using the configured tool prefix.
  * New `discoveredResources` status field in server registrations reports discovered resource counts.
  * Resource templates are supported with automatic URI rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->