### PR TITLE
feat(router): add plumbing for MCP sampling support

### DIFF
--- a/config/mcp-gateway/base/mcpgatewayextension.yaml
+++ b/config/mcp-gateway/base/mcpgatewayextension.yaml
@@ -3,6 +3,7 @@ kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway-extension
 spec:
+  httpRouteManagement: Disabled
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1330,6 +1330,23 @@ func TestBuildGatewayHTTPRoute(t *testing.T) {
 			if parentRef.SectionName == nil || string(*parentRef.SectionName) != tt.mcpExt.Spec.TargetRef.SectionName {
 				t.Errorf("parentRef sectionName = %v, want %q", parentRef.SectionName, tt.mcpExt.Spec.TargetRef.SectionName)
 			}
+			if len(route.Spec.Rules) != 2 {
+				t.Fatalf("rules len = %d, want 2", len(route.Spec.Rules))
+			}
+
+			gotPaths := map[string]bool{}
+			for _, rule := range route.Spec.Rules {
+				if len(rule.Matches) == 0 || rule.Matches[0].Path == nil || rule.Matches[0].Path.Value == nil {
+					t.Fatalf("rule missing path match: %+v", rule)
+				}
+				gotPaths[*rule.Matches[0].Path.Value] = true
+			}
+			if !gotPaths["/mcp"] {
+				t.Errorf("missing /mcp rule")
+			}
+			if !gotPaths["/.well-known/oauth-protected-resource"] {
+				t.Errorf("missing /.well-known/oauth-protected-resource rule")
+			}
 		})
 	}
 }

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
+	"github.com/Kuadrant/mcp-gateway/internal/idmap"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
 	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -73,6 +74,9 @@ const (
 	elicitationActionAccept  = "accept"
 	elicitationActionDecline = "decline"
 	elicitationActionCancel  = "cancel"
+
+	samplingResultRole    = "role"
+	samplingResultContent = "content"
 )
 
 // MCPRequest encapsulates a mcp protocol request to the gateway
@@ -81,7 +85,7 @@ type MCPRequest struct {
 	JSONRPC           string            `json:"jsonrpc"`
 	Method            string            `json:"method,omitempty"`
 	Params            map[string]any    `json:"params,omitempty"`
-	Result            map[string]any    `json:"result,omitempty"` // set in elicitation responses (which are a request from the client)
+	Result            map[string]any    `json:"result,omitempty"` // set in elicitation/sampling responses (which are a request from the client)
 	Headers           *corev3.HeaderMap `json:"-"`
 	Streaming         bool              `json:"-"`
 	sessionID         string            `json:"-"`
@@ -111,8 +115,8 @@ func (mr *MCPRequest) Validate() (bool, error) {
 	if mr.JSONRPC != "2.0" {
 		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("json rpc version invalid"))
 	}
-	// elicitation responses (sent as a request to the server) do not have the method set
-	if mr.Method == "" && !mr.isElicitationResponse() {
+	// elicitation/sampling responses (sent as a request to the server) do not have the method set
+	if mr.Method == "" && !mr.isElicitationResponse() && !mr.isSamplingResponse() {
 		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("no method set in json rpc payload"))
 	}
 	if mr.ID == nil && !mr.isNotificationRequest() {
@@ -151,6 +155,19 @@ func (mr *MCPRequest) clientSupportsElicitation() bool {
 	}
 	_, hasElicitation := capsMap["elicitation"]
 	return hasElicitation
+}
+
+func (mr *MCPRequest) isSamplingResponse() bool {
+	if mr.Method != "" || mr.Result == nil {
+		return false
+	}
+	if _, ok := mr.Result[samplingResultRole].(string); !ok {
+		return false
+	}
+	if _, ok := mr.Result[samplingResultContent]; !ok {
+		return false
+	}
+	return true
 }
 
 func (mr *MCPRequest) isElicitationResponse() bool {
@@ -249,6 +266,9 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	case mcpReq.isElicitationResponse():
 		span.SetAttributes(attribute.String("mcp.route", "elicitation-response"))
 		return s.HandleElicitationResponse(ctx, mcpReq)
+	case mcpReq.isSamplingResponse():
+		span.SetAttributes(attribute.String("mcp.route", "sampling-response"))
+		return s.HandleSamplingResponse(ctx, mcpReq)
 	case mcpReq.Method == methodToolCall:
 		span.SetAttributes(attribute.String("mcp.route", "tool-call"))
 		return s.HandleToolCall(ctx, mcpReq)
@@ -579,7 +599,27 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	ctx context.Context,
 	mcpReq *MCPRequest,
 ) []*eppb.ProcessingResponse {
-	ctx, span := tracer().Start(ctx, "mcp-router.elicitation-response",
+	return s.handleServerInitiatedResponse(ctx, mcpReq, s.ElicitationMap, "elicitation")
+}
+
+// HandleSamplingResponse routes a sampling/createMessage response from the client to the correct backend server
+func (s *ExtProcServer) HandleSamplingResponse(
+	ctx context.Context,
+	mcpReq *MCPRequest,
+) []*eppb.ProcessingResponse {
+	return s.handleServerInitiatedResponse(ctx, mcpReq, s.SamplingMap, "sampling")
+}
+
+// handleServerInitiatedResponse routes a client response for a server-initiated request
+// (elicitation/create or sampling/createMessage) back to the correct backend server using
+// the supplied id map.
+func (s *ExtProcServer) handleServerInitiatedResponse(
+	ctx context.Context,
+	mcpReq *MCPRequest,
+	idMap idmap.Map,
+	kind string,
+) []*eppb.ProcessingResponse {
+	ctx, span := tracer().Start(ctx, "mcp-router."+kind+"-response",
 		trace.WithAttributes(
 			componentAttr,
 			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
@@ -597,23 +637,23 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	gatewayID := fmt.Sprint(mcpReq.ID)
 
-	entry, ok, err := s.ElicitationMap.Lookup(ctx, gatewayID)
+	entry, ok, err := idMap.Lookup(ctx, gatewayID)
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to lookup elicitation mapping", "error", err, "gatewayID", gatewayID)
-		mcpotel.SpanError(span, err, "elicitation lookup failed")
+		s.Logger.ErrorContext(ctx, "failed to lookup "+kind+" mapping", "error", err, "gatewayID", gatewayID)
+		mcpotel.SpanError(span, err, kind+" lookup failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
 	if !ok {
-		lookupErr := fmt.Errorf("elicitation response for unknown gateway ID: %s", gatewayID)
-		s.Logger.ErrorContext(ctx, "elicitation response for unknown gateway ID", "gatewayID", gatewayID)
-		mcpotel.SpanError(span, lookupErr, "unknown elicitation ID")
-		response.WithImmediateResponse(400, "unknown elicitation ID")
+		lookupErr := fmt.Errorf("%s response for unknown gateway ID: %s", kind, gatewayID)
+		s.Logger.ErrorContext(ctx, kind+" response for unknown gateway ID", "gatewayID", gatewayID)
+		mcpotel.SpanError(span, lookupErr, "unknown "+kind+" ID")
+		response.WithImmediateResponse(400, "unknown "+kind+" ID")
 		return response.Build()
 	}
 	if entry.GatewaySessionID != mcpReq.GetSessionID() {
-		mismatchErr := fmt.Errorf("elicitation session mismatch: expected %s, got %s", entry.GatewaySessionID, mcpReq.GetSessionID())
-		s.Logger.ErrorContext(ctx, "elicitation session mismatch", "gatewayID", gatewayID, "expected", entry.GatewaySessionID, "got", mcpReq.GetSessionID())
+		mismatchErr := fmt.Errorf("%s session mismatch: expected %s, got %s", kind, entry.GatewaySessionID, mcpReq.GetSessionID())
+		s.Logger.ErrorContext(ctx, kind+" session mismatch", "gatewayID", gatewayID, "expected", entry.GatewaySessionID, "got", mcpReq.GetSessionID())
 		mcpotel.SpanError(span, mismatchErr, "session mismatch")
 		response.WithImmediateResponse(403, "session mismatch")
 		return response.Build()
@@ -624,7 +664,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(entry.ServerName)
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "server not found for elicitation response", "server", entry.ServerName)
+		s.Logger.ErrorContext(ctx, "server not found for "+kind+" response", "server", entry.ServerName)
 		mcpotel.SpanError(span, err, "server not found")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
@@ -632,7 +672,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	headers := NewHeaders()
 	headers.WithAuthority(mcpServerConfig.Hostname)
-	headers.WithMCPSession(entry.SessionID) // entry.SessionID contains the backend session id from when the elicitation request was made
+	headers.WithMCPSession(entry.SessionID) // backend session id captured when the server-initiated request was made
 	headers.WithMCPServerName(entry.ServerName)
 	path, err := mcpServerConfig.Path()
 	if err != nil {
@@ -645,7 +685,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	body, err := mcpReq.ToBytes()
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to get bytes for elicitation response", "mcpReqID", mcpReq.ID, "serverName", entry.ServerName)
+		s.Logger.ErrorContext(ctx, "failed to get bytes for "+kind+" response", "mcpReqID", mcpReq.ID, "serverName", entry.ServerName)
 		mcpotel.SpanError(span, err, "marshal failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
@@ -654,8 +694,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	headers.WithContentLength(len(body))
 	response.WithRequestBodyHeadersAndBodyResponse(headers.Build(), body)
 
-	// remove the mapping only after the response was successfully built
-	s.ElicitationMap.Remove(ctx, gatewayID)
+	idMap.Remove(ctx, gatewayID)
 
 	return response.Build()
 }

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -34,6 +34,8 @@ type SessionCache interface {
 	SetUserToken(ctx context.Context, sessionID, serverName, token string) error
 	GetUserToken(ctx context.Context, sessionID, serverName string) (string, bool, error)
 	DeleteUserToken(ctx context.Context, sessionID, serverName string) error
+	SetClientSampling(ctx context.Context, gatewaySessionID string) error
+	GetClientSampling(ctx context.Context, gatewaySessionID string) (bool, error)
 }
 
 // InitForClient defines a function for initializing an MCP server for a client.
@@ -50,6 +52,7 @@ type ExtProcServer struct {
 	SessionCache        SessionCache
 	ElicitationMap      idmap.Map
 	TokenElicitationMap elicitation.Map
+	SamplingMap         idmap.Map
 	MaxRequestBodySize  int
 	ElicitationEnabled  bool
 	//TODO this should not be needed

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -10,7 +10,10 @@ import (
 	redis "github.com/redis/go-redis/v9"
 )
 
-const clientElicitationPrefix = "clientelicitation:"
+const (
+	clientElicitationPrefix = "clientelicitation:"
+	clientSamplingPrefix    = "clientsampling:"
+)
 
 const userTokenFieldPrefix = "token:"
 
@@ -59,12 +62,13 @@ func (c *Cache) DeleteSessions(ctx context.Context, key ...string) error {
 		for _, k := range key {
 			c.inmemory.Delete(k)
 			c.inmemory.Delete(clientElicitationPrefix + k)
+			c.inmemory.Delete(clientSamplingPrefix + k)
 		}
 		return nil
 	}
-	allKeys := make([]string, 0, len(key)*2)
+	allKeys := make([]string, 0, len(key)*3)
 	for _, k := range key {
-		allKeys = append(allKeys, k, clientElicitationPrefix+k)
+		allKeys = append(allKeys, k, clientElicitationPrefix+k, clientSamplingPrefix+k)
 	}
 	return c.extClient.Del(ctx, allKeys...).Err()
 }
@@ -229,6 +233,33 @@ func (c *Cache) DeleteUserToken(ctx context.Context, sessionID, serverName strin
 		return nil
 	}
 	return c.extClient.HDel(ctx, sessionID, field).Err()
+}
+
+// SetClientSampling records that the client for this gateway session supports sampling
+func (c *Cache) SetClientSampling(ctx context.Context, gatewaySessionID string) error {
+	key := clientSamplingPrefix + gatewaySessionID
+	if c.inmemory != nil {
+		c.inmemory.Store(key, true)
+		return nil
+	}
+	return c.extClient.Set(ctx, key, "1", 0).Err()
+}
+
+// GetClientSampling returns whether the client for this gateway session supports sampling
+func (c *Cache) GetClientSampling(ctx context.Context, gatewaySessionID string) (bool, error) {
+	key := clientSamplingPrefix + gatewaySessionID
+	if c.inmemory != nil {
+		_, ok := c.inmemory.Load(key)
+		return ok, nil
+	}
+	val, err := c.extClient.Get(ctx, key).Result()
+	if errors.Is(err, redis.Nil) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return val == "1", nil
 }
 
 // NewCache returns a new cache. Pass WithRedisClient to use an external redis


### PR DESCRIPTION
## Description

Phase 1 plumbing for MCP Sampling support . No user-visible behaviour change, this PR wires the data structures and dispatch path; capability negotiation and SSE rewriting will follow in later PRs.

## Fixes (part of)
* #949 

## Changes

- **`internal/session/cache.go`**
  - Adds `SetClientSampling` and `GetClientSampling`.
  - Updates `DeleteSessions` to also clear the sampling key for the gateway session.

- **`internal/mcp-router/server.go`**
  - Adds `ExtProcServer.SamplingMap`.
  - Extends the `SessionCache` interface with sampling cache methods.

- **`internal/mcp-router/request_handlers.go`**
  - Adds `isSamplingResponse()` predicate.
  - Adds a new dispatch case in `RouteMCPRequest`.
  - Adds `HandleSamplingResponse`.
  - Refactors `HandleElicitationResponse` to delegate to a shared `handleServerInitiatedResponse` helper used by both elicitation and sampling flows.


##  Why

Sampling (`sampling/createMessage`) is, like elicitation, a server-initiated JSON-RPC request sent over the SSE response stream, with the client response arriving as a separate HTTP request.

Reusing the elicitation routing machinery keeps the two flows symmetric and avoids divergent code paths.


## Follow-ups (not in this PR)

- Phase 2:
  - Declare sampling capability in `clients.Initialize`.
  - Store/read the flag on `initialize`.
  - Advertise upstream from the broker.

- Phase 3:
  - Extend `sseRewriter` to match `sampling/createMessage`.
  - Set `STREAMED` response mode.
  - Construct `SamplingMap` in `cmd/mcp-broker-router/main.go`.

- Phase 4:
  - Add a test server emitting `sampling/createMessage`.
  - Add e2e and unit tests.
  - Add optional per-`MCPServerRegistration` opt-in support.

## Manually verified as:

```bash
go build 
make lint
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sampling responses in the MCP router alongside existing elicitation responses
  * Extended session management to persist and retrieve client sampling state

* **Configuration**
  * Disabled HTTP route management in gateway extension

* **Tests**
  * Strengthened HTTP route validation to verify rule count and path matches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->