### PR TITLE
Docs: clean up kubernetes mcp server guide and remove internal setup steps

### DIFF
--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -12,7 +12,7 @@ This guide demonstrates how to add the [Kubernetes MCP server](https://github.co
 
 In this use case, the Kubernetes MCP server does not handle authentication for the client. It uses the access from the current `.kube/config` file to connect to the known Kubernetes clusters when tools are called.
 
-### ❶ Run the Kubernetes MCP server
+### Step 1: Run the Kubernetes MCP server
 
 You can run the Kubernetes MCP server as a container. It needs access to your `.kube/config` to interact with Kubernetes clusters.
 
@@ -25,7 +25,7 @@ docker run -d --name kubernetes-mcp \
 
 > **Note:** If you prefer to run it as a binary, you can download it from the [releases page](https://github.com/containers/kubernetes-mcp-server/releases).
 
-### ❸ Register the MCP server with the MCP Gateway
+### Step 2: Register the MCP server with the MCP Gateway
 
 Add a dedicated gateway listener for the MCP server. Replace `<HOST_IP_OR_HOSTNAME>` with the address where the Kubernetes MCP server is reachable from the cluster (e.g., `host.docker.internal` for local development environments):
 
@@ -151,11 +151,11 @@ The accessible Kubernetes API servers accept same-domain OIDC access tokens, whi
 
 **Requisite:** You have successfully completed [Use case 1: No auth](#use-case-1-no-auth).
 
-### ❶ Enable auth in the MCP Gateway
+### Step 1: Enable auth in the MCP Gateway
 
 Ensure that your MCP Gateway is configured with an authentication provider (e.g., Keycloak or Authorino). You will need an OIDC issuer and credentials for token exchange.
 
-### ❷ Create an AuthPolicy for the Kubernetes MCP server route
+### Step 2: Create an AuthPolicy for the Kubernetes MCP server route
 
 ```sh
 kubectl apply -f -<<EOF
@@ -247,7 +247,7 @@ spec:
 EOF
 ```
 
-### ❸ Authorize the `mcp` Keycloak user for the Kubernetes API server
+### Step 3: Authorize the `mcp` Keycloak user for the Kubernetes API server
 
 ```sh
 kubectl apply -f -<<EOF
@@ -266,7 +266,7 @@ subjects:
 EOF
 ```
 
-### ❹ Try the MCP server with OIDC authentication
+### Step 4: Try the MCP server with OIDC authentication
 
 Connect to the MCP Gateway using the MCP Inspector as before.
 

--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -2,62 +2,40 @@
 
 This guide demonstrates how to add the [Kubernetes MCP server](https://github.com/containers/kubernetes-mcp-server) as an external MCP server behind the MCP Gateway.
 
-The Kubernetes MCP server runs on the local machine alongside a Kubernetes Kind cluster that has the MCP Gateway stack deployed to it.
+## Prerequisites
 
-This demo is part of a 3-use case series:
-
-1. [No auth](#use-case-1-no-auth) ✅
-2. [OIDC auth](#use-case-2-oidc-auth) ✅
-3. [Cross-domain auth](#use-case-3-cross-domain-auth)
-
-<br/>
+- **MCP Gateway**: Installed and running in your Kubernetes cluster.
+- **kubectl**: Configured to access your cluster.
+- **Kubernetes MCP Server**: The server binary or container.
 
 ## Use case 1: No auth
 
 In this use case, the Kubernetes MCP server does not handle authentication for the client. It uses the access from the current `.kube/config` file to connect to the known Kubernetes clusters when tools are called.
 
-### ❶ Setup a local cluster with the MCP Gateway stack
+### ❶ Run the Kubernetes MCP server
 
-Clone the MCP Gateway repo (so you have the tooling to easily setup a local dev/test environment):
-
-```sh
-git clone git@github.com:Kuadrant/mcp-gateway.git && cd mcp-gateway
-```
-
-Create a local cluster with MCP Gateway:
+First, clone and build the Kubernetes MCP server:
 
 ```sh
-make local-env-setup
-```
-
-### ❷ Run the Kubernetes MCP server locally
-
-Clone the Kubernetes MCP server repo:
-
-```sh
-git clone git@github.com:containers/kubernetes-mcp-server.git && cd kubernetes-mcp-server
-```
-
-Build a fresh new version of the MCP server:
-
-```sh
+git clone https://github.com/containers/kubernetes-mcp-server.git
+cd kubernetes-mcp-server
 make build
 ```
 
-Run the MCP server on port 9999:
+Run the MCP server (for example, on port 9999):
 
 ```sh
 ./kubernetes-mcp-server --port 9999
 ```
 
-> **Note:** The command above will hold the shell. Start a new session to run the next steps.
+> **Note:** If running locally and connecting from a cluster, ensure the port is accessible (e.g., using a tunnel or host-to-cluster networking).
 
 ### ❸ Register the MCP server with the MCP Gateway
 
-Add a dedicated gateway listener for the MCP server:
+Add a dedicated gateway listener for the MCP server. Replace `<HOST_IP_OR_HOSTNAME>` with the address where the Kubernetes MCP server is reachable from the cluster (e.g., `host.docker.internal` for Docker Desktop/Kind):
 
 ```sh
-export CONTAINERS_HOSTNAME=$(which podman &>/dev/null && echo "host.containers.internal" || echo "host.docker.internal")
+export SERVER_HOST="<HOST_IP_OR_HOSTNAME>"
 
 kubectl patch gateway mcp-gateway -n gateway-system --type json -p="[
   {
@@ -65,7 +43,7 @@ kubectl patch gateway mcp-gateway -n gateway-system --type json -p="[
     \"path\": \"/spec/listeners/-\",
     \"value\": {
       \"name\": \"kubernetes-mcp\",
-      \"hostname\": \"$CONTAINERS_HOSTNAME\",
+      \"hostname\": \"$SERVER_HOST\",
       \"port\": 8080,
       \"protocol\": \"HTTP\",
       \"allowedRoutes\": {
@@ -78,14 +56,14 @@ kubectl patch gateway mcp-gateway -n gateway-system --type json -p="[
 ]"
 ```
 
-Create a route, external service and `MCPServer` custom resource:
+Create a route, external service and `MCPServerRegistration` custom resource:
 
-```sh
-kubectl apply -n mcp-test -f - <<EOF
+```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: kubernetes-mcp
+  namespace: mcp-test
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -93,7 +71,7 @@ spec:
     name: mcp-gateway
     namespace: gateway-system
   hostnames:
-  - $CONTAINERS_HOSTNAME
+  - "<HOST_IP_OR_HOSTNAME>"
   rules:
   - matches:
     - path:
@@ -109,9 +87,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-mcp-external
+  namespace: mcp-test
 spec:
   type: ExternalName
-  externalName: $CONTAINERS_HOSTNAME
+  externalName: "<HOST_IP_OR_HOSTNAME>"
   ports:
   - name: http
     port: 9999
@@ -119,41 +98,20 @@ spec:
     protocol: TCP
     appProtocol: http
 ---
-apiVersion: networking.istio.io/v1beta1
-kind: ServiceEntry
-metadata:
-  name: kubernetes-mcp
-  namespace: mcp-test
-spec:
-  hosts:
-  - $CONTAINERS_HOSTNAME
-  ports:
-  - number: 9999
-    name: https
-    protocol: HTTP
-  location: MESH_EXTERNAL
-  resolution: DNS
----
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: kubernetes-mcp-server
+  namespace: mcp-test
 spec:
   toolPrefix: kube_
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: kubernetes-mcp
-EOF
 ```
 
-### ❹ Try the MCP server behind the gateway
-
-From the MCP gateway repo, run the following command to launch the MCP Inspector on your default web browser:
-
-```sh
-make inspect-gateway
-```
+To verify the setup, you can use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector). Connect the inspector to your MCP Gateway endpoint (e.g., `http://mcp.example.com/mcp`).
 
 In the MCP Inspector, click _Connect_:
 
@@ -185,11 +143,9 @@ The accessible Kubernetes API servers accept same-domain OIDC access tokens, whi
 
 **Requisite:** You have successfully completed [Use case 1: No auth](#use-case-1-no-auth).
 
-### ❶ Enable auth for `tool/list` and `tool/call` requests in the MCP Gateway
+### ❶ Enable auth in the MCP Gateway
 
-```sh
-make auth-example-setup
-```
+Ensure that your MCP Gateway is configured with an authentication provider (e.g., Keycloak or Authorino). You will need an OIDC issuer and credentials for token exchange.
 
 ### ❷ Create an AuthPolicy for the Kubernetes MCP server route
 
@@ -209,13 +165,13 @@ spec:
     authentication: #validates the token
       'keycloak':
         jwt:
-          issuerUrl: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
+          issuerUrl: https://<KEYCLOAK_URL>/realms/mcp
     metadata:
       oauth-token-exchange:
         when:
           - predicate: type(auth.identity.aud) != string || auth.identity.aud != request.headers['x-mcp-servername']
         http:
-          url: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token
+          url: https://<KEYCLOAK_URL>/realms/mcp/protocol/openid-connect/token
           method: POST
           credentials:
             authorizationHeader:
@@ -266,7 +222,7 @@ spec:
       unauthenticated:
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://<MCP_GATEWAY_URL>/.well-known/oauth-protected-resource/mcp
         body:
           value: |
             {
@@ -298,13 +254,13 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp#mcp
+  name: https://<KEYCLOAK_URL>/realms/mcp#mcp
 EOF
 ```
 
-### ❹ Try the MCP server behind the gateway with OIDC authentication and token exchange performed by the MCP gateway
+### ❹ Try the MCP server with OIDC authentication
 
-Follow the same steps as [before](#-try-the-mcp-server-behind-the-gateway) to try the MCP server behind the gateway using the MCP Inspector as client.
+Connect to the MCP Gateway using the MCP Inspector as before.
 
 > **Note:** You may need to add an exception for your browser to trust the Keycloak self-signed server certificate.
 
@@ -327,7 +283,7 @@ When calling any of the Kubernetes MCP server tools, an authentication token suc
     "mcp-users"
   ],
   "iat": 1763121281,
-  "iss": "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp",
+  "iss": "https://<KEYCLOAK_URL>/realms/mcp",
   "jti": "ntrtte:1a144de4-8206-3ae1-1c12-9e67a5cc207f",
   "name": "mcp mcp",
   "preferred_username": "mcp",

--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -14,25 +14,20 @@ In this use case, the Kubernetes MCP server does not handle authentication for t
 
 ### ❶ Run the Kubernetes MCP server
 
-First, clone and build the Kubernetes MCP server:
+You can run the Kubernetes MCP server as a container. It needs access to your `.kube/config` to interact with Kubernetes clusters.
 
 ```sh
-git clone https://github.com/containers/kubernetes-mcp-server.git
-cd kubernetes-mcp-server
-make build
+docker run -d --name kubernetes-mcp \
+  -p 9999:9999 \
+  -v ~/.kube/config:/root/.kube/config:ro \
+  quay.io/containers/kubernetes_mcp_server:latest --port 9999
 ```
 
-Run the MCP server (for example, on port 9999):
-
-```sh
-./kubernetes-mcp-server --port 9999
-```
-
-> **Note:** If running locally and connecting from a cluster, ensure the port is accessible (e.g., using a tunnel or host-to-cluster networking).
+> **Note:** If you prefer to run it as a binary, you can download it from the [releases page](https://github.com/containers/kubernetes-mcp-server/releases).
 
 ### ❸ Register the MCP server with the MCP Gateway
 
-Add a dedicated gateway listener for the MCP server. Replace `<HOST_IP_OR_HOSTNAME>` with the address where the Kubernetes MCP server is reachable from the cluster (e.g., `host.docker.internal` for Docker Desktop/Kind):
+Add a dedicated gateway listener for the MCP server. Replace `<HOST_IP_OR_HOSTNAME>` with the address where the Kubernetes MCP server is reachable from the cluster (e.g., `host.docker.internal` for local development environments):
 
 ```sh
 export SERVER_HOST="<HOST_IP_OR_HOSTNAME>"
@@ -56,14 +51,14 @@ kubectl patch gateway mcp-gateway -n gateway-system --type json -p="[
 ]"
 ```
 
-Create a route, external service and `MCPServerRegistration` custom resource:
+Create a route, external service, and `MCPServerRegistration` custom resource. If you are using Istio as your Gateway API provider, also include the `ServiceEntry`:
 
-```yaml
+```sh
+kubectl apply -n mcp-test -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: kubernetes-mcp
-  namespace: mcp-test
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -87,7 +82,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-mcp-external
-  namespace: mcp-test
 spec:
   type: ExternalName
   externalName: "<HOST_IP_OR_HOSTNAME>"
@@ -98,17 +92,31 @@ spec:
     protocol: TCP
     appProtocol: http
 ---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: kubernetes-mcp
+spec:
+  hosts:
+  - "<HOST_IP_OR_HOSTNAME>"
+  ports:
+  - number: 9999
+    name: http
+    protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: DNS
+---
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: kubernetes-mcp-server
-  namespace: mcp-test
 spec:
   toolPrefix: kube_
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: kubernetes-mcp
+EOF
 ```
 
 To verify the setup, you can use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector). Connect the inspector to your MCP Gateway endpoint (e.g., `http://mcp.example.com/mcp`).


### PR DESCRIPTION
This updates the kubernetes-mcp-server guide to make it easier to follow for end users.

Removed repo-specific setup steps like cloning the gateway repo and running Makefile targets, and replaced them with simpler, more portable instructions. The guide now assumes MCP Gateway is already installed and focuses only on how to connect an external MCP server.

Also switched to a container-based example for running the Kubernetes MCP server and updated all manifests to be copy-paste friendly using kubectl. Added a note for Istio users where a ServiceEntry may be required.

Overall, the goal is to keep the guide clean, environment-agnostic, and usable across different Kubernetes setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes MCP server guide with container-based setup and docker run instructions
  * Restructured OIDC authentication section with placeholder-based configuration examples
  * Added prerequisites list and MCP Inspector verification steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->