### PR TITLE
feat: add local A2A agent fixture for design validation

### DIFF
--- a/tests/servers/a2a-agent/Dockerfile
+++ b/tests/servers/a2a-agent/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -o /a2a-fixture-agent
+
+FROM alpine:3.21
+COPY --from=builder /a2a-fixture-agent /a2a-fixture-agent
+CMD ["/a2a-fixture-agent"]

--- a/tests/servers/a2a-agent/README.md
+++ b/tests/servers/a2a-agent/README.md
@@ -1,0 +1,130 @@
+# a2a-fixture-agent
+
+A minimal local A2A agent for design validation. No external dependencies, no gateway changes.
+
+Serves two skills:
+- **echo**: returns the input text unchanged
+- **reverse**: returns the input text reversed
+
+## Run locally
+
+```bash
+go run . --http localhost:8090
+```
+
+## Build and run with Docker
+
+```bash
+docker build --load --tag a2a-fixture-agent .
+docker run --publish 8090:8090 a2a-fixture-agent /a2a-fixture-agent --http 0.0.0.0:8090
+```
+
+## Endpoints
+
+| path | description |
+|---|---|
+| `GET /.well-known/agent.json` | agent card |
+| `POST /` | JSON-RPC 2.0 task endpoint |
+
+## Supported JSON-RPC methods
+
+| method | description |
+|---|---|
+| `tasks/send` | create task, returns completed task with artifact |
+| `tasks/sendSubscribe` | create task, streams status events as SSE |
+| `tasks/get` | get task by ID |
+| `tasks/cancel` | cancel task by ID |
+| `tasks/pushNotificationConfig/set` | stub, always returns ok |
+
+## curl examples
+
+**Get agent card:**
+```bash
+curl http://localhost:8090/.well-known/agent.json | jq
+```
+
+**Send a task (echo):**
+```bash
+curl -X POST http://localhost:8090 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tasks/send",
+    "params": {
+      "id": "task-001",
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "hello world"}]
+      }
+    }
+  }' | jq
+```
+
+Expected response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "task-001",
+    "status": {"state": "completed", "timestamp": "..."},
+    "artifacts": [{"name": "result", "index": 0, "parts": [{"type": "text", "text": "hello world"}]}]
+  }
+}
+```
+
+**Send a task (reverse):**
+```bash
+curl -X POST http://localhost:8090 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tasks/send",
+    "params": {
+      "id": "task-002",
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "reverse hello"}]
+      }
+    }
+  }' | jq
+```
+
+Expected artifact text: `"olleh"`
+
+**Stream a task:**
+```bash
+curl -X POST http://localhost:8090 \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tasks/sendSubscribe",
+    "params": {
+      "id": "task-003",
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "hello stream"}]
+      }
+    }
+  }'
+```
+
+Expected SSE events: `submitted` -> `working` -> `completed` (with artifact on final event).
+
+**Get a task:**
+```bash
+curl -X POST http://localhost:8090 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tasks/get","params":{"id":"task-001"}}' | jq
+```
+
+**Cancel a task:**
+```bash
+curl -X POST http://localhost:8090 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tasks/cancel","params":{"id":"task-001"}}' | jq
+```

--- a/tests/servers/a2a-agent/go.mod
+++ b/tests/servers/a2a-agent/go.mod
@@ -1,0 +1,11 @@
+module github.com/Kuadrant/mcp-gateway/tests/servers/a2a-agent
+
+go 1.25.5
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/tests/servers/a2a-agent/go.sum
+++ b/tests/servers/a2a-agent/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/servers/a2a-agent/main.go
+++ b/tests/servers/a2a-agent/main.go
@@ -1,0 +1,400 @@
+// A minimal A2A agent fixture for design validation.
+// Serves an agent card, accepts tasks, returns deterministic responses,
+// and streams task status events. No external dependencies.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+var httpAddr = flag.String("http", "0.0.0.0:8090", "listen address")
+
+// --- A2A protocol types ---
+
+type AgentCard struct {
+	Name              string          `json:"name"`
+	Description       string          `json:"description"`
+	URL               string          `json:"url"`
+	Version           string          `json:"version"`
+	Skills            []Skill         `json:"skills"`
+	Capabilities      AgentCapability `json:"capabilities"`
+	DefaultInputModes []string        `json:"defaultInputModes"`
+	DefaultOutputModes []string       `json:"defaultOutputModes"`
+}
+
+type Skill struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+	InputModes  []string `json:"inputModes"`
+	OutputModes []string `json:"outputModes"`
+}
+
+type AgentCapability struct {
+	Streaming        bool `json:"streaming"`
+	PushNotifications bool `json:"pushNotifications"`
+	StateTransitionHistory bool `json:"stateTransitionHistory"`
+}
+
+type Task struct {
+	ID       string      `json:"id"`
+	Status   TaskStatus  `json:"status"`
+	Artifacts []Artifact `json:"artifacts,omitempty"`
+}
+
+type TaskStatus struct {
+	State     string    `json:"state"`
+	Timestamp time.Time `json:"timestamp"`
+	Message   *Message  `json:"message,omitempty"`
+}
+
+type Artifact struct {
+	Name  string    `json:"name"`
+	Parts []Part    `json:"parts"`
+	Index int       `json:"index"`
+}
+
+type Part struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type Message struct {
+	Role  string `json:"role"`
+	Parts []Part `json:"parts"`
+}
+
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id"`
+	Result  any    `json:"result,omitempty"`
+	Error   *RPCError `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type TaskSendParams struct {
+	ID      string  `json:"id"`
+	Message Message `json:"message"`
+}
+
+type TaskGetParams struct {
+	ID string `json:"id"`
+}
+
+type TaskCancelParams struct {
+	ID string `json:"id"`
+}
+
+// --- task store ---
+
+type taskStore struct {
+	mu    sync.RWMutex
+	tasks map[string]*Task
+}
+
+func newTaskStore() *taskStore {
+	return &taskStore{tasks: make(map[string]*Task)}
+}
+
+func (s *taskStore) get(id string) (*Task, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.tasks[id]
+	return t, ok
+}
+
+func (s *taskStore) set(t *Task) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tasks[t.ID] = t
+}
+
+func (s *taskStore) cancel(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.tasks[id]
+	if !ok {
+		return false
+	}
+	t.Status = TaskStatus{State: "canceled", Timestamp: time.Now()}
+	return true
+}
+
+// --- agent card ---
+
+func agentCard(baseURL string) AgentCard {
+	return AgentCard{
+		Name:        "a2a-fixture-agent",
+		Description: "local A2A fixture for design validation",
+		URL:         baseURL,
+		Version:     "0.1.0",
+		DefaultInputModes:  []string{"text"},
+		DefaultOutputModes: []string{"text"},
+		Capabilities: AgentCapability{
+			Streaming:              true,
+			PushNotifications:      true,
+			StateTransitionHistory: false,
+		},
+		Skills: []Skill{
+			{
+				ID:          "echo",
+				Name:        "Echo",
+				Description: "returns the input text unchanged",
+				Tags:        []string{"read-only", "safe"},
+				InputModes:  []string{"text"},
+				OutputModes: []string{"text"},
+			},
+			{
+				ID:          "reverse",
+				Name:        "Reverse",
+				Description: "returns the input text reversed",
+				Tags:        []string{"read-only", "safe"},
+				InputModes:  []string{"text"},
+				OutputModes: []string{"text"},
+			},
+		},
+	}
+}
+
+// --- handlers ---
+
+func handleAgentCard(baseURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(agentCard(baseURL))
+	}
+}
+
+func handleRPC(store *taskStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req JSONRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, nil, -32700, "parse error")
+			return
+		}
+		if req.JSONRPC != "2.0" {
+			writeError(w, req.ID, -32600, "invalid request")
+			return
+		}
+
+		switch req.Method {
+		case "tasks/send":
+			handleTaskSend(w, r, req, store)
+		case "tasks/sendSubscribe":
+			handleTaskSendSubscribe(w, r, req, store)
+		case "tasks/get":
+			handleTaskGet(w, req, store)
+		case "tasks/cancel":
+			handleTaskCancel(w, req, store)
+		case "tasks/pushNotificationConfig/set":
+			// stub: accept and acknowledge
+			writeResult(w, req.ID, map[string]bool{"ok": true})
+		default:
+			writeError(w, req.ID, -32601, "method not found")
+		}
+	}
+}
+
+func handleTaskSend(w http.ResponseWriter, _ *http.Request, req JSONRPCRequest, store *taskStore) {
+	var p TaskSendParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		writeError(w, req.ID, -32602, "invalid params")
+		return
+	}
+
+	output := processMessage(p.Message)
+	t := &Task{
+		ID:     p.ID,
+		Status: TaskStatus{State: "completed", Timestamp: time.Now()},
+		Artifacts: []Artifact{
+			{
+				Name:  "result",
+				Index: 0,
+				Parts: []Part{{Type: "text", Text: output}},
+			},
+		},
+	}
+	store.set(t)
+	writeResult(w, req.ID, t)
+}
+
+func handleTaskSendSubscribe(w http.ResponseWriter, _ *http.Request, req JSONRPCRequest, store *taskStore) {
+	var p TaskSendParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		writeError(w, req.ID, -32602, "invalid params")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	output := processMessage(p.Message)
+
+	events := []TaskStatus{
+		{State: "submitted", Timestamp: time.Now()},
+		{State: "working", Timestamp: time.Now(), Message: &Message{
+			Role:  "agent",
+			Parts: []Part{{Type: "text", Text: "processing..."}},
+		}},
+		{State: "completed", Timestamp: time.Now()},
+	}
+
+	for i, status := range events {
+		update := map[string]any{
+			"id":     p.ID,
+			"status": status,
+			"final":  i == len(events)-1,
+		}
+		if i == len(events)-1 {
+			update["artifacts"] = []Artifact{
+				{
+					Name:  "result",
+					Index: 0,
+					Parts: []Part{{Type: "text", Text: output}},
+				},
+			}
+		}
+
+		data, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  update,
+		})
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+
+		if i < len(events)-1 {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	t := &Task{
+		ID:     p.ID,
+		Status: TaskStatus{State: "completed", Timestamp: time.Now()},
+		Artifacts: []Artifact{
+			{Name: "result", Index: 0, Parts: []Part{{Type: "text", Text: output}}},
+		},
+	}
+	store.set(t)
+}
+
+func handleTaskGet(w http.ResponseWriter, req JSONRPCRequest, store *taskStore) {
+	var p TaskGetParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		writeError(w, req.ID, -32602, "invalid params")
+		return
+	}
+	t, ok := store.get(p.ID)
+	if !ok {
+		writeError(w, req.ID, -32001, "task not found")
+		return
+	}
+	writeResult(w, req.ID, t)
+}
+
+func handleTaskCancel(w http.ResponseWriter, req JSONRPCRequest, store *taskStore) {
+	var p TaskCancelParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		writeError(w, req.ID, -32602, "invalid params")
+		return
+	}
+	if !store.cancel(p.ID) {
+		writeError(w, req.ID, -32001, "task not found")
+		return
+	}
+	t, _ := store.get(p.ID)
+	writeResult(w, req.ID, t)
+}
+
+func processMessage(msg Message) string {
+	var parts []string
+	for _, p := range msg.Parts {
+		if p.Type == "text" {
+			parts = append(parts, p.Text)
+		}
+	}
+	text := strings.Join(parts, " ")
+
+	// skill routing by first word or fallback to echo
+	if strings.HasPrefix(strings.ToLower(text), "reverse ") {
+		runes := []rune(strings.TrimPrefix(text, "reverse "))
+		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+			runes[i], runes[j] = runes[j], runes[i]
+		}
+		return string(runes)
+	}
+	return text
+}
+
+func writeResult(w http.ResponseWriter, id any, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	})
+}
+
+func writeError(w http.ResponseWriter, id any, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &RPCError{Code: code, Message: msg},
+	})
+}
+
+func main() {
+	flag.Parse()
+
+	baseURL := "http://" + *httpAddr
+	store := newTaskStore()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/agent.json", handleAgentCard(baseURL))
+	mux.HandleFunc("/", handleRPC(store))
+
+	log.Printf("a2a-fixture-agent listening at %s", *httpAddr)
+	log.Printf("agent card: %s/.well-known/agent.json", baseURL)
+
+	srv := &http.Server{
+		Addr:              *httpAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/tests/servers/a2a-agent/main_test.go
+++ b/tests/servers/a2a-agent/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentCard(t *testing.T) {
+	card := agentCard("http://localhost:8090")
+	require.Equal(t, "a2a-fixture-agent", card.Name)
+	require.Equal(t, "http://localhost:8090", card.URL)
+	require.Len(t, card.Skills, 2)
+	require.Equal(t, "echo", card.Skills[0].ID)
+	require.Equal(t, "reverse", card.Skills[1].ID)
+	require.True(t, card.Capabilities.Streaming)
+	require.True(t, card.Capabilities.PushNotifications)
+}
+
+func TestProcessMessage_Echo(t *testing.T) {
+	msg := Message{
+		Role:  "user",
+		Parts: []Part{{Type: "text", Text: "hello world"}},
+	}
+	require.Equal(t, "hello world", processMessage(msg))
+}
+
+func TestProcessMessage_Reverse(t *testing.T) {
+	msg := Message{
+		Role:  "user",
+		Parts: []Part{{Type: "text", Text: "reverse hello"}},
+	}
+	require.Equal(t, "olleh", processMessage(msg))
+}
+
+func TestProcessMessage_NonTextPartsIgnored(t *testing.T) {
+	msg := Message{
+		Role: "user",
+		Parts: []Part{
+			{Type: "file"},
+			{Type: "text", Text: "hi"},
+		},
+	}
+	require.Equal(t, "hi", processMessage(msg))
+}
+
+func TestTaskStore(t *testing.T) {
+	store := newTaskStore()
+
+	_, ok := store.get("missing")
+	require.False(t, ok)
+
+	task := &Task{
+		ID:     "task-1",
+		Status: TaskStatus{State: "completed"},
+	}
+	store.set(task)
+
+	got, ok := store.get("task-1")
+	require.True(t, ok)
+	require.Equal(t, "completed", got.Status.State)
+}
+
+func TestTaskStore_Cancel(t *testing.T) {
+	store := newTaskStore()
+	store.set(&Task{ID: "task-2", Status: TaskStatus{State: "working"}})
+
+	ok := store.cancel("task-2")
+	require.True(t, ok)
+
+	t2, _ := store.get("task-2")
+	require.Equal(t, "canceled", t2.Status.State)
+
+	require.False(t, store.cancel("nonexistent"))
+}
+
+func TestAgentCardJSON(t *testing.T) {
+	card := agentCard("http://localhost:8090")
+	b, err := json.Marshal(card)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(b), `"id":"echo"`))
+	require.True(t, strings.Contains(string(b), `"id":"reverse"`))
+}


### PR DESCRIPTION
part of the A2A protocol support investigation under #766.

before any gateway routing work can happen for A2A, the design discussions need concrete request/response examples to stay grounded. this adds a minimal local A2A agent under tests/servers/a2a-agent that exercises the core protocol paths.

the fixture serves two skills (echo and reverse), handles both non-streaming tasks/send and streaming tasks/sendSubscribe with SSE events, and supports tasks/get and tasks/cancel. it also has a stub for tasks/pushNotificationConfig/set since that endpoint will be relevant for the push notification design work. no gateway code is changed.

it is built with only the standard library so there is no new dependency on the main module. the agent card is at /.well-known/agent.json with two stable skills and deterministic responses, which makes it usable as a reference for the config model, discovery, and streaming design issues.

the README has curl examples for all supported methods with expected output.

all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added A2A fixture agent implementation with comprehensive test coverage for message processing behaviors, task storage operations, and endpoint validation.

* **Documentation**
  * Added A2A fixture agent documentation detailing HTTP endpoints, supported JSON-RPC methods, and curl examples.

* **Chores**
  * Added Docker containerization and Go module configuration for A2A fixture agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->