### PR TITLE
fix: serialize concurrent manage calls in MCPManager

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -85,6 +85,8 @@ type MCPManager struct {
 	servedToolsMap map[string]*mcp.Tool
 	// toolsLock protects tools, serverTools
 	toolsLock sync.RWMutex
+	// manageMu serializes concurrent manage calls from the ticker and notification goroutines
+	manageMu sync.Mutex
 
 	logger *slog.Logger
 
@@ -186,6 +188,8 @@ func (man *MCPManager) registerCallbacks(ctx context.Context) func() {
 
 // manage should be the only entry point that triggers changes to tools
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
+	man.manageMu.Lock()
+	defer man.manageMu.Unlock()
 	man.logger.Debug("managing connection", "upstream mcp server", man.MCP.ID(), "event type", event)
 	var numberOfTools = 0
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.


### PR DESCRIPTION
The previous fixes had me reading through the broker and manager code longer than I planned. The comment on line 187 of `manager.go` says "manage should be the only entry point that triggers changes to tools"; it is, but that's not the same as being called from one goroutine.

`Start` drives the ticker loop and calls `manage` on every tick. `registerCallbacks` wires up `OnNotification`, which calls `manage` directly from the mcp-go SSE-reader goroutine whenever the backend sends `notifications/tools/list_changed`. Nothing serialises them.

The race is a read-compute-write: both callers snapshot `man.tools` under `RLock`, call `MCP.ListTools()` with the lock released, compute a diff against their snapshot, then take `toolsLock.Lock()` to commit. If the notification goroutine finishes first with a correct `servedToolsMap ; {A, B, C}`, and the timer goroutine, which started from a slightly staler snapshot of `[A, B]` ; acquires the write lock second, it overwrites: `man.tools = [A, B]`, `servedToolsMap = {A, B}`. C is gone from the lookup table even though the mcp-go gateway server has it registered.

What keeps it stuck: `shouldFetchTools` only lets timer ticks re-fetch when `len(man.serverTools) == 0`. After the race, `serverTools` has duplicates and is non-zero, so every subsequent tick returns early. No periodic recovery. The only escape is another `notifications/tools/list_changed` from the backend, which won't arrive if nothing else changes.

From a client's view: `tools/list` shows C, `tools/call` on C returns "Tool not found". Nothing in the logs surfaces the divergence between the gateway server's registry and `servedToolsMap`.

Fix is one mutex at the top of `manage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stability of tool management operations by preventing conflicts between concurrent operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/936)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->