### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -128,8 +128,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          file: ./${{ matrix.dockerfile }}          
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           provenance: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -196,8 +196,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./bundle.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          file: ./bundle.Dockerfile          
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
           provenance: false
           tags: |

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -113,7 +113,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ endif
 ifeq ($(ARCH),aarch64)
     ARCH = arm64
 endif
+ifeq ($(ARCH),ppc64le)
+    ARCH = ppc64le
+endif
 
 LOG_LEVEL ?= -4
 
@@ -290,8 +293,8 @@ load-image: kind ## Load the mcp-gateway image into the kind cluster
 
 .PHONY: build-image
 build-image: kind ## Build the mcp-gateway image
-	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --build-arg LDFLAGS="$(LDFLAGS)" -t $(GATEWAY_IMG) .
-	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --file Dockerfile.controller -t $(IMAGE_TAG_BASE):$(IMAGE_TAG) .
+	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --network=host --build-arg LDFLAGS="$(LDFLAGS)" -t $(GATEWAY_IMG) .
+	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) --network=host --file Dockerfile.controller -t $(IMAGE_TAG_BASE):$(IMAGE_TAG) .
 
 # Deploy example MCPServerRegistration
 deploy-example: install-crd ## Deploy example MCPServerRegistration resource
@@ -558,7 +561,7 @@ reload: build docker-build kind ## Build, load to Kind, and restart both control
 
 # Build multi-platform image
 docker-buildx: ## Build multi-platform container image
-	$(CONTAINER_ENGINE) buildx build --platform linux/amd64,linux/arm64 $(CONTAINER_ENGINE_EXTRA_FLAGS) -t mcp-gateway:local .
+	$(CONTAINER_ENGINE) buildx build --platform linux/amd64,linux/arm64,linux/ppc64le $(CONTAINER_ENGINE_EXTRA_FLAGS) -t mcp-gateway:local .
 
 # Download dependencies
 deps:

--- a/build/istio.mk
+++ b/build/istio.mk
@@ -1,34 +1,49 @@
 # Istio
 
-SAIL_VERSION = 1.27.0
-ISTIO_NAMESPACE = istio-system
-ISTIO_VERSION = 1.27.0
+ARCH ?= $(shell uname -m)
+SAIL_VERSION ?= 1.27.0
+ISTIO_NAMESPACE ?= istio-system
+ISTIO_VERSION ?= 1.27.0
 
 # istioctl tool
 ISTIOCTL = bin/istioctl
+ISTIO_SRC_DIR = /tmp/istio-src-$(ISTIO_VERSION)
+
 $(ISTIOCTL):
 	mkdir -p bin
-	curl -sL https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIO_VERSION) TARGET_ARCH=$(ARCH) sh -
-	mv istio-$(ISTIO_VERSION)/bin/istioctl bin/
-	rm -rf istio-$(ISTIO_VERSION)
+	@if [ "$(ARCH)" = "ppc64le" ]; then \
+		echo "Building istioctl $(ISTIO_VERSION) for $(ARCH)..."; \
+          	rm -rf "$(ISTIO_SRC_DIR)"; \
+        	git clone --depth 1 --branch "$(ISTIO_VERSION)" https://github.com/istio/istio.git "$(ISTIO_SRC_DIR)"; \
+        	cd "$(ISTIO_SRC_DIR)" && \
+            	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o "$(CURDIR)/$(ISTIOCTL)" ./istioctl/cmd/istioctl; \
+        	rm -rf "$(ISTIO_SRC_DIR)"; \
+   	 else \
+        	echo "Downloading istioctl $(ISTIO_VERSION) for $(ARCH)..."; \
+        	curl -sL https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIO_VERSION) TARGET_ARCH=$(ARCH) sh -; \
+       		mv "istio-$(ISTIO_VERSION)/bin/istioctl" bin/; \
+       		rm -rf "istio-$(ISTIO_VERSION)"; \
+   	 fi
 
+.PHONY: istioctl-impl
 istioctl-impl: $(ISTIOCTL)
 	@echo "istioctl installed at: $(ISTIOCTL)"
 	@echo "Version: $$($(ISTIOCTL) version --remote=false)"
 
 .PHONY: istio-install
-istio-install: $(HELM) # Install Istio using Sail operator
+istio-install: $(HELM) ## Install Istio using Sail operator
 	$(HELM) upgrade --install sail-operator \
 		--create-namespace \
-		--namespace $(ISTIO_NAMESPACE) \
-		--wait \
-		--timeout=300s \
-		https://github.com/istio-ecosystem/sail-operator/releases/download/$(SAIL_VERSION)/sail-operator-$(SAIL_VERSION).tgz
+        	--namespace $(ISTIO_NAMESPACE) \
+        	--wait \
+        	--timeout=300s \
+        	https://github.com/istio-ecosystem/sail-operator/releases/download/$(SAIL_VERSION)/sail-operator-$(SAIL_VERSION).tgz
 	kubectl apply -f config/istio/istio.yaml
 	kubectl -n $(ISTIO_NAMESPACE) wait --for=condition=Ready istio/default --timeout=300s
 
 .PHONY: istio-uninstall
-istio-uninstall: $(HELM) # Uninstall Istio and Sail operator
+istio-uninstall: $(HELM) ## Uninstall Istio and Sail operator
 	- kubectl delete -f config/istio/istio.yaml
 	$(HELM) uninstall sail-operator -n $(ISTIO_NAMESPACE)
 	- kubectl delete namespace $(ISTIO_NAMESPACE)
+

--- a/build/istio.mk
+++ b/build/istio.mk
@@ -1,9 +1,9 @@
 # Istio
 
 ARCH ?= $(shell uname -m)
-SAIL_VERSION ?= 1.27.0
+SAIL_VERSION ?= 1.30.0
 ISTIO_NAMESPACE ?= istio-system
-ISTIO_VERSION ?= 1.27.0
+ISTIO_VERSION ?= 1.30.0
 
 # istioctl tool
 ISTIOCTL = bin/istioctl

--- a/build/kind.mk
+++ b/build/kind.mk
@@ -1,5 +1,6 @@
 # Kind
 
+ARCH ?= $(shell uname -m)
 KIND_CLUSTER_NAME ?= mcp-gateway
 
 # node image for CI clusters; the baked CI node image overrides this on a
@@ -15,26 +16,59 @@ KIND_CLUSTER_IMAGE ?= $(KIND_NODE_IMAGE)
 .PHONY: kind-create-cluster-ci
 kind-create-cluster-ci: kind # Create the CI kind cluster with the pinned kind binary and node image
 	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config config/kind/cluster-ci.yaml --image "$(KIND_CLUSTER_IMAGE)"
+# Match the Kubernetes version your repo expects for kind
+KIND_K8S_VERSION ?= v1.33.1
+
+# Default upstream kind node image name for supported arches
+KIND_NODE_IMAGE ?= kindest/node:$(KIND_K8S_VERSION)
+
+# Custom node image name for ppc64le
+ifeq ($(ARCH),ppc64le)
+	KIND_NODE_IMAGE_PPC64LE := quay.io/powercloud/kind-node:$(KIND_K8S_VERSION)
+else
+	KIND_NODE_IMAGE_PPC64LE := docker.io/kindest/node:$(KIND_K8S_VERSION)
+endif
+
+.PHONY: kind-node-image
+kind-node-image: kind ## Build custom kind node image for ppc64le when needed
+	@if [ "$(ARCH)" = "ppc64le" ]; then \
+		echo "Ensuring custom Kind node image exists for $(ARCH)..."; \
+		if ! $(CONTAINER_ENGINE) image inspect "$(KIND_NODE_IMAGE_PPC64LE)" >/dev/null 2>&1; then \
+			echo "Building $(KIND_NODE_IMAGE_PPC64LE) from Kubernetes release $(KIND_K8S_VERSION)..."; \
+			KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) build node-image \
+				--image "$(KIND_NODE_IMAGE_PPC64LE)" \
+				--type release \
+				"$(KIND_K8S_VERSION)"; \
+		else \
+			echo "[OK] Custom Kind node image already exists: $(KIND_NODE_IMAGE_PPC64LE)"; \
+		fi; \
+	else \
+		echo "[OK] Default kind node image will be used for $(ARCH)"; \
+	fi
 
 .PHONY: kind-create-cluster
-kind-create-cluster: kind # Create the "mcp-gateway" kind cluster.
+kind-create-cluster: kind kind-node-image ## Create the "mcp-gateway" kind cluster.
 	@./utils/generate-placeholder-ca.sh
 	@# Set KIND provider for podman
 	@if echo "$(CONTAINER_ENGINE)" | grep -q "podman"; then \
 		export KIND_EXPERIMENTAL_PROVIDER=podman; \
 	fi; \
+	NODE_IMAGE="$(KIND_NODE_IMAGE)"; \
+	if [ "$(ARCH)" = "ppc64le" ]; then \
+		NODE_IMAGE="$(KIND_NODE_IMAGE_PPC64LE)"; \
+	fi; \
 	if $(KIND) get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
 		echo "Kind cluster '$(KIND_CLUSTER_NAME)' already exists, skipping creation"; \
 	else \
-		echo "Creating Kind cluster '$(KIND_CLUSTER_NAME)' with MCP_GATEWAY port $(KIND_HOST_PORT_MCP_GATEWAY) and KEYCLOAK port $(KIND_HOST_PORT_KEYCLOAK)..."; \
+		echo "Creating Kind cluster '$(KIND_CLUSTER_NAME)' with image $$NODE_IMAGE ..."; \
 		cat config/kind/cluster.yaml | sed \
 			-e 's/hostPort: 8001/hostPort: $(KIND_HOST_PORT_MCP_GATEWAY)/' \
 			-e 's/hostPort: 8002/hostPort: $(KIND_HOST_PORT_KEYCLOAK)/' | \
-		$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config -; \
+		$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image "$$NODE_IMAGE" --config -; \
 	fi
 
 .PHONY: kind-delete-cluster
-kind-delete-cluster: kind # Delete the "mcp-gateway" kind cluster.
+kind-delete-cluster: kind ## Delete the "mcp-gateway" kind cluster.
 	@# Set KIND provider for podman
 	@if echo "$(CONTAINER_ENGINE)" | grep -q "podman"; then \
 		export KIND_EXPERIMENTAL_PROVIDER=podman; \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added PowerPC 64-bit (ppc64le) to container image builds and expanded the affected workflows to publish multi-architecture images.
  * Updated local build tooling to detect ppc64le and build/select compatible Kind node images, ensuring clusters can be created on that architecture.
  * Made build tooling architecture-aware for installing tools (including the istioctl workflow), with safer defaulting for version/namespace variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->