### PR TITLE
docs: add mcps listener to the gateway setup guide

### DIFF
--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -1,7 +1,7 @@
 
 # Configure MCP Gateway Listener and Route
 
-This guide covers adding an MCP listener to your existing Gateway. The controller automatically creates an HTTPRoute when the MCPGatewayExtension becomes ready. This guide also covers how to use a custom HTTPRoute if you need CORS headers or additional path rules.
+This guide covers adding the required MCP listeners to your existing Gateway. The controller automatically creates an HTTPRoute when the MCPGatewayExtension becomes ready. This guide also covers how to use a custom HTTPRoute if you need CORS headers or additional path rules.
 
 ## Prerequisites
 
@@ -9,9 +9,14 @@ This guide covers adding an MCP listener to your existing Gateway. The controlle
 - Existing [Gateway](https://gateway-api.sigs.k8s.io/) resource
 - Gateway API provider (e.g. Istio) configured
 
-## Step 1: Add MCP Listener to Gateway
+## Step 1: Add MCP Listeners to Gateway
 
-Add a listener for MCP traffic to your existing Gateway. Patch it to add a new listener entry:
+MCP Gateway requires two listeners on your Gateway:
+
+- **`mcp`**: the public-facing listener for MCP client traffic. The hostname must resolve to your Gateway's external address.
+- **`mcps`**: an internal listener used for routing to registered MCP servers. MCPServerRegistration HTTPRoutes attach to this listener. The hostname is a wildcard that does not need to be publicly resolvable.
+
+Patch your Gateway to add both listeners:
 
 ```bash
 kubectl patch gateway your-gateway-name -n your-gateway-namespace --type merge -p '
@@ -24,10 +29,17 @@ spec:
     allowedRoutes:
       namespaces:
         from: All
+  - name: mcps
+    hostname: "*.mcp.local"
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
 '
 ```
 
-Replace `your-gateway-name`, `your-gateway-namespace`, and the hostname with your values. The hostname must resolve to your Gateway's external address.
+Replace `your-gateway-name`, `your-gateway-namespace`, and the `mcp` hostname with your values. The `mcps` wildcard hostname (`*.mcp.local`) is only used for internal cluster routing. You can use any wildcard hostname here (e.g. `*.mcp.internal`).
 
 > **Note:** The patch above replaces all listeners. To preserve existing listeners, use a JSON patch or edit the Gateway directly with `kubectl edit gateway your-gateway-name -n your-gateway-namespace`.
 

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -49,6 +49,14 @@ Replace `your-gateway-name`, `your-gateway-namespace`, and the `mcp` hostname wi
 >   --set gateway.publicHost=mcp.127-0-0-1.sslip.io
 > ```
 
+Verify both listeners were added:
+
+```bash
+kubectl get gateway your-gateway-name -n your-gateway-namespace -o jsonpath='{.spec.listeners[*].name}'
+```
+
+You should see both `mcp` and `mcps` in the output.
+
 ## Step 2: HTTPRoute (Automatic)
 
 The MCPGatewayExtension controller automatically creates an HTTPRoute named `mcp-gateway-route` when the extension becomes ready. The HTTPRoute:

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -5,7 +5,7 @@ You must register your MCP servers to be discovered and routed by the MCP Gatewa
 ## Prerequisites
 
 - You installed and configured the MCP Gateway
-- You configured a gateway and `HTTPRoute` for the MCP Gateway
+- Your Gateway has both the `mcp` and `mcps` listeners configured (see [Configure MCP Gateway Listener and Route](./configure-mcp-gateway-listener-and-router.md))
 - An MCP server is running in your cluster
 
 ## Procedure
@@ -63,7 +63,7 @@ kubectl wait --for=condition=Ready mcpgatewayextension/mcp-extension -n mcp-test
 
 ## Step 2: Create an HTTPRoute
 
-Create an `HTTPRoute` that routes to your MCP server:
+Create an `HTTPRoute` that routes to your MCP server. The hostname must match the wildcard on the `mcps` listener of your Gateway (e.g. `*.mcp.local`). This is an internal-only hostname used for routing through the gateway and does not need to be publicly resolvable.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -76,8 +76,9 @@ spec:
   parentRefs:
     - name: mcp-gateway
       namespace: gateway-system
+      sectionName: mcps
   hostnames:
-    - 'my-mcp-server.mcp.local'  # Internal routing hostname
+    - 'my-mcp-server.mcp.local'  # must match the mcps listener wildcard
   rules:
     - matches:
         - path:


### PR DESCRIPTION
fixes #680

the docs were missing any mention of the `mcps` listener. without it, MCPServerRegistration HTTPRoutes won't attach to a matching listener and the controller won't pick them up. david-martin's comment also flagged that register-mcp-servers.md might be missing something, and it was.

changes:
- `configure-mcp-gateway-listener-and-router.md`: step 1 now shows both listeners in the patch command with a short note explaining what each one is for
- `register-mcp-servers.md`: updated prerequisites to require both listeners, step 2 now adds `sectionName: mcps` to the parentRef and explains that the hostname must match the mcps listener wildcard

Signed-off-by: puneeth_aditya_5656 <myakampuneeth@gmail.com>