### PR TITLE
feat(router): add MCP audit metadata headers for tool call tracing (#710)

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -241,12 +241,6 @@ func (s *ExtProcServer) validateSession(sessionID string) *RouterError {
 // HandleToolCall will handle an MCP Tool Call
 func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
 	toolName := mcpReq.ToolName()
-	//  Audit metadata headers
-	passThroughHeaders := map[string]string{
-		"x-mcp-toolname": toolName,
-		"x-mcp-method":   mcpReq.Method,
-		"x-mcp-session":  mcpReq.GetSessionID(),
-	}
 
 	ctx, span := tracer().Start(ctx, "mcp-router.tool-call",
 		trace.WithAttributes(
@@ -533,9 +527,19 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			}
 		}
 		// ensure these gateway heades are set
-		passThroughHeaders["x-mcp-method"] = mcpReq.Method
-		passThroughHeaders["x-mcp-servername"] = mcpReq.serverName
-		passThroughHeaders["x-mcp-toolname"] = mcpReq.ToolName()
+		toolName := mcpReq.ToolName()
+
+		if toolName != "" {
+			passThroughHeaders["x-mcp-toolname"] = toolName
+		}
+
+		if mcpReq.Method != "" {
+			passThroughHeaders["x-mcp-method"] = mcpReq.Method
+		}
+
+		if sessionID := mcpReq.GetSessionID(); sessionID != "" {
+			passThroughHeaders["x-mcp-session"] = sessionID
+		}
 		passThroughHeaders["user-agent"] = "mcp-router"
 	}
 	s.Logger.DebugContext(ctx, "initializing target as no mcp-session-id found for client", "server ", mcpReq.serverName, "with passthrough headers", passThroughHeaders)

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -241,6 +241,12 @@ func (s *ExtProcServer) validateSession(sessionID string) *RouterError {
 // HandleToolCall will handle an MCP Tool Call
 func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
 	toolName := mcpReq.ToolName()
+	//  Audit metadata headers
+passThroughHeaders := map[string]string{
+    "x-mcp-toolname": toolName,
+    "x-mcp-method":   mcpReq.Method,
+    "x-mcp-session":  mcpReq.GetSessionID(),
+}
 
 	ctx, span := tracer().Start(ctx, "mcp-router.tool-call",
 		trace.WithAttributes(

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -242,11 +242,11 @@ func (s *ExtProcServer) validateSession(sessionID string) *RouterError {
 func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
 	toolName := mcpReq.ToolName()
 	//  Audit metadata headers
-passThroughHeaders := map[string]string{
-    "x-mcp-toolname": toolName,
-    "x-mcp-method":   mcpReq.Method,
-    "x-mcp-session":  mcpReq.GetSessionID(),
-}
+	passThroughHeaders := map[string]string{
+		"x-mcp-toolname": toolName,
+		"x-mcp-method":   mcpReq.Method,
+		"x-mcp-session":  mcpReq.GetSessionID(),
+	}
 
 	ctx, span := tracer().Start(ctx, "mcp-router.tool-call",
 		trace.WithAttributes(


### PR DESCRIPTION
## Summary

This PR introduces audit metadata propagation for MCP tool calls by injecting key request attributes into headers within the MCP router.

During the handling of a `tools/call` request, the router now attaches the following headers:

* `x-mcp-toolname`: Name of the invoked tool
* `x-mcp-method`: MCP method (e.g., `tools/call`)
* `x-mcp-session`: MCP session identifier

These headers flow downstream to Envoy, enabling access logs to include tool-level context for each request.

---

## Motivation

Currently, Envoy access logs provide network-level visibility (request path, status, upstream, etc.) but lack application-level context about MCP tool usage. This makes it difficult to answer questions like:

* Which tool was invoked?
* Which session initiated the call?
* What type of MCP request was processed?

By exposing this metadata through headers, we enable:

* Tool-level audit trails
* Better observability of MCP interactions
* Easier debugging of agent behavior and routing decisions
* Foundation for compliance and accountability use cases

---

## Implementation Details

* Injected audit metadata inside `HandleToolCall` in the MCP router
* Reused the existing header propagation mechanism (`passThroughHeaders`)
* Extracted metadata directly from the parsed `MCPRequest`:

  * Tool name via `mcpReq.ToolName()`
  * Method via `mcpReq.Method`
  * Session via `mcpReq.GetSessionID()`
* Ensured headers are added only for tool call flows (no impact on non-tool requests)
* No changes made to Envoy configuration; this PR focuses on metadata exposure only

---

## Example

After this change, a tool call request will include headers like:

```
x-mcp-toolname: create_user
x-mcp-method: tools/call
x-mcp-session: abc123
```

When Envoy access logging is configured to include request headers, these values can be used to generate audit logs such as:

```
tool=create_user method=tools/call session=abc123 status=200
```

---

## Impact

* No breaking changes
* No changes to existing routing logic
* Backward compatible with current MCP and Envoy setup
* Enables downstream systems (Envoy, logging pipelines, observability tools) to build audit trails without modifying request payloads

---

## Notes

* This PR intentionally avoids logging sensitive tool parameters
* Envoy access log formatting is expected to be configured separately at the gateway level
* This approach keeps the router lightweight while enabling flexible observability downstream

---

## Future Work

* Move from header-based metadata to Envoy dynamic metadata for tighter integration
* Add optional parameter logging with sanitization
* Integrate with structured logging or tracing pipelines (e.g., OpenTelemetry)

---

Closes #710


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced audit metadata tracking for tool call requests with session and method information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->