### PR TITLE
fix: add missing mcpLock.RLock in findServerByName to prevent data race

### DIFF
--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -135,6 +135,8 @@ func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []strin
 }
 
 func (broker *mcpBrokerImpl) findServerByName(name string) *upstream.MCPManager {
+	broker.mcpLock.RLock()
+	defer broker.mcpLock.RUnlock()
 	for _, upstream := range broker.mcpServers {
 		if upstream.MCPName() == name {
 			return upstream

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -609,7 +609,7 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 	}
 }
 func TestFindServerByName_ConcurrentConfigChange(t *testing.T) {
-	b := NewBroker(logger)
+	b := NewBroker(slog.Default())
 	bImpl, ok := b.(*mcpBrokerImpl)
 	require.True(t, ok)
 

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -5,15 +5,19 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -603,4 +607,46 @@ func TestCombinedAuthorizedToolsAndVirtualServer(t *testing.T) {
 			}
 		})
 	}
+}
+func TestFindServerByName_ConcurrentConfigChange(t *testing.T) {
+	b := NewBroker(logger)
+	bImpl, ok := b.(*mcpBrokerImpl)
+	require.True(t, ok)
+
+	bImpl.mcpServers["server1"] = createTestManager(t, "server1", "", []mcp.Tool{
+		mcp.NewTool("tool1"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					bImpl.findServerByName("server1")
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			bImpl.mcpLock.Lock()
+			id := config.UpstreamMCPID(fmt.Sprintf("server%d", i))
+			bImpl.mcpServers[id] = createTestManager(t, fmt.Sprintf("server%d", i), "", []mcp.Tool{})
+			bImpl.mcpLock.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #947

`findServerByName` in `filtered_tools_handler.go` was iterating `broker.mcpServers` with no lock held. Every other method that reads `mcpServers` acquires `mcpLock.RLock()` first — this was a clear oversight.

`findServerByName` is called from `filterToolsByServerMap` → `FilterTools` which fires on every concurrent `tools/list` request, while `OnConfigChange` writes to `mcpServers` under `mcpLock.Lock()`. This is a data race in production.

Fix adds `mcpLock.RLock()/RUnlock()` to `findServerByName` and includes a regression test that confirms the race is gone with `go test -race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved concurrent access handling during server lookup operations to enhance system stability under simultaneous requests.

## Tests
* Added concurrency test validating server configuration behavior during active concurrent lookups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/951)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->