### PR TITLE
fix(router): prevent connection leaks on backend 404 errors

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -16,7 +16,7 @@ import (
 
 // Initialize will create a new initialize and initialized request and return the associated http client for connection management
 // This method makes a request back to the gateway setting the target mcp server to initialize. We hairpin through the gateway to ensure any Auth applied to that host is triggered for the call.
-func Initialize(ctx context.Context, gatewayHost, routerKey string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool) (*client.Client, error) {
+func Initialize(ctx context.Context, gatewayHost, routerKey string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool) (mcprouter.MCPClient, error) {
 	//mcp-gateway-istio
 	// force the initialize to hairpin back through envoy
 	passThroughHeaders[mcprouter.RoutingKey] = routerKey

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -495,7 +495,6 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 // initializeMCPSeverSession will create a new session and connection with the backend MCP server
 // This connection is kept open for the life of the gateway session to ensure the backend session is not closed/invalidated.
-// TODO when we receive a 404 from a backend MCP Server we should have a way to close the connection at that point also currently when we receive a 404 we remove the session from cache and will open a new connection. They will all be closed once the gateway session expires or the client sends a delete but it is a source of potential leaks
 func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *MCPRequest) (string, error) {
 	ctx, initSpan := tracer().Start(ctx, "mcp-router.session-init",
 		trace.WithAttributes(
@@ -551,8 +550,13 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		initSpan.SetStatus(codes.Error, "failed to initialize backend session")
 		return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 	}
+
+	connKey := mcpReq.GetSessionID() + ":" + mcpReq.serverName
+	s.connections.Store(connKey, clientHandle)
+
 	var sessionCloser = func() {
 		s.Logger.DebugContext(ctx, "gateway session expired closing client", "Session ", mcpReq.GetSessionID())
+		s.connections.Delete(connKey)
 		if err := clientHandle.Close(); err != nil {
 			s.Logger.DebugContext(ctx, "failed to close client connection", "err", err)
 		}

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -591,6 +591,10 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		if storeErr != nil {
 			s.Logger.ErrorContext(ctx, "failed to add remote session to cache", "error", storeErr)
 			// again if this fails it is likely terminal due to a network connection error
+			s.connections.Delete(connKey)
+			if err := clientHandle.Close(); err != nil {
+				s.Logger.ErrorContext(ctx, "failed to close connection after AddSession failure", "error", err)
+			}
 			return "", NewRouterError(500, fmt.Errorf("internal error"))
 		}
 	}

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	"github.com/mark3labs/mcp-go/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -178,7 +177,7 @@ func TestHandleRequestBody(t *testing.T) {
 	require.True(t, sessionAdded)
 
 	// Mock InitForClient - should not be called since session exists
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (MCPClient, error) {
 		// This should not be called in this test since session exists in cache
 		return nil, fmt.Errorf("InitForClient should not be called when session exists")
 	}

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -43,6 +43,16 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 			// not much we can do here log and continue
 			s.Logger.ErrorContext(ctx, "failed to remove server session ", "server", req.serverName, "session", req.GetSessionID())
 		}
+		// close and remove the connection if it exists in our registry
+		connKey := req.GetSessionID() + ":" + req.serverName
+		if conn, ok := s.connections.LoadAndDelete(connKey); ok {
+			if client, ok := conn.(MCPClient); ok {
+				s.Logger.DebugContext(ctx, "closing connection after backend 404", "server", req.serverName)
+				if err := client.Close(); err != nil {
+					s.Logger.ErrorContext(ctx, "failed to close connection after 404", "error", err)
+				}
+			}
+		}
 	}
 
 	responses := response.WithResponseHeaderResponse(responseHeaderBuilder.Build()).Build()

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -310,6 +310,78 @@ func TestHandleResponseHeaders_404WithMultipleServerSessions(t *testing.T) {
 	require.False(t, exists)
 }
 
+type mockMCPClient struct {
+	closed bool
+}
+
+func (m *mockMCPClient) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockMCPClient) GetSessionId() string {
+	return "mock-session"
+}
+
+func TestHandleResponseHeaders_404ClosesConnection(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	server := &ExtProcServer{
+		Logger:       logger,
+		SessionCache: cache,
+		Broker:       newMockBroker(nil, map[string]string{}),
+	}
+
+	gatewaySessionID := "gateway-session-123"
+	serverName := "test-server"
+
+	// Add a mock connection to the registry
+	mockClient := &mockMCPClient{}
+	connKey := gatewaySessionID + ":" + serverName
+	server.connections.Store(connKey, mockClient)
+
+	// request headers with gateway session ID
+	requestHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{
+					Key:      "mcp-session-id",
+					RawValue: []byte(gatewaySessionID),
+				},
+			},
+		},
+	}
+
+	// response headers with 404 status
+	responseHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{
+					Key:      ":status",
+					RawValue: []byte("404"),
+				},
+			},
+		},
+	}
+
+	// create MCP request with server name
+	mcpReq := &MCPRequest{
+		sessionID:  gatewaySessionID,
+		serverName: serverName,
+		Method:     "tools/call",
+	}
+
+	_, err = server.HandleResponseHeaders(context.Background(), responseHeaders, requestHeaders, mcpReq)
+	require.NoError(t, err)
+
+	// Verify the connection was closed and removed from the registry
+	require.True(t, mockClient.closed, "connection should be closed")
+	_, exists := server.connections.Load(connKey)
+	require.False(t, exists, "connection should be removed from registry")
+}
+
 func TestHandleResponseHeaders_SuccessStatusDoesNotRemoveSession(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cache, err := session.NewCache()

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	extProcV3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	"github.com/mark3labs/mcp-go/client"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -30,8 +30,14 @@ type SessionCache interface {
 	GetClientElicitation(ctx context.Context, gatewaySessionID string) (bool, error)
 }
 
+// MCPClient defines the interface for an MCP client
+type MCPClient interface {
+	Close() error
+	GetSessionId() string
+}
+
 // InitForClient defines a function for initializing an MCP server for a client
-type InitForClient func(ctx context.Context, gatewayHost, routerKey string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool) (*client.Client, error)
+type InitForClient func(ctx context.Context, gatewayHost, routerKey string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool) (MCPClient, error)
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {
@@ -44,6 +50,8 @@ type ExtProcServer struct {
 	MaxRequestBodySize int
 	//TODO this should not be needed
 	Broker broker.MCPBroker
+
+	connections sync.Map // map[string]*client.Client, key is gatewaySessionID + ":" + serverName
 }
 
 // OnConfigChange is used to register the router for config changes


### PR DESCRIPTION
Fixes #903

This PR addresses a resource leak where backend MCP connections were not closed when a 404 status was received (indicating an invalid session).

Changes:
- Introduce MCPClient interface for better testability.
- Add connection registry to ExtProcServer to track active backend connections.
- Explicitly close and remove connections when backend returns 404.
- Refactor clients.Initialize to return the MCPClient interface.
- Add unit test to verify connection closure on 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced backend connection lifecycle management to prevent connection and session leaks.
  * Backend client connections are now properly tracked and automatically closed when servers respond with error conditions, ensuring cleaner resource cleanup and improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->