### PR TITLE
feat: add span attributes and events for tracing and error attribution

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -215,13 +215,22 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	s.Logger.DebugContext(ctx, "HandleMCPRequest ", "session id", mcpReq.GetSessionID())
 	switch {
 	case mcpReq.isElicitationResponse():
-		span.SetAttributes(attribute.String("mcp.route", "elicitation-response"))
+		span.SetAttributes(
+			attribute.String("mcp.route", "elicitation-response"),
+			attribute.Bool("decision.allowed", true),
+		)
 		return s.HandleElicitationResponse(ctx, mcpReq)
 	case mcpReq.Method == methodToolCall:
-		span.SetAttributes(attribute.String("mcp.route", "tool-call"))
+		span.SetAttributes(
+			attribute.String("mcp.route", "tool-call"),
+			attribute.Bool("decision.allowed", true),
+		)
 		return s.HandleToolCall(ctx, mcpReq)
 	default:
-		span.SetAttributes(attribute.String("mcp.route", "broker"))
+		span.SetAttributes(
+			attribute.String("mcp.route", "broker"),
+			attribute.Bool("decision.allowed", true),
+		)
 		return s.HandleNoneToolCall(ctx, mcpReq)
 	}
 }
@@ -253,17 +262,15 @@ func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) 
 	calculatedResponse := NewResponse()
 	// handle tools call
 	if toolName == "" {
+		err := fmt.Errorf("no tool name set in tools/call")
 		s.Logger.ErrorContext(ctx, "[EXT-PROC] HandleRequestBody no tool name set in tools/call")
-		span.SetStatus(codes.Error, "no tool name set")
-		span.SetAttributes(attribute.String("error.type", "missing_tool_name"))
+		recordImmediateResponse(span, err, 400)
 		calculatedResponse.WithImmediateResponse(400, "no tool name set")
 		return calculatedResponse.Build()
 	}
 	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
 		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
-		span.RecordError(sessionErr)
-		span.SetStatus(codes.Error, sessionErr.Error())
-		span.SetAttributes(attribute.String("error.type", "invalid_session"))
+		recordImmediateResponse(span, sessionErr, sessionErr.Code())
 		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
 		return calculatedResponse.Build()
 	}

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -381,14 +381,15 @@ data: {"result":{"content":[{"type":"text","text":"MCP error -32602: Tool not fo
 		id, err := s.initializeMCPSeverSession(ctx, mcpReq)
 		if err != nil {
 			var routerErr *RouterError
+			statusCode := int32(500)
 			if errors.As(err, &routerErr) {
+				statusCode = routerErr.Code()
 				calculatedResponse.WithImmediateResponse(routerErr.Code(), routerErr.Error())
 			} else {
 				calculatedResponse.WithImmediateResponse(500, "internal error")
 			}
 			s.Logger.ErrorContext(ctx, "failed to get remote mcp server session id ", "error ", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "session initialization failed")
+			recordBackendError(span, err, statusCode)
 			span.SetAttributes(attribute.String("error.type", "session_init_error"))
 			return calculatedResponse.Build()
 		}

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -77,7 +77,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 		case *extProcV3.ProcessingRequest_RequestHeaders:
 			if r.RequestHeaders == nil {
 				err := fmt.Errorf("no request headers present")
-				recordError(span, err, 500)
+				recordImmediateResponse(span, err, 500)
 				resp := responseBuilder.WithImmediateResponse(500, "internal error").Build()
 				for _, res := range resp {
 					if sendErr := stream.Send(res); sendErr != nil {
@@ -132,7 +132,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			if localRequestHeaders == nil || localRequestHeaders.Headers == nil {
 				err := fmt.Errorf("request body received before headers")
 				s.Logger.ErrorContext(ctx, err.Error())
-				recordError(span, err, 500)
+				recordImmediateResponse(span, err, 500)
 				resp := responseBuilder.WithImmediateResponse(500, "internal error").Build()
 				for _, res := range resp {
 					if sendErr := stream.Send(res); sendErr != nil {
@@ -147,7 +147,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			if s.MaxRequestBodySize > 0 && len(bodyBuffer)+len(r.RequestBody.Body) > s.MaxRequestBodySize {
 				err := fmt.Errorf("request body too large: %d bytes exceeds limit of %d", len(bodyBuffer)+len(r.RequestBody.Body), s.MaxRequestBodySize)
 				s.Logger.ErrorContext(ctx, err.Error(), "request id", requestID)
-				recordError(span, err, 413)
+				recordImmediateResponse(span, err, 413)
 				resp := responseBuilder.WithImmediateResponse(413, "request body too large").Build()
 				for _, res := range resp {
 					if sendErr := stream.Send(res); sendErr != nil {
@@ -187,7 +187,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			}
 			if err := json.Unmarshal(bodyBuffer, &mcpRequest); err != nil {
 				s.Logger.ErrorContext(ctx, "error unmarshalling request body", "error", err)
-				recordError(span, err, 400)
+				recordImmediateResponse(span, err, 400)
 				resp := responseBuilder.WithImmediateResponse(400, "invalid request body").Build()
 				for _, res := range resp {
 					if err := stream.Send(res); err != nil {
@@ -199,7 +199,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			}
 			if _, err := mcpRequest.Validate(); err != nil {
 				s.Logger.ErrorContext(ctx, "Invalid MCPRequest", "error", err)
-				recordError(span, err, 400)
+				recordImmediateResponse(span, err, 400)
 				resp := responseBuilder.WithImmediateResponse(400, "invalid mcp request").Build()
 				for _, res := range resp {
 					if err := stream.Send(res); err != nil {
@@ -229,7 +229,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 		case *extProcV3.ProcessingRequest_ResponseHeaders:
 			if r.ResponseHeaders == nil || localRequestHeaders == nil {
 				err := fmt.Errorf("no response headers or request headers")
-				recordError(span, err, 500)
+				recordImmediateResponse(span, err, 500)
 				resp := responseBuilder.WithImmediateResponse(500, "internal error").Build()
 				for _, res := range resp {
 					if sendErr := stream.Send(res); sendErr != nil {
@@ -241,7 +241,23 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			s.Logger.DebugContext(ctx, "[ext_proc ] Process: ProcessingRequest_ResponseHeaders", "request id:", requestID)
 
 			statusCode := getSingleValueHeader(r.ResponseHeaders.Headers, ":status")
-			span.SetAttributes(attribute.String("http.status_code", statusCode))
+			if span.IsRecording() {
+				span.SetAttributes(attribute.String("http.status_code", statusCode))
+				if rcd := getSingleValueHeader(r.ResponseHeaders.Headers, "x-envoy-response-code-details"); rcd != "" {
+					span.SetAttributes(attribute.String("response_code_details", rcd))
+				}
+				if statusCode == "404" {
+					eventAttrs := []attribute.KeyValue{}
+					if mcpRequest != nil {
+						eventAttrs = append(eventAttrs,
+							attribute.String("mcp.server", mcpRequest.serverName),
+							attribute.String("mcp.session.id", mcpRequest.GetSessionID()),
+						)
+					}
+					span.AddEvent("backend_404", trace.WithAttributes(eventAttrs...))
+					span.SetAttributes(attribute.String("error_source", "backend"))
+				}
+			}
 
 			if mcpRequest != nil && mcpRequest.isToolCall() {
 				clientElicitation, elErr := s.SessionCache.GetClientElicitation(ctx, mcpRequest.GetSessionID())

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -340,6 +340,116 @@ func TestProcessSpanEnded(t *testing.T) {
 	require.True(t, found, "expected mcp-router.process span to be recorded")
 }
 
+func TestProcessSpan_ImmediateResponseEvent(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	srv := newTestServer(t)
+
+	// send an invalid body to trigger a 400 immediate response, then a recv error to end the loop
+	mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+		requestHeadersStep(),
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestBody{
+					RequestBody: &extProcV3.HttpBody{
+						Body:        []byte(`not json`),
+						EndOfStream: true,
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{immediateResponse(typev3.StatusCode_BadRequest)},
+		},
+		{msgErr: fmt.Errorf("stream closed")},
+	})
+
+	err := srv.Process(mock)
+	require.Error(t, err)
+	mock.verifyAllResponsesConsumed()
+
+	spans := exporter.GetSpans()
+	var processSpan *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "mcp-router.process" {
+			processSpan = &spans[i]
+			break
+		}
+	}
+	require.NotNil(t, processSpan, "expected mcp-router.process span")
+
+	foundEvent := false
+	for _, e := range processSpan.Events {
+		if e.Name == "immediate_response" {
+			foundEvent = true
+			break
+		}
+	}
+	require.True(t, foundEvent, "expected immediate_response event on span")
+}
+
+func TestProcessSpan_Backend404Event(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	srv := newTestServer(t)
+
+	// drive through request headers then a 404 response headers — simulates backend returning 404
+	mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+		requestHeadersStep(),
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_ResponseHeaders{
+					ResponseHeaders: &extProcV3.HttpHeaders{
+						Headers: &corev3.HeaderMap{
+							Headers: []*corev3.HeaderValue{
+								{Key: ":status", RawValue: []byte("404")},
+							},
+						},
+					},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{
+				{Response: &extProcV3.ProcessingResponse_ResponseHeaders{
+					ResponseHeaders: &extProcV3.HeadersResponse{},
+				}},
+			},
+		},
+	})
+
+	require.NoError(t, srv.Process(mock))
+	mock.verifyAllResponsesConsumed()
+
+	spans := exporter.GetSpans()
+	var processSpan *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "mcp-router.process" {
+			processSpan = &spans[i]
+		}
+	}
+	require.NotNil(t, processSpan, "expected mcp-router.process span")
+
+	foundEvent := false
+	for _, e := range processSpan.Events {
+		if e.Name == "backend_404" {
+			foundEvent = true
+			break
+		}
+	}
+	require.True(t, foundEvent, "expected backend_404 event on span when backend returns 404")
+}
+
 func TestProcess_StreamedBodyMultipleChunks(t *testing.T) {
 	srv := newTestServer(t)
 

--- a/internal/mcp-router/tracing.go
+++ b/internal/mcp-router/tracing.go
@@ -50,6 +50,7 @@ func spanAttributes(mcpReq *MCPRequest) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String("mcp.method.name", mcpReq.Method),
 		attribute.String("jsonrpc.protocol.version", mcpReq.JSONRPC),
+		attribute.String("component", "mcp-router"),
 	}
 
 	if mcpReq.ID != nil {

--- a/internal/mcp-router/tracing.go
+++ b/internal/mcp-router/tracing.go
@@ -65,7 +65,10 @@ func spanAttributes(mcpReq *MCPRequest) []attribute.KeyValue {
 	}
 
 	if toolName := mcpReq.ToolName(); toolName != "" {
-		attrs = append(attrs, attribute.String("gen_ai.tool.name", toolName))
+		attrs = append(attrs,
+			attribute.String("gen_ai.tool.name", toolName),
+			attribute.String("mcp.tool", toolName),
+		)
 	}
 
 	attrs = append(attrs, attribute.String("gen_ai.operation.name", mcpReq.Method))
@@ -77,6 +80,33 @@ func spanAttributes(mcpReq *MCPRequest) []attribute.KeyValue {
 	}
 
 	return attrs
+}
+
+// recordImmediateResponse records an ext-proc immediate response as a span event
+// and sets the error status and source attributes.
+func recordImmediateResponse(span trace.Span, err error, statusCode int32) {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.AddEvent("immediate_response", trace.WithAttributes(
+		attribute.Int("http.status_code", int(statusCode)),
+		attribute.String("message", err.Error()),
+	))
+	span.SetAttributes(
+		attribute.String("error.type", fmt.Sprintf("%T", err)),
+		attribute.String("error_source", "ext-proc"),
+		attribute.Int("http.status_code", int(statusCode)),
+	)
+}
+
+// recordBackendError records an error originating from a backend MCP server.
+func recordBackendError(span trace.Span, err error, statusCode int32) {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.SetAttributes(
+		attribute.String("error.type", fmt.Sprintf("%T", err)),
+		attribute.String("error_source", "backend"),
+		attribute.Int("http.status_code", int(statusCode)),
+	)
 }
 
 func recordError(span trace.Span, err error, statusCode int32) {


### PR DESCRIPTION
fixes #428

the existing tracing was missing several attributes from the observability phase 2 plan and had no way to tell where an error came from. added `mcp.tool`, `component`, and `decision.allowed` to spans, switched immediate response paths to emit a named `immediate_response` span event, added `response_code_details` from envoy headers, and tagged backend 404s with a `backend_404` event and `error_source: backend` so ext-proc errors and upstream errors are distinguishable in traces.

two new tests cover the event recording. all existing tests pass.

## demo

unit tests verify immediate_response and backend_404 span events are recorded correctly
<img width="1285" height="485" alt="image" src="https://github.com/user-attachments/assets/92ee18f7-39bb-41b3-b5cd-2071e7a3a2b6" />

all mcp-router tests pass including the new span attribute coverage
<img width="1285" height="403" alt="image" src="https://github.com/user-attachments/assets/f95a0487-35dc-4814-97fd-9bde231659ab" />
