### PR TITLE
fix(broker): remove nested RLock in ValidateAllServers

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -307,7 +307,11 @@ func (m *mcpBrokerImpl) ValidateAllServers() StatusResponse {
 
 	m.logger.Debug("ValidateAllServers: checking servers", "# servers", len(m.mcpServers))
 
-	for _, upstream := range m.RegisteredMCPServers() {
+	// access m.mcpServers directly; RLock is already held.
+	// Calling RegisteredMCPServers() here would attempt a second RLock on the same
+	// goroutine. Go's sync.RWMutex blocks new readers when a writer is waiting, so a
+	// concurrent OnConfigChange() Lock() causes both goroutines to deadlock.
+	for _, upstream := range m.mcpServers {
 		status := upstream.GetStatus()
 		response.Servers = append(response.Servers, status)
 

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -91,3 +91,76 @@ func TestStatusHandlerGetAll(t *testing.T) {
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 }
+
+func TestValidateAllServers(t *testing.T) {
+	tests := []struct {
+		name             string
+		setup            func(b *mcpBrokerImpl)
+		wantTotal        int
+		wantHealthy      int
+		wantUnhealthy    int
+		wantOverallValid bool
+	}{
+		{
+			name:             "no servers",
+			setup:            func(_ *mcpBrokerImpl) {},
+			wantTotal:        0,
+			wantHealthy:      0,
+			wantUnhealthy:    0,
+			wantOverallValid: true,
+		},
+		{
+			name: "one unhealthy server",
+			setup: func(b *mcpBrokerImpl) {
+				mgr := createTestManagerForStatus(t, "s1", nil)
+				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: false})
+				b.mcpServers["s1"] = mgr
+			},
+			wantTotal:        1,
+			wantHealthy:      0,
+			wantUnhealthy:    1,
+			wantOverallValid: false,
+		},
+		{
+			name: "one healthy server",
+			setup: func(b *mcpBrokerImpl) {
+				mgr := createTestManagerForStatus(t, "s1", nil)
+				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
+				b.mcpServers["s1"] = mgr
+			},
+			wantTotal:        1,
+			wantHealthy:      1,
+			wantUnhealthy:    0,
+			wantOverallValid: true,
+		},
+		{
+			name: "mixed healthy and unhealthy",
+			setup: func(b *mcpBrokerImpl) {
+				m1 := createTestManagerForStatus(t, "s1", nil)
+				m1.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
+				b.mcpServers["s1"] = m1
+				m2 := createTestManagerForStatus(t, "s2", nil)
+				m2.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s2", Ready: false})
+				b.mcpServers["s2"] = m2
+			},
+			wantTotal:        2,
+			wantHealthy:      1,
+			wantUnhealthy:    1,
+			wantOverallValid: false,
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBroker(logger).(*mcpBrokerImpl)
+			tt.setup(b)
+			resp := b.ValidateAllServers()
+			require.Equal(t, tt.wantTotal, resp.TotalServers)
+			require.Equal(t, tt.wantHealthy, resp.HealthyServers)
+			require.Equal(t, tt.wantUnhealthy, resp.UnHealthyServers)
+			require.Equal(t, tt.wantOverallValid, resp.OverallValid)
+			require.Len(t, resp.Servers, tt.wantTotal)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`ValidateAllServers()` acquires `mcpLock.RLock()` and then calls
`RegisteredMCPServers()`, which attempts a second `mcpLock.RLock()` on the
same goroutine.

Go's `sync.RWMutex` blocks new readers when a writer is waiting, so the
following sequence deadlocks:

1. `ValidateAllServers()` acquires `mcpLock.RLock()`
2. A concurrent `OnConfigChange()` calls `mcpLock.Lock()` — blocked by the
   existing reader, waits
3. `ValidateAllServers()` calls `RegisteredMCPServers()` → tries
   `mcpLock.RLock()` — blocked because a writer is pending
4. Both goroutines wait on each other → deadlock

This was a latent hazard when `/status` was hit only by humans.  It becomes a
live hazard once `/readyz` probes every 10 s (#760), because the probe
concurrently calls `ValidateAllServers()` via `IsReady()` while
`OnConfigChange()` reconfigures the broker.

## Fix

Access `m.mcpServers` directly inside `ValidateAllServers()` — the method
already holds `mcpLock.RLock()`, so the inner map access is safe without a
second lock acquisition.

## Tests

Added `TestValidateAllServers` in `internal/broker/status_test.go` covering:
- no servers (OverallValid=true, counts=0)
- one unhealthy server (OverallValid=false)
- one healthy server (OverallValid=true)
- mixed healthy + unhealthy (OverallValid=false, correct counts)

Verified with `go test -race ./internal/broker/...` — no races detected.

Closes #760 (partial — deadlock component only; readiness probe wired in separate PR #848)