### PR TITLE
use MCPGatewayExtension for trusted headers key configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -635,11 +635,9 @@ local-env-teardown: ## Tear down the local Kind cluster
 
 .PHONY: add-jwt-key
 add-jwt-key: #add the public key needed to validate any incoming jwt based headers such as x-mcp-authorized
-	@for i in 1 2 3 4 5; do \
-		kubectl get deployment/$(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) -o yaml | \
-		bin/yq '.spec.template.spec.containers[0].env += [{"name":"TRUSTED_HEADER_PUBLIC_KEY","valueFrom":{"secretKeyRef":{"name":"trusted-headers-public-key","key":"key"}}}] | .spec.template.spec.containers[0].env |= unique_by(.name)' | \
-		kubectl apply -f - && break || (echo "Retry $$i/5 failed, waiting 2s..." && sleep 2); \
-	done
+	@kubectl apply -f config/mcp-system/trusted-header-public-key.yaml -n $(MCP_GATEWAY_NAMESPACE)
+	@kubectl patch mcpgatewayextension mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --type='merge' \
+		-p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
 
 .PHONY: dev
 dev: ## Setup cluster for local development (binaries run on host)


### PR DESCRIPTION
### Summary
Refactors the `add-jwt-key` Makefile target. The new implementation patches the `MCPGatewayExtension` CRD, allowing the operator to handle deployment reconciliation automatically instead of patching the Deployment directly.

### Changes
- Replace imperative deployment mutation (kubectl get/yq/apply with retry loop) with declarative `kubectl patch` on `MCPGatewayExtension`
- Apply trusted-headers secret directly from config file

### Verification
`make local-env-setup # it calls add-jwt-key under the hood`

Verify the MCPGatewayExtension was patched correctly:
`kubectl get mcpgatewayextension mcp-gateway-extension -n mcp-system -o yaml | grep -A 2 trustedHeadersKey`

Verify the broker-router deployment was updated by the operator:
`kubectl get deployment mcp-gateway -n mcp-system -o yaml | grep -A 5 TRUSTED_HEADER_PUBLIC_KEY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration process for trusted header keys. The setup now applies configuration more efficiently through a streamlined approach instead of previous retry-based patching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->