### PR TITLE
fix: eliminate data race between LoadConfig and broker OnConfigChange

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -385,26 +385,26 @@ func LoadConfig(path string) {
 	if err != nil {
 		log.Fatalf("Error reading config file: %s", err)
 	}
-	// reset the servers to avoid old configs being written to
-	mcpConfig.Servers = []*config.MCPServer{}
-	err = viper.UnmarshalKey("servers", &mcpConfig.Servers)
+	var newServers []*config.MCPServer
+	err = viper.UnmarshalKey("servers", &newServers)
 	if err != nil {
 		log.Fatalf("Unable to decode server config into struct: %s", err)
 	}
-	mcpConfig.VirtualServers = []*config.VirtualServer{}
+	var newVirtualServers []*config.VirtualServer
 	// Load virtualServers if present - this is optional
 	if viper.IsSet("virtualServers") {
-		err = viper.UnmarshalKey("virtualServers", &mcpConfig.VirtualServers)
+		err = viper.UnmarshalKey("virtualServers", &newVirtualServers)
 		if err != nil {
 			log.Fatal("Failed to parse virtualServers configuration", "error", err)
 		}
 	} else {
 		logger.Debug("No virtualServers section found in configuration")
 	}
+	mcpConfig.SetServers(newServers, newVirtualServers)
 
-	logger.Debug("config successfully loaded", "# servers", len(mcpConfig.Servers))
+	logger.Debug("config successfully loaded", "# servers", len(newServers))
 
-	for _, s := range mcpConfig.Servers {
+	for _, s := range newServers {
 		logger.Debug(
 			"server config",
 			"server name",

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -159,13 +159,18 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 }
 
 func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServersConfig) {
-	m.logger.Debug("Broker OnConfigChange start", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(conf.Servers))
+	// Take a consistent snapshot before acquiring mcpLock; LoadConfig may be
+	// concurrently replacing conf.Servers/VirtualServers under its own write lock.
+	servers := conf.ListServers()
+	virtualServers := conf.ListVirtualServers()
+
+	m.logger.Debug("Broker OnConfigChange start", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(servers))
 	// unregister decommissioned servers
 	m.mcpLock.Lock()
 	defer m.mcpLock.Unlock()
 
 	for serverID := range m.mcpServers {
-		if !slices.ContainsFunc(conf.Servers, func(s *config.MCPServer) bool {
+		if !slices.ContainsFunc(servers, func(s *config.MCPServer) bool {
 			return serverID == s.ID()
 		}) {
 			m.logger.Info("un-register upstream server", "server id", serverID)
@@ -178,7 +183,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	}
 	// ensure new servers registered
 
-	for _, mcpServer := range conf.Servers {
+	for _, mcpServer := range servers {
 		man, ok := m.mcpServers[mcpServer.ID()]
 		if ok {
 			m.logger.Info("Server is registered", "mcpID", mcpServer.ID())
@@ -203,11 +208,11 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	}
 	// register virtual servers
 	m.vsLock.Lock()
-	for _, vs := range conf.VirtualServers {
+	for _, vs := range virtualServers {
 		m.virtualServers[vs.Name] = vs
 	}
 	m.vsLock.Unlock()
-	m.logger.Debug("Broker OnConfigChange done", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(conf.Servers))
+	m.logger.Debug("Broker OnConfigChange done", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(servers))
 }
 
 func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]*upstream.MCPManager {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -32,6 +32,32 @@ func (config *MCPServersConfig) RegisterObserver(obs Observer) {
 	config.observers = append(config.observers, obs)
 }
 
+// SetServers atomically replaces the server and virtual-server lists.
+func (config *MCPServersConfig) SetServers(servers []*MCPServer, virtualServers []*VirtualServer) {
+	config.lock.Lock()
+	defer config.lock.Unlock()
+	config.Servers = servers
+	config.VirtualServers = virtualServers
+}
+
+// ListServers returns a consistent snapshot of the current server list.
+func (config *MCPServersConfig) ListServers() []*MCPServer {
+	config.lock.RLock()
+	defer config.lock.RUnlock()
+	out := make([]*MCPServer, len(config.Servers))
+	copy(out, config.Servers)
+	return out
+}
+
+// ListVirtualServers returns a consistent snapshot of the current virtual-server list.
+func (config *MCPServersConfig) ListVirtualServers() []*VirtualServer {
+	config.lock.RLock()
+	defer config.lock.RUnlock()
+	out := make([]*VirtualServer, len(config.VirtualServers))
+	copy(out, config.VirtualServers)
+	return out
+}
+
 // Notify notifies registered observers of config changes
 func (config *MCPServersConfig) Notify(ctx context.Context) {
 	config.lock.RLock()


### PR DESCRIPTION
`MCPServersConfig` has a `lock sync.RWMutex` (it's right there on the struct), and every read accessor uses it correctly ; `GetServerConfigByName` takes `RLock`, `RegisterObserver` takes `Lock`, `Notify` takes `RLock`. But `LoadConfig` in `main.go` writes `mcpConfig.Servers` and `mcpConfig.VirtualServers` directly as raw field assignments, completely bypassing the lock. The reason it was never caught is that lock is unexported, so nothing outside the config package can call it, and a locked setter method was never added. The field itself is public so the write compiles fine and looks innocent.

The race fires during a hot-reload when the broker's `OnConfigChange` goroutine from a previous `Notify` is still running ; which is realistic because that goroutine connects to backend servers, and dialling + MCP initialize can take a few seconds. While it's inside the deregistration loop reading `conf.Servers` through `slices.ContainsFunc`, `LoadConfig` sets `mcpConfig.Servers = []*config.MCPServer{}` to reset before unmarshalling. `slices.ContainsFunc` over an empty slice always returns false, so every server ID fails the membership check and every manager gets `Stop()`-ped: connections closed, tools removed from the gateway. In Kubernetes this is normal usage ; the controller writes the config Secret, the pod remounts it, and `fsnotify` delivers two close-spaced events (an unlink and a create) for one logical update. The broker goroutine from event one is still connecting when event two fires `LoadConfig`. No panic, no error log, just a silent window where `tools/list` returns empty and every `tools/call` gets "tool not found".

The fix adds `SetServers` to `MCPServersConfig` as the proper locked write path, along with `ListServers` and `ListVirtualServers` for locked snapshots on the read side. `LoadConfig` now unmarshals into local variables and calls `SetServers` once the full new config is ready, so the shared struct is never in a half-written state. The broker's `OnConfigChange` takes a snapshot of both slices at the very top of the function, before acquiring `mcpLock`, so everything it does after that is working off an immutable local copy that `LoadConfig` can't touch mid-loop.