### PR TITLE
broker: fix data race on MCPManager.status

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -312,7 +312,7 @@ func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []Invali
 	}
 	man.status.TotalTools = toolCount
 	man.status.Ready = true
-	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d", len(man.serverTools))
+	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d", toolCount)
 }
 
 func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {
@@ -398,6 +398,8 @@ func (man *MCPManager) SetToolsForTesting(tools []mcp.Tool) {
 // SetStatusForTesting sets the status directly for testing purposes.
 // This bypasses the normal status update flow and should only be used in tests.
 func (man *MCPManager) SetStatusForTesting(status ServerValidationStatus) {
+	man.statusLock.Lock()
+	defer man.statusLock.Unlock()
 	man.status = status
 }
 

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -91,9 +91,10 @@ type MCPManager struct {
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy mcpv1alpha1.InvalidToolPolicy
 
-	stopOnce sync.Once     // ensures Stop() is only executed once
-	done     chan struct{} // triggers the exit of the select and routine
-	status   ServerValidationStatus
+	stopOnce   sync.Once     // ensures Stop() is only executed once
+	done       chan struct{} // triggers the exit of the select and routine
+	status     ServerValidationStatus
+	statusLock sync.RWMutex // protects status
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
@@ -290,12 +291,15 @@ func (man *MCPManager) shouldFetchTools(event eventType) bool {
 }
 
 // GetStatus returns the current status of the MCP Server
-// no locking is done here as it is expected to be called multiple times
 func (man *MCPManager) GetStatus() ServerValidationStatus {
+	man.statusLock.RLock()
+	defer man.statusLock.RUnlock()
 	return man.status
 }
 
 func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []InvalidToolInfo) {
+	man.statusLock.Lock()
+	defer man.statusLock.Unlock()
 	man.status.ID = string(man.MCP.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -312,7 +312,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 		By("Waiting for gateway rollout after enabling Redis")
-		Expect(WaitForDeploymentReplicas(SystemNamespace, deploymentName, 1, gen)).To(Succeed())
+		WaitForDeploymentReplicas(SystemNamespace, deploymentName, 1, gen)
 
 		By("Initializing a raw HTTP session with the gateway")
 		var sessionID string

--- a/tests/e2e/kubectl_helpers.go
+++ b/tests/e2e/kubectl_helpers.go
@@ -50,10 +50,11 @@ func GetDeploymentGeneration(namespace, name string) (string, error) {
 // has actually started (generation changes) then wait for it to complete.
 func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGeneration string) error {
 	// wait for generation to change (confirming the spec mutation was picked up)
-	Eventually(func() string {
-		gen, _ := GetDeploymentGeneration(namespace, name)
-		return gen
-	}, "30s", "1s").ShouldNot(Equal(prevGeneration),
+	Eventually(func(g Gomega) {
+		gen, err := GetDeploymentGeneration(namespace, name)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(gen).NotTo(Equal(prevGeneration))
+	}, "30s", "1s").Should(Succeed(),
 		fmt.Sprintf("deployment %s generation did not change from %s", name, prevGeneration))
 
 	// now rollout status will correctly block on the new rollout

--- a/tests/e2e/kubectl_helpers.go
+++ b/tests/e2e/kubectl_helpers.go
@@ -48,7 +48,7 @@ func GetDeploymentGeneration(namespace, name string) (string, error) {
 // with the expected number of ready replicas. It requires the caller to pass
 // the generation from before any changes, so it can detect when the rollout
 // has actually started (generation changes) then wait for it to complete.
-func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGeneration string) error {
+func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGeneration string) {
 	// wait for generation to change (confirming the spec mutation was picked up)
 	Eventually(func(g Gomega) {
 		gen, err := GetDeploymentGeneration(namespace, name)
@@ -60,20 +60,16 @@ func WaitForDeploymentReplicas(namespace, name string, replicas int, prevGenerat
 	// now rollout status will correctly block on the new rollout
 	cmd := exec.Command("kubectl", "rollout", "status", "deployment", name,
 		"-n", namespace, "--timeout=120s")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("deployment %s rollout not complete: %s: %w", name, string(output), err)
-	}
+	output, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("deployment %s rollout not complete: %s", name, string(output)))
 
 	// confirm exact ready replica count
 	cmd = exec.Command("kubectl", "wait", "deployment", name,
 		"-n", namespace,
 		fmt.Sprintf("--for=jsonpath={.status.readyReplicas}=%d", replicas),
 		"--timeout=120s")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("deployment %s readyReplicas != %d: %s: %w",
-			name, replicas, string(output), err)
-	}
-	return nil
+	output, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("deployment %s readyReplicas != %d: %s", name, replicas, string(output)))
 }
 
 // RestartDeploymentAndWait triggers a rollout restart on a deployment and waits


### PR DESCRIPTION
`GetStatus()` and `setStatus()` accessed `man.status` concurrently from
different goroutines — the HTTP handler goroutine (via `ValidateAllServers`
→ `/status`) and the manager goroutine (via `manage()`) — with no
synchronization. `ServerValidationStatus` contains `time.Time`,
`[]InvalidToolInfo`, and `string` fields, none of which are safe for
concurrent unsynchronized access.

Add `statusLock sync.RWMutex` to `MCPManager`. Take `RLock` in `GetStatus`
and `Lock` in `setStatus`.

Fixes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved reliability of deployment verification in end-to-end tests to ensure more accurate detection of deployment state changes.

* **Refactor**
  * Enhanced internal concurrency safety to prevent potential race conditions during status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->