### PR TITLE
fix: use custom programmed condition for HTTPRoute

### DIFF
--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -552,7 +552,7 @@ func (r *MCPReconciler) updateHTTPRouteStatus(ctx context.Context, mcpsr *mcpv1a
 	}
 
 	condition := metav1.Condition{
-		Type:               "Programmed",
+		Type:               "mcp.kuadrant.io/Programmed",
 		ObservedGeneration: httpRoute.Generation,
 		LastTransitionTime: metav1.Now(),
 	}
@@ -561,19 +561,26 @@ func (r *MCPReconciler) updateHTTPRouteStatus(ctx context.Context, mcpsr *mcpv1a
 	condition.Reason = "InUseByMCPServerRegistration"
 	// We don't include the MCP Server in the status because >1 MCPServerRegistration may reference the same HTTPRoute
 	condition.Message = "HTTPRoute is referenced by at least one MCPServerRegistration"
+	
 	var changed bool
 	for i := range httpRoute.Status.Parents {
+		var conditionChanged bool
 		if mcpsr.DeletionTimestamp != nil {
-			changed = meta.RemoveStatusCondition(&httpRoute.Status.Parents[i].Conditions, "Programmed")
+			conditionChanged = meta.RemoveStatusCondition(&httpRoute.Status.Parents[i].Conditions, condition.Type)
 		} else {
-			changed = meta.SetStatusCondition(&httpRoute.Status.Parents[i].Conditions, condition)
+			conditionChanged = meta.SetStatusCondition(&httpRoute.Status.Parents[i].Conditions, condition)
 		}
-		if changed {
-			if err := r.Status().Update(ctx, httpRoute); err != nil {
-				return err
-			}
+		if conditionChanged {
+			changed = true
 		}
 	}
+
+	if changed {
+		if err := r.Status().Update(ctx, httpRoute); err != nil {
+			return err
+		}
+	}
+
 	return nil
 
 }

--- a/internal/controller/mcpserverregistration_controller_httproute_test.go
+++ b/internal/controller/mcpserverregistration_controller_httproute_test.go
@@ -1,0 +1,105 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestUpdateHTTPRouteStatus(t *testing.T) {
+	err := mcpv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatalf("failed to add mcp scheme: %v", err)
+	}
+	err = gatewayv1.Install(scheme.Scheme)
+	if err != nil {
+		t.Fatalf("failed to add gatewayv1 scheme: %v", err)
+	}
+
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
+					{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Accepted",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mcpsr := &mcpv1alpha1.MCPServerRegistration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mcpsr",
+			Namespace: "default",
+		},
+		Spec: mcpv1alpha1.MCPServerRegistrationSpec{
+			TargetRef: mcpv1alpha1.TargetReference{
+				Kind:      "HTTPRoute",
+				Name:      "test-route",
+				Namespace: "default",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(&gatewayv1.HTTPRoute{}).WithObjects(httpRoute).Build()
+
+	reconciler := &MCPReconciler{
+		Client: fakeClient,
+		Scheme: scheme.Scheme,
+	}
+
+	err = reconciler.updateHTTPRouteStatus(context.Background(), mcpsr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updatedRoute := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-route", Namespace: "default"}, updatedRoute)
+	if err != nil {
+		t.Fatalf("unexpected error getting route: %v", err)
+	}
+
+	if len(updatedRoute.Status.Parents) == 0 {
+		t.Fatalf("expected parents in status")
+	}
+
+	foundProgrammed := false
+	for _, cond := range updatedRoute.Status.Parents[0].Conditions {
+		if cond.Type == "mcp.kuadrant.io/Programmed" {
+			foundProgrammed = true
+			if cond.Status != metav1.ConditionTrue {
+				t.Errorf("expected condition status True, got %v", cond.Status)
+			}
+			if cond.Reason != "InUseByMCPServerRegistration" {
+				t.Errorf("expected reason InUseByMCPServerRegistration, got %v", cond.Reason)
+			}
+		}
+		if cond.Type == "Programmed" {
+			if cond.Reason != "Accepted" {
+				t.Errorf("expected original Programmed condition to be untouched, got %v", cond.Reason)
+			}
+		}
+	}
+
+	if !foundProgrammed {
+		t.Errorf("expected mcp.kuadrant.io/Programmed condition to be set")
+	}
+}


### PR DESCRIPTION
## Title
Fix infinite reconciliation loop caused by HTTPRoute `Programmed` condition overwrite

## Summary
This PR fixes a critical split-brain issue between the Kuadrant MCP Gateway controller and Gateway API controllers (e.g., Istio), which caused an infinite reconciliation loop and high CPU usage.

## Problem
The controller was overwriting the standard `Programmed` condition on `HTTPRoute.Status.Parents`, a field owned by the Gateway controller.  
This resulted in both controllers continuously reverting each other's changes, causing:
- Infinite reconciliation loop
- High CPU usage
- Excessive API server and etcd load
- Potential control plane instability

Additionally, `Status().Update()` was called inside a loop, leading to multiple unnecessary API calls.

## Fix
- Replaced mutation of the standard `Programmed` condition with a custom condition:
  - `mcp.kuadrant.io/Programmed`
- Ensured Gateway-owned conditions remain untouched
- Moved `r.Status().Update()` outside the loop to perform a single update per reconciliation

## Tests
- Existing unit and integration tests pass without modification
- Added new test:
  - `TestUpdateHTTPRouteStatus`
  - Verifies:
    - Original `Programmed` condition is preserved
    - Custom condition is correctly added

## Impact
- Eliminates infinite reconciliation loop
- Prevents controller contention over status fields
- Reduces API server load and avoids etcd bloat
- Aligns with Gateway API contract and best practices
- Improves overall cluster stability

## Notes
This change ensures the MCP controller only manages its own status conditions and does not interfere with Gateway controller-owned fields.

Fixes #878 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP route status condition handling and consolidation for better reliability.

* **Tests**
  * Added comprehensive test coverage for HTTP route status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->