### PR TITLE
fix: clean up elicitation idmap entries on interrupted ext_proc streams

### DIFF
--- a/internal/mcp-router/elicitation.go
+++ b/internal/mcp-router/elicitation.go
@@ -58,12 +58,14 @@ func (w *sseRewriter) Process(ctx context.Context, chunk []byte) []byte {
 
 // Flush flushes the buffer and cleans up any gatewayIDs created by the rewriter
 // This allows us to deal with orphaned elicitation id mappings
+// Safe to call multiple times; subsequent calls are no-ops
 func (w *sseRewriter) Flush(ctx context.Context) []byte {
 	remaining := w.buf
 	w.buf = nil
 	for _, id := range w.gatewayIDs {
 		w.idMap.Remove(ctx, id) // tool request + response finished, no need to hold onto the mappings any more
 	}
+	w.gatewayIDs = nil
 	return remaining
 }
 

--- a/internal/mcp-router/elicitation_test.go
+++ b/internal/mcp-router/elicitation_test.go
@@ -269,6 +269,36 @@ func TestSSERewriter_Flush(t *testing.T) {
 		flushed := w.Flush(ctx)
 		require.Nil(t, flushed)
 	})
+
+	t.Run("is idempotent across multiple calls", func(t *testing.T) {
+		m, err := idmap.New()
+		require.NoError(t, err)
+		w := &sseRewriter{
+			idMap:  m,
+			logger: logger,
+			req: &MCPRequest{
+				serverName:       "test-server",
+				backendSessionID: "test-session",
+			},
+		}
+
+		input := `data: {"jsonrpc":"2.0","method":"elicitation/create","id":1,"params":{}}` + "\n"
+		w.Process(ctx, []byte(input))
+		require.Len(t, w.gatewayIDs, 1)
+		gatewayID := w.gatewayIDs[0]
+
+		// first flush cleans up
+		w.Flush(ctx)
+		require.Empty(t, w.gatewayIDs)
+		_, ok, err := m.Lookup(ctx, gatewayID)
+		require.NoError(t, err)
+		require.False(t, ok)
+
+		// subsequent flush is a no-op; no panic, no state change
+		require.NotPanics(t, func() { w.Flush(ctx) })
+		require.Empty(t, w.gatewayIDs)
+		require.Nil(t, w.buf)
+	})
 }
 
 func TestSSERewriter_MaybeRewriteElicitation(t *testing.T) {

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -64,6 +64,14 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 	)
 	span := trace.SpanFromContext(ctx)
 	defer func() { span.End() }()
+	// ensure orphaned elicitation idmap entries are cleaned up on any exit path
+	// (e.g. stream.Recv/Send errors before endOfStream). Flush is idempotent so
+	// this is a no-op on the happy path where it has already run.
+	defer func() {
+		if rewriter != nil {
+			_ = rewriter.Flush(ctx)
+		}
+	}()
 	for {
 		req, err := stream.Recv()
 


### PR DESCRIPTION
While reading through the elicitation flow I noticed the cleanup contract in `docs/design/notifications.md:339`:

> Mappings persist for the tool call duration and are removed when the response stream ends. In Redis-backed deployments, a 1-hour TTL acts as a safety net for orphaned entries.

The "removed when the response stream ends" half doesn't hold for all the ways a stream can end.

In `internal/mcp-router/server.go:Process()`, `rewriter.Flush(ctx)` is called from exactly one site — line 285, inside `ProcessingRequest_ResponseBody` when `endOfStream` is true. After the rewriter is created at line 253 there are several `return err` paths that bypass it:

- `stream.Recv()` error on the next iteration (client disconnect / Envoy stream close)
- `stream.Send` error on the routing response
- `stream.Send` error on the response body

Each abandoned stream then leaks N entries in `ElicitationMap`, where N is the number of `elicitation/create` messages already buffered before the stream died.

For the in-memory `idmap` (`internal/idmap/inmemory.go`) this is unbounded — unlike `redis.go` it has no `entryTTL`, no safety net. Memory grows with streaming-tool-call traffic that includes elicitations. The Redis-backed deployments still hold the orphaned entries until the 1-hour TTL kicks in.

The fix is two small pieces: a function-level `defer` in `Process` that calls `rewriter.Flush` on any exit path, plus making `Flush` idempotent (clear `w.gatewayIDs` after the Remove loop) so the happy-path call followed by the defer is a clean no-op.

Added a subtest under `TestSSERewriter_Flush` covering the idempotency contract. All `internal/` tests pass with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during stream processing errors. The system now properly handles orphaned entries when stream receive/send errors occur, ensuring cleanup happens regardless of exit conditions. Made resource cleanup operations idempotent to prevent duplicate processing attempts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/941)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->