### PR TITLE
fix(broker): take RLock in findServerByName and use MCPName() in log

### DIFF
--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -135,6 +135,10 @@ func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []strin
 }
 
 func (broker *mcpBrokerImpl) findServerByName(name string) upstream.ActiveMCPServer {
+	// Avoid race with OnConfigChange()
+	broker.mcpLock.RLock()
+	defer broker.mcpLock.RUnlock()
+
 	for _, upstream := range broker.mcpServers {
 		if upstream.MCPName() == name {
 			return upstream
@@ -155,7 +159,7 @@ func (broker *mcpBrokerImpl) filterToolsByServerMap(allowedTools map[string][]st
 		}
 		tools := upstream.GetManagedTools()
 		if tools == nil {
-			broker.logger.Debug("no tools registered for upstream server", "server", upstream.MCPName)
+			broker.logger.Debug("no tools registered for upstream server", "server", upstream.MCPName())
 			continue
 		}
 

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/pem"
 	"log/slog"
 	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
@@ -605,4 +607,77 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFilterTools_DataRace ensures that FilterTools (which calls findServerByName)
+// is safe to invoke concurrently with mutations to broker.mcpServers under
+// broker.mcpLock, mirroring the locking pattern used by OnConfigChange. Run
+// this with `go test -race ./internal/broker/...`.
+func TestFilterTools_DataRace(t *testing.T) {
+	serverID := config.UpstreamMCPID("mcp-test/test-server1:test1_:http://test.local/mcp")
+	mcpBroker := &mcpBrokerImpl{
+		enforceCapabilityFilter: true,
+		trustedHeadersPublicKey: testPublicKey,
+		logger:                  slog.Default(),
+		mcpServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			serverID: upstream.NewActiveForTesting(createTestManager(t,
+				"mcp-test/test-server1",
+				"test1_",
+				[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
+			)),
+		},
+	}
+
+	jwtHeader := createTestJWT(t, map[string][]string{
+		"mcp-test/test-server1": {"tool"},
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// reader: repeatedly invoke FilterTools, which calls findServerByName.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				request := &mcp.ListToolsRequest{Header: http.Header{
+					authorizedCapabilitiesHeader: {jwtHeader},
+				}}
+				result := &mcp.ListToolsResult{Tools: []mcp.Tool{
+					{Name: "test1_tool"},
+				}}
+				mcpBroker.FilterTools(context.Background(), 1, request, result)
+			}
+		}
+	}()
+
+	// writer: mirror OnConfigChange by mutating mcpServers under the write lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		replacement := upstream.NewActiveForTesting(createTestManager(t,
+			"mcp-test/test-server1",
+			"test1_",
+			[]mcp.Tool{{Name: "tool"}},
+		))
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				mcpBroker.mcpLock.Lock()
+				delete(mcpBroker.mcpServers, serverID)
+				mcpBroker.mcpServers[serverID] = replacement
+				mcpBroker.mcpLock.Unlock()
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Found another concurrency hole in the broker, in the same family as the recent `mcpServers` / session-cache fixes (#860, #872, #888, #918, #921).

`findServerByName` in `internal/broker/filtered_tools_handler.go` iterates `broker.mcpServers` without taking `broker.mcpLock`. `OnConfigChange` mutates the same map under the write lock at `broker.go:175,190,197`, so a `tools/list` request that lands during a config reload races on the iteration. The existing helpers `ToolAnnotations` and `GetServerInfo` already RLock around the same map, so this fix just brings `findServerByName` into line.

While I was in the file I also fixed an adjacent log line in `filterToolsByServerMap`. It passed the method value `upstream.MCPName` instead of calling it (`MCPName()`), so slog rendered a method-value formatter string in place of the actual server name. Happy to split that into a separate PR if preferred.

`TestFilterTools_DataRace` exercises `FilterTools` and a mutator that mirrors `OnConfigChange` under `broker.mcpLock` from two goroutines. Pattern matches `manager_test.go::TestMCPManager_status_DataRace`. Run with `go test -race ./internal/broker/...`.

## Verification

```
go build ./...
go vet ./...
go test -race -count=1 -timeout 60s ./internal/broker/...
make lint
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition in tool filtering that could occur during concurrent configuration updates.
  * Corrected server identification logging in tool filtering operations.

* **Tests**
  * Added a concurrency test to validate thread safety during simultaneous tool filtering and configuration mutations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/923)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->