### PR TITLE
e2e: handle GetDeploymentGeneration errors in WaitForDeploymentReplicas

### DIFF
--- a/tests/e2e/kubectl_helpers.go
+++ b/tests/e2e/kubectl_helpers.go
@@ -50,10 +50,11 @@ func GetDeploymentGeneration(namespace, name string) (string, error) {
 // has actually started (generation changes) then wait for it to complete.
 func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGeneration string) error {
 	// wait for generation to change (confirming the spec mutation was picked up)
-	Eventually(func() string {
-		gen, _ := GetDeploymentGeneration(namespace, name)
-		return gen
-	}, "30s", "1s").ShouldNot(Equal(prevGeneration),
+	Eventually(func(g Gomega) {
+		gen, err := GetDeploymentGeneration(namespace, name)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(gen).NotTo(Equal(prevGeneration))
+	}, "30s", "1s").Should(Succeed(),
 		fmt.Sprintf("deployment %s generation did not change from %s", name, prevGeneration))
 
 	// now rollout status will correctly block on the new rollout


### PR DESCRIPTION
`WaitForDeploymentReplicas` silently discards the error from
`GetDeploymentGeneration` using `_`. When kubectl has a transient failure
it returns `("", err)` — the empty string doesn't equal the previous
generation (e.g. `"1"`), so `Eventually` passes falsely and the test
continues as if the rollout started when it never did.

Fix by using Gomega's `Eventually(func(g Gomega))` pattern so errors
are properly surfaced and retried rather than swallowed.

Fixes #843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved end-to-end test reliability by strengthening error handling during deployment status verification. Tests now properly fail when critical deployment operations encounter errors, instead of silently continuing with potentially invalid state information. This ensures more accurate and trustworthy test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->