### PR TITLE
upgrade Keycloak to 26.4 and update proxy configuration

### DIFF
--- a/config/keycloak/deployment.yaml
+++ b/config/keycloak/deployment.yaml
@@ -17,19 +17,17 @@ spec:
     spec:
       containers:
       - name: keycloak
-        image: quay.io/keycloak/keycloak:26.3
+        image: quay.io/keycloak/keycloak:26.4
         args:
         - start-dev
         - --import-realm
-        - --proxy=edge
+        - --proxy-headers=xforwarded
         - --verbose
         env:
         - name: KEYCLOAK_ADMIN
           value: "admin"
         - name: KEYCLOAK_ADMIN_PASSWORD
           value: "admin"
-        - name: KC_PROXY
-          value: "edge"
         - name: KC_HOSTNAME_STRICT
           value: "false"
         - name: KC_HTTP_ENABLED

--- a/project-words.txt
+++ b/project-words.txt
@@ -399,3 +399,4 @@ Zscifu
 ztunnels
 startswith
 unmarshals
+xforwarded


### PR DESCRIPTION
## Summary

Upgrades Keycloak from version 26.3 to 26.4 and updates the proxy configuration to use the new `--proxy-headers=xforwarded` flag instead of the deprecated `--proxy=edge` flag.

### Changes

- Bump Keycloak container image from `26.3` to `26.4`
- Replace `--proxy=edge` with `--proxy-headers=xforwarded` flag

### Verification

```
make local-env-setup
kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/config/keycloak/realm-import.yaml
kubectl apply -f config/keycloak/deployment.yaml
kubectl set env deployment/keycloak -n keycloak KC_HOSTNAME=http://keycloak.127-0-0-1.sslip.io:8002
kubectl wait --for=condition=ready pod -l app=keycloak -n keycloak --timeout=120s
```
I think that this is enough for verification but I you want to be more thorough you can follow the AuthN guide:
https://github.com/Kuadrant/mcp-gateway/blob/main/docs/guides/authentication.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Keycloak authentication service to v26.4 and updated proxy header handling.

* **Documentation**
  * Added two entries to the project word list: "402" and "xforwarded".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->