### PR TITLE
add /healthz and /readyz endpoints to broker-router

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -348,11 +348,28 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 		w.WriteHeader(http.StatusOK)
 	})
 
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.Handle("/readyz", readyzHandler(mcpBroker))
 	mux.HandleFunc("/status", mcpBroker.HandleStatusRequest)
 	mux.HandleFunc("/status/", mcpBroker.HandleStatusRequest)
 	mux.Handle("/mcp", streamableHTTPServer)
 
 	return httpSrv, streamableHTTPServer
+}
+
+// readyzHandler returns 503 when upstream MCP servers are configured but none are healthy,
+// blocking traffic during the startup window before connections are established.
+func readyzHandler(b broker.MCPBroker) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		s := b.ValidateAllServers()
+		if s.TotalServers > 0 && s.HealthyServers == 0 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
 }
 
 func setUpRouter(broker broker.MCPBroker, logger *slog.Logger, jwtManager *session.JWTManager, sessionCache *session.Cache, elicitationMap idmap.Map) (*grpc.Server, *mcpRouter.ExtProcServer) {

--- a/cmd/mcp-broker-router/main_test.go
+++ b/cmd/mcp-broker-router/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker"
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+type stubBroker struct {
+	status broker.StatusResponse
+}
+
+func (s *stubBroker) ValidateAllServers() broker.StatusResponse { return s.status }
+func (s *stubBroker) GetServerInfo(_ string) (*config.MCPServer, error) {
+	panic("unused")
+}
+func (s *stubBroker) MCPServer() *mcpserver.MCPServer { panic("unused") }
+func (s *stubBroker) RegisteredMCPServers() map[config.UpstreamMCPID]*upstream.MCPManager {
+	panic("unused")
+}
+func (s *stubBroker) GetVirtualSeverByHeader(_ string) (config.VirtualServer, error) {
+	panic("unused")
+}
+func (s *stubBroker) HandleStatusRequest(_ http.ResponseWriter, _ *http.Request) { panic("unused") }
+func (s *stubBroker) Shutdown(_ context.Context) error                           { panic("unused") }
+func (s *stubBroker) OnConfigChange(_ context.Context, _ *config.MCPServersConfig) {
+	panic("unused")
+}
+func (s *stubBroker) ToolAnnotations(_ config.UpstreamMCPID, _ string) (mcp.ToolAnnotation, bool) {
+	return mcp.ToolAnnotation{}, false
+}
+
+func TestReadyzHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     broker.StatusResponse
+		wantStatus int
+	}{
+		{
+			name:       "no servers configured",
+			status:     broker.StatusResponse{TotalServers: 0, HealthyServers: 0},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "servers configured, none healthy yet",
+			status:     broker.StatusResponse{TotalServers: 2, HealthyServers: 0, UnHealthyServers: 2},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "servers configured, partial healthy",
+			status:     broker.StatusResponse{TotalServers: 2, HealthyServers: 1, UnHealthyServers: 1},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "all servers healthy",
+			status:     broker.StatusResponse{TotalServers: 3, HealthyServers: 3},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := readyzHandler(&stubBroker{status: tt.status})
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("readyzHandler() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -166,6 +166,26 @@ func (r *MCPGatewayExtensionReconciler) buildBrokerRouterDeployment(mcpExt *mcpv
 									ReadOnly:  true,
 								},
 							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt(brokerHTTPPort),
+									},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       30,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/readyz",
+										Port: intstr.FromInt(brokerHTTPPort),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+							},
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -447,6 +467,12 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 	}
 	if !equality.Semantic.DeepEqual(desired.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
 		return true, fmt.Sprintf("volumes changed: %+v -> %+v", existing.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes)
+	}
+	if !equality.Semantic.DeepEqual(desiredContainer.LivenessProbe, existingContainer.LivenessProbe) {
+		return true, "livenessProbe changed"
+	}
+	if !equality.Semantic.DeepEqual(desiredContainer.ReadinessProbe, existingContainer.ReadinessProbe) {
+		return true, "readinessProbe changed"
 	}
 	// only compare env vars the controller manages; user-added env vars are preserved
 	desiredEnv := filterManagedEnvVars(desiredContainer.Env)

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1512,3 +1512,135 @@ func TestHTTPRouteNeedsUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildBrokerRouterDeployment_HealthProbes(t *testing.T) {
+	r := &MCPGatewayExtensionReconciler{
+		BrokerRouterImage: "test-image:v1",
+	}
+	mcpExt := &mcpv1alpha1.MCPGatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ext",
+			Namespace: "test-ns",
+		},
+		Spec: mcpv1alpha1.MCPGatewayExtensionSpec{
+			TargetRef: mcpv1alpha1.MCPGatewayExtensionTargetReference{
+				Name:      "my-gateway",
+				Namespace: "gateway-system",
+			},
+		},
+	}
+
+	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080))
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	if container.LivenessProbe == nil {
+		t.Fatal("expected LivenessProbe to be set")
+	}
+	if container.LivenessProbe.HTTPGet == nil {
+		t.Fatal("expected LivenessProbe HTTPGet to be set")
+	}
+	if container.LivenessProbe.HTTPGet.Path != "/healthz" {
+		t.Errorf("LivenessProbe path = %q, want /healthz", container.LivenessProbe.HTTPGet.Path)
+	}
+	if container.LivenessProbe.HTTPGet.Port.IntVal != brokerHTTPPort {
+		t.Errorf("LivenessProbe port = %d, want %d", container.LivenessProbe.HTTPGet.Port.IntVal, brokerHTTPPort)
+	}
+
+	if container.ReadinessProbe == nil {
+		t.Fatal("expected ReadinessProbe to be set")
+	}
+	if container.ReadinessProbe.HTTPGet == nil {
+		t.Fatal("expected ReadinessProbe HTTPGet to be set")
+	}
+	if container.ReadinessProbe.HTTPGet.Path != "/readyz" {
+		t.Errorf("ReadinessProbe path = %q, want /readyz", container.ReadinessProbe.HTTPGet.Path)
+	}
+	if container.ReadinessProbe.HTTPGet.Port.IntVal != brokerHTTPPort {
+		t.Errorf("ReadinessProbe port = %d, want %d", container.ReadinessProbe.HTTPGet.Port.IntVal, brokerHTTPPort)
+	}
+}
+
+func TestDeploymentNeedsUpdate_ProbeChanges(t *testing.T) {
+	baseWithProbes := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "mcp-gateway",
+								Image: "test:latest",
+								LivenessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path: "/healthz",
+											Port: intstr.FromInt(brokerHTTPPort),
+										},
+									},
+									InitialDelaySeconds: 10,
+									PeriodSeconds:       30,
+								},
+								ReadinessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path: "/readyz",
+											Port: intstr.FromInt(brokerHTTPPort),
+										},
+									},
+									InitialDelaySeconds: 5,
+									PeriodSeconds:       10,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		modify   func(d *appsv1.Deployment)
+		expected bool
+	}{
+		{
+			name:     "probes unchanged",
+			modify:   func(_ *appsv1.Deployment) {},
+			expected: false,
+		},
+		{
+			name: "liveness probe path changed",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path = "/other"
+			},
+			expected: true,
+		},
+		{
+			name: "readiness probe removed",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
+			},
+			expected: true,
+		},
+		{
+			name: "both probes absent on existing deployment",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].LivenessProbe = nil
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := baseWithProbes()
+			existing := baseWithProbes()
+			tt.modify(existing)
+			result, reason := deploymentNeedsUpdate(desired, existing)
+			if result != tt.expected {
+				t.Errorf("deploymentNeedsUpdate() = %v, expected %v, reason: %s", result, tt.expected, reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Both endpoints were referenced in `config/mcp-system/deployment-broker.yaml` and the Helm chart smoke test (`test-connection.yaml`) but never actually registered on the HTTP server. Any `GET /healthz` or `GET /readyz` just fell through to the `"/"` catch-all and returned `200` unconditionally; meaning the readiness probe was always passing regardless of whether a single upstream MCP server had connected.

This matters most during startup. The broker's first connection attempt fires on the one-minute ticker (`DefaultTickerInterval`). Without a real readiness gate, Kubernetes marks the pod `Ready` immediately and starts routing traffic before any upstream is available. Every `tools/call` during that window fails. This makes HPA scale-out (#628) unreliable; new pods advertise themselves as ready ~60 seconds before they actually are.

**What this adds:**

- `/healthz` : simple liveness, always `200` once the HTTP server is up
- `/readyz` : `503` when upstream servers are configured but none are healthy yet; `200` otherwise (including when no servers are configured at all, since the broker can still serve `initialize` and return an empty tool list)
- `LivenessProbe` and `ReadinessProbe` added to `buildBrokerRouterDeployment` in the operator — operator-deployed pods were missing probes entirely
- `deploymentNeedsUpdate` now checks probes so existing deployments get updated on next reconcile

**Files changed:**
- `cmd/mcp-broker-router/main.go` : register the handlers in `setUpHTTPServer`
- `internal/controller/broker_router.go` : add probes to deployment spec and update detection
- `cmd/mcp-broker-router/main_test.go` : table tests for `readyzHandler` (no servers / none healthy / partial / all healthy)
- `internal/controller/deployment_test.go` : assert probe spec is set correctly and that probe changes trigger a deployment update

```
make test-unit  # all pass
```