### PR TITLE
Add guide for using credentialRef with internal MCP servers

### DIFF
--- a/docs/guides/internal-mcp-credentialref.md
+++ b/docs/guides/internal-mcp-credentialref.md
@@ -70,21 +70,45 @@ After creating the resource, verify that the MCP Gateway has successfully proces
 
 ```bash
 # Check the status of the registration
-kubectl get mcpserverregistration -n mcp-test
+kubectl get mcpserverregistration internal-api-key-server -n mcp-test
+```
 
+Example output:
+```
+NAME                      AGE   STATUS
+internal-api-key-server   1m    Enabled
+```
+
+```bash
 # Describe the resource to see status conditions
 kubectl describe mcpserverregistration internal-api-key-server -n mcp-test
 ```
 
-The `Status` field should indicate that the server is `Enabled` and that tools have been discovered.
+Example output (under `Status`):
+```yaml
+Status:
+  Conditions:
+    ...
+    Message:               Tools successfully discovered
+    Reason:                Registered
+    Status:                True
+    Type:                  Ready
+```
 
 ## How it Works
 
 1. **Discovery**: The MCP Gateway controller watches for `MCPServerRegistration` resources. When it sees a `credentialRef`, it verifies the Secret exists and has the required label.
 2. **Aggregation**: The controller securely copies the credential into an aggregated secret used by the MCP Gateway components.
-3. **Injection**: 
-   - **Broker**: Uses the credential to authenticate during the tool discovery phase.
-   - **Router**: (Envoy external processor) injects the `Authorization` header into requests sent to the upstream MCP server.
+3. **Injection & Credential Isolation**: 
+   - **Broker**: Uses the credential *only* during tool discovery and authentication with the upstream MCP server.
+   - **Router**: Does **NOT** inject this broker credential during client tool invocation. This establishes a strict security boundary.
+   
+   > [!IMPORTANT]
+   > Because the router does not automatically forward the `credentialRef` credentials, clients invoking tools must either:
+   > - Provide their own `Authorization` headers, or
+   > - Configure an `AuthPolicy` on the `HTTPRoute` for gateway-level token exchange.
+   > 
+   > Without one of these, client tool invocations will receive a `401 Unauthorized` response from the upstream server.
 4. **Security**: Credentials are never exposed in the `MCPServerRegistration` spec or in the gateway logs.
 
 ## Troubleshooting

--- a/docs/guides/internal-mcp-credentialref.md
+++ b/docs/guides/internal-mcp-credentialref.md
@@ -1,0 +1,76 @@
+# Connecting to Private Internal MCP Servers using credentialRef
+
+This guide explains how to connect the MCP Gateway to a private internal MCP server that requires authentication using the `credentialRef` field in the `MCPServerRegistration` resource.
+
+
+## Overview
+
+When an internal MCP server (running inside your Kubernetes cluster) is protected by authentication (e.g., a static API key or a shared token), the MCP Gateway can securely store and inject these credentials into the request flow.
+
+The process involves:
+1. Creating a Kubernetes Secret containing the credential.
+2. Labeling the Secret so the MCP Gateway can access it.
+3. Referencing the Secret in your `MCPServerRegistration`.
+
+
+## 1. Create the Credential Secret
+
+First, create a Secret containing your authentication token. 
+
+> [!IMPORTANT]
+> The Secret **must** have the label `mcp.kuadrant.io/secret: "true"`. Without this label, the MCP Gateway will not be able to read the credential.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-key-server-secret
+  namespace: mcp-test
+  labels:
+    mcp.kuadrant.io/secret: "true"
+type: Opaque
+stringData:
+  token: "Bearer your-secret-api-key"
+EOF
+```
+
+
+## 2. Register the MCP Server
+
+Create the `MCPServerRegistration` resource and point the `credentialRef` to the Secret created above.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: internal-api-key-server
+  namespace: mcp-test
+spec:
+  toolPrefix: internal_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: api-key-server-route
+  credentialRef:
+    name: api-key-server-secret
+    key: token
+EOF
+```
+
+
+## How it Works
+
+1. **Discovery**: The MCP Gateway controller watches for `MCPServerRegistration` resources. When it sees a `credentialRef`, it verifies the Secret exists and has the required label.
+2. **Aggregation**: The controller securely copies the credential into an aggregated secret used by the MCP Gateway components.
+3. **Injection**: 
+   - **Broker**: Uses the credential to authenticate during the tool discovery phase.
+   - **Router**: (Envoy external processor) injects the `Authorization` header into requests sent to the upstream MCP server.
+4. **Security**: Credentials are never exposed in the `MCPServerRegistration` spec or in the gateway logs.
+
+
+## Troubleshooting
+
+- **Validation Error**: If you get a validation error when applying the `MCPServerRegistration`, double-check that your Secret has the `mcp.kuadrant.io/secret: "true"` label.
+- **Unauthorized Errors**: If the gateway logs show `401 Unauthorized` when connecting to the upstream server, ensure the `key` in `credentialRef` matches the key used in the Secret's `stringData` (in this example, `token`).

--- a/docs/guides/internal-mcp-credentialref.md
+++ b/docs/guides/internal-mcp-credentialref.md
@@ -2,23 +2,29 @@
 
 This guide explains how to connect the MCP Gateway to a private internal MCP server that requires authentication using the `credentialRef` field in the `MCPServerRegistration` resource.
 
+## Prerequisites
+
+Before starting, ensure you have:
+- **MCP Gateway**: Installed and running in your Kubernetes cluster.
+- **Access Permissions**: Permissions to create `Secrets`, `HTTPRoutes`, and `MCPServerRegistration` resources in your namespace.
+- **Connectivity**: An `HTTPRoute` already configured and pointing to your internal MCP server.
+- **Internal MCP Server**: Reachable from within the cluster.
 
 ## Overview
 
-When an internal MCP server (running inside your Kubernetes cluster) is protected by authentication (e.g., a static API key or a shared token), the MCP Gateway can securely store and inject these credentials into the request flow.
+When an internal MCP server is protected by authentication (e.g., a static API key or a shared token), the MCP Gateway can securely store and inject these credentials into the request flow.
 
 The process involves:
 1. Creating a Kubernetes Secret containing the credential.
 2. Labeling the Secret so the MCP Gateway can access it.
 3. Referencing the Secret in your `MCPServerRegistration`.
 
-
 ## 1. Create the Credential Secret
 
 First, create a Secret containing your authentication token. 
 
 > [!IMPORTANT]
-> The Secret **must** have the label `mcp.kuadrant.io/secret: "true"`. Without this label, the MCP Gateway will not be able to read the credential.
+> The Secret **must** have the label `mcp.kuadrant.io/secret: "true"`. Without this label, the MCP Gateway will not be able to read the credential for security reasons.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -34,7 +40,6 @@ stringData:
   token: "Bearer your-secret-api-key"
 EOF
 ```
-
 
 ## 2. Register the MCP Server
 
@@ -59,6 +64,19 @@ spec:
 EOF
 ```
 
+## 3. Verify the Registration
+
+After creating the resource, verify that the MCP Gateway has successfully processed the registration and discovered the tools.
+
+```bash
+# Check the status of the registration
+kubectl get mcpserverregistration -n mcp-test
+
+# Describe the resource to see status conditions
+kubectl describe mcpserverregistration internal-api-key-server -n mcp-test
+```
+
+The `Status` field should indicate that the server is `Enabled` and that tools have been discovered.
 
 ## How it Works
 
@@ -69,8 +87,14 @@ EOF
    - **Router**: (Envoy external processor) injects the `Authorization` header into requests sent to the upstream MCP server.
 4. **Security**: Credentials are never exposed in the `MCPServerRegistration` spec or in the gateway logs.
 
-
 ## Troubleshooting
 
 - **Validation Error**: If you get a validation error when applying the `MCPServerRegistration`, double-check that your Secret has the `mcp.kuadrant.io/secret: "true"` label.
 - **Unauthorized Errors**: If the gateway logs show `401 Unauthorized` when connecting to the upstream server, ensure the `key` in `credentialRef` matches the key used in the Secret's `stringData` (in this example, `token`).
+- **Resource Not Found**: Ensure the `HTTPRoute` referenced in `targetRef` exists and is in the same namespace or accessible according to your Gateway's `allowedRoutes` policy.
+
+## Next Steps
+
+- [Connecting to External MCP Servers](./external-mcp-server.md)
+- [Kubernetes MCP Server Integration](./kubernetes-mcp-server.md)
+- [Troubleshooting Authentication Issues](../troubleshooting/auth.md)


### PR DESCRIPTION
This adds a short guide showing how to use credentialRef when connecting to internal MCP servers that require authentication.

With the GitHub external server guide moving to client-supplied tokens, there wasn’t a clear example anymore for cases where the gateway should manage a shared credential. This guide fills that gap with a simple internal setup.

It includes :-

1. Creating a labeled Secret for credentials
2. Referencing it via credentialRef in MCPServerRegistration
3. A quick explanation of how the gateway uses the credential
4. Basic troubleshooting notes

fixes #786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for configuring the MCP Gateway to connect to private internal MCP servers using credential references. 
  * Includes prerequisites, step-by-step setup (creating and labeling secrets, referencing credentials), verification steps to confirm registration and discovery, and security notes about broker credential handling and required client authorization.
  * Adds troubleshooting tips for secret labeling, credential key mismatches, and route/target issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/864)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->