### PR TITLE
fix: prevent concurrent map write panic in Cache.AddSession and Remov…

### DIFF
--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -14,6 +14,7 @@ const clientElicitationPrefix = "clientelicitation:"
 type Cache struct {
 	inmemory  *sync.Map
 	extClient *redis.Client
+	mu        sync.Mutex
 }
 
 // KeyExists checks if a key exists in the cache
@@ -64,6 +65,8 @@ func (c *Cache) DeleteSessions(ctx context.Context, key ...string) error {
 // AddSession will add a session under the key. If the key exists it will append that session
 func (c *Cache) AddSession(ctx context.Context, key, mcpServerID, mcpSession string) (bool, error) {
 	if c.inmemory != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		session, err := c.GetSession(ctx, key)
 		if err != nil {
 			return false, err
@@ -82,6 +85,8 @@ func (c *Cache) AddSession(ctx context.Context, key, mcpServerID, mcpSession str
 // RemoveServerSession remove specific server session form cache
 func (c *Cache) RemoveServerSession(ctx context.Context, key, mcpServerID string) error {
 	if c.inmemory != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		session, err := c.GetSession(ctx, key)
 		if err != nil {
 			return err

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -308,4 +308,9 @@ func TestInMemoryCache_AddSession_Concurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+
+	// verify all sessions were stored
+	sessions, err := cache.GetSession(ctx, "gateway-session-1")
+	require.NoError(t, err)
+	require.Len(t, sessions, 100)
 }

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -288,4 +290,22 @@ func TestInMemoryCache_DeleteSessionsCleansUpElicitation(t *testing.T) {
 	sessions, err = cache.GetSession(ctx, sessionID)
 	require.NoError(t, err)
 	require.Empty(t, sessions)
+}
+
+func TestInMemoryCache_AddSession_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			serverName := fmt.Sprintf("server%d", i)
+			_, err := cache.AddSession(ctx, "gateway-session-1", serverName, "upstream-session")
+			require.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #939

Cache.AddSession() and Cache.RemoveServerSession() were performing a read-modify-write on an inner map[string]string stored inside a sync.Map. While sync.Map protects individual Load/Store calls, it does not protect the sequence as a whole two concurrent callers could both load the same map, modify it, and store back, causing a concurrent map write panic.

Fix adds a sync.Mutex to Cache to serialize the read-modify-write sequence in both methods for the in-memory path.

Verified with go test -race including a new concurrent reproducer test that previously panicked and now passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache thread safety by adding proper synchronization to prevent race conditions during concurrent operations.

* **Tests**
  * Added test coverage for concurrent cache operations to validate stability under high concurrency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/940)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->