### PR TITLE
audit and sync source/OpenShift docs with current gateway behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,18 @@ make run
 The broker watches the config file for changes and hot-reloads configuration automatically.
 
 ### Controller Mode (Kubernetes)
-Discovers MCP servers dynamically from Kubernetes Gateway API `HTTPRoute` resources:
+Runs the Kubernetes controller that discovers MCP servers dynamically from `MCPServerRegistration` resources and their referenced Gateway API `HTTPRoute` objects:
 
 ```bash
 make run-controller
 # Or directly:
-./bin/mcp-broker-router --controller
+./bin/mcp-controller
 ```
 
 In controller mode:
-- Watches `MCPServer` custom resources
-- Discovers servers via `HTTPRoute` references
-- Generates aggregated configuration in `ConfigMap`, for use by the broker/router
+- Watches `MCPServerRegistration`, `MCPGatewayExtension`, and `MCPVirtualServer` custom resources
+- Resolves backend MCP servers via referenced `HTTPRoute` objects
+- Generates aggregated configuration in a Secret for the broker/router
 - Exposes health endpoints on `:8081` and metrics on `:8082`
 
 ## Configuration
@@ -153,15 +153,15 @@ servers:
 
 #### MCPServerRegistration Resource
 
-The `MCPServer` is a Kubernetes Custom Resource that defines an MCP (Model Context Protocol) server to be aggregated by the gateway. It enables discovery and federation of tools from backend MCP servers through Gateway API `HTTPRoute` references.
+The `MCPServerRegistration` resource is a Kubernetes Custom Resource that defines an MCP (Model Context Protocol) server to be aggregated by the gateway. It enables discovery and federation of tools from backend MCP servers through Gateway API `HTTPRoute` references.
 
-Each `MCPServer` resource:
+Each `MCPServerRegistration` resource:
 - References a single HTTPRoute that points to a backend MCP service
 - Configures a prefix to avoid naming conflicts when federating tools
 - Enables the controller to automatically discover and configure the broker with available MCP servers
 - Maintains status conditions to indicate whether the server is successfully discovered, valid and ready
 
-Create `MCPServer` resources that reference HTTPRoutes:
+Create `MCPServerRegistration` resources that reference HTTPRoutes:
 
 ```yaml
 apiVersion: mcp.kuadrant.io/v1alpha1
@@ -193,7 +193,12 @@ spec:
 --mcp-router-address            # gRPC ext_proc address (default: 0.0.0.0:50051)
 --mcp-broker-public-address     # HTTP broker address (default: 0.0.0.0:8080)
 --mcp-gateway-config            # Config file path (default: ./config/samples/config.yaml)
---controller                    # Enable Kubernetes controller mode
+--mcp-gateway-public-host       # Public hostname the gateway expects on incoming requests
+--mcp-gateway-private-host      # Internal host used for hairpin requests
+--session-signing-key           # JWT signing key for session tokens
+--cache-connection-string       # Optional Redis connection string for session storage
+--mcp-check-interval            # Backend health check interval in seconds
+--invalid-tool-policy           # FilterOut (default) or RejectServer for invalid upstream tools
 ```
 
 ### OAuth Configuration

--- a/config/install/README.md
+++ b/config/install/README.md
@@ -7,7 +7,7 @@ This directory provides a minimal installation of MCP Gateway with just the core
 - Kubernetes cluster (1.28+)
 - **gateway API CRDs installed** (required!)
   ```bash
-  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
   ```
 - gateway controller (istio, envoy gateway, etc.)
 - kubectl configured
@@ -16,7 +16,7 @@ This directory provides a minimal installation of MCP Gateway with just the core
 
 ## What gets installed
 
-- MCP Gateway CRDs (`MCPServer`)
+- MCP Gateway CRDs (`MCPGatewayExtension`, `MCPServerRegistration`, `MCPVirtualServer`)
 - MCP broker/router deployment
 - MCP controller deployment
 - RBAC (service accounts, roles, bindings)

--- a/config/openshift/README.md
+++ b/config/openshift/README.md
@@ -1,21 +1,36 @@
 # MCP Gateway Deployment on OpenShift
 
-The MCP Gateway can be deployed to an OpenShift environment. The assets included within this directory include resources in both Kustomize and Helm Chart formats including:
+The MCP Gateway can be deployed to an OpenShift environment. The assets in this directory cover the main OpenShift deployment flows:
 
-* OpenShift Service Mesh
-* Red Hat Connectivity Link
-* MCP Gateway
-* MCP Gateway Ingress
+- OpenShift Service Mesh or OpenShift Cluster Ingress-backed Gateway API
+- MCP Gateway controller and gateway instance
+- OpenShift Route exposure for the gateway
+- Optional Red Hat Connectivity Link installation
 
 ## Deploying to OpenShift
 
 A script named [deploy_openshift.sh](deploy_openshift.sh) is available to facilitate the deployment to OpenShift.
 
-Execute the following command to deploy each of the aforementioned components to an OpenShift cluster:
+By default the script:
+
+- installs Service Mesh support unless `INSTALL_SERVICE_MESH=false`
+- skips Red Hat Connectivity Link unless `INSTALL_RHCL=true`
+- installs the MCP Gateway controller through OLM
+- deploys the gateway instance and an OpenShift Route
+
+Execute the following command to deploy:
 
 ```shell
 ./deploy_openshift.sh
 ```
+
+Useful environment variables:
+
+- `MCP_GATEWAY_HOST` to override the public hostname
+- `MCP_GATEWAY_NAMESPACE` to change the MCP Gateway namespace
+- `GATEWAY_NAMESPACE` to change the Gateway namespace
+- `INSTALL_RHCL=true` to install Red Hat Connectivity Link explicitly
+- `USE_OCP_INGRESS=false` to use the Istio GatewayClass path instead of `openshift-default`
 
 The MCP Gateway will be available at the output of the following command:
 
@@ -53,12 +68,12 @@ To confirm that MCP Gateway has been deployed successfully, execute the followin
 ```shell
 curl -k -LX POST https://$(oc get routes -n gateway-system -o jsonpath='{ .items[0].spec.host }')/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize"}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"verify","version":"1.0"}}}'
 ```
 
 A response similar to the following indicates the MCP Gateway was successfully deployed
 
 
 ```shell
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Kagenti MCP Broker","version":"0.0.1"}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Kuadrant MCP Gateway","version":"0.0.1"}}}
 ```

--- a/docs/design/flows.md
+++ b/docs/design/flows.md
@@ -191,9 +191,9 @@ sequenceDiagram
         note left of Authorino: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource
         WASM->>MCPClient: 401 WWW-Authenticate
         note left of WASM: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource
-        MCPClient->>Gateway: .well-known/oauth-protected-resource
-        Gateway->>MCPRouter: .well-known/oauth-protected-resource
-        Gateway->>MCPBroker: .well-known/oauth-protected-resource
+        MCPClient->>Gateway: GET /.well-known/oauth-protected-resource
+        Gateway->>MCPRouter: GET /.well-known/oauth-protected-resource
+        Gateway->>MCPBroker: GET /.well-known/oauth-protected-resource
         MCPBroker->>MCPClient: auth metadata response
         MCPClient->>AuthServer: Authenticate (dynamic client reg etc)
         AuthServer->>MCPClient: Authenticated !!

--- a/docs/design/flows.md
+++ b/docs/design/flows.md
@@ -152,11 +152,11 @@ sequenceDiagram
         Gateway->>WASM: POST /mcp init
         WASM->>Authorino: Apply Auth
         Authorino->>MCPClient: 401 WWW-Authenticate with resource meta-data
-        note left of Authorino: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource/mcp
-        MCPClient->>Gateway: GET /.well-known/oauth-protected-resource/mcp
-        Gateway->>MCPRouter: GET /.well-known/oauth-protected-resource/mcp
+        note left of Authorino: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource
+        MCPClient->>Gateway: GET /.well-known/oauth-protected-resource
+        Gateway->>MCPRouter: GET /.well-known/oauth-protected-resource
         MCPRouter->>Gateway: no routing needed
-        Gateway->>MCPBroker: GET /.well-known/oauth-protected-resource/mcp
+        Gateway->>MCPBroker: GET /.well-known/oauth-protected-resource
         MCPBroker->>MCPClient: responds with resource json with configured auth server etc
         MCPClient->>AuthServer: register
         MCPClient->>AuthServer: authenticate
@@ -188,12 +188,12 @@ sequenceDiagram
         WASM->>Authorino: apply auth
         note right of Authorino: checking JWT and tool name <br/> defined in AuthPolicy
         Authorino->>WASM: 401 WWW-Authenticate
-        note left of Authorino: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource/mcp
+        note left of Authorino: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource
         WASM->>MCPClient: 401 WWW-Authenticate
-        note left of WASM: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource/mcp
-        MCPClient->>Gateway: .well-known/oauth-protected-resource/mcp
-        Gateway->>MCPRouter: .well-known/oauth-protected-resource/mcp
-        Gateway->>MCPBroker: .well-known/oauth-protected-resource/mcp
+        note left of WASM: WWW-Authenticate: Bearer <br/> resource_metadata=<host>/.well-known/oauth-protected-resource
+        MCPClient->>Gateway: .well-known/oauth-protected-resource
+        Gateway->>MCPRouter: .well-known/oauth-protected-resource
+        Gateway->>MCPBroker: .well-known/oauth-protected-resource
         MCPBroker->>MCPClient: auth metadata response
         MCPClient->>AuthServer: Authenticate (dynamic client reg etc)
         AuthServer->>MCPClient: Authenticated !!

--- a/docs/design/security-architecture.md
+++ b/docs/design/security-architecture.md
@@ -89,7 +89,7 @@ Authentication and authorization are enforced via [Kuadrant AuthPolicy](https://
 
 ### Client authentication
 
-Clients authenticate via OAuth2/OIDC. The gateway serves MCP-spec resource metadata at `/.well-known/oauth-protected-resource/mcp`, pointing clients to the authorization server. JWT tokens are validated against the OIDC provider.
+Clients authenticate via OAuth2/OIDC. The gateway serves MCP-spec resource metadata at `/.well-known/oauth-protected-resource`, pointing clients to the authorization server. JWT tokens are validated against the OIDC provider.
 
 ### Token exchange
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -164,7 +164,7 @@ spec:
           code: 401
           headers:
             'WWW-Authenticate':
-              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+              value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
           body:
             value: |
               {

--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -81,7 +81,7 @@ spec:
       unauthenticated:
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
         body:
           value: |
             {

--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -256,7 +256,7 @@ spec:
       unauthenticated:
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
         body:
           value: |
             {
@@ -267,7 +267,7 @@ spec:
         code: 401
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8001/.well-known/oauth-protected-resource
         body:
           value: |
             {

--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -266,7 +266,7 @@ spec:
       unauthenticated:
         headers:
           'WWW-Authenticate':
-            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=http://mcp.127-0-0-1.sslip.io:8888/.well-known/oauth-protected-resource
         body:
           value: |
             {

--- a/docs/guides/openshift-local-development.md
+++ b/docs/guides/openshift-local-development.md
@@ -4,7 +4,7 @@ This guide documents the process of deploying the MCP Gateway on OpenShift and c
 
 ## 1. Deploying to OpenShift
 
-Use the provided helper script to deploy the necessary components (Service Mesh, Connectivity Link, and MCP Gateway):
+Use the provided helper script to deploy the current OpenShift integration:
 
 ```bash
 cd config/openshift
@@ -14,81 +14,40 @@ cd config/openshift
 This script will output the public URL of your MCP Gateway, for example:
 `https://mcp.apps.your-cluster-domain.com/mcp`
 
-## 2. Enabling Internal Session Management
+By default the script installs the MCP Gateway controller through OLM, deploys the gateway instance, and creates an OpenShift Route. Red Hat Connectivity Link is optional and is only installed when `INSTALL_RHCL=true`.
 
-For the MCP Gateway to manage sessions and tool calls correctly, it must be able to communicate with itself using its internal cluster address. By default, OpenShift ingress may block these internal "hairpin" requests.
+## 2. Verify Internal Gateway Wiring
 
-Execute these commands to allow internal traffic:
+The current Helm/chart-based OpenShift deployment already configures the internal listener and private host needed for session management. Before connecting an off-cluster MCP server, verify those resources exist instead of patching them manually.
 
-### A. Update the Gateway Listener
-Allow the Gateway to accept traffic for any hostname (required for internal service-to-service calls) and add a listener on port 8081 for internal traffic (bypassing the ExtProc filter):
-
-```bash
-# Allow wildcard hostname on main listener
-kubectl patch gateway mcp-gateway -n gateway-system --type='json' -p='[{"op": "remove", "path": "/spec/listeners/0/hostname"}]'
-
-# Add internal listener on port 8081
-kubectl patch gateway mcp-gateway -n gateway-system --type='json' -p='[
-  {
-    "op": "add",
-    "path": "/spec/listeners/-",
-    "value": {
-      "name": "internal-mcp",
-      "port": 8081,
-      "protocol": "HTTP",
-      "allowedRoutes": {"namespaces": {"from": "All"}}
-    }
-  }
-]'
-```
-
-### B. Update the Main HTTPRoute
-Add the internal service address to the allowed hostnames of the main MCP route:
+Check the Gateway listeners:
 
 ```bash
-kubectl patch httproute mcp-gateway-ingress-httproute -n mcp-system --type='json' -p='[
-  {
-    "op": "add",
-    "path": "/spec/hostnames/-",
-    "value": "mcp-gateway-istio.gateway-system.svc.cluster.local"
-  }
-]'
+kubectl get gateway mcp-gateway -n gateway-system -o yaml
 ```
 
-### C. Update the Broker Deployment
-Ensure the broker is configured to use the correct internal gateway address for session initialization, and add a HostAlias to route internal traffic correctly through the Gateway.
+Expected result:
 
-First, get the ClusterIP of the Gateway:
+- a public listener named `mcp`
+- an internal listener named `mcps`
+
+Then confirm the broker/router deployment has a private host flag:
+
 ```bash
-GATEWAY_IP=$(oc get svc mcp-gateway-istio -n gateway-system -o jsonpath='{.spec.clusterIP}')
+kubectl get deployment mcp-gateway -n mcp-system -o jsonpath='{.spec.template.spec.containers[0].command}'
 ```
 
-Then patch the deployment to use port 8081 (bypassing ExtProc) and map a local alias:
-```bash
-kubectl patch deployment mcp-gateway -n mcp-system --type='json' -p="[
-  {
-    \"op\": \"add\",
-    \"path\": \"/spec/template/spec/hostAliases\",
-    \"value\": [
-      {
-        \"ip\": \"$GATEWAY_IP\",
-        \"hostnames\": [\"local-dev.mcp.local\"]
-      }
-    ]
-  },
-  {
-    \"op\": \"replace\",
-    \"path\": \"/spec/template/spec/containers/0/command/4\",
-    \"value\": \"--mcp-gateway-private-host=local-dev.mcp.local:8081\"
-  }
-]"
-```
+Expected result:
+
+- one command argument starts with `--mcp-gateway-private-host=`
+
+If those resources are present, no extra hairpin patching is needed for the current deployment flow.
 
 ## 3. Connecting an External MCP Server
 
 To connect an MCP server running off-cluster (e.g., on your laptop), you need to expose it via a public URL (using tools like `ngrok`, `localtunnel`, or a static IP).
 
-The provided automation script helps configure the necessary Istio `ServiceEntry`, `DestinationRule`, and Gateway `HTTPRoute` resources to route traffic from the cluster to your external server.
+The provided automation script configures the required Istio and Gateway API resources so the gateway can route to that external server.
 
 ### Start your Tunnel (Optional)
 If you don't have a public IP, start a tunnel. For example, using ngrok:
@@ -105,10 +64,11 @@ Run the connection script and provide your external domain when prompted:
 *Note: You can pass the domain as an argument: `./config/local-tunnel/connect_external_server.sh my-tunnel.ngrok-free.dev`*
 
 This script automates the creation of:
-1.  **ServiceEntry:** Registers the external domain and maps port 80 traffic to port 443.
-2.  **DestinationRule:** Enforces TLS and SNI for the external connection.
-3.  **Service & Route:** Maps internal "hairpin" traffic to the external service.
-4.  **Headers:** Adds `ngrok-skip-browser-warning: true` (harmless for non-ngrok domains, but required for ngrok free tier).
+1. **ServiceEntry:** Registers the external domain and maps port 80 traffic to port 443.
+2. **DestinationRule:** Enforces TLS and SNI for the external connection.
+3. **HTTPRoute:** Creates `local-tunnel-route` with hostnames for both `local-dev.mcp.local` and your external domain.
+4. **MCPServerRegistration:** Creates `local-dev-server` with the `local_` prefix.
+5. **Headers:** Adds `ngrok-skip-browser-warning: true` (harmless for non-ngrok domains, but required for ngrok free tier).
 
 ## 4. Verification
 
@@ -150,7 +110,7 @@ NODE_TLS_REJECT_UNAUTHORIZED=0 gemini
     *   Ensure your `DestinationRule` has the correct `sni` matching your ngrok domain.
     *   Ensure your `DestinationRule` and `ServiceEntry` are in `gateway-system` or have `exportTo: ["*"]`.
 3.  **Ngrok Host Header:** Ensure you have the `URLRewrite` filter in your `HTTPRoute`. Ngrok servers reject requests if the `Host` header doesn't match the tunnel domain.
-4.  **Bypass ExtProc:** The Broker must use port 8081 (configured via `internal-mcp` listener) to talk to the Gateway internally, bypassing the EnvoyFilter that rewrites headers.
+4.  **Internal Listener:** Ensure the gateway still has the internal `mcps` listener and the broker deployment still includes `--mcp-gateway-private-host`.
 5.  **Session Invalidation:** If you restart the Broker, all existing sessions are lost. You must restart your client (Gemini) to establish a new session.
 6.  **Protocol Mismatch (202 vs 200):** 
     *   **Symptom:** `Streamable HTTP error: Error POSTing to endpoint: `

--- a/docs/guides/tool-discovery.md
+++ b/docs/guides/tool-discovery.md
@@ -1,185 +1,73 @@
-# Tool Discovery Walkthrough
+# Tool Discovery
 
-This guide walks through the progressive tool discovery feature using a local Kind cluster. You will deploy the gateway with demo MCP servers, connect an AI agent, and observe how the agent uses `discover_tools` and `select_tools` to find and scope relevant tools instead of receiving the full tool catalog upfront.
+This guide explains the tool discovery behavior that MCP Gateway supports today.
+
+## Current behavior
+
+MCP Gateway federates tools from every Ready `MCPServerRegistration` into the gateway's standard MCP `tools/list` response. Clients discover tools by connecting to the gateway and calling `tools/list`.
+
+Today, MCP Gateway does **not** expose progressive discovery meta-tools such as `discover_tools` or `select_tools`, and `MCPServerRegistration` does **not** support discovery metadata fields such as `category` or `hint`.
+
+If you are looking for that future direction, see the design proposal in [docs/design/tool-discovery.md](../design/tool-discovery.md). Treat that design doc as roadmap material rather than current product behavior.
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/engine/install/) or [Podman](https://podman.io/docs/installation) installed and running
-- [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) installed
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) installed
-- [Helm](https://helm.sh/docs/intro/install/) installed
-- An MCP-capable AI agent (e.g., Claude Desktop, Claude Code, or any MCP client)
-- The MCP Gateway repository cloned locally
+- A running MCP Gateway deployment
+- One or more Ready `MCPServerRegistration` resources
+- An MCP client such as MCP Inspector
 
-## Step 1: Set up the local environment
+## Discover tools through the gateway
 
-From the repository root, create a Kind cluster with the gateway and test servers:
+Start the local demo environment if needed:
 
 ```bash
 make local-env-setup
 ```
 
-This creates a Kind cluster, installs Istio as the Gateway API provider, deploys the MCP Gateway controller and broker, and registers the default test MCP servers.
-
-Verify the gateway is running:
-
-```bash
-kubectl -n mcp-system get deployment mcp-gateway
-```
-
-Expected output:
-
-```
-NAME          READY   UP-TO-DATE   AVAILABLE   AGE
-mcp-gateway   1/1     1            1           ...
-```
-
-## Step 2: Apply discovery metadata
-
-`make local-env-setup` already builds and deploys all test servers (including the restaurant and messaging servers) and registers them with the base MCPServerRegistrations. To enable discovery metadata (categories and hints), apply the discovery variant:
-
-```bash
-kubectl apply -f config/samples/mcpserverregistration-discovery.yaml
-```
-
-Verify the registrations have the expected categories:
-
-```bash
-kubectl -n mcp-test get mcpserverregistrations
-```
-
-Expected output shows servers with discovery metadata alongside the base registrations:
-
-```
-NAME                PREFIX        TARGET                        PATH   READY   TOOLS   CREDENTIALS   AGE
-restaurant-server   restaurant_   mcp-restaurant-server-route   /mcp   True    5                     ...
-messaging-server    messaging_    mcp-messaging-server-route    /mcp   True    5                     ...
-test-server1        test1_        mcp-server1-route             /mcp   True    5                     ...
-test-server2        test2_        mcp-server2-route             /mcp   True    7                     ...
-test-server3        test3_        mcp-server3-route             /mcp   True    7                     ...
-...
-```
-
-At this point the gateway federates tools from multiple servers. The total tool count exceeds the default discovery threshold of 10, so new sessions will only see the discovery meta-tools.
-
-## Step 3: Connect the gateway to your AI agent
-
-The gateway is accessible at `http://mcp.127-0-0-1.sslip.io:8001/mcp`.
-
-### Claude Code
-
-```bash
-claude mcp add --transport http -s user mcp-gateway http://mcp.127-0-0-1.sslip.io:8001/mcp
-```
-
-### MCP Inspector (for manual testing)
+Open MCP Inspector:
 
 ```bash
 make inspect-gateway
 ```
 
-## Step 4: Observe progressive discovery
+Connect MCP Inspector to:
 
-Send the following prompt to your agent:
-
-> Using the mcp-gateway, I would like to book an Italian restaurant in New York for 4 people on Saturday. After each turn, show me the tools in your context.
-
-### What to expect
-
-**Turn 1 — Initial tool list**
-
-The agent's initial `tools/list` call returns only two tools:
-
-- `discover_tools` — browse available servers, categories, and tool names
-- `select_tools` — scope the session to specific tools
-
-No upstream tools are visible. The agent must use the discovery flow.
-
-**Turn 2 — Discovery**
-
-The agent calls `discover_tools` and receives lightweight metadata about all registered servers:
-
-```json
-{
-  "servers": [
-    {
-      "name": "mcp-test/restaurant-server",
-      "category": "dining reservations",
-      "hint": "search restaurants by cuisine and location, check table availability, make and cancel reservations",
-      "tools": ["restaurant_search_restaurants", "restaurant_get_restaurant_details", "restaurant_check_availability", "restaurant_make_reservation", "restaurant_cancel_reservation"]
-    },
-    {
-      "name": "mcp-test/messaging-server",
-      "category": "communication contacts",
-      "hint": "find contacts, send messages via email/sms/slack, view message history, create messaging groups",
-      "tools": ["messaging_find_contacts", "messaging_get_contact", "messaging_send_message", "messaging_get_messages", "messaging_create_group"]
-    },
-    ...
-  ]
-}
+```text
+http://mcp.127-0-0-1.sslip.io:8001/mcp
 ```
 
-The agent identifies the restaurant tools as relevant and calls `select_tools` with those tool names.
+After connecting, use **Tools -> List Tools** to view the federated tool catalog returned by the gateway.
 
-**Turn 3 — Scoped tools**
+## Verify which servers contributed tools
 
-After `select_tools`, the gateway sends a `notifications/tools/list_changed` notification. The agent's next `tools/list` call returns only the selected restaurant tools plus the two meta-tools. The agent now has full schemas for just the tools it needs and proceeds to search restaurants, check availability, and make a reservation.
-
-### Key observations
-
-- **Before discovery**: the agent sees 2 tools (meta-tools only)
-- **After select_tools**: the agent sees ~7 tools (5 restaurant + 2 meta-tools) instead of 30+ from all servers
-- **Token savings**: the agent never ingests schemas for messaging, math, greeting, or other irrelevant tools
-- **Re-scoping**: if the conversation shifts (e.g., "now send a confirmation message"), the agent can call `discover_tools` again and `select_tools` with a different set
-
-### Shifting context mid-conversation
-
-After the restaurant is booked, send a follow-up prompt that requires a different set of tools:
-
-> Great but now I would like to invite my friends. Can show me my contacts so I can message them?
-
-The agent recognises that messaging tools are needed. It calls `discover_tools` again, identifies the messaging server, and calls `select_tools` with the messaging tool names. After re-scoping, the agent's tool list changes from the restaurant tools to the messaging tools (plus the two meta-tools). The agent can then look up contacts and send invitations without ever loading the full tool set.
-
-## Configuration
-
-### Discovery threshold
-
-The `--discovery-tool-threshold` flag (default: 10) controls when progressive discovery activates. When the total number of non-meta tools exceeds this threshold, new sessions only see meta-tools. At or below the threshold, all tools are shown directly.
-
-To change the threshold on a running deployment:
+Check the registration status first:
 
 ```bash
-kubectl -n mcp-system set env deployment/mcp-gateway -- DISCOVERY_TOOL_THRESHOLD=20
+kubectl get mcpsr -A
 ```
 
-Or add the flag to the deployment command args:
+Example output:
+
+```text
+NAMESPACE   NAME            PREFIX      TARGET               PATH   READY   TOOLS   CREDENTIALS   AGE
+mcp-test    test-server1    test1_      mcp-server1-route    /mcp   True    5                     2m
+mcp-test    test-server2    test2_      mcp-server2-route    /mcp   True    7                     2m
+```
+
+The `PREFIX` column tells you how the gateway namespaces tools from each backend server. For example, a backend `greet` tool registered with prefix `test1_` appears to clients as `test1_greet`.
+
+If a registration is not Ready, inspect it for details:
 
 ```bash
-kubectl -n mcp-system patch deployment mcp-gateway --type=json \
-  -p='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--discovery-tool-threshold=20"}]'
+kubectl describe mcpserverregistration test-server1 -n mcp-test
 ```
 
-Setting the threshold to 0 always requires discovery regardless of tool count.
+## Keep the tool set focused
 
-### Adding discovery metadata to your servers
+Because clients currently receive the gateway's normal federated `tools/list`, the main ways to keep tool discovery manageable are:
 
-Add `category` and `hint` fields to your MCPServerRegistration resources:
+- Register only the MCP servers you want exposed through a given gateway listener
+- Use prefixes consistently so tool ownership is obvious
+- Use `MCPVirtualServer` resources when you want a curated subset of tools for a specific endpoint
 
-```yaml
-apiVersion: mcp.kuadrant.io/v1alpha1
-kind: MCPServerRegistration
-metadata:
-  name: my-server
-  namespace: mcp-test
-spec:
-  toolPrefix: myprefix_
-  category: "my domain"
-  hint: "short description of what tools this server provides"
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: my-server-route
-```
-
-- **category**: free-text classification (e.g., "payments", "analytics", "communication"). Servers without a category appear as "uncategorised".
-- **hint**: natural-language summary of the server's tools. Gives the LLM enough context to decide relevance without full schemas.
+For virtual server setup, see [virtual-mcp-servers.md](./virtual-mcp-servers.md).

--- a/docs/guides/tool-discovery.md
+++ b/docs/guides/tool-discovery.md
@@ -18,19 +18,19 @@ If you are looking for that future direction, see the design proposal in [docs/d
 
 ## Discover tools through the gateway
 
-Start the local demo environment if needed:
+Confirm your registrations are Ready:
 
 ```bash
-make local-env-setup
+kubectl get mcpsr -A
 ```
 
-Open MCP Inspector:
+Start MCP Inspector:
 
 ```bash
-make inspect-gateway
+DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1
 ```
 
-Connect MCP Inspector to:
+Then connect it to your MCP Gateway endpoint. For example:
 
 ```text
 http://mcp.127-0-0-1.sslip.io:8001/mcp
@@ -40,7 +40,7 @@ After connecting, use **Tools -> List Tools** to view the federated tool catalog
 
 ## Verify which servers contributed tools
 
-Check the registration status first:
+Check the registration status:
 
 ```bash
 kubectl get mcpsr -A

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -567,7 +567,7 @@ If you continue to experience issues:
 
 2. Check resource status:
    ```bash
-   kubectl describe mcpserver -A > mcpserver-status.txt
+   kubectl describe mcpserverregistration -A > mcpserver-status.txt
    kubectl describe gateway -A > gateway-status.txt
    kubectl describe httproute -A > httproute-status.txt
    ```

--- a/docs/guides/understanding-mcp-gateway-architecture.md
+++ b/docs/guides/understanding-mcp-gateway-architecture.md
@@ -18,14 +18,14 @@ Before observing the system in action, let's understand how it's configured.
 
 ### MCPServerRegistration Resources
 
-MCPServer custom resources define backend servers:
+MCPServerRegistration custom resources define backend servers:
 
 ```bash
 # View all MCPServerRegistration resources
 kubectl get mcpsr -A
 
 # Describe a specific MCPServerRegistration
-kubectl describe mcpserver api-key-server -n mcp-test
+kubectl describe mcpserverregistration api-key-server -n mcp-test
 ```
 
 **Example MCPServerRegistration spec:**
@@ -353,7 +353,7 @@ kubectl get configmap mcp-gateway-config -n mcp-system -o yaml
 2. **Check MCPServerRegistration status:**
 ```bash
 kubectl get mcpsr -A
-kubectl describe mcpserver <name> -n mcp-test
+kubectl describe mcpserverregistration <name> -n mcp-test
 ```
 
 3. **Check broker logs for connection issues:**

--- a/docs/guides/understanding-mcp-gateway-architecture.md
+++ b/docs/guides/understanding-mcp-gateway-architecture.md
@@ -45,23 +45,21 @@ spec:
 
 ### Generated Configuration
 
-The controller generates a ConfigMap that the broker/router consumes:
+The controller generates a Secret that the broker/router consumes:
 
 ```bash
 # View generated configuration
-kubectl get configmap mcp-gateway-config -n mcp-system -o yaml
+kubectl get secret mcp-gateway-config -n mcp-system -o jsonpath='{.data.config\.yaml}' | base64 -d
 ```
 
 **Configuration structure:**
 ```yaml
-data:
-  config.yaml: |
-    servers:
-      - name: mcp-test/mcp-server1-route
-        url: http://mcp-test-server1.mcp-test.svc.cluster.local:9090/mcp
-        hostname: server1.mcp.local
-        prefix: test1_
-        enabled: true
+servers:
+  - name: mcp-test/mcp-server1-route
+    url: http://mcp-test-server1.mcp-test.svc.cluster.local:9090/mcp
+    hostname: server1.mcp.local
+    prefix: test1_
+    enabled: true
 ```
 
 **What each server entry contains:**
@@ -347,7 +345,7 @@ data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Hi Pat
 
 1. **Check if tool exists in aggregated list using MCP Inspector** (Step 3) or:
 ```bash
-kubectl get configmap mcp-gateway-config -n mcp-system -o yaml
+kubectl get secret mcp-gateway-config -n mcp-system -o jsonpath='{.data.config\.yaml}' | base64 -d
 ```
 
 2. **Check MCPServerRegistration status:**
@@ -404,7 +402,7 @@ kubectl logs deployment/mcp-gateway -n mcp-system | grep -E "(routing|authority|
 
 2. **Verify prefix mappings in configuration:**
 ```bash
-kubectl get configmap mcp-gateway-config -n mcp-system -o jsonpath='{.data.config\.yaml}' | grep -A 5 prefix
+kubectl get secret mcp-gateway-config -n mcp-system -o jsonpath='{.data.config\.yaml}' | base64 -d | grep -A 5 prefix
 ```
 
 3. **Check Envoy routing configuration:**

--- a/docs/guides/user-based-tool-filter.md
+++ b/docs/guides/user-based-tool-filter.md
@@ -180,7 +180,7 @@ spec:
         code: 401
         headers:
           WWW-Authenticate:
-            value: Bearer resource_metadata=https://mcp.example.com/.well-known/oauth-protected-resource/mcp
+            value: Bearer resource_metadata=https://mcp.example.com/.well-known/oauth-protected-resource
         body:
           value: |
             {


### PR DESCRIPTION
## Summary

Fixes #816 by auditing the current `mcp-gateway` documentation against the source code and deployment assets in this repo.

## What changed

- synced controller/broker usage docs in `README.md` with the current binaries and flags
- corrected CRD/resource terminology to use `MCPServerRegistration`
- fixed OAuth protected-resource endpoint references to `/.well-known/oauth-protected-resource`
- replaced the inaccurate current-state `tool-discovery` guide with documentation that matches implemented behavior
- updated OpenShift docs to match the current deployment scripts and chart behavior
- aligned design docs where they described current behavior incorrectly

## Verification

- `go test ./...`
- `npm exec --yes cspell@9.4.0 -- cspell --quiet --config cspell.json .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes deployment guides to reflect current controller architecture and MCPServerRegistration resource usage.
  * Revised OAuth protected resource metadata endpoint paths across authentication and authorization guides.
  * Clarified tool discovery behavior and capabilities in gateway documentation.
  * Updated OpenShift deployment instructions and example payloads.
  * Refreshed architecture documentation with current resource names and command-line flags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/954)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->