### PR TITLE
feat: implement exponential backoff for MCP health checks

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -105,7 +107,11 @@ type MCPManager struct {
 	ticker *time.Ticker
 	// tickerInterval is the interval between backend health checks
 	tickerInterval time.Duration
-	gatewayServer  ToolsAdderDeleter
+	// backoff is used to calculate the next interval on failure
+	backoff wait.Backoff
+	// baseBackoff stores the initial backoff configuration for resets
+	baseBackoff   wait.Backoff
+	gatewayServer ToolsAdderDeleter
 	// serverTools is an internal copy that contains the managed MCP's tools with prefixed names. It is these that are externally available via the gateway
 	serverTools []server.ServerTool
 	// tools is the original set from MCP server with no prefix
@@ -153,12 +159,22 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 		tickerInterval = DefaultTickerInterval
 	}
 
+	bo := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2,
+		Jitter:   0.1,
+		Steps:    10, // effectively unlimited if we cap it
+		Cap:      tickerInterval,
+	}
+
 	return &MCPManager{
 		mcp:               upstream,
 		gatewayServer:     gatewayServer,
 		promptsServer:     promptsServer,
 		tickerInterval:    tickerInterval,
 		ticker:            time.NewTicker(tickerInterval),
+		backoff:           bo,
+		baseBackoff:       bo,
 		logger:            logger,
 		invalidToolPolicy: policy,
 		toolEvents:        make(chan struct{}, 1),
@@ -273,6 +289,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.logger.Debug("attempting to connect", "upstream mcp server", man.mcp.ID())
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
 		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.mcp.ID(), err)
+		man.logger.Error("connection failed", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.removeAllTools()
 		man.removeAllPrompts()
 		// we call disconnect here as we may have connected but failed to initialize
@@ -445,12 +462,25 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
+		man.applyBackoff()
 		return
 	}
 	man.status.TotalTools = toolCount
 	man.status.TotalPrompts = promptCount
 	man.status.Ready = true
 	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
+	man.resetBackoff()
+}
+
+func (man *MCPManager) resetBackoff() {
+	man.backoff = man.baseBackoff
+	man.ticker.Reset(man.tickerInterval)
+}
+
+func (man *MCPManager) applyBackoff() {
+	duration := man.backoff.Step()
+	man.logger.Debug("applying backoff", "duration", duration, "upstream mcp server", man.mcp.ID())
+	man.ticker.Reset(duration)
 }
 
 func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1361,3 +1361,54 @@ func TestMCPManager_manage_PromptsNilServer(t *testing.T) {
 	assert.True(t, status.Ready)
 	assert.Equal(t, 1, status.TotalTools)
 }
+
+func TestMCPManager_Backoff(t *testing.T) {
+	ctx := context.Background()
+
+	mock := newMockMCP("test-server", "")
+	mock.hasToolsCap = false // Force it to fetch tools on every tick
+	gateway := newMockToolsAdderDeleter()
+
+	// Set a long ticker interval
+	tickerInterval := time.Minute
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, slog.Default(), tickerInterval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	// Initially, steps should be 10 (as configured in NewUpstreamMCPManager)
+	assert.Equal(t, 10, manager.backoff.Steps)
+
+	// 1. Simulate failure
+	mock.connectErr = fmt.Errorf("connect error")
+	manager.manage(ctx, eventTypeTimer)
+
+	// After failure, Steps should be 9
+	assert.Equal(t, 9, manager.backoff.Steps)
+
+	// 2. Simulate another failure
+	manager.manage(ctx, eventTypeTimer)
+	assert.Equal(t, 8, manager.backoff.Steps)
+
+	// 3. Simulate success
+	mock.connectErr = nil
+	manager.manage(ctx, eventTypeTimer)
+
+	// 4. Test Ping failure
+	mock.pingErr = fmt.Errorf("ping error")
+	manager.manage(ctx, eventTypeTimer)
+	assert.Equal(t, 9, manager.backoff.Steps)
+
+	// Reset
+	mock.pingErr = nil
+	manager.manage(ctx, eventTypeTimer)
+	assert.Equal(t, 10, manager.backoff.Steps)
+
+	// 5. Test ListTools failure
+	mock.listToolsErr = fmt.Errorf("list tools error")
+	manager.manage(ctx, eventTypeTimer)
+	assert.Equal(t, 9, manager.backoff.Steps)
+
+	// Reset
+	mock.listToolsErr = nil
+	manager.manage(ctx, eventTypeTimer)
+	assert.Equal(t, 10, manager.backoff.Steps)
+}

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -967,7 +967,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			"X-Mcp-Virtualserver": virtualServerHeader,
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer virtualServerClient.Close()
+		defer func() { _ = virtualServerClient.Close() }()
 
 		By("Verifying only the allowed prompt is returned via virtual server")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
Implements exponential backoff for MCP health checks using k8s.io/apimachinery/pkg/util/wait.

This addresses the feedback from PR #805:
- Uses a standard Kubernetes utility instead of a custom one.
- Includes jitter to prevent thundering herd.
- Resets backoff immediately on success.
- Applies backoff immediately after the first failure.

Closes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exponential backoff to upstream manager error handling for improved failure recovery.

* **Bug Fixes**
  * Enhanced status reporting to reflect current tool count when tool fetching is skipped.
  * Added error logging for connection failures.

* **Tests**
  * Added test coverage for backoff behavior under various failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/948)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->