### PR TITLE
remove .md and docs file from codestyle ignored paths

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [ 'main',  ]
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
       - 'examples/**'
       - 'LICENSE'
       - 'evals/**'

--- a/project-words.txt
+++ b/project-words.txt
@@ -408,3 +408,4 @@ CONNLINK
 HKDF
 HMAC
 usercred
+myprefix


### PR DESCRIPTION
The code-style.yaml workflow had paths-ignore entries for **.md and docs/**, meaning PRs that only touched markdown or docs files skipped the workflow entirely. But make spell runs cspell  against the entire repo. So a doc-only PR could merge with an unknown word (e.g. myprefix in docs/guides/tool-discovery.md), and then the next PR touching .go files would trigger the workflow, CSpell would scan the whole repo, find that word, and fail — even though that PR didn't introduce it.
