### PR TITLE
fix: use context.Background() in sessionCloser to prevent Redis sessi…

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -552,12 +552,14 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 	}
 	var sessionCloser = func() {
-		s.Logger.DebugContext(ctx, "gateway session expired closing client", "Session ", mcpReq.GetSessionID())
+		// use a fresh context: the request-scoped ctx is canceled long before this fires
+		cleanupCtx := context.Background()
+		s.Logger.DebugContext(cleanupCtx, "gateway session expired closing client", "Session ", mcpReq.GetSessionID())
 		if err := clientHandle.Close(); err != nil {
-			s.Logger.DebugContext(ctx, "failed to close client connection", "err", err)
+			s.Logger.DebugContext(cleanupCtx, "failed to close client connection", "err", err)
 		}
-		if err := s.SessionCache.DeleteSessions(ctx, mcpReq.GetSessionID()); err != nil {
-			s.Logger.DebugContext(ctx, "failed to delete session", "session", mcpReq.GetSessionID(), "err", err)
+		if err := s.SessionCache.DeleteSessions(cleanupCtx, mcpReq.GetSessionID()); err != nil {
+			s.Logger.DebugContext(cleanupCtx, "failed to delete session", "session", mcpReq.GetSessionID(), "err", err)
 		}
 	}
 	// close connection with remote backend and delete any sessions when our gateway session expires

--- a/project-words.txt
+++ b/project-words.txt
@@ -408,3 +408,4 @@ CONNLINK
 HKDF
 HMAC
 usercred
+myprefix


### PR DESCRIPTION
Third session-related fix from me after #872 and #888. Those two covered the in-memory side; concurrent writes and copy-on-write cleanup. This one is about what happens at the other end of a session's life: the teardown.

When a client calls a tool against a backend server for the first time, `initializeMCPSeverSession` opens the connection and schedules a `time.AfterFunc` to clean up when the JWT expires. The closure captures `ctx` from the surrounding call, which is the gRPC `ext_proc` stream context for that single HTTP request. That context is cancelled the moment the response is delivered, usually within a second.

The timer fires 24 hours later with a context that's been dead for nearly 24 hours. `clientHandle.Close()` is fine, doesn't need a context. But `DeleteSessions(ctx, ...)` hits Redis with a cancelled context, gets `context canceled` back immediately, and the session keys just stay there. The error is swallowed at `DebugContext`, so there's no signal.

The fix is already in the codebase; `JWTManager.Terminate` does this exact same cleanup and correctly uses `context.TODO()`. `sessionCloser` just didn't follow the same pattern.

Switched to `context.Background()`. No change for in-memory deployments (context is ignored there, so #872/#888 land is unaffected), full cleanup restored for Redis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session cleanup during gateway-session expiration, ensuring cleanup operations complete properly even when request handling is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->