### PR TITLE
fix: periodically refresh MCPServerRegistration status

### DIFF
--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -248,7 +248,7 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		}
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
 
 }
 


### PR DESCRIPTION
## Summary

Fixes stale `DiscoveredTools` counts on `MCPServerRegistration` resources by periodically requeuing successful reconciliations.

Currently, backend MCP server tool refreshes are reflected correctly by the broker, but the `MCPServerRegistration` reconcile loop is not triggered again after backend config/image/tool changes. As a result, the `DiscoveredTools` field on the CR status can remain stale indefinitely.

This change adds a periodic `RequeueAfter` on the successful reconcile path so the controller periodically refreshes registration status from the broker state.

Closes #666

## Changes

* Added periodic reconcile requeue on successful `MCPServerRegistration` reconciliation
* Keeps `DiscoveredTools` status in sync with broker-refreshed tool state
* Avoids introducing additional watches/indexing complexity

## Testing

```bash
go fmt ./internal/controller/...
go test ./internal/controller/...
```

Verified that:

* controller tests pass
* successful reconciles now periodically refresh registration status
* stale `DiscoveredTools` counts are eventually updated after backend MCP server changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCPServerRegistration reconciliation to perform periodic status checks at regular intervals, enhancing system reliability and consistency monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->