### PR TITLE
Fix: concurrent map race in session cache

### DIFF
--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -13,6 +13,7 @@ const clientElicitationPrefix = "clientelicitation:"
 // Cache implements a cache
 type Cache struct {
 	inmemory  *sync.Map
+	innerMu   sync.Mutex // serializes copy-on-write mutations on inner map[string]string values
 	extClient *redis.Client
 }
 
@@ -64,16 +65,21 @@ func (c *Cache) DeleteSessions(ctx context.Context, key ...string) error {
 // AddSession will add a session under the key. If the key exists it will append that session
 func (c *Cache) AddSession(ctx context.Context, key, mcpServerID, mcpSession string) (bool, error) {
 	if c.inmemory != nil {
-		session, err := c.GetSession(ctx, key)
-		if err != nil {
-			return false, err
+		c.innerMu.Lock()
+		defer c.innerMu.Unlock()
+		var existing map[string]string
+		if val, ok := c.inmemory.Load(key); ok {
+			existing = val.(map[string]string)
 		}
-		session[mcpServerID] = mcpSession
-		c.inmemory.Store(key, session)
+		next := make(map[string]string, len(existing)+1)
+		for k, v := range existing {
+			next[k] = v
+		}
+		next[mcpServerID] = mcpSession
+		c.inmemory.Store(key, next)
 		return true, nil
 	}
-	err := c.extClient.HSet(ctx, key, mcpServerID, mcpSession).Err()
-	if err != nil {
+	if err := c.extClient.HSet(ctx, key, mcpServerID, mcpSession).Err(); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -82,12 +88,20 @@ func (c *Cache) AddSession(ctx context.Context, key, mcpServerID, mcpSession str
 // RemoveServerSession remove specific server session form cache
 func (c *Cache) RemoveServerSession(ctx context.Context, key, mcpServerID string) error {
 	if c.inmemory != nil {
-		session, err := c.GetSession(ctx, key)
-		if err != nil {
-			return err
+		c.innerMu.Lock()
+		defer c.innerMu.Unlock()
+		val, ok := c.inmemory.Load(key)
+		if !ok {
+			return nil
 		}
-		delete(session, mcpServerID)
-		c.inmemory.Store(key, session)
+		existing := val.(map[string]string)
+		next := make(map[string]string, len(existing))
+		for k, v := range existing {
+			if k != mcpServerID {
+				next[k] = v
+			}
+		}
+		c.inmemory.Store(key, next)
 		return nil
 	}
 	return c.extClient.HDel(ctx, key, mcpServerID).Err()

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -49,6 +49,8 @@ func (c *Cache) GetSession(ctx context.Context, key string) (map[string]string, 
 // DeleteSessions deletes sessions and associated metadata from the cache
 func (c *Cache) DeleteSessions(ctx context.Context, key ...string) error {
 	if c.inmemory != nil {
+		c.innerMu.Lock()
+		defer c.innerMu.Unlock()
 		for _, k := range key {
 			c.inmemory.Delete(k)
 			c.inmemory.Delete(clientElicitationPrefix + k)

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -278,7 +279,7 @@ func TestInMemoryCache_AddSession_Concurrent(t *testing.T) {
 				fmt.Sprintf("server%d", i),
 				fmt.Sprintf("upstream-session-%d", i),
 			)
-			require.NoError(t, addErr)
+			assert.NoError(t, addErr)
 		}(i)
 	}
 	wg.Wait()
@@ -307,7 +308,7 @@ func TestInMemoryCache_RemoveServerSession_Concurrent(t *testing.T) {
 	for i := range n {
 		go func(i int) {
 			defer wg.Done()
-			require.NoError(t, cache.RemoveServerSession(ctx, "gateway-session-1",
+			assert.NoError(t, cache.RemoveServerSession(ctx, "gateway-session-1",
 				fmt.Sprintf("server%d", i),
 			))
 		}(i)
@@ -336,12 +337,12 @@ func TestInMemoryCache_DeleteSessions_Concurrent(t *testing.T) {
 				fmt.Sprintf("server%d", i),
 				fmt.Sprintf("upstream-session-%d", i),
 			)
-			require.NoError(t, addErr)
+			assert.NoError(t, addErr)
 		}(i)
 
 		go func() {
 			defer wg.Done()
-			require.NoError(t, cache.DeleteSessions(ctx, "gateway-session-1"))
+			assert.NoError(t, cache.DeleteSessions(ctx, "gateway-session-1"))
 		}()
 	}
 	wg.Wait()

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -319,6 +319,34 @@ func TestInMemoryCache_RemoveServerSession_Concurrent(t *testing.T) {
 	require.Empty(t, sessions)
 }
 
+func TestInMemoryCache_DeleteSessions_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	// concurrent AddSession and DeleteSessions on the same key
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			_, addErr := cache.AddSession(ctx, "gateway-session-1",
+				fmt.Sprintf("server%d", i),
+				fmt.Sprintf("upstream-session-%d", i),
+			)
+			require.NoError(t, addErr)
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			require.NoError(t, cache.DeleteSessions(ctx, "gateway-session-1"))
+		}()
+	}
+	wg.Wait()
+}
+
 func TestInMemoryCache_DeleteSessionsCleansUpElicitation(t *testing.T) {
 	ctx := context.Background()
 	cache, err := NewCache()

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -255,6 +257,66 @@ func TestInMemoryCache_SetAndGetClientElicitation(t *testing.T) {
 	val, err = cache.GetClientElicitation(ctx, sessionID)
 	require.NoError(t, err)
 	require.True(t, val)
+}
+
+func TestInMemoryCache_AddSession_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	// seed one entry so concurrent callers retrieve the same stored map reference
+	_, err = cache.AddSession(ctx, "gateway-session-1", "seed", "seed-session")
+	require.NoError(t, err)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			_, addErr := cache.AddSession(ctx, "gateway-session-1",
+				fmt.Sprintf("server%d", i),
+				fmt.Sprintf("upstream-session-%d", i),
+			)
+			require.NoError(t, addErr)
+		}(i)
+	}
+	wg.Wait()
+
+	sessions, err := cache.GetSession(ctx, "gateway-session-1")
+	require.NoError(t, err)
+	require.Len(t, sessions, n+1) // n concurrent entries + seed
+}
+
+func TestInMemoryCache_RemoveServerSession_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	const n = 50
+	for i := range n {
+		_, err = cache.AddSession(ctx, "gateway-session-1",
+			fmt.Sprintf("server%d", i),
+			fmt.Sprintf("upstream-session-%d", i),
+		)
+		require.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			require.NoError(t, cache.RemoveServerSession(ctx, "gateway-session-1",
+				fmt.Sprintf("server%d", i),
+			))
+		}(i)
+	}
+	wg.Wait()
+
+	sessions, err := cache.GetSession(ctx, "gateway-session-1")
+	require.NoError(t, err)
+	require.Empty(t, sessions)
 }
 
 func TestInMemoryCache_DeleteSessionsCleansUpElicitation(t *testing.T) {


### PR DESCRIPTION
The in-memory session cache was storing a raw `map[string]string` in a `sync.Map` and returning the live reference from `GetSession`. Both `AddSession` and `RemoveServerSession` would then mutate that live map directly, with no lock around it.

This means if two tool calls hit the router at the same time, targeting different backend servers on the same gateway session ; both goroutines end up writing to the exact same map concurrently. Go's runtime detects this and panics with `fatal error: concurrent map writes`, taking down the entire `ext_proc` router process.

The fix is straightforward: serialize mutations with a mutex and use copy-on-write. Instead of mutating the stored map in place, `AddSession` and `RemoveServerSession` now copy the current entries into a fresh map, apply the change, and swap it in. Readers always get a stable snapshot. Also fixed a small pre-existing issue where `RemoveServerSession` on a non-existent key would accidentally write an empty map entry.

Added two concurrent tests (50 goroutines, race detector enabled) that would have panicked on the old code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cache synchronization to ensure safe, reliable behavior during concurrent operations without changing public APIs.

* **Tests**
  * Added concurrency tests covering session add/remove/delete flows to validate thread-safety and prevent race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->