### PR TITLE
fix(session): bound JWTManager.Terminate cache deletion with a 5s timeout

### DIFF
--- a/internal/session/jwt.go
+++ b/internal/session/jwt.go
@@ -211,8 +211,7 @@ func (m *JWTManager) GetExpiresIn(tokenValue string) (time.Time, error) {
 	return nd.Time, nil
 }
 
-// terminateTimeout bounds the cache deletion call made by Terminate so a stalled
-// backing store cannot block the upstream session manager indefinitely.
+// bounds cache deletion in Terminate so a stalled store cannot block forever
 const terminateTimeout = 5 * time.Second
 
 // Terminate part of the SessionIDManager interface. Will remove the associated sessions from cache
@@ -220,8 +219,7 @@ func (m *JWTManager) Terminate(sessionID string) (isNotAllowed bool, err error) 
 	m.logger.Info("terminate session id in jwt session manager", "session", sessionID)
 	if m.sessionDeleter != nil {
 		// TODO(craig) this method will be invoked by the MCPBroker so we can probably do the cache deletion there rather than in this manager
-		// The SessionIdManager interface does not pass a context, so derive one from
-		// Background with a deadline. Mirrors the sessionCloser fix in PR #911.
+		// background ctx with deadline; SessionIdManager interface gives us none
 		ctx, cancel := context.WithTimeout(context.Background(), terminateTimeout)
 		defer cancel()
 		if err := m.sessionDeleter.DeleteSessions(ctx, sessionID); err != nil {

--- a/internal/session/jwt.go
+++ b/internal/session/jwt.go
@@ -211,12 +211,19 @@ func (m *JWTManager) GetExpiresIn(tokenValue string) (time.Time, error) {
 	return nd.Time, nil
 }
 
+// terminateTimeout bounds the cache deletion call made by Terminate so a stalled
+// backing store cannot block the upstream session manager indefinitely.
+const terminateTimeout = 5 * time.Second
+
 // Terminate part of the SessionIDManager interface. Will remove the associated sessions from cache
 func (m *JWTManager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 	m.logger.Info("terminate session id in jwt session manager", "session", sessionID)
 	if m.sessionDeleter != nil {
 		// TODO(craig) this method will be invoked by the MCPBroker so we can probably do the cache deletion there rather than in this manager
-		ctx := context.TODO()
+		// The SessionIdManager interface does not pass a context, so derive one from
+		// Background with a deadline. Mirrors the sessionCloser fix in PR #911.
+		ctx, cancel := context.WithTimeout(context.Background(), terminateTimeout)
+		defer cancel()
 		if err := m.sessionDeleter.DeleteSessions(ctx, sessionID); err != nil {
 			return false, fmt.Errorf("error clearing out associated sessions : %w", err)
 		}

--- a/internal/session/jwt_test.go
+++ b/internal/session/jwt_test.go
@@ -394,10 +394,10 @@ func TestTerminate(t *testing.T) {
 			t.Fatalf("unexpected error constructing manager: %v", err)
 		}
 
-		done := make(chan struct{})
+		errCh := make(chan error, 1)
 		go func() {
-			defer close(done)
-			_, _ = manager.Terminate("session-id")
+			_, err := manager.Terminate("session-id")
+			errCh <- err
 		}()
 
 		select {
@@ -407,7 +407,10 @@ func TestTerminate(t *testing.T) {
 		}
 
 		select {
-		case <-done:
+		case err := <-errCh:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+			}
 		case <-time.After(terminateTimeout + 2*time.Second):
 			t.Fatalf("Terminate did not return within %v of the configured deadline", terminateTimeout)
 		}

--- a/internal/session/jwt_test.go
+++ b/internal/session/jwt_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -9,6 +10,20 @@ import (
 
 	jwt "github.com/golang-jwt/jwt/v5"
 )
+
+// blockingDeleter blocks DeleteSessions until the supplied context is canceled
+// or its deadline elapses, then returns ctx.Err().
+type blockingDeleter struct {
+	called chan struct{}
+}
+
+func (b *blockingDeleter) DeleteSessions(ctx context.Context, _ ...string) error {
+	if b.called != nil {
+		close(b.called)
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
 
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -366,6 +381,35 @@ func TestTerminate(t *testing.T) {
 		}
 		if isNotAllowed {
 			t.Error("expected isNotAllowed to be false")
+		}
+	})
+
+	t.Run("terminate bounds a stalled deleter via context deadline", func(t *testing.T) {
+		// Wire a deleter whose DeleteSessions blocks until the passed context
+		// is canceled. Without the WithTimeout fix, Terminate would block
+		// indefinitely; with it, Terminate must return within ~terminateTimeout.
+		deleter := &blockingDeleter{called: make(chan struct{})}
+		manager, err := NewJWTManager("test-key", 0, testLogger(), deleter)
+		if err != nil {
+			t.Fatalf("unexpected error constructing manager: %v", err)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			_, _ = manager.Terminate("session-id")
+		}()
+
+		select {
+		case <-deleter.called:
+		case <-time.After(2 * time.Second):
+			t.Fatal("DeleteSessions was not invoked")
+		}
+
+		select {
+		case <-done:
+		case <-time.After(terminateTimeout + 2*time.Second):
+			t.Fatalf("Terminate did not return within %v of the configured deadline", terminateTimeout)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Symmetric fix to #911 on the JWT-manager side of session teardown.

`JWTManager.Terminate` is invoked by the upstream MCP server library when the gateway needs to close a session. The `SessionIdManager` interface from `mark3labs/mcp-go` does not pass a `context.Context`, so the implementation creates one internally, but it used `context.TODO()`. That has no cancellation and no deadline, so if `sessionDeleter` is the Redis-backed cache and Redis is unreachable, the goroutine driving session expiry blocks indefinitely on the cache deletion call. That leaks the goroutine and can hold the upstream library's session-manager lock.

Replace `context.TODO()` with `context.WithTimeout(context.Background(), terminateTimeout)` and defer the cancel. `terminateTimeout` is a package-level constant set to 5 seconds so the value is visible at one site and easy to tune. Same shape as #911, just on the other end of the session lifecycle.

`TestTerminate` gains a subtest that wires `JWTManager` with a `Deleter` whose `DeleteSessions` blocks until the supplied context is canceled. Without the fix, `Terminate` blocks forever; with it, `Terminate` returns within the deadline plus a small buffer.

## Verification

```
go build ./...
go vet ./...
go test -race -count=1 -timeout 60s ./internal/session/...
make lint
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session termination operations now have a bounded timeout to prevent indefinite blocking.

* **Tests**
  * Added test coverage for session termination timeout behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/924)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->