### PR TITLE
Refactor/manager channel event loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,10 @@ Test servers in `config/test-servers/`:
 - **Conformance Server**: Typescript SDK conformance test server
 - **Custom Response Server**: Tests custom response handling
 
+## Concurrency
+
+Before using a mutex to protect memory access, consider whether golang channels are a better solution. Favour the principle of sharing memory by communicating rather than communicating via shared memory.
+
 ## Performance
 
 Broker and router are hot paths. Avoid allocations in per-request code.

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -32,7 +32,7 @@ type MCPBroker interface {
 	MCPServer() *server.MCPServer
 
 	//RegisteredServers returns the map of registered servers
-	RegisteredMCPServers() map[config.UpstreamMCPID]*upstream.MCPManager
+	RegisteredMCPServers() map[config.UpstreamMCPID]upstream.ActiveMCPServer
 
 	// GetVirtualSeverByHeader returns a virtual server definition based on a header where the header is the namespaced/name of the virtual server resource
 	GetVirtualSeverByHeader(namespaceName string) (config.VirtualServer, error)
@@ -61,7 +61,7 @@ type mcpBrokerImpl struct {
 	vsLock         sync.RWMutex //vsLock is for managing access to the virtual servers
 
 	// mcpServers tracks the known servers
-	mcpServers map[config.UpstreamMCPID]*upstream.MCPManager
+	mcpServers map[config.UpstreamMCPID]upstream.ActiveMCPServer
 	// protects mcpServers
 	mcpLock sync.RWMutex
 
@@ -120,7 +120,7 @@ func WithInvalidToolPolicy(policy mcpv1alpha1.InvalidToolPolicy) Option {
 // NewBroker creates a new MCPBroker accepts optional config functions such as WithEnforceCapabilityFilter
 func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	mcpBkr := &mcpBrokerImpl{
-		mcpServers:            map[config.UpstreamMCPID]*upstream.MCPManager{},
+		mcpServers:            map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
 		logger:                logger,
 		virtualServers:        map[string]*config.VirtualServer{},
 		managerTickerInterval: time.Second * 60,
@@ -189,7 +189,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		if ok {
 			m.logger.Info("Server is registered", "mcpID", mcpServer.ID())
 			// already have a manger
-			if mcpServer.ConfigChanged(man.MCP.GetConfig()) {
+			if mcpServer.ConfigChanged(man.Config()) {
 				// todo prob could look at just updating the config
 				m.logger.Info("Server Config Changed removing manager", "mcpID", mcpServer.ID())
 				man.Stop()
@@ -204,11 +204,8 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 				m.logger.Error("failed to create manager", "server id", mcpServer.ID(), "error", err)
 				continue
 			}
-			m.mcpServers[mcpServer.ID()] = manager
-			go func() {
-				m.logger.Info("Starting manager for", "mcpID", mcpServer.ID())
-				manager.Start(ctx)
-			}()
+			m.logger.Info("Starting manager for", "mcpID", mcpServer.ID())
+			m.mcpServers[mcpServer.ID()] = manager.Start(ctx)
 		}
 	}
 	// register virtual servers
@@ -220,7 +217,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	m.logger.Debug("Broker OnConfigChange done", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(conf.Servers))
 }
 
-func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]*upstream.MCPManager {
+func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]upstream.ActiveMCPServer {
 	m.mcpLock.RLock()
 	defer m.mcpLock.RUnlock()
 	return m.mcpServers
@@ -264,9 +261,9 @@ func (m *mcpBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 		if t != nil {
 			m.logger.Debug("found matching server",
 				"toolName", tool,
-				"serverPrefix", upstream.MCP.GetPrefix(),
-				"serverName", upstream.MCP.GetName())
-			retval := upstream.MCP.GetConfig()
+				"serverPrefix", upstream.Config().Prefix,
+				"serverName", upstream.MCPName())
+			retval := upstream.Config()
 			return &retval, nil
 		}
 	}

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -194,16 +194,16 @@ func TestGetServerInfo(t *testing.T) {
 	// Attach phony tools to the upstreams
 	bImpl, ok := b.(*mcpBrokerImpl)
 	require.True(t, ok)
-	bImpl.mcpServers["test1"] = createTestManager(t, "test1", "", []mcp.Tool{
+	bImpl.mcpServers["test1"] = upstream.NewActiveForTesting(createTestManager(t, "test1", "", []mcp.Tool{
 		mcp.NewTool("pour_chocolate"),
-	})
-	bImpl.mcpServers["test2"] = createTestManager(t, "test2", "", []mcp.Tool{
+	}))
+	bImpl.mcpServers["test2"] = upstream.NewActiveForTesting(createTestManager(t, "test2", "", []mcp.Tool{
 		mcp.NewTool("restore_from_tape"),
-	})
-	bImpl.mcpServers["test3"] = createTestManager(t, "test3", "t", []mcp.Tool{
+	}))
+	bImpl.mcpServers["test3"] = upstream.NewActiveForTesting(createTestManager(t, "test3", "t", []mcp.Tool{
 		mcp.NewTool("restore_from_tape"),
-	})
-	bImpl.mcpServers["test4"] = createTestManager(t, "test4", "tt", []mcp.Tool{})
+	}))
+	bImpl.mcpServers["test4"] = upstream.NewActiveForTesting(createTestManager(t, "test4", "tt", []mcp.Tool{}))
 
 	svr, err := b.GetServerInfo("pour_chocolate")
 	require.NotNil(t, svr)
@@ -238,7 +238,7 @@ func TestToolAnnotations(t *testing.T) {
 	// Attach phony tools to the upstreams
 	bImpl, ok := b.(*mcpBrokerImpl)
 	require.True(t, ok)
-	bImpl.mcpServers["test1"] = createTestManager(t, "test1", "", []mcp.Tool{
+	bImpl.mcpServers["test1"] = upstream.NewActiveForTesting(createTestManager(t, "test1", "", []mcp.Tool{
 		mcp.NewTool("get_status", mcp.WithToolAnnotation(mcp.ToolAnnotation{
 			ReadOnlyHint:   mcp.ToBoolPtr(true),
 			IdempotentHint: mcp.ToBoolPtr(true),
@@ -247,7 +247,7 @@ func TestToolAnnotations(t *testing.T) {
 			ReadOnlyHint:   mcp.ToBoolPtr(false),
 			IdempotentHint: mcp.ToBoolPtr(false),
 		})),
-	})
+	}))
 
 	testCases := []struct {
 		name       string
@@ -317,7 +317,7 @@ func TestIsReady(t *testing.T) {
 			setup: func(b *mcpBrokerImpl) {
 				mgr := createTestManager(t, "s1", "", nil)
 				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: false})
-				b.mcpServers["s1"] = mgr
+				b.mcpServers["s1"] = upstream.NewActiveForTesting(mgr)
 			},
 			expected: false,
 		},
@@ -326,10 +326,10 @@ func TestIsReady(t *testing.T) {
 			setup: func(b *mcpBrokerImpl) {
 				m1 := createTestManager(t, "s1", "", nil)
 				m1.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: false})
-				b.mcpServers["s1"] = m1
+				b.mcpServers["s1"] = upstream.NewActiveForTesting(m1)
 				m2 := createTestManager(t, "s2", "", nil)
 				m2.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s2", Ready: true})
-				b.mcpServers["s2"] = m2
+				b.mcpServers["s2"] = upstream.NewActiveForTesting(m2)
 			},
 			expected: true,
 		},
@@ -338,7 +338,7 @@ func TestIsReady(t *testing.T) {
 			setup: func(b *mcpBrokerImpl) {
 				mgr := createTestManager(t, "s1", "", nil)
 				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
-				b.mcpServers["s1"] = mgr
+				b.mcpServers["s1"] = upstream.NewActiveForTesting(mgr)
 			},
 			expected: true,
 		},

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -134,7 +134,7 @@ func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []strin
 	return capabilities, nil
 }
 
-func (broker *mcpBrokerImpl) findServerByName(name string) *upstream.MCPManager {
+func (broker *mcpBrokerImpl) findServerByName(name string) upstream.ActiveMCPServer {
 	for _, upstream := range broker.mcpServers {
 		if upstream.MCPName() == name {
 			return upstream
@@ -163,7 +163,7 @@ func (broker *mcpBrokerImpl) filterToolsByServerMap(allowedTools map[string][]st
 			broker.logger.Debug("checking access", "tool", tool.Name, "against", toolNames)
 			if slices.Contains(toolNames, tool.Name) {
 				broker.logger.Debug("access granted", "tool", tool.Name)
-				tool.Name = fmt.Sprintf("%s%s", upstream.MCP.GetPrefix(), tool.Name)
+				tool.Name = fmt.Sprintf("%s%s", upstream.Config().Prefix, tool.Name)
 				filtered = append(filtered, tool)
 			}
 		}

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -72,7 +72,7 @@ func TestFilteredTools(t *testing.T) {
 		Name                 string
 		FullToolList         *mcp.ListToolsResult
 		AllowedToolsList     map[string][]string
-		RegisteredMCPServers map[config.UpstreamMCPID]*upstream.MCPManager
+		RegisteredMCPServers map[config.UpstreamMCPID]upstream.ActiveMCPServer
 		enforceFilterList    bool
 		ExpectedTools        []mcp.Tool
 	}{
@@ -82,12 +82,12 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test_tool"},
 				{Name: "test_tool2"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			AllowedToolsList: map[string][]string{
 				"mcp-test/test-server1": {"tool"},
@@ -103,17 +103,17 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool"},
 				{Name: "test2_tool"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test1_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
-				"mcp-test/test-server2:test2_:http://test.local/mcp": createTestManager(t,
+				)),
+				"mcp-test/test-server2:test2_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server2",
 					"test2_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			AllowedToolsList: map[string][]string{
 				"mcp-test/test-server1": {"tool"},
@@ -131,17 +131,17 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool"},
 				{Name: "test2_tool"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test1_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
-				"mcp-test/test-server2:test2_:http://test.local/mcp": createTestManager(t,
+				)),
+				"mcp-test/test-server2:test2_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server2",
 					"test2_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			AllowedToolsList:  map[string][]string{},
 			enforceFilterList: true,
@@ -153,12 +153,12 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool"},
 				{Name: "test1_tool2"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test1_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			AllowedToolsList:  nil,
 			enforceFilterList: false,
@@ -180,7 +180,7 @@ func TestFilteredTools(t *testing.T) {
 		Name                 string
 		FullToolList         *mcp.ListToolsResult
 		AllowedToolsList     map[string][]string
-		RegisteredMCPServers map[config.UpstreamMCPID]*upstream.MCPManager
+		RegisteredMCPServers map[config.UpstreamMCPID]upstream.ActiveMCPServer
 		enforceFilterList    bool
 		ExpectedTools        []mcp.Tool
 		jwtOverride          string
@@ -191,12 +191,12 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool"},
 				{Name: "test1_tool2"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test1_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			enforceFilterList: false,
 			jwtOverride:       promptsOnlyJWT,
@@ -211,12 +211,12 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool"},
 				{Name: "test1_tool2"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test1_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			enforceFilterList: true,
 			jwtOverride:       promptsOnlyJWT,
@@ -228,12 +228,12 @@ func TestFilteredTools(t *testing.T) {
 				{Name: "test1_tool"},
 				{Name: "test1_tool2"},
 			}},
-			RegisteredMCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/test-server1:test1_:http://test.local/mcp": createTestManager(t,
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/test-server1:test1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/test-server1",
 					"test1_",
 					[]mcp.Tool{{Name: "tool"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			enforceFilterList: true,
 			jwtOverride:       toolsAndPromptsJWT,
@@ -461,7 +461,7 @@ func TestFilterToolsSerializesAsEmptyArray(t *testing.T) {
 func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 	testCases := []struct {
 		Name             string
-		MCPServers       map[config.UpstreamMCPID]*upstream.MCPManager
+		MCPServers       map[config.UpstreamMCPID]upstream.ActiveMCPServer
 		VirtualServers   map[string]*config.VirtualServer
 		AllowedToolsList map[string][]string
 		VirtualServerID  string
@@ -469,12 +469,12 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 	}{
 		{
 			Name: "x-mcp-authorized filtered first then virtual server filters further",
-			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
+			MCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/server1:s1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/server1",
 					"s1_",
 					[]mcp.Tool{{Name: "tool1"}, {Name: "tool2"}, {Name: "tool3"}},
-				),
+				)),
 			},
 			VirtualServers: map[string]*config.VirtualServer{
 				"mcp-test/my-vs": {
@@ -493,12 +493,12 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 		},
 		{
 			Name: "x-mcp-authorized only when no virtual server header",
-			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
+			MCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/server1:s1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/server1",
 					"s1_",
 					[]mcp.Tool{{Name: "tool1"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			VirtualServers: map[string]*config.VirtualServer{
 				"mcp-test/my-vs": {
@@ -514,12 +514,12 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 		},
 		{
 			Name: "virtual server only when no x-mcp-authorized header",
-			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
+			MCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/server1:s1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/server1",
 					"s1_",
 					[]mcp.Tool{{Name: "tool1"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			VirtualServers: map[string]*config.VirtualServer{
 				"mcp-test/my-vs": {
@@ -533,12 +533,12 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 		},
 		{
 			Name: "empty result when filters have no intersection",
-			MCPServers: map[config.UpstreamMCPID]*upstream.MCPManager{
-				"mcp-test/server1:s1_:http://test.local/mcp": createTestManager(t,
+			MCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/server1:s1_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
 					"mcp-test/server1",
 					"s1_",
 					[]mcp.Tool{{Name: "tool1"}, {Name: "tool2"}},
-				),
+				)),
 			},
 			VirtualServers: map[string]*config.VirtualServer{
 				"mcp-test/my-vs": {
@@ -572,7 +572,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 			for _, manager := range tc.MCPServers {
 				for _, tool := range manager.GetManagedTools() {
 					inputTools.Tools = append(inputTools.Tools, mcp.Tool{
-						Name: manager.MCP.GetPrefix() + tool.Name,
+						Name: manager.Config().Prefix + tool.Name,
 					})
 				}
 			}

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -58,10 +58,10 @@ func TestStatusHandlerGetSingleServer(t *testing.T) {
 	// Add a server
 	brokerImpl, ok := mcpBroker.(*mcpBrokerImpl)
 	require.True(t, ok)
-	brokerImpl.mcpServers["dummyServer:test_:http://test.local/mcp"] = createTestManagerForStatus(t,
+	brokerImpl.mcpServers["dummyServer:test_:http://test.local/mcp"] = upstream.NewActiveForTesting(createTestManagerForStatus(t,
 		"dummyServer",
 		[]mcp.Tool{{Name: "dummyTool"}},
-	)
+	))
 
 	w = httptest.NewRecorder()
 	sh.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/status/dummyServer", nil))
@@ -77,10 +77,10 @@ func TestStatusHandlerGetAll(t *testing.T) {
 	// Add a server
 	brokerImpl, ok := mcpBroker.(*mcpBrokerImpl)
 	require.True(t, ok)
-	brokerImpl.mcpServers["dummyServer:test_:http://test.local/mcp"] = createTestManagerForStatus(t,
+	brokerImpl.mcpServers["dummyServer:test_:http://test.local/mcp"] = upstream.NewActiveForTesting(createTestManagerForStatus(t,
 		"dummyServer",
 		[]mcp.Tool{{Name: "dummyTool"}},
-	)
+	))
 
 	w := httptest.NewRecorder()
 	sh.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/status", nil))
@@ -115,7 +115,7 @@ func TestValidateAllServers(t *testing.T) {
 			setup: func(b *mcpBrokerImpl) {
 				mgr := createTestManagerForStatus(t, "s1", nil)
 				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: false})
-				b.mcpServers["s1"] = mgr
+				b.mcpServers["s1"] = upstream.NewActiveForTesting(mgr)
 			},
 			wantTotal:        1,
 			wantHealthy:      0,
@@ -127,7 +127,7 @@ func TestValidateAllServers(t *testing.T) {
 			setup: func(b *mcpBrokerImpl) {
 				mgr := createTestManagerForStatus(t, "s1", nil)
 				mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
-				b.mcpServers["s1"] = mgr
+				b.mcpServers["s1"] = upstream.NewActiveForTesting(mgr)
 			},
 			wantTotal:        1,
 			wantHealthy:      1,
@@ -139,10 +139,10 @@ func TestValidateAllServers(t *testing.T) {
 			setup: func(b *mcpBrokerImpl) {
 				m1 := createTestManagerForStatus(t, "s1", nil)
 				m1.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
-				b.mcpServers["s1"] = m1
+				b.mcpServers["s1"] = upstream.NewActiveForTesting(m1)
 				m2 := createTestManagerForStatus(t, "s2", nil)
 				m2.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s2", Ready: false})
-				b.mcpServers["s2"] = m2
+				b.mcpServers["s2"] = upstream.NewActiveForTesting(m2)
 			},
 			wantTotal:        2,
 			wantHealthy:      1,

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -93,10 +93,10 @@ type MCPManager struct {
 
 	// events funnels notifications into the Start() loop. Buffer of 1 coalesces
 	// rapid notifications; safe because manage() always does a full tool sync.
-	events   chan eventType
-	stopOnce sync.Once     // ensures Stop() is only executed once
-	done     chan struct{} // triggers the exit of the select and routine
-	status   ServerValidationStatus
+	events chan eventType
+	cancel context.CancelFunc // cancels the internal context to stop the event loop
+	done   chan struct{}      // closed when the event loop exits
+	status ServerValidationStatus
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
@@ -138,39 +138,41 @@ func (man *MCPManager) MCPName() string {
 // registers notification callbacks to handle tool list changes. This method blocks
 // until Stop is called or the context is cancelled.
 func (man *MCPManager) Start(ctx context.Context) {
+	ctx, man.cancel = context.WithCancel(ctx)
 	man.ticker.Reset(man.tickerInterval)
 	man.manage(ctx, eventTypeTimer)
 
 	for {
 		select {
 		case <-ctx.Done():
-			man.Stop()
+			man.ticker.Stop()
+			if err := man.MCP.Disconnect(); err != nil {
+				man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.MCP.ID(), "error", err)
+			}
+			man.removeAllTools()
+
+			close(man.done)
+			man.logger.Debug("manager stopped", "upstream mcp server", man.MCP.ID())
+			return
 		case <-man.ticker.C:
 			man.logger.Debug("health check tick", "upstream mcp server", man.MCP.ID())
 			man.manage(ctx, eventTypeTimer)
 		case evt := <-man.events:
 			man.logger.Debug("received event", "upstream mcp server", man.MCP.ID(), "event", evt)
 			man.manage(ctx, evt)
-		case <-man.done:
-			man.logger.Debug("shutting down manager", "upstream mcp server", man.MCP.ID())
-			return
 		}
 	}
 }
 
-// Stop gracefully shuts down the manager. It stops the ticker, removes all tools
-// from the gateway, disconnects from the upstream server, and waits for the Start
-// goroutine to complete. Safe to call multiple times.
+// Stop cancels the event loop and waits for teardown to complete.
+// All cleanup (remove tools, disconnect) happens on the event loop goroutine.
+// Safe to call before Start (no-op) and multiple times.
 func (man *MCPManager) Stop() {
-	man.stopOnce.Do(func() {
-		man.ticker.Stop()
-		man.removeAllTools()
-		if err := man.MCP.Disconnect(); err != nil {
-			man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.MCP.ID(), "error", err)
-		}
-		close(man.done)
-		man.logger.Debug("manager stopped", "upstream mcp server", man.MCP.ID())
-	})
+	if man.cancel == nil {
+		return
+	}
+	man.cancel()
+	<-man.done
 }
 
 func (man *MCPManager) registerCallbacks() func() {

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -149,9 +149,9 @@ func (man *MCPManager) MCPName() string {
 func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 	ctx, cancel := context.WithCancel(ctx)
 	man.ticker.Reset(man.tickerInterval)
-	man.manage(ctx, eventTypeTimer)
 
 	go func() {
+		man.manage(ctx, eventTypeTimer)
 		for {
 			select {
 			case <-ctx.Done():

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -93,8 +93,11 @@ type MCPManager struct {
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy mcpv1alpha1.InvalidToolPolicy
 
-	stopOnce sync.Once     // ensures Stop() is only executed once
-	done     chan struct{} // triggers the exit of the select and routine
+	// events funnels notifications into the Start() loop. Buffer of 1 coalesces
+	// rapid notifications; safe because manage() always does a full tool sync.
+	events chan eventType
+	stopOnce sync.Once      // ensures Stop() is only executed once
+	done     chan struct{}  // triggers the exit of the select and routine
 	status   ServerValidationStatus
 }
 
@@ -119,6 +122,7 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, logger
 		ticker:            time.NewTicker(tickerInterval),
 		logger:            logger,
 		invalidToolPolicy: policy,
+		events:            make(chan eventType, 1),
 		done:              make(chan struct{}),
 		toolsMap:          map[string]*mcp.Tool{},
 		servedToolsMap:    map[string]*mcp.Tool{},
@@ -146,6 +150,9 @@ func (man *MCPManager) Start(ctx context.Context) {
 		case <-man.ticker.C:
 			man.logger.Debug("health check tick", "upstream mcp server", man.MCP.ID())
 			man.manage(ctx, eventTypeTimer)
+		case evt := <-man.events:
+			man.logger.Debug("received event", "upstream mcp server", man.MCP.ID(), "event", evt)
+			man.manage(ctx, evt)
 		case <-man.done:
 			man.logger.Debug("shutting down manager", "upstream mcp server", man.MCP.ID())
 			return
@@ -168,13 +175,16 @@ func (man *MCPManager) Stop() {
 	})
 }
 
-func (man *MCPManager) registerCallbacks(ctx context.Context) func() {
+func (man *MCPManager) registerCallbacks() func() {
 	man.logger.Debug("registering callbacks", "upstream mcp server", man.MCP.ID())
 	return func() {
 		man.MCP.OnNotification(func(notification mcp.JSONRPCNotification) {
 			if notification.Method == notificationToolsListChanged {
 				man.logger.Debug("received notification", "upstream mcp server", man.MCP.ID(), "notification", notification)
-				man.manage(ctx, eventTypeNotification)
+				select {
+				case man.events <- eventTypeNotification:
+				default:
+				}
 				return
 			}
 		})
@@ -194,7 +204,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	var numberOfTools = 0
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
 	man.logger.Debug("attempting to connect", "upstream mcp server", man.MCP.ID())
-	if err := man.MCP.Connect(ctx, man.registerCallbacks(ctx)); err != nil {
+	if err := man.MCP.Connect(ctx, man.registerCallbacks()); err != nil {
 		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.MCP.ID(), err)
 		man.removeAllTools()
 		// we call disconnect here as we may have connected but failed to initialize
@@ -255,7 +265,6 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.toolsLock.Lock()
 	man.tools = fetched
 	numberOfTools = len(fetched)
-	// set a tools map for quick look up by other functions
 	man.toolsMap = make(map[string]*mcp.Tool, len(fetched))
 	man.servedToolsMap = make(map[string]*mcp.Tool, len(fetched))
 	for i := range fetched {
@@ -263,7 +272,12 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		toolName := prefixedName(man.MCP.GetPrefix(), fetched[i].Name)
 		man.servedToolsMap[toolName] = &fetched[i]
 	}
-	// serverTools will have the prefix if one is set
+	man.serverTools = slices.DeleteFunc(man.serverTools, func(tool server.ServerTool) bool {
+		return slices.Contains(toRemove, tool.Tool.Name)
+	})
+	man.serverTools = append(man.serverTools, toAdd...)
+	man.toolsLock.Unlock()
+
 	man.logger.Debug("updating gateway tools", "upstream mcp server", man.MCP.ID(), "adding", len(toAdd), "removing", len(toRemove))
 	if len(toRemove) > 0 {
 		man.gatewayServer.DeleteTools(toRemove...)
@@ -271,15 +285,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	if len(toAdd) > 0 {
 		man.gatewayServer.AddTools(toAdd...)
 	}
-
-	// rebuild our internal tools
-	man.serverTools = slices.DeleteFunc(man.serverTools, func(tool server.ServerTool) bool {
-		return slices.Contains(toRemove, tool.Tool.Name)
-	})
-
-	man.serverTools = append(man.serverTools, toAdd...)
 	man.logger.Debug("internal tools", "upstream mcp server", man.MCP.ID(), "total", len(man.serverTools))
-	man.toolsLock.Unlock()
 	man.setStatus(nil, numberOfTools, invalidTools)
 }
 
@@ -352,12 +358,10 @@ func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {
 	return nil
 }
 
-// getTools return the existing, and new tools
+// getTools return the existing, and new tools. Must only be called from the Start() event loop.
 func (man *MCPManager) getTools(ctx context.Context) ([]mcp.Tool, []mcp.Tool, error) {
-	man.toolsLock.RLock()
 	tools := make([]mcp.Tool, len(man.tools))
 	copy(tools, man.tools)
-	man.toolsLock.RUnlock()
 	res, err := man.MCP.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {
 		return tools, tools, fmt.Errorf("failed to get tools: %w", err)
@@ -406,7 +410,6 @@ func (man *MCPManager) SetStatusForTesting(status ServerValidationStatus) {
 
 func (man *MCPManager) removeAllTools() {
 	man.toolsLock.Lock()
-	defer man.toolsLock.Unlock()
 	toolsToRemove := make([]string, 0, len(man.serverTools))
 	man.logger.Debug("removing tools from gateway", "upstream mcp server", man.MCP.ID(), "total", len(man.serverTools))
 	for _, tool := range man.serverTools {
@@ -417,6 +420,7 @@ func (man *MCPManager) removeAllTools() {
 	man.tools = []mcp.Tool{}
 	man.toolsMap = map[string]*mcp.Tool{}
 	man.servedToolsMap = map[string]*mcp.Tool{}
+	man.toolsLock.Unlock()
 	man.gatewayServer.DeleteTools(toolsToRemove...)
 	man.logger.Debug("removed all tools", "upstream mcp server", man.MCP.ID(), "count", len(toolsToRemove))
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -69,9 +69,20 @@ type MCP interface {
 	Ping(context.Context) error
 }
 
+// ActiveMCPServer is the handle returned by Start. It exposes read-only
+// queries and a Stop method that cleanly shuts down the event loop.
+type ActiveMCPServer interface {
+	Stop()
+	MCPName() string
+	GetStatus() ServerValidationStatus
+	GetManagedTools() []mcp.Tool
+	GetServedManagedTool(toolName string) *mcp.Tool
+	Config() config.MCPServer
+}
+
 // MCPManager manages a single backend MCPServer for the broker. It does not act on behalf of clients. It is the only thing that should be connecting to the MCP Server for the broker. It handles tools updates, disconnection, notifications, liveness checks and updating the status for the MCP server. It is responsible for adding and removing tools to the broker. It is intended to be long lived and have 1:1 relationship with a backend MCP server.
 type MCPManager struct {
-	MCP MCP
+	mcp MCP
 	// ticker allows for us to continue to probe and retry the backend
 	ticker *time.Ticker
 	// tickerInterval is the interval between backend health checks
@@ -94,8 +105,7 @@ type MCPManager struct {
 	// events funnels notifications into the Start() loop. Buffer of 1 coalesces
 	// rapid notifications; safe because manage() always does a full tool sync.
 	events chan eventType
-	cancel context.CancelFunc // cancels the internal context to stop the event loop
-	done   chan struct{}      // closed when the event loop exits
+	done   chan struct{} // closed when the event loop exits
 	status ServerValidationStatus
 }
 
@@ -114,7 +124,7 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, logger
 	}
 
 	return &MCPManager{
-		MCP:               upstream,
+		mcp:               upstream,
 		gatewayServer:     gatewayServer,
 		tickerInterval:    tickerInterval,
 		ticker:            time.NewTicker(tickerInterval),
@@ -130,57 +140,66 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, logger
 
 // MCPName returns the name of the upstream MCP server being managed
 func (man *MCPManager) MCPName() string {
-	return man.MCP.GetName()
+	return man.mcp.GetName()
 }
 
-// Start begins the management loop for the upstream MCP server. It connects to
-// the server, discovers tools, and periodically validates the connection. It also
-// registers notification callbacks to handle tool list changes. This method blocks
-// until Stop is called or the context is cancelled.
-func (man *MCPManager) Start(ctx context.Context) {
-	ctx, man.cancel = context.WithCancel(ctx)
+// Start launches the event loop in a background goroutine and returns an
+// ActiveMCPServer handle. The cancel func is captured inside the returned
+// wrapper so there is no shared mutable state between Start and Stop.
+func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
+	ctx, cancel := context.WithCancel(ctx)
 	man.ticker.Reset(man.tickerInterval)
 	man.manage(ctx, eventTypeTimer)
 
-	for {
-		select {
-		case <-ctx.Done():
-			man.ticker.Stop()
-			if err := man.MCP.Disconnect(); err != nil {
-				man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.MCP.ID(), "error", err)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				man.ticker.Stop()
+				if err := man.mcp.Disconnect(); err != nil {
+					man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.mcp.ID(), "error", err)
+				}
+				man.removeAllTools()
+
+				close(man.done)
+				man.logger.Debug("manager stopped", "upstream mcp server", man.mcp.ID())
+				return
+			case <-man.ticker.C:
+				man.logger.Debug("health check tick", "upstream mcp server", man.mcp.ID())
+				man.manage(ctx, eventTypeTimer)
+			case evt := <-man.events:
+				man.logger.Debug("received event", "upstream mcp server", man.mcp.ID(), "event", evt)
+				man.manage(ctx, evt)
 			}
-			man.removeAllTools()
-
-			close(man.done)
-			man.logger.Debug("manager stopped", "upstream mcp server", man.MCP.ID())
-			return
-		case <-man.ticker.C:
-			man.logger.Debug("health check tick", "upstream mcp server", man.MCP.ID())
-			man.manage(ctx, eventTypeTimer)
-		case evt := <-man.events:
-			man.logger.Debug("received event", "upstream mcp server", man.MCP.ID(), "event", evt)
-			man.manage(ctx, evt)
 		}
-	}
+	}()
+
+	return &activeMCP{manager: man, cancel: cancel}
 }
 
-// Stop cancels the event loop and waits for teardown to complete.
-// All cleanup (remove tools, disconnect) happens on the event loop goroutine.
-// Safe to call before Start (no-op) and multiple times.
-func (man *MCPManager) Stop() {
-	if man.cancel == nil {
-		return
-	}
-	man.cancel()
-	<-man.done
+// activeMCP implements ActiveMCPServer. It holds the cancel func returned by
+// context.WithCancel so that Stop can shut down the event loop without any
+// shared mutable field on MCPManager.
+type activeMCP struct {
+	manager *MCPManager
+	cancel  context.CancelFunc
 }
+
+func (a *activeMCP) Stop()                             { a.cancel(); <-a.manager.done }
+func (a *activeMCP) MCPName() string                   { return a.manager.MCPName() }
+func (a *activeMCP) GetStatus() ServerValidationStatus { return a.manager.GetStatus() }
+func (a *activeMCP) GetManagedTools() []mcp.Tool       { return a.manager.GetManagedTools() }
+func (a *activeMCP) GetServedManagedTool(t string) *mcp.Tool {
+	return a.manager.GetServedManagedTool(t)
+}
+func (a *activeMCP) Config() config.MCPServer { return a.manager.mcp.GetConfig() }
 
 func (man *MCPManager) registerCallbacks() func() {
-	man.logger.Debug("registering callbacks", "upstream mcp server", man.MCP.ID())
+	man.logger.Debug("registering callbacks", "upstream mcp server", man.mcp.ID())
 	return func() {
-		man.MCP.OnNotification(func(notification mcp.JSONRPCNotification) {
+		man.mcp.OnNotification(func(notification mcp.JSONRPCNotification) {
 			if notification.Method == notificationToolsListChanged {
-				man.logger.Debug("received notification", "upstream mcp server", man.MCP.ID(), "notification", notification)
+				man.logger.Debug("received notification", "upstream mcp server", man.mcp.ID(), "notification", notification)
 				select {
 				case man.events <- eventTypeNotification:
 				default:
@@ -189,48 +208,48 @@ func (man *MCPManager) registerCallbacks() func() {
 			}
 		})
 
-		man.MCP.OnConnectionLost(func(err error) {
+		man.mcp.OnConnectionLost(func(err error) {
 			// just logging for visibility as will be re-connected on next tick
-			man.logger.Error("connection lost", "upstream mcp server", man.MCP.ID(), "error", err)
+			man.logger.Error("connection lost", "upstream mcp server", man.mcp.ID(), "error", err)
 		})
 	}
 }
 
 // manage should be the only entry point that triggers changes to tools
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
-	man.logger.Debug("managing connection", "upstream mcp server", man.MCP.ID(), "event type", event)
+	man.logger.Debug("managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
 	var numberOfTools = 0
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
-	man.logger.Debug("attempting to connect", "upstream mcp server", man.MCP.ID())
-	if err := man.MCP.Connect(ctx, man.registerCallbacks()); err != nil {
-		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.MCP.ID(), err)
+	man.logger.Debug("attempting to connect", "upstream mcp server", man.mcp.ID())
+	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
+		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.mcp.ID(), err)
 		man.removeAllTools()
 		// we call disconnect here as we may have connected but failed to initialize
-		_ = man.MCP.Disconnect()
+		_ = man.mcp.Disconnect()
 		man.setStatus(err, numberOfTools, nil)
 		return
 	}
 	// there may be an active client so we also ping
-	if err := man.MCP.Ping(ctx); err != nil {
+	if err := man.mcp.Ping(ctx); err != nil {
 		// if we fail to ping we disconnect to ensure a fresh connection next time around
-		err = fmt.Errorf("upstream mcp failed to ping server %s removing tools : %w", man.MCP.ID(), err)
-		man.logger.Error("ping failed", "upstream mcp server", man.MCP.ID(), "error", err)
+		err = fmt.Errorf("upstream mcp failed to ping server %s removing tools : %w", man.mcp.ID(), err)
+		man.logger.Error("ping failed", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.removeAllTools()
-		_ = man.MCP.Disconnect()
+		_ = man.mcp.Disconnect()
 		man.setStatus(err, numberOfTools, nil)
 		return
 	}
 
 	if !man.shouldFetchTools(event) {
-		man.logger.Debug("not fetching tools", "event", event, "upstream mcp server", man.MCP.ID(), "waiting for notification", notificationToolsListChanged)
+		man.logger.Debug("not fetching tools", "event", event, "upstream mcp server", man.mcp.ID(), "waiting for notification", notificationToolsListChanged)
 		return
 	}
 
-	man.logger.Debug("fetching tools", "upstream mcp server", man.MCP.ID())
+	man.logger.Debug("fetching tools", "upstream mcp server", man.mcp.ID())
 	current, fetched, err := man.getTools(ctx)
 	if err != nil {
-		err = fmt.Errorf("upstream mcp failed to list tools server %s : %w", man.MCP.ID(), err)
-		man.logger.Error("failed to list tools", "upstream mcp server", man.MCP.ID(), "error", err)
+		err = fmt.Errorf("upstream mcp failed to list tools server %s : %w", man.mcp.ID(), err)
+		man.logger.Error("failed to list tools", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.setStatus(err, numberOfTools, nil)
 		return
 	}
@@ -238,12 +257,12 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	// validate fetched tools
 	validTools, invalidTools := ValidateTools(fetched)
 	if len(invalidTools) > 0 {
-		man.logger.Error("invalid tools detected", "upstream mcp server", man.MCP.ID(), "invalid", len(invalidTools), "valid", len(validTools))
+		man.logger.Error("invalid tools detected", "upstream mcp server", man.mcp.ID(), "invalid", len(invalidTools), "valid", len(validTools))
 		for _, info := range invalidTools {
-			man.logger.Error("invalid tool", "upstream mcp server", man.MCP.ID(), "tool", info.Name, "errors", info.Errors)
+			man.logger.Error("invalid tool", "upstream mcp server", man.mcp.ID(), "tool", info.Name, "errors", info.Errors)
 		}
 		if man.invalidToolPolicy == mcpv1alpha1.InvalidToolPolicyRejectServer {
-			err = fmt.Errorf("upstream mcp %s rejected: %d invalid tools found", man.MCP.ID(), len(invalidTools))
+			err = fmt.Errorf("upstream mcp %s rejected: %d invalid tools found", man.mcp.ID(), len(invalidTools))
 			man.removeAllTools()
 			man.setStatus(err, numberOfTools, invalidTools)
 			return
@@ -255,8 +274,8 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	// always compare the tools without prefix
 	toAdd, toRemove := man.diffTools(current, fetched)
 	if err := man.findToolConflicts(toAdd); err != nil {
-		err = fmt.Errorf("upstream mcp failed to add tools to gateway %s : %w", man.MCP.ID(), err)
-		man.logger.Error("tool conflict detected", "upstream mcp server", man.MCP.ID(), "error", err)
+		err = fmt.Errorf("upstream mcp failed to add tools to gateway %s : %w", man.mcp.ID(), err)
+		man.logger.Error("tool conflict detected", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.setStatus(err, numberOfTools, invalidTools)
 		return
 	}
@@ -267,7 +286,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.servedToolsMap = make(map[string]*mcp.Tool, len(fetched))
 	for i := range fetched {
 		man.toolsMap[fetched[i].Name] = &fetched[i]
-		toolName := prefixedName(man.MCP.GetPrefix(), fetched[i].Name)
+		toolName := prefixedName(man.mcp.GetPrefix(), fetched[i].Name)
 		man.servedToolsMap[toolName] = &fetched[i]
 	}
 	man.serverTools = slices.DeleteFunc(man.serverTools, func(tool server.ServerTool) bool {
@@ -276,20 +295,20 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.serverTools = append(man.serverTools, toAdd...)
 	man.toolsLock.Unlock()
 
-	man.logger.Debug("updating gateway tools", "upstream mcp server", man.MCP.ID(), "adding", len(toAdd), "removing", len(toRemove))
+	man.logger.Debug("updating gateway tools", "upstream mcp server", man.mcp.ID(), "adding", len(toAdd), "removing", len(toRemove))
 	if len(toRemove) > 0 {
 		man.gatewayServer.DeleteTools(toRemove...)
 	}
 	if len(toAdd) > 0 {
 		man.gatewayServer.AddTools(toAdd...)
 	}
-	man.logger.Debug("internal tools", "upstream mcp server", man.MCP.ID(), "total", len(man.serverTools))
+	man.logger.Debug("internal tools", "upstream mcp server", man.mcp.ID(), "total", len(man.serverTools))
 	man.setStatus(nil, numberOfTools, invalidTools)
 }
 
 func (man *MCPManager) shouldFetchTools(event eventType) bool {
 	// fetch if no support for tools list change notifications
-	if !man.MCP.SupportsToolsListChanged() {
+	if !man.mcp.SupportsToolsListChanged() {
 		return true
 	}
 	// fetch if it is a notification
@@ -307,7 +326,7 @@ func (man *MCPManager) GetStatus() ServerValidationStatus {
 }
 
 func (man *MCPManager) setStatus(err error, toolCount int, invalidTools []InvalidToolInfo) {
-	man.status.ID = string(man.MCP.ID())
+	man.status.ID = string(man.mcp.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()
 	man.status.InvalidTools = len(invalidTools)
@@ -332,18 +351,18 @@ func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {
 			existingToolID, ok := existingTool.Meta.AdditionalFields[gatewayServerID]
 			if !ok {
 				// should never happen as we are adding every time
-				man.logger.Error("unable to check conflict, tool id is missing", "upstream mcp server", man.MCP.ID())
+				man.logger.Error("unable to check conflict, tool id is missing", "upstream mcp server", man.mcp.ID())
 				continue
 			}
 			toolID, is := existingToolID.(string)
 			if !is {
 				// also should never happen
-				man.logger.Error("unable to check conflict, tool id is not a string", "upstream mcp server", man.MCP.ID(), "type", reflect.TypeOf(existingToolID))
+				man.logger.Error("unable to check conflict, tool id is not a string", "upstream mcp server", man.mcp.ID(), "type", reflect.TypeOf(existingToolID))
 				continue
 			}
 
-			if existingToolName == tool.Tool.GetName() && toolID != string(man.MCP.ID()) {
-				man.logger.Debug("tool name conflict found", "upstream mcp server", man.MCP.ID(), "existing", existingToolName, "new", tool.Tool.GetName(), "conflicting server", toolID)
+			if existingToolName == tool.Tool.GetName() && toolID != string(man.mcp.ID()) {
+				man.logger.Debug("tool name conflict found", "upstream mcp server", man.mcp.ID(), "existing", existingToolName, "new", tool.Tool.GetName(), "conflicting server", toolID)
 				conflictingToolNames = append(conflictingToolNames, tool.Tool.GetName())
 			}
 
@@ -360,7 +379,7 @@ func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {
 func (man *MCPManager) getTools(ctx context.Context) ([]mcp.Tool, []mcp.Tool, error) {
 	tools := make([]mcp.Tool, len(man.tools))
 	copy(tools, man.tools)
-	res, err := man.MCP.ListTools(ctx, mcp.ListToolsRequest{})
+	res, err := man.mcp.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {
 		return tools, tools, fmt.Errorf("failed to get tools: %w", err)
 	}
@@ -396,7 +415,7 @@ func (man *MCPManager) SetToolsForTesting(tools []mcp.Tool) {
 	// set a tools map for quick look up by other functions
 	for i := range tools {
 		man.toolsMap[tools[i].Name] = &tools[i]
-		man.servedToolsMap[prefixedName(man.MCP.GetPrefix(), tools[i].Name)] = &tools[i]
+		man.servedToolsMap[prefixedName(man.mcp.GetPrefix(), tools[i].Name)] = &tools[i]
 	}
 }
 
@@ -406,12 +425,19 @@ func (man *MCPManager) SetStatusForTesting(status ServerValidationStatus) {
 	man.status = status
 }
 
+// NewActiveForTesting wraps a manager as an ActiveMCPServer without starting
+// the event loop. Stop is a no-op. Only for use in tests that need a static
+// manager with pre-seeded tools/status.
+func NewActiveForTesting(man *MCPManager) ActiveMCPServer {
+	return &activeMCP{manager: man, cancel: func() {}}
+}
+
 func (man *MCPManager) removeAllTools() {
 	man.toolsLock.Lock()
 	toolsToRemove := make([]string, 0, len(man.serverTools))
-	man.logger.Debug("removing tools from gateway", "upstream mcp server", man.MCP.ID(), "total", len(man.serverTools))
+	man.logger.Debug("removing tools from gateway", "upstream mcp server", man.mcp.ID(), "total", len(man.serverTools))
 	for _, tool := range man.serverTools {
-		man.logger.Debug("removing tool from server ", "upstream mcp server", man.MCP.ID(), "tool", tool.Tool.Name)
+		man.logger.Debug("removing tool from server ", "upstream mcp server", man.mcp.ID(), "tool", tool.Tool.Name)
 		toolsToRemove = append(toolsToRemove, tool.Tool.Name)
 	}
 	man.serverTools = []server.ServerTool{}
@@ -420,13 +446,13 @@ func (man *MCPManager) removeAllTools() {
 	man.servedToolsMap = map[string]*mcp.Tool{}
 	man.toolsLock.Unlock()
 	man.gatewayServer.DeleteTools(toolsToRemove...)
-	man.logger.Debug("removed all tools", "upstream mcp server", man.MCP.ID(), "count", len(toolsToRemove))
+	man.logger.Debug("removed all tools", "upstream mcp server", man.mcp.ID(), "count", len(toolsToRemove))
 }
 
 func (man *MCPManager) toolToServerTool(newTool mcp.Tool) server.ServerTool {
-	newTool.Name = prefixedName(man.MCP.GetPrefix(), newTool.Name)
+	newTool.Name = prefixedName(man.mcp.GetPrefix(), newTool.Name)
 	newTool.Meta = mcp.NewMetaFromMap(map[string]any{
-		gatewayServerID: string(man.MCP.ID()),
+		gatewayServerID: string(man.mcp.ID()),
 	})
 	return server.ServerTool{
 		Tool: newTool,
@@ -459,7 +485,7 @@ func (man *MCPManager) diffTools(oldTools, newTools []mcp.Tool) ([]server.Server
 	for _, oldTool := range oldToolMap {
 		_, ok := newToolMap[oldTool.Name]
 		if !ok {
-			removedTools = append(removedTools, prefixedName(man.MCP.GetPrefix(), oldTool.Name))
+			removedTools = append(removedTools, prefixedName(man.mcp.GetPrefix(), oldTool.Name))
 		}
 	}
 

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -85,8 +85,6 @@ type MCPManager struct {
 	servedToolsMap map[string]*mcp.Tool
 	// toolsLock protects tools, serverTools
 	toolsLock sync.RWMutex
-	// manageMu serializes concurrent manage calls from the ticker and notification goroutines
-	manageMu sync.Mutex
 
 	logger *slog.Logger
 
@@ -198,8 +196,6 @@ func (man *MCPManager) registerCallbacks() func() {
 
 // manage should be the only entry point that triggers changes to tools
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
-	man.manageMu.Lock()
-	defer man.manageMu.Unlock()
 	man.logger.Debug("managing connection", "upstream mcp server", man.MCP.ID(), "event type", event)
 	var numberOfTools = 0
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -93,9 +93,9 @@ type MCPManager struct {
 
 	// events funnels notifications into the Start() loop. Buffer of 1 coalesces
 	// rapid notifications; safe because manage() always does a full tool sync.
-	events chan eventType
-	stopOnce sync.Once      // ensures Stop() is only executed once
-	done     chan struct{}  // triggers the exit of the select and routine
+	events   chan eventType
+	stopOnce sync.Once     // ensures Stop() is only executed once
+	done     chan struct{} // triggers the exit of the select and routine
 	status   ServerValidationStatus
 }
 

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,9 +28,10 @@ type MockMCP struct {
 	pingErr             error
 	tools               []mcp.Tool
 	listToolsErr        error
+	listToolsDelay      time.Duration
 	protocolVersion     string
 	hasToolsCap         bool
-	connected           bool
+	connected           atomic.Bool
 	notificationHandler func(mcp.JSONRPCNotification)
 }
 
@@ -53,7 +55,7 @@ func (m *MockMCP) Connect(_ context.Context, onConnected func()) error {
 	if m.connectErr != nil {
 		return m.connectErr
 	}
-	m.connected = true
+	m.connected.Store(true)
 	if onConnected != nil {
 		onConnected()
 	}
@@ -65,11 +67,18 @@ func (m *MockMCP) SupportsToolsListChanged() bool {
 }
 
 func (m *MockMCP) Disconnect() error {
-	m.connected = false
+	m.connected.Store(false)
 	return nil
 }
 
-func (m *MockMCP) ListTools(_ context.Context, _ mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+func (m *MockMCP) ListTools(ctx context.Context, _ mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+	if m.listToolsDelay > 0 {
+		select {
+		case <-time.After(m.listToolsDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	if m.listToolsErr != nil {
 		return nil, m.listToolsErr
 	}
@@ -435,7 +444,7 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	manager.Stop()
 
 	// verify manager state after stop
-	assert.False(t, mock.connected, "mock should be disconnected after stop")
+	assert.False(t, mock.connected.Load(), "mock should be disconnected after stop")
 }
 
 func TestMCPManager_manage_ConnectError(t *testing.T) {
@@ -1094,4 +1103,41 @@ func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 	wg.Wait()
 	tools := manager.GetManagedTools()
 	assert.NotEmpty(t, tools, "tools should be present after concurrent access")
+}
+
+// TestMCPManager_StopRaceWithManage calls Stop() from a separate goroutine
+// while manage() is in flight. Run with -race to catch unsynchronized reads
+// of man.tools and man.serverTools in getTools/shouldFetchTools/setStatus.
+func TestMCPManager_StopRaceWithManage(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("race-server", "race_")
+	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
+	mock.hasToolsCap = false
+	// slow down ListTools so manage() is mid-flight when Stop() fires
+	mock.listToolsDelay = 50 * time.Millisecond
+	gateway := NewMockGatewayServer()
+	manager, err := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// seed tools so getTools reads a non-empty slice
+	manager.SetToolsForTesting([]mcp.Tool{validTool("tool1"), validTool("tool2")})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		manager.manage(ctx, eventTypeTimer)
+	}()
+
+	// give manage() time to enter getTools -> ListTools (which is delayed)
+	time.Sleep(10 * time.Millisecond)
+
+	// Stop() from a different goroutine — removeAllTools writes man.tools
+	// while getTools is reading it
+	manager.Stop()
+
+	wg.Wait()
 }

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -19,17 +19,18 @@ import (
 
 // MockMCP implements the MCP interface for testing
 type MockMCP struct {
-	name            string
-	prefix          string
-	id              config.UpstreamMCPID
-	cfg             *config.MCPServer
-	connectErr      error
-	pingErr         error
-	tools           []mcp.Tool
-	listToolsErr    error
-	protocolVersion string
-	hasToolsCap     bool
-	connected       bool
+	name                string
+	prefix              string
+	id                  config.UpstreamMCPID
+	cfg                 *config.MCPServer
+	connectErr          error
+	pingErr             error
+	tools               []mcp.Tool
+	listToolsErr        error
+	protocolVersion     string
+	hasToolsCap         bool
+	connected           bool
+	notificationHandler func(mcp.JSONRPCNotification)
 }
 
 func (m *MockMCP) GetName() string {
@@ -75,7 +76,9 @@ func (m *MockMCP) ListTools(_ context.Context, _ mcp.ListToolsRequest) (*mcp.Lis
 	return &mcp.ListToolsResult{Tools: m.tools}, nil
 }
 
-func (m *MockMCP) OnNotification(_ func(notification mcp.JSONRPCNotification)) {}
+func (m *MockMCP) OnNotification(handler func(notification mcp.JSONRPCNotification)) {
+	m.notificationHandler = handler
+}
 
 func (m *MockMCP) OnConnectionLost(_ func(err error)) {}
 
@@ -1016,4 +1019,77 @@ func TestMCPManager_NewUpstreamMCPManager_nilGateway(t *testing.T) {
 	_, err := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gateway server is required")
+}
+
+func TestMCPManager_EventChannel_NotificationRoutesThrough(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	mock.tools = []mcp.Tool{validTool("tool1")}
+	mock.hasToolsCap = true
+	gateway := NewMockGatewayServer()
+	manager, err := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go manager.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return len(gateway.ListTools()) == 1
+	}, time.Second, 10*time.Millisecond, "initial tools should be added")
+
+	// simulate upstream adding a tool
+	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
+
+	// fire notification through the captured callback
+	require.NotNil(t, mock.notificationHandler, "notification handler should be registered")
+	mock.notificationHandler(mcp.JSONRPCNotification{
+		Notification: mcp.Notification{Method: notificationToolsListChanged},
+	})
+
+	require.Eventually(t, func() bool {
+		tools := gateway.ListTools()
+		_, has := tools["test_tool2"]
+		return len(tools) == 2 && has
+	}, time.Second, 10*time.Millisecond, "notification should trigger tool sync")
+}
+
+func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	mock.hasToolsCap = false
+	gateway := newMockToolsAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	const readers = 10
+	const iterations = 100
+
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				tools := manager.GetManagedTools()
+				assert.NotNil(t, tools)
+				_ = manager.GetServedManagedTool("test_tool1")
+			}
+		}()
+	}
+
+	for i := range iterations {
+		if i%2 == 0 {
+			mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
+		} else {
+			mock.tools = []mcp.Tool{validTool("tool1")}
+		}
+		manager.manage(ctx, eventTypeTimer)
+	}
+
+	wg.Wait()
+	tools := manager.GetManagedTools()
+	assert.NotEmpty(t, tools, "tools should be present after concurrent access")
 }

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1055,6 +1055,7 @@ func TestMCPManager_EventChannel_NotificationRoutesThrough(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "notification should trigger tool sync")
 }
 
+// verifies GetManagedTools/GetServedManagedTool don't race with manage() under -race.
 func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	mock := newMockMCP("test-server", "test_")
@@ -1074,7 +1075,8 @@ func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 			defer wg.Done()
 			for range iterations {
 				tools := manager.GetManagedTools()
-				assert.NotNil(t, tools)
+				n := len(tools)
+				assert.True(t, n == 0 || n == 1 || n == 2, "unexpected tool count: %d", n)
 				_ = manager.GetServedManagedTool("test_tool1")
 			}
 		}()

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -438,10 +438,12 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	manager, err := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
+	active := manager.Start(context.Background())
+
 	// calling Stop multiple times should not panic
-	manager.Stop()
-	manager.Stop()
-	manager.Stop()
+	active.Stop()
+	active.Stop()
+	active.Stop()
 
 	// verify manager state after stop
 	assert.False(t, mock.connected.Load(), "mock should be disconnected after stop")
@@ -1105,39 +1107,33 @@ func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 	assert.NotEmpty(t, tools, "tools should be present after concurrent access")
 }
 
-// TestMCPManager_StopRaceWithManage calls Stop() from a separate goroutine
-// while manage() is in flight. Run with -race to catch unsynchronized reads
-// of man.tools and man.serverTools in getTools/shouldFetchTools/setStatus.
-func TestMCPManager_StopRaceWithManage(t *testing.T) {
+// TestMCPManager_StopDuringManage starts the event loop, triggers a manage()
+// cycle via the events channel (with a slow ListTools), then calls Stop() while
+// manage() is in-flight. Verifies the shutdown path completes without deadlock.
+func TestMCPManager_StopDuringManage(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	mock := newMockMCP("race-server", "race_")
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false
 	// slow down ListTools so manage() is mid-flight when Stop() fires
-	mock.listToolsDelay = 50 * time.Millisecond
+	mock.listToolsDelay = 100 * time.Millisecond
 	gateway := NewMockGatewayServer()
 	manager, err := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	active := manager.Start(context.Background())
+	// let Start complete its initial manage() call
+	time.Sleep(200 * time.Millisecond)
 
-	// seed tools so getTools reads a non-empty slice
-	manager.SetToolsForTesting([]mcp.Tool{validTool("tool1"), validTool("tool2")})
+	// trigger another manage() on the event loop via the events channel;
+	// ListTools will block for 100ms giving us time to call Stop()
+	manager.events <- eventTypeNotification
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		manager.manage(ctx, eventTypeTimer)
-	}()
-
-	// give manage() time to enter getTools -> ListTools (which is delayed)
 	time.Sleep(10 * time.Millisecond)
 
-	// Stop() from a different goroutine — removeAllTools writes man.tools
-	// while getTools is reading it
-	manager.Stop()
+	// Stop() cancels the context; the event loop will finish the in-flight
+	// manage(), then select ctx.Done() and run removeAllTools
+	active.Stop()
 
-	wg.Wait()
+	assert.False(t, mock.connected.Load(), "mock should be disconnected after stop")
 }

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -514,7 +514,7 @@ func (m *mockBrokerImpl) OnConfigChange(_ context.Context, _ *config.MCPServersC
 }
 
 // RegisteredMCPServers implements broker.MCPBroker.
-func (m *mockBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]*upstream.MCPManager {
+func (m *mockBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]upstream.ActiveMCPServer {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION

**Summary**

Move to channel based synchronisation rather than mutex. Based on recent PRs , I was prompted to re-think how the manager behaves. Not code I had looked at for some time. But looking at it fresh, decided to make a change to use channels rather than mutex on the manger.

- Uses a buffer to manage if multiple notifications arrive at once rather than queuing many calls to manager behind the lock
- All mutation flows through one goroutine's select loop now. 
- toolsLock only exists for external readers
- Aligns the pattern for notification with the ticker that also uses a channel
- Sending on the channel, ensures notification handling is none blocking for the caller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Manager startup is now asynchronous and returns an active server handle with explicit Stop/inspect methods; teardown and event processing moved to an internal event loop for safer concurrency and shutdown.

* **Tests**
  * Added tests covering notification-driven updates, concurrent reads during updates, and stop-during-update shutdown races.

* **Documentation**
  * Added a “Concurrency” guideline recommending channel-based coordination before defaulting to mutexes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/943)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->