### PR TITLE
fix: avoid recursive RLock deadlock in ValidateAllServers

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -114,6 +114,13 @@ jobs:
 
           echo "Ollama setup complete using model $MODEL_NAME"
 
+      - name: Warm up Ollama model
+        if: env.OPENAI_API_KEY == 'ollama'
+        run: |
+          echo "Warming up model to ensure it is loaded before eval..."
+          curl -s -X POST http://localhost:11434/api/generate \
+            -d '{"model":"qwen2.5:1.5b","prompt":"hi","stream":false}' > /dev/null || true
+
       - name: Run mcpchecker
         run: |
           echo "Installing mcpchecker..."

--- a/evals/gemini-agent/agent.yaml
+++ b/evals/gemini-agent/agent.yaml
@@ -5,7 +5,7 @@ builtin:
   # Using openai-agent type as a generic LLM client that supports OpenAI API format
   # Set MODEL_BASE_URL to point to Gemini (e.g. https://generativelanguage.googleapis.com/v1beta/openai/)
   # or any other OpenAI-compatible endpoint.
-  type: "openai"
+  type: "llm-agent"
 
   model: "openai:qwen2.5:1.5b"
   params:

--- a/evals/gemini-agent/agent.yaml
+++ b/evals/gemini-agent/agent.yaml
@@ -5,7 +5,7 @@ builtin:
   # Using openai-agent type as a generic LLM client that supports OpenAI API format
   # Set MODEL_BASE_URL to point to Gemini (e.g. https://generativelanguage.googleapis.com/v1beta/openai/)
   # or any other OpenAI-compatible endpoint.
-  type: "openai-acp"
+  type: "openai"
 
   model: "openai:qwen2.5:1.5b"
   params:

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -307,7 +307,7 @@ func (m *mcpBrokerImpl) ValidateAllServers() StatusResponse {
 
 	m.logger.Debug("ValidateAllServers: checking servers", "# servers", len(m.mcpServers))
 
-	for _, upstream := range m.RegisteredMCPServers() {
+	for _, upstream := range m.mcpServers {
 		status := upstream.GetStatus()
 		response.Servers = append(response.Servers, status)
 


### PR DESCRIPTION
Fourth concurrency issue I've found in this area since #872. This one is in the broker itself rather than the session cache, but same class of problem, a lock being acquired in a way the Go runtime explicitly says it doesn't support.

`ValidateAllServers` takes `m.mcpLock.RLock()` at the top of the function, then immediately calls `m.RegisteredMCPServers()`, which takes `m.mcpLock.RLock()` again internally. The Go docs for `sync.RWMutex` call this out directly: if any goroutine is waiting for the write lock between those two read-lock calls, the second `RLock` blocks. The first read lock never gets released because the goroutine is stuck waiting. The writer never unblocks because it's waiting for that first reader. Permanent deadlock.

The failure window is: a readiness probe or monitoring system hits `/status` (which calls `ValidateAllServers`) at the same moment `OnConfigChange` is trying to acquire the write lock for a config reload. In a Kubernetes deployment with a liveness probe running every ~10s and a controller reconciling `MCPServerRegistration` objects on any cluster change, this race is just a matter of time. When it hits, the process stays up but `m.mcpLock` is stuck forever; and since `GetServerInfo` and `ToolAnnotations` both take `m.mcpLock.RLock()`, every subsequent tool call deadlocks too. No panic, no log line, just silent routing death.

Fix is a one-liner: `ValidateAllServers` already holds the outer `RLock`, so the call to `RegisteredMCPServers()` is redundant; just iterate `m.mcpServers` directly. `RegisteredMCPServers()` keeps its own lock for any external callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved evaluation workflow by adding model initialization step to ensure Ollama model is ready before tests run.
  * Updated agent configuration type for enhanced system compatibility.
  * Optimized internal server validation mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->