### PR TITLE
feat: add support for productized MCP Gateway installation

### DIFF
--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -6,9 +6,14 @@ MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-local}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"
-INSTALL_RHCL="${INSTALL_RHCL:-true}"
+INSTALL_RHCL="${INSTALL_RHCL:-false}"
 INSTALL_SERVICE_MESH="${INSTALL_SERVICE_MESH:-true}"
 USE_OCP_INGRESS="${USE_OCP_INGRESS:-true}"
+
+# If set to true then MCP Gateway from official Red Hat Catalog is installed
+# CATALOG_IMG env var is ignored, no custom CatalogSource is created
+INSTALL_PRODUCTIZED_VERSION="${INSTALL_PRODUCTIZED_VERSION:-false}"
+CHANNEL="${CHANNEL:-preview}"
 
 # GATEWAY_CLASS_NAME value depends on how Service Mesh was (or is about to be) installed
 if [ "$USE_OCP_INGRESS" = "true" ]; then
@@ -45,55 +50,63 @@ else
 fi
 
 # Install Connectivity Link Operator
+# typically not needed since RHCL Operator is listed as an OLM dependency of MCP Gateway Controller
 if [ "$INSTALL_RHCL" = "true" ]; then
   echo "Installing Connectivity Link Operator..."
   oc apply -k "$SCRIPT_BASE_DIR/kustomize/connectivity-link/operator/base"
 
   echo "Waiting for Connectivity Link Operator to be ready..."
   until oc wait crd/kuadrants.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
-
-  # Install Connectivity Link Instance
-  echo "Installing Connectivity Link Instance..."
-  oc apply -k "$SCRIPT_BASE_DIR/kustomize/connectivity-link/instance/base"
 else
-  echo "Skipping Connectivity Link installation (INSTALL_RHCL=$INSTALL_RHCL)..."
+  echo "Skipping Connectivity Link Operator installation (INSTALL_RHCL=$INSTALL_RHCL)..."
 fi
 
 # Create gateway namespace
-oc create ns $GATEWAY_NAMESPACE --dry-run=client -o yaml | oc apply -f -
+oc create ns "$GATEWAY_NAMESPACE" --dry-run=client -o yaml | oc apply -f -
 
 # Install MCP Gateway Controller via OLM
 echo "Installing MCP Gateway Controller via OLM..."
-oc create ns $MCP_GATEWAY_NAMESPACE --dry-run=client -o yaml | oc apply -f -
+oc create ns "$MCP_GATEWAY_NAMESPACE" --dry-run=client -o yaml | oc apply -f -
 
-if [ -n "${CATALOG_IMG:-}" ]; then
-  sed "s|image: .*|image: ${CATALOG_IMG}|" \
-    "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" | oc apply -n openshift-marketplace -f -
-else
-  oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" -n openshift-marketplace
+if [ "$INSTALL_PRODUCTIZED_VERSION" != "true" ]; then
+  if [ -n "${CATALOG_IMG:-}" ]; then
+    sed "s|image: .*|image: ${CATALOG_IMG}|" \
+      "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" | oc apply -n openshift-marketplace -f -
+  else
+    oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" -n openshift-marketplace
+  fi
+
+  echo "Waiting for CatalogSource to be ready..."
+  retries=0
+  until oc get catalogsource mcp-gateway-catalog -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null | grep -q "READY"; do
+    retries=$((retries + 1))
+    if [ $retries -ge 60 ]; then
+      echo "Timed out waiting for CatalogSource to be ready"
+      exit 1
+    fi
+    sleep 5
+  done
 fi
 
-echo "Waiting for CatalogSource to be ready..."
-retries=0
-until oc get catalogsource mcp-gateway-catalog -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null | grep -q "READY"; do
-  retries=$((retries + 1))
-  if [ $retries -ge 60 ]; then
-    echo "Timed out waiting for CatalogSource to be ready"
-    exit 1
-  fi
-  sleep 5
-done
-
-oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/operatorgroup.yaml" -n $MCP_GATEWAY_NAMESPACE
+oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/operatorgroup.yaml" -n "$MCP_GATEWAY_NAMESPACE"
 
 # patch subscription sourceNamespace for OpenShift
 sed "s|sourceNamespace: .*|sourceNamespace: openshift-marketplace|" \
   "$SCRIPT_BASE_DIR/../deploy/olm/subscription.yaml" > /tmp/mcp-subscription.yaml
-oc apply -f /tmp/mcp-subscription.yaml -n $MCP_GATEWAY_NAMESPACE
+
+# patch subscription channel for OpenShift
+sed -i "s|channel: .*|channel: $CHANNEL|" /tmp/mcp-subscription.yaml
+
+# patch subscription source for OpenShift
+if [ "$INSTALL_PRODUCTIZED_VERSION" = "true" ]; then
+  sed -i "s|source: .*|source: redhat-operators|" /tmp/mcp-subscription.yaml
+fi
+
+oc apply -f /tmp/mcp-subscription.yaml -n "$MCP_GATEWAY_NAMESPACE"
 
 echo "Waiting for controller CSV to succeed..."
 retries=0
-until oc get csv -n $MCP_GATEWAY_NAMESPACE -l operators.coreos.com/mcp-gateway.$MCP_GATEWAY_NAMESPACE="" -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Succeeded"; do
+until oc get csv -n "$MCP_GATEWAY_NAMESPACE" -l "operators.coreos.com/mcp-gateway.$MCP_GATEWAY_NAMESPACE"="" -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Succeeded"; do
   retries=$((retries + 1))
   if [ $retries -ge 60 ]; then
     echo "Timed out waiting for controller CSV to succeed"
@@ -102,6 +115,18 @@ until oc get csv -n $MCP_GATEWAY_NAMESPACE -l operators.coreos.com/mcp-gateway.$
   sleep 5
 done
 echo "MCP Gateway Controller installed via OLM"
+
+echo "Waiting for Kuadrant CRD to be established..."
+until oc wait crd/kuadrants.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
+
+# Create RHCL Instance if not already exists
+if oc get kuadrant -A -o name 2>/dev/null | grep -q .; then
+  echo "Kuadrant CR already exists, skipping creation..."
+else
+  echo "Creating Kuadrant Instance..."
+  sed "s|namespace: .*|namespace: $MCP_GATEWAY_NAMESPACE|" \
+    "$SCRIPT_BASE_DIR/kustomize/connectivity-link/instance/base/kuadrant.yaml" | oc apply -n "$MCP_GATEWAY_NAMESPACE" -f -
+fi
 
 echo "Waiting for MCP Gateway CRDs to be established..."
 until oc wait crd/mcpgatewayextensions.mcp.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
@@ -117,26 +142,26 @@ else
   VERSION_FLAG="--version $MCP_GATEWAY_VERSION"
 fi
 
-helm upgrade -i mcp-gateway $CHART_REF \
+helm upgrade -i mcp-gateway "$CHART_REF" \
   $VERSION_FLAG \
-  --namespace $MCP_GATEWAY_NAMESPACE \
+  --namespace "$MCP_GATEWAY_NAMESPACE" \
   --skip-crds \
   --set controller.enabled=false \
   --set gateway.create=true \
   --set gateway.name=mcp-gateway \
-  --set gateway.namespace=$GATEWAY_NAMESPACE \
+  --set gateway.namespace="$GATEWAY_NAMESPACE" \
   --set gateway.publicHost="$MCP_GATEWAY_HOST" \
   --set gateway.internalHostPattern="*.mcp.local" \
   --set gateway.gatewayClassName="$GATEWAY_CLASS_NAME" \
   --set mcpGatewayExtension.create=true \
   --set mcpGatewayExtension.gatewayRef.name=mcp-gateway \
-  --set mcpGatewayExtension.gatewayRef.namespace=$GATEWAY_NAMESPACE \
+  --set mcpGatewayExtension.gatewayRef.namespace="$GATEWAY_NAMESPACE" \
   --set mcpGatewayExtension.gatewayRef.sectionName=mcp
 
 # Create OpenShift Route
 echo "Creating OpenShift Route..."
 helm upgrade -i mcp-gateway-ingress "$SCRIPT_BASE_DIR/charts/mcp-gateway-ingress" \
-  --namespace $GATEWAY_NAMESPACE \
+  --namespace "$GATEWAY_NAMESPACE" \
   --set mcpGateway.host="$MCP_GATEWAY_HOST" \
   --set gateway.name=mcp-gateway \
   --set gateway.class="$GATEWAY_CLASS_NAME" \


### PR DESCRIPTION
### Summary
Add support for installing MCP Gateway from the official Red Hat catalog instead of custom CatalogSource.

### Changes
- Add INSTALL_PRODUCTIZED_VERSION flag to control installation source
-  Add CHANNEL variable to configure OLM subscription channel (default: preview)
-  Skip CatalogSource creation when using productized version
-  Dynamically patch subscription channel and source based on configuration
-  Change INSTALL_RHCL default to false (RHCL is an OLM dependency)
- - but create Kuadrant CR if it does not exist already  
-  Quote shell variables throughout script for safety

### Verification
You can validate this by running against OpenShift using various values for env vars, example:
```
MCP_GATEWAY_VERSION=0.6.0 INSTALL_PRODUCTIZED_VERSION=true CHANNEL=preview INSTALL_RHCL=false INSTALL_SERVICE_MESH=true USE_OCP_INGRESS=true ./config/openshift/deploy_openshift.sh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds automatic Kuadrant instance creation during deployment.

* **Chores**
  * Deployment defaults updated to disable MCP and Connectivity Link installation by default and add new configuration options.
  * Connectivity Link installation now runs only when explicitly enabled.
  * MCP Gateway deployment made more configurable with clearer, explicit parameters and conditional catalog/source handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/887)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->