### PR TITLE
ci: add linkinator broken-link check for documentation

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,10 +1,13 @@
-name: CI Docs Skip
+name: CI Docs
 
 # Provides pass statuses for required checks when only non-code files change.
 # Without this, PRs touching only these paths can never merge because the real
 # workflows use paths-ignore and never report a status for the required checks.
 # The paths list below is the union of all paths-ignore entries from
 # images.yaml, tests.yaml, and code-style.yaml.
+#
+# linkinator checks for broken links in changed markdown files.
+# Experimental: see https://github.com/Kuadrant/mcp-gateway/pull/952
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -52,3 +55,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Docs-only change, skipping code style"
+
+  documentation-links:
+    name: Documentation Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed markdown files
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            files=$(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '*.md')
+          else
+            files="**/*.md"
+          fi
+
+          if [ -z "$files" ]; then
+            echo "paths=" >> "$GITHUB_OUTPUT"
+            echo "No markdown files changed"
+          else
+            paths=$(echo "$files" | tr '\n' ' ')
+            echo "paths=$paths" >> "$GITHUB_OUTPUT"
+            echo "Scanning: $paths"
+          fi
+
+      - uses: JustinBeckwith/linkinator-action@v2
+        if: steps.changed.outputs.paths != ''
+        with:
+          paths: ${{ steps.changed.outputs.paths }}

--- a/.github/workflows/linkinator-weekly.yaml
+++ b/.github/workflows/linkinator-weekly.yaml
@@ -1,0 +1,24 @@
+name: Documentation Link Check (Weekly)
+
+# Weekly full-repo broken link scan.
+# Experimental: see https://github.com/Kuadrant/mcp-gateway/pull/952
+
+on:
+  schedule:
+    # Monday at 06:07 UTC
+    - cron: '7 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-link-check:
+    name: Full Documentation Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JustinBeckwith/linkinator-action@v2
+        with:
+          paths: "**/*.md"

--- a/docs/design/auth-phase-1.md
+++ b/docs/design/auth-phase-1.md
@@ -44,7 +44,7 @@ To provide auth integration, the MCP gateway uses [Kuadrant](https://kuadrant.io
 
 The MCP gateway exposes a single endpoint via the Ingress gateway that acts as an MCP server to MCP clients. It is this host and path the client will connect to. To enforce authenticated access, the gateway `HTTPRoute` exposing the MCP gateway to clients, uses a Kuadrant AuthPolicy resource. This resource can define what authentication must be met and also enforce authorization requirements:
 
-[Example AuthPolicy](./../../config/mcp-system/authpolicy.yaml)
+[Example AuthPolicy](./../../config/samples/remote-github/authpolicy.yaml)
 
 
 With this policy in place any unauthenticated request not going to the /.well-known endpoints will get a 401 and WWW-Authenticate header with a resource_metadata url specified. It is then up to the client to leverage this information to retrieve the resource metadata to know how to authenticate to access the resource. 
@@ -95,7 +95,7 @@ example response:
 
 ### Authenticated MCP Gateway Calls
 
-Once a client has obtained a token, it can then make requests to the MCP Gateway. When a request comes to the gateway, the Kuadrant WASM plugin intercepts this request and based on configuration, will decide whether or not to call to the Authorino component. With the [Example AuthPolicy](./../../config/mcp-system/authpolicy.yaml), Authorino will receive the request and then validate the token with the configured auth server before allowing the request to continue.
+Once a client has obtained a token, it can then make requests to the MCP Gateway. When a request comes to the gateway, the Kuadrant WASM plugin intercepts this request and based on configuration, will decide whether or not to call to the Authorino component. With the [Example AuthPolicy](./../../config/samples/remote-github/authpolicy.yaml), Authorino will receive the request and then validate the token with the configured auth server before allowing the request to continue.
 
 ### Token Exchange for Legacy API Keys
 
@@ -108,7 +108,7 @@ When the router receives a tools/call, it sets some headers for use by other com
 `x-mcp-toolname:` used to indicate what tool (including prefix) is being accessed
 `x-mcp-method:` used to indicate the json RPC method being called
 
-There is an [example second AuthPolicy](../../config/mcp-system/tool-call-auth.yaml) that targets a second listener in the Gateway that is dedicated to routing MCP server requests. This AuthPolicy, via Authorino, fetches metadata that defines an ACL. This is a simplistic example to illustrate how data can be fetched dynamically to make these decisions. It then uses this data in the authorization phase to allow or deny access.
+There is an [example second AuthPolicy](../../config/samples/oauth-token-exchange/tools-call-auth.yaml) that targets a second listener in the Gateway that is dedicated to routing MCP server requests. This AuthPolicy, via Authorino, fetches metadata that defines an ACL. This is a simplistic example to illustrate how data can be fetched dynamically to make these decisions. It then uses this data in the authorization phase to allow or deny access.
 In addition to this simplistic ACL, we will also provide an example that uses the Keycloak resource roles feature to define access to tools.
 
 AuthPolicy here uses 3 key phases

--- a/docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md
+++ b/docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md
@@ -365,11 +365,11 @@ If the upstream MCP server shares the same identity provider as the gateway, onl
 
 | Approach | When to Use |
 |----------|-------------|
-| **credentialRef** (static secret) | Broker-only token for tool discovery and caching |
-| **Header-based token replacement** ([guide](../../guides/external-mcp-server-with-token-replacement.md)) | Client supports custom headers, simple setup |
-| **Vault token exchange** ([guide](../../guides/vault-token-exchange.md)) | Centralized token management, admin-provisioned per-user secrets |
-| **URL elicitation + broker page** (this design) | Self-service per-user tokens, no client configuration, no external infrastructure |
-| **URL elicitation + external UI** (this design) | Self-service per-user tokens with existing token infrastructure (e.g., Vault), AuthPolicy handles injection |
+| **credentialRef** (static secret) | Broker-only credential for tool discovery and caching |
+| **Header-based token replacement** | Client supports custom headers, simple setup |
+| **Vault token exchange** ([guide](../../guides/vault-token-exchange.md)) | Centralized credential management, admin-provisioned per-user secrets |
+| **URL elicitation + broker page** (this design) | Self-service per-user credentials, no client configuration, no external infrastructure |
+| **URL elicitation + external UI** (this design) | Self-service per-user credentials with existing credential infrastructure (e.g., Vault), AuthPolicy handles injection |
 
 ## Future Considerations
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,0 +1,12 @@
+{
+    "skip": [
+        "^https?://localhost:(3000|6274|8080|8200|8888|15000)",
+        "sslip\\.io",
+        "api\\.githubcopilot\\.com",
+        "example\\.com",
+        "your-cluster"
+    ],
+    "recurse": true,
+    "directoryListing": true,
+    "markdown": true
+}


### PR DESCRIPTION
# Summary

- Adds a per-PR linkinator job to `ci-docs.yaml` that scans only changed markdown files for broken links
- Adds a weekly full-repo link scan (`linkinator-weekly.yaml`) on Monday mornings with manual dispatch support
- Fixes four broken documentation links in `auth-phase-1.md` and `gateway-url-token-elicitation-design.md` found during initial linkinator testing
- Adds `linkinator.config.json` to skip localhost, example, and placeholder URLs
- Renames `ci-docs-skip.yaml` to `ci-docs.yaml` to reflect expanded scope

# Details

The PR job only scans markdown files that changed in the PR (`git diff --diff-filter=d`), keeping CI fast for typical doc-only changes. The weekly job scans all `**/*.md` to catch link rot from upstream changes (renamed files, removed pages, expired external URLs).

The config file skips URLs that are expected to be unreachable in CI: localhost ports used in guides, `sslip.io` dynamic DNS, `example.com` placeholders, and `api.githubcopilot.com`.

Both workflows are marked experimental with a link back to this PR for tracking.

# Broken links fixed

- `config/mcp-system/authpolicy.yaml` → `config/samples/remote-github/authpolicy.yaml` (file was moved)
- `config/mcp-system/tool-call-auth.yaml` → `config/samples/oauth-token-exchange/tools-call-auth.yaml` (file was moved)
- Removed dead link to `docs/guides/external-mcp-server-with-token-replacement.md` (file does not exist)
- Added missing trailing newline to `auth-phase-1.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the CI Docs workflow and added a conditional per-PR Markdown link-check job that runs only when docs change; added a new weekly scheduled link-check workflow with concurrency control.
  * Expanded link-check configuration to skip additional local-dev ports and extra development domains/patterns.

* **Documentation**
  * Updated design docs to reference different sample configurations, refined examples/diagrams, and adjusted wording and link references in a comparison table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->