### PR TITLE
fix(mcp-router): make ExtProcServer.RoutingConfig swap race-free

### DIFF
--- a/cmd/mcp-broker-router/router.go
+++ b/cmd/mcp-broker-router/router.go
@@ -22,7 +22,7 @@ func (a *app) createRouter() {
 		MaxRequestBodySize:  cfg.maxRequestBodySize,
 		ElicitationEnabled:  cfg.enableURLElicitation,
 	}
-	// seed initial routing config so reader sites never observe a nil pointer before the first OnConfigChange fires.
+	// seed initial routing config so readers never see a nil pointer.
 	if a.mcpConfig == nil {
 		panic("mcpConfig must be non-nil before constructing the ext_proc server")
 	}

--- a/cmd/mcp-broker-router/router.go
+++ b/cmd/mcp-broker-router/router.go
@@ -11,7 +11,6 @@ func (a *app) createRouter() {
 	cfg := &a.routerCfg
 	a.grpcServer = grpc.NewServer()
 	a.router = &mcpRouter.ExtProcServer{
-		RoutingConfig:       a.mcpConfig,
 		Logger:              a.logger.With("component", "router"),
 		JWTManager:          a.jwtMgr,
 		InitForClient:       clients.Initialize,
@@ -23,6 +22,11 @@ func (a *app) createRouter() {
 		MaxRequestBodySize:  cfg.maxRequestBodySize,
 		ElicitationEnabled:  cfg.enableURLElicitation,
 	}
+	// seed initial routing config so reader sites never observe a nil pointer before the first OnConfigChange fires.
+	if a.mcpConfig == nil {
+		panic("mcpConfig must be non-nil before constructing the ext_proc server")
+	}
+	a.router.RoutingConfig.Store(a.mcpConfig)
 
 	extProcV3.RegisterExternalProcessorServer(a.grpcServer, a.router)
 }

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -229,7 +229,7 @@ func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, headers *eppb.
 	s.Logger.DebugContext(ctx, "Request Handler: HandleRequestHeaders called")
 	requestHeaders := NewHeaders()
 	response := NewResponse()
-	requestHeaders.WithAuthority(s.RoutingConfig.MCPGatewayExternalHostname)
+	requestHeaders.WithAuthority(s.RoutingConfig.Load().MCPGatewayExternalHostname)
 	// Trust model: ExtractSubClaim only decodes the JWT payload, it does NOT
 	// verify the signature. That is safe here because AuthPolicy validates the
 	// Authorization JWT before the request reaches ext_proc, so by this point
@@ -632,7 +632,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	// restore the id for the request
 	mcpReq.ID = entry.BackendID
 
-	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(entry.ServerName)
+	mcpServerConfig, err := s.RoutingConfig.Load().GetServerConfigByName(entry.ServerName)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "server not found for elicitation response", "server", entry.ServerName)
 		mcpotel.SpanError(span, err, "server not found")
@@ -683,7 +683,9 @@ func (s *ExtProcServer) initializeMCPServerSession(ctx context.Context, mcpReq *
 	)
 	defer initSpan.End()
 
-	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(mcpReq.serverName)
+	// snapshot once to avoid torn reads if config is swapped mid-function
+	routingCfg := s.RoutingConfig.Load()
+	mcpServerConfig, err := routingCfg.GetServerConfigByName(mcpReq.serverName)
 	if err != nil {
 		return "", NewRouterErrorf(500, "failed check for server: %w", err)
 	}
@@ -765,7 +767,7 @@ func (s *ExtProcServer) initializeMCPServerSession(ctx context.Context, mcpReq *
 		}
 		passThroughHeaders[RoutingKey] = initToken
 		passThroughHeaders["mcp-init-host"] = mcpServerConfig.Hostname
-		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation, s.HairpinClientPool)
+		clientHandle, err := s.InitForClient(ctx, routingCfg.MCPGatewayInternalHostname, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation, s.HairpinClientPool)
 		if err != nil {
 			s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
 			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -200,9 +200,6 @@ func TestHandleRequestBody(t *testing.T) {
 	}
 
 	server := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: serverConfigs,
-		},
 		JWTManager:    jwtManager,
 		Logger:        logger,
 		SessionCache:  cache,
@@ -211,6 +208,7 @@ func TestHandleRequestBody(t *testing.T) {
 			"s_mytool": "dummy",
 		}),
 	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{Servers: serverConfigs})
 
 	data := &MCPRequest{
 		ID:      ptr.To(0),
@@ -782,15 +780,13 @@ func TestHandleElicitationResponse(t *testing.T) {
 		gatewayID := mustStoreIDMap(t, elicitationMap, float64(42), "weather-server", "backend-session-abc", validToken)
 
 		server := &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{
-				Servers: serverConfigs,
-			},
 			JWTManager:     jwtManager,
 			Logger:         logger,
 			SessionCache:   cache,
 			ElicitationMap: elicitationMap,
 			Broker:         newMockBroker(serverConfigs, map[string]string{}),
 		}
+		server.RoutingConfig.Store(&config.MCPServersConfig{Servers: serverConfigs})
 
 		data := &MCPRequest{
 			ID:      gatewayID,
@@ -891,15 +887,14 @@ func TestHandleElicitationResponse(t *testing.T) {
 		gatewayID := mustStoreIDMap(t, elicitationMap, float64(1), "nonexistent-server", "session-123", validToken)
 
 		server := &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{
-				Servers: []*config.MCPServer{}, // no servers configured
-			},
 			JWTManager:     jwtManager,
 			Logger:         logger,
 			SessionCache:   cache,
 			ElicitationMap: elicitationMap,
 			Broker:         newMockBroker(nil, map[string]string{}),
 		}
+		// no servers configured
+		server.RoutingConfig.Store(&config.MCPServersConfig{Servers: []*config.MCPServer{}})
 
 		data := &MCPRequest{
 			ID:      gatewayID,
@@ -940,15 +935,13 @@ func TestHandleElicitationResponse(t *testing.T) {
 		gatewayID := mustStoreIDMap(t, elicitationMap, "original-string-id", "test-server", "backend-session-xyz", validToken)
 
 		server := &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{
-				Servers: serverConfigs,
-			},
 			JWTManager:     jwtManager,
 			Logger:         logger,
 			SessionCache:   cache,
 			ElicitationMap: elicitationMap,
 			Broker:         newMockBroker(serverConfigs, map[string]string{}),
 		}
+		server.RoutingConfig.Store(&config.MCPServersConfig{Servers: serverConfigs})
 
 		data := &MCPRequest{
 			ID:      gatewayID,
@@ -997,15 +990,13 @@ func TestHandleElicitationResponse_ViaRouteMCPRequest(t *testing.T) {
 	gatewayID := mustStoreIDMap(t, elicitationMap, float64(99), "test-server", "backend-session-456", validToken)
 
 	server := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: serverConfigs,
-		},
 		JWTManager:     jwtManager,
 		Logger:         logger,
 		SessionCache:   cache,
 		ElicitationMap: elicitationMap,
 		Broker:         newMockBroker(serverConfigs, map[string]string{}),
 	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{Servers: serverConfigs})
 
 	// elicitation response routed via RouteMCPRequest (the main switch)
 	data := &MCPRequest{
@@ -1058,13 +1049,14 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		require.NoError(t, err)
 		jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 		require.NoError(t, err)
-		return &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{},
-			JWTManager:    jwtManager,
-			Logger:        logger,
-			SessionCache:  cache,
-			Broker:        newMockBroker(nil, map[string]string{}),
+		server := &ExtProcServer{
+			JWTManager:   jwtManager,
+			Logger:       logger,
+			SessionCache: cache,
+			Broker:       newMockBroker(nil, map[string]string{}),
 		}
+		server.RoutingConfig.Store(&config.MCPServersConfig{})
+		return server
 	}
 
 	mustImmediate := func(t *testing.T, resp []*eppb.ProcessingResponse, expectedCode int32) {
@@ -1238,16 +1230,16 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 		},
 	}
 	srv := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers:                    serverConfigs,
-			MCPGatewayInternalHostname: "mcp-gateway.local",
-		},
 		JWTManager:    jwtManager,
 		Logger:        logger,
 		SessionCache:  cache,
 		InitForClient: mockInitForClient,
 		Broker:        newMockBroker(serverConfigs, map[string]string{}),
 	}
+	srv.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers:                    serverConfigs,
+		MCPGatewayInternalHostname: "mcp-gateway.local",
+	})
 
 	req := &MCPRequest{
 		ID:         ptr.To(0),
@@ -1340,12 +1332,12 @@ func TestHandleRequestHeaders(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			server := &ExtProcServer{
-				RoutingConfig: &config.MCPServersConfig{
-					MCPGatewayExternalHostname: tc.GatewayHostname,
-				},
 				Logger: logger,
 				Broker: newMockBroker(nil, map[string]string{}),
 			}
+			server.RoutingConfig.Store(&config.MCPServersConfig{
+				MCPGatewayExternalHostname: tc.GatewayHostname,
+			})
 
 			incomingHeaders := []*corev3.HeaderValue{
 				{Key: ":authority", RawValue: []byte("original.host.com")},
@@ -1513,15 +1505,15 @@ func TestHandlePromptGet(t *testing.T) {
 	}
 
 	srv := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: serverConfigs,
-		},
 		JWTManager:    jwtManager,
 		Logger:        logger,
 		SessionCache:  cache,
 		InitForClient: mockInitForClient,
 		Broker:        testBroker,
 	}
+	srv.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers: serverConfigs,
+	})
 
 	data := &MCPRequest{
 		ID:      ptr.To(0),
@@ -1589,10 +1581,6 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 	}
 
 	server := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers:                    serverConfigs,
-			MCPGatewayExternalHostname: "gateway.example.com",
-		},
 		JWTManager:   jwtManager,
 		Logger:       logger,
 		SessionCache: cache,
@@ -1604,6 +1592,10 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 		TokenElicitationMap: tokenElicitationMap,
 		ElicitationEnabled:  true,
 	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers:                    serverConfigs,
+		MCPGatewayExternalHostname: "gateway.example.com",
+	})
 	return server, validToken
 }
 

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -59,7 +59,7 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 	// intercept 401 from backend: if the server uses URL token elicitation,
 	// delete the cached user token so the next tool call triggers re-elicitation
 	if status == "401" && req != nil && s.ElicitationEnabled {
-		serverInfo, cfgErr := s.RoutingConfig.GetServerConfigByName(req.serverName)
+		serverInfo, cfgErr := s.RoutingConfig.Load().GetServerConfigByName(req.serverName)
 		if cfgErr == nil && serverInfo.TokenURLElicitation != nil {
 			span := trace.SpanFromContext(ctx)
 			span.SetAttributes(

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -492,9 +492,9 @@ func TestHandleResponseHeaders_401DeletesUserToken(t *testing.T) {
 		Logger:             logger,
 		SessionCache:       cache,
 		Broker:             newMockBroker(nil, map[string]string{}),
-		RoutingConfig:      routingConfig,
 		ElicitationEnabled: true,
 	}
+	srv.RoutingConfig.Store(routingConfig)
 
 	// store a user token in the cache
 	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "expired-token"))
@@ -571,9 +571,9 @@ func TestHandleResponseHeaders_401SkipsTokenDeleteWhenNotApplicable(t *testing.T
 				Logger:             logger,
 				SessionCache:       cache,
 				Broker:             newMockBroker(nil, map[string]string{}),
-				RoutingConfig:      routingConfig,
 				ElicitationEnabled: tt.elicitationEnabled,
 			}
+			srv.RoutingConfig.Store(routingConfig)
 
 			require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, tt.serverName, "my-token"))
 
@@ -660,9 +660,9 @@ func TestHandleResponseHeaders_SuccessStatusDoesNotDeleteUserToken(t *testing.T)
 		Logger:             logger,
 		SessionCache:       cache,
 		Broker:             newMockBroker(nil, map[string]string{}),
-		RoutingConfig:      routingConfig,
 		ElicitationEnabled: true,
 	}
+	srv.RoutingConfig.Store(routingConfig)
 
 	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "valid-token"))
 

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -45,9 +45,7 @@ type InitForClient func(ctx context.Context, gatewayHost string, conf *config.MC
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {
-	// RoutingConfig is replaced wholesale by OnConfigChange (which fires from
-	// viper's fsnotify goroutine) while ext_proc handlers read it from the
-	// per-stream Process goroutines. atomic.Pointer keeps the swap race-free.
+	// RoutingConfig is swapped by OnConfigChange and read by ext_proc handlers.
 	RoutingConfig       atomic.Pointer[config.MCPServersConfig]
 	JWTManager          *session.JWTManager
 	Logger              *slog.Logger

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
@@ -44,7 +45,10 @@ type InitForClient func(ctx context.Context, gatewayHost string, conf *config.MC
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {
-	RoutingConfig       *config.MCPServersConfig
+	// RoutingConfig is replaced wholesale by OnConfigChange (which fires from
+	// viper's fsnotify goroutine) while ext_proc handlers read it from the
+	// per-stream Process goroutines. atomic.Pointer keeps the swap race-free.
+	RoutingConfig       atomic.Pointer[config.MCPServersConfig]
 	JWTManager          *session.JWTManager
 	Logger              *slog.Logger
 	InitForClient       InitForClient
@@ -63,7 +67,7 @@ type ExtProcServer struct {
 
 // OnConfigChange is used to register the router for config changes
 func (s *ExtProcServer) OnConfigChange(_ context.Context, newConfig *config.MCPServersConfig) {
-	s.RoutingConfig = newConfig
+	s.RoutingConfig.Store(newConfig)
 }
 
 // Process function

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -785,7 +785,7 @@ func requireMatchingHTTPStatus(t *testing.T, expected, actual *typev3.HttpStatus
 // TestExtProcServer_OnConfigChange_DataRace exercises a config-reload landing
 // concurrently with a request-handler read of RoutingConfig. The race detector
 // is the assertion; run with go test -race ./internal/mcp-router/...
-func TestExtProcServer_OnConfigChange_DataRace(_ *testing.T) {
+func TestExtProcServer_OnConfigChange_DataRace(t *testing.T) {
 	server := &ExtProcServer{
 		Logger: slog.Default(),
 	}

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -804,7 +804,10 @@ func TestExtProcServer_OnConfigChange_DataRace(t *testing.T) {
 		defer wg.Done()
 		<-start
 		for range iterations {
-			_, _ = server.HandleRequestHeaders(context.Background(), nil)
+			if _, err := server.HandleRequestHeaders(context.Background(), nil); err != nil {
+				t.Errorf("HandleRequestHeaders returned error during race exercise: %v", err)
+				return
+			}
 		}
 	}()
 

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
@@ -794,20 +793,18 @@ func TestExtProcServer_OnConfigChange_DataRace(_ *testing.T) {
 		MCPGatewayExternalHostname: "initial.gateway",
 	})
 
-	stop := make(chan struct{})
+	const iterations = 5000
+
 	var wg sync.WaitGroup
+	start := make(chan struct{})
 
 	// reader: invoke a handler that reads RoutingConfig.Load() on the hot path
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				_, _ = server.HandleRequestHeaders(context.Background(), nil)
-			}
+		<-start
+		for range iterations {
+			_, _ = server.HandleRequestHeaders(context.Background(), nil)
 		}
 	}()
 
@@ -815,19 +812,15 @@ func TestExtProcServer_OnConfigChange_DataRace(_ *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				server.OnConfigChange(context.Background(), &config.MCPServersConfig{
-					MCPGatewayExternalHostname: "replacement.gateway",
-				})
-			}
+		<-start
+		for range iterations {
+			server.OnConfigChange(context.Background(), &config.MCPServersConfig{
+				MCPGatewayExternalHostname: "replacement.gateway",
+			})
 		}
 	}()
 
-	time.Sleep(200 * time.Millisecond)
-	close(stop)
+	// release both goroutines together for deterministic concurrent exercise of Load/Store
+	close(start)
 	wg.Wait()
 }

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
@@ -528,22 +530,23 @@ func newTestServer(t *testing.T) *ExtProcServer {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cache, err := session.NewCache()
 	require.NoError(t, err)
-	return &ExtProcServer{
+	server := &ExtProcServer{
 		Logger:       logger,
 		SessionCache: cache,
 		Broker:       newMockBroker(nil, map[string]string{}),
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: []*config.MCPServer{
-				{
-					Name:     "dummy",
-					URL:      "http://localhost:9090",
-					Prefix:   "",
-					State:    "Enabled",
-					Hostname: "dummy",
-				},
+	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers: []*config.MCPServer{
+			{
+				Name:     "dummy",
+				URL:      "http://localhost:9090",
+				Prefix:   "",
+				State:    "Enabled",
+				Hostname: "dummy",
 			},
 		},
-	}
+	})
+	return server
 }
 
 // requestHeadersStep returns a standard request headers step
@@ -778,4 +781,53 @@ func requireMatchingHTTPStatus(t *testing.T, expected, actual *typev3.HttpStatus
 	require.NotNil(t, expected, "actual HTTP status is %d", actual.Code)
 	require.NotNil(t, actual)
 	require.Equal(t, expected.Code, actual.Code)
+}
+
+// TestExtProcServer_OnConfigChange_DataRace exercises a config-reload landing
+// concurrently with a request-handler read of RoutingConfig. The race detector
+// is the assertion; run with go test -race ./internal/mcp-router/...
+func TestExtProcServer_OnConfigChange_DataRace(_ *testing.T) {
+	server := &ExtProcServer{
+		Logger: slog.Default(),
+	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{
+		MCPGatewayExternalHostname: "initial.gateway",
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// reader: invoke a handler that reads RoutingConfig.Load() on the hot path
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = server.HandleRequestHeaders(context.Background(), nil)
+			}
+		}
+	}()
+
+	// writer: mirror OnConfigChange firing repeatedly from viper fsnotify
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				server.OnConfigChange(context.Background(), &config.MCPServersConfig{
+					MCPGatewayExternalHostname: "replacement.gateway",
+				})
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Same lock-discipline class as the recent broker race fixes (#860, #872, #888, #918, #921, #911), this one on the router side.

`ExtProcServer.OnConfigChange` in `internal/mcp-router/server.go` mutates `s.RoutingConfig` with a single bare assignment. It is registered as a `config.Observer` and fires from viper's fsnotify-driven goroutine, while `Process` is invoked once per concurrent ext_proc gRPC stream and the handlers it dispatches read `s.RoutingConfig` from at least five sites in `request_handlers.go` (`MCPGatewayExternalHostname`, `GetServerConfigByName`, `MCPGatewayInternalHostname`, `RouterAPIKey`). The pointer write is not atomic in Go, the race detector fires, and a config reload that lands during a `tools/call` can leave a goroutine reading a stale `MCPServersConfig` under the new pointer. In practice that surfaces as wrong-server routing, or 401 if `RouterAPIKey` rotated.

Convert `ExtProcServer.RoutingConfig` to `atomic.Pointer[config.MCPServersConfig]`. `OnConfigChange` becomes `Store`, readers become `Load`. `initializeMCPSeverSession` reads both `MCPGatewayInternalHostname` and `RouterAPIKey` for the same logical operation, so it captures the snapshot once via `routingConfig := s.RoutingConfig.Load()`. That keeps the host and the API key from the same configuration generation rather than re-Loading twice and risking a torn read across a reload.

`setUpRouter` seeds the initial pointer so `Load()` is non-nil before the first `OnConfigChange` fires. It also panics with a clear message if `mcpConfig` is unexpectedly nil at construction time, which is a new failure mode but a loud one (better than a deferred nil deref deep in a hot path).

Test fixtures in `server_test.go` and `request_handlers_test.go` updated to use the `atomic.Pointer` accessor.

## Verification

```
go build ./...
go vet ./...
go test -race -count=1 -timeout 60s ./internal/mcp-router/...
make lint
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing configuration handling to be race-free, preventing requests from using nil or partially-updated routing state.
  * Request and response flows now consistently use the active routing configuration for `:authority` rewriting and backend target/server resolution during token elicitation.

* **Tests**
  * Updated routing-config initialization in tests to apply configuration after server creation.
  * Added a race-focused concurrency test to verify safe routing config updates while request handling runs concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->