### PR TITLE
test: add regression test for concurrent manage() data race

### DIFF
--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -986,3 +986,35 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 	assert.Empty(t, status.InvalidToolList)
 	assert.Len(t, gateway.tools, 2)
 }
+func TestMCPManager_manage_ConcurrentRace(t *testing.T) {
+	mock := newMockMCP("test-server", "test_")
+	gateway := NewMockGatewayServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			manager.manage(ctx, eventTypeTimer)
+		}()
+		go func() {
+			defer wg.Done()
+			manager.manage(ctx, eventTypeNotification)
+		}()
+	}
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("concurrent manage calls timed out: %v", ctx.Err())
+	}
+}


### PR DESCRIPTION
Adds a regression test for the data race reported in #916 and fixed in #936.

The test calls `manage()` concurrently from multiple goroutines to simulate the ticker loop and notification callback firing simultaneously. Running with `go test -race` confirms the race, ensuring the fix in #936 won't regress.

The existing CI already runs with `-race` via `make test-unit`, so this test will be caught automatically on future PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a concurrency/race-focused test to improve coverage around concurrent operations, increasing confidence in thread-safety and reliability under concurrent load.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/937)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->