### PR TITLE
fix(broker): guard against nil gatewayServer to prevent panic

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -102,14 +102,14 @@ const DefaultTickerInterval = time.Minute * 1
 // NewUpstreamMCPManager creates a new MCPManager for managing a single upstream MCP server.
 // The addTools and removeTools callbacks are used to update the gateway's tool registry.
 // The tickerInterval controls how often the manager checks backend health (use 0 for default).
-func NewUpstreamMCPManager(upstream MCP, gatewaySever ToolsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) *MCPManager {
+func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) *MCPManager {
 	if tickerInterval <= 0 {
 		tickerInterval = DefaultTickerInterval
 	}
 
 	return &MCPManager{
 		MCP:               upstream,
-		gatewayServer:     gatewaySever,
+		gatewayServer:     gatewayServer,
 		tickerInterval:    tickerInterval,
 		ticker:            time.NewTicker(tickerInterval),
 		logger:            logger,
@@ -258,11 +258,13 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	}
 	// serverTools will have the prefix if one is set
 	man.logger.Debug("updating gateway tools", "upstream mcp server", man.MCP.ID(), "adding", len(toAdd), "removing", len(toRemove))
-	if len(toRemove) > 0 {
-		man.gatewayServer.DeleteTools(toRemove...)
-	}
-	if len(toAdd) > 0 {
-		man.gatewayServer.AddTools(toAdd...)
+	if man.gatewayServer != nil {
+		if len(toRemove) > 0 {
+			man.gatewayServer.DeleteTools(toRemove...)
+		}
+		if len(toAdd) > 0 {
+			man.gatewayServer.AddTools(toAdd...)
+		}
 	}
 
 	// rebuild our internal tools
@@ -312,6 +314,9 @@ func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []Invali
 }
 
 func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {
+	if man.gatewayServer == nil {
+		return nil
+	}
 	gatewayServerTools := man.gatewayServer.ListTools()
 	var conflictingToolNames []string
 	for _, tool := range mcpTools {
@@ -410,7 +415,9 @@ func (man *MCPManager) removeAllTools() {
 	man.tools = []mcp.Tool{}
 	man.toolsMap = map[string]*mcp.Tool{}
 	man.servedToolsMap = map[string]*mcp.Tool{}
-	man.gatewayServer.DeleteTools(toolsToRemove...)
+	if man.gatewayServer != nil {
+		man.gatewayServer.DeleteTools(toolsToRemove...)
+	}
 	man.logger.Debug("removed all tools", "upstream mcp server", man.MCP.ID(), "count", len(toolsToRemove))
 }
 

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -187,8 +187,6 @@ func TestMCPManager_MCPName(t *testing.T) {
 	assert.Equal(t, "my-test-server", manager.MCPName())
 }
 
-// TestMCPManager_NilGatewayServer_NoPanic is a regression test for
-// https://github.com/Kuadrant/mcp-gateway/issues/882.
 // manage() must not panic when gatewayServer is nil — tools/list_changed
 // notifications can fire before the broker wires up the gateway server.
 func TestMCPManager_NilGatewayServer_NoPanic(t *testing.T) {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -187,6 +187,20 @@ func TestMCPManager_MCPName(t *testing.T) {
 	assert.Equal(t, "my-test-server", manager.MCPName())
 }
 
+// TestMCPManager_NilGatewayServer_NoPanic is a regression test for
+// https://github.com/Kuadrant/mcp-gateway/issues/882.
+// manage() must not panic when gatewayServer is nil — tools/list_changed
+// notifications can fire before the broker wires up the gateway server.
+func TestMCPManager_NilGatewayServer_NoPanic(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test-server", "s1_")
+	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	assert.NotPanics(t, func() {
+		manager.manage(context.Background(), eventTypeTimer)
+	})
+}
+
 func TestMCPManager_GetStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")


### PR DESCRIPTION
**Problem**

When a `tools/list_changed` notification fires before the broker has fully
wired up the gateway server, `manage()` calls into `findToolConflicts()`,
`removeAllTools()`, and the `AddTools`/`DeleteTools` sync block on a nil
`gatewayServer`. This causes a nil pointer dereference panic, crashing the
broker into CrashLoopBackOff.

**Solution**

Add nil guards at the three call sites that dereference `gatewayServer`:

- `findToolConflicts()` — return nil early (no conflicts to check)
- `removeAllTools()` — skip the `DeleteTools` call
- `manage()` — skip the `AddTools`/`DeleteTools` sync block

This is preferable to rejecting nil at construction time because nil is a
valid state for managers that do not exercise tool sync. Many existing tests
rely on this intentionally.

Also fixes a pre-existing parameter name typo: `gatewaySever` → `gatewayServer`.

**Testing**

Added `TestMCPManager_NilGatewayServer_NoPanic` as a regression test that
calls `manage()` with a nil gateway server and asserts no panic. All
existing tests continue to pass.

Fixes #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes in the upstream manager when operating without a configured gateway server
  * Enhanced stability of tool management operations to handle missing gateway components gracefully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->