### PR TITLE
feat: add OTel tracing and context-aware logging to broker and router

### DIFF
--- a/.claude/otel-tracing-and-logging.md
+++ b/.claude/otel-tracing-and-logging.md
@@ -18,28 +18,49 @@ The logger is created with `NewTracingLogger()` which wraps slog with trace cont
 ## Tracing Conventions
 
 ### Span Naming
-All spans use the prefix `mcp-router.` followed by a descriptive name:
+Spans are prefixed by component:
+
+**Router** (`mcp-router.`):
 - `mcp-router.process` -- root span for the full ext_proc stream lifecycle
-- `mcp-router.route-decision` -- routing decision (tool-call vs broker passthrough)
+- `mcp-router.route-decision` -- routing decision (tool-call, prompt-get, elicitation-response, or broker)
 - `mcp-router.tool-call` -- full tool call handling
+- `mcp-router.prompt-get` -- full prompt get handling
+- `mcp-router.elicitation-response` -- elicitation response routing
 - `mcp-router.broker-passthrough` -- pass-through to broker
-- `mcp-router.broker.get-server-info` -- broker lookup for server info
+- `mcp-router.broker.get-server-info` -- broker lookup for tool server info
+- `mcp-router.broker.get-server-info-by-prompt` -- broker lookup for prompt server info
 - `mcp-router.session-cache.get` -- session cache read
 - `mcp-router.session-cache.store` -- session cache write
 - `mcp-router.session-init` -- hairpin initialize to backend
 
-When adding new spans, follow this naming pattern: `mcp-router.<component>.<action>`.
+**Broker** (`mcp-broker.`):
+- `mcp-broker.handle-request` -- wraps every MCP request to the broker
+- `mcp-broker.tools-list` -- tools/list filtering (authorization, virtual server, gateway metadata)
+- `mcp-broker.prompts-list` -- prompts/list filtering
+- `mcp-broker.upstream-manage` -- periodic backend health check and tool/prompt discovery
+
+When adding new spans, follow the naming pattern: `<component>.<action>`.
+
+### Tracer Names
+Tracer names are defined as constants:
+- `mcpotel.BrokerTracerName` (`internal/otel/otel.go`) -- used by broker and upstream packages
+- `tracerName` (`internal/mcp-router/tracing.go`) -- router-local constant
 
 
 ### Span Attributes
 Follow [OpenTelemetry MCP Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#server):
 
-- `mcp.method.name` -- MCP method (initialize, tools/call, tools/list)
+- `mcp.method.name` -- MCP method (initialize, tools/call, tools/list, prompts/get, prompts/list)
+- `mcp.method` -- MCP method (broker spans use this shorter form)
+- `mcp.route` -- routing decision: `tool-call`, `prompt-get`, `elicitation-response`, or `broker`
 - `gen_ai.tool.name` -- tool name
 - `gen_ai.operation.name` -- same as mcp.method.name
 - `mcp.session.id` -- gateway session ID
 - `mcp.server` -- backend server name
 - `mcp.server.hostname` -- backend server hostname
+- `mcp.prompt.name` -- prompt name (prompts/get)
+- `mcp.tools.count` -- number of tools after filtering (broker tools-list span)
+- `mcp.prompts.count` -- number of prompts after filtering (broker prompts-list span)
 - `jsonrpc.request.id` -- JSON-RPC request ID
 - `jsonrpc.protocol.version` -- always "2.0"
 - `http.method`, `http.path`, `http.request_id`, `http.status_code`
@@ -48,20 +69,19 @@ Follow [OpenTelemetry MCP Semantic Conventions](https://opentelemetry.io/docs/sp
 For new attributes, check OTel semantic conventions first before inventing custom ones.
 
 ### Error Recording
-Use the `recordError()` helper for consistent error attributes:
+Use `mcpotel.SpanError()` (`internal/otel/otel.go`) for the common `RecordError` + `SetStatus` pair:
 
 ```go
-recordError(span, err, 500)
+mcpotel.SpanError(span, err, "description of what failed")
 ```
 
-This sets `error.type`, `error_source`, and `http.status_code` on the span. For inline
-error recording without the helper:
+The component-specific wrappers add extra attributes on top of `SpanError`:
+- `recordError(span, err, statusCode)` in `internal/mcp-router/tracing.go` -- adds `error_source=ext-proc` and `http.status_code`
+- `recordBrokerError(span, err)` in `internal/broker/tracing.go` -- adds `error_source=broker`
+- `recordBackendError(span, err)` in `internal/broker/upstream/manager.go` -- adds `error_source=backend` and `mcp.server`
 
-```go
-span.RecordError(err)
-span.SetStatus(codes.Error, "description")
-span.SetAttributes(attribute.String("error.type", "specific_error_type"))
-```
+Use the component wrapper when you need the extra attributes. Use `mcpotel.SpanError` directly
+when only the error + status is needed (most cases).
 
 ### Trace Context Propagation
 The router extracts W3C `traceparent` from Envoy headers via `extractTraceContext()`.

--- a/Makefile
+++ b/Makefile
@@ -761,7 +761,7 @@ otel: ## Deploy OpenTelemetry observability stack. Use ISTIO_TRACING=1, AUTH_TRA
 ifeq ($(ISTIO_TRACING),1)
 	kubectl apply -f examples/otel/istio-telemetry.yaml
 	kubectl patch istio default --type='merge' \
-		-p='{"spec":{"values":{"meshConfig":{"enableTracing":true,"defaultConfig":{"tracing":{}},"extensionProviders":[{"name":"tempo-otlp","opentelemetry":{"port":4317,"service":"$(OTEL_COLLECTOR_HOST)"}}]}}}}'
+		-p='{"spec":{"values":{"meshConfig":{"accessLogFile":"/dev/stdout","enableTracing":true,"defaultConfig":{"tracing":{}},"extensionProviders":[{"name":"tempo-otlp","opentelemetry":{"port":4317,"service":"$(OTEL_COLLECTOR_HOST)"}}]}}}}'
 	@sleep 5
 endif
 	kubectl set env deployment/mcp-gateway -n $(MCP_GATEWAY_NAMESPACE) \

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -30,6 +30,8 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -383,7 +385,7 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 		mux.Handle("/tokens", tokenHandler)
 		mux.Handle("/mcp/elicitation", elicitationHandler)
 	}
-	mux.Handle("/mcp", streamableHTTPServer)
+	mux.Handle("/mcp", traceContextMiddleware(streamableHTTPServer))
 
 	return httpSrv, streamableHTTPServer
 }
@@ -451,4 +453,11 @@ func LoadConfig(path string) {
 			s.Hostname,
 		)
 	}
+}
+
+func traceContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }

--- a/examples/otel/README.md
+++ b/examples/otel/README.md
@@ -73,13 +73,15 @@ The MCP Broker emits spans for request handling, capability filtering, and upstr
 
 ### Span Hierarchy
 
-```
+The router and broker run in the same process. Broker spans are correlated to the
+router trace via W3C Trace Context propagation (the `traceContextMiddleware` extracts
+`traceparent` from the forwarded HTTP request), so they appear in the same trace but
+are **not** direct parent-child spans of the router spans.
+
+```text
 mcp-router.process
 ├── mcp-router.route-decision
 │   ├── mcp-router.broker-passthrough        (if initialize, tools/list, prompts/list, etc.)
-│   │   └── mcp-broker.handle-request        (broker-side)
-│   │       ├── mcp-broker.tools-list        (if tools/list)
-│   │       └── mcp-broker.prompts-list      (if prompts/list)
 │   ├── mcp-router.tool-call                 (if tools/call)
 │   │   ├── mcp-router.broker.get-server-info
 │   │   ├── mcp-router.session-cache.get
@@ -91,6 +93,10 @@ mcp-router.process
 │   │   ├── mcp-router.session-init          (if cache miss)
 │   │   └── mcp-router.session-cache.store   (if cache miss)
 │   └── mcp-router.elicitation-response      (if elicitation response)
+
+mcp-broker.handle-request                    (correlated via traceparent, not a child of router spans)
+├── mcp-broker.tools-list                    (if tools/list)
+└── mcp-broker.prompts-list                  (if prompts/list)
 
 mcp-broker.upstream-manage                   (periodic, not request-scoped)
 ```
@@ -193,7 +199,7 @@ outside the mesh to create end-to-end traces.
 
 ## Architecture
 
-```
+```text
 ┌─────────────────┐     ┌──────────────────────┐     ┌─────────────┐
 │   MCP Gateway   │────▶│   OTEL Collector     │────▶│    Tempo    │
 │                 │     │                      │     │  (traces)   │

--- a/examples/otel/README.md
+++ b/examples/otel/README.md
@@ -49,25 +49,50 @@ request (request headers -> request body -> response headers).
 | Span | When | Description |
 |------|------|-------------|
 | `mcp-router.process` | Every ext_proc stream | Root span. Starts when request headers arrive, ends after response headers are processed. |
-| `mcp-router.route-decision` | Request body parsed | Routing decision: tool-call vs pass-through to broker. |
-| `mcp-router.broker-passthrough` | Non-tool-call requests | Pass-through to broker (initialize, tools/list, notifications). No child spans — broker is not instrumented. |
+| `mcp-router.route-decision` | Request body parsed | Routing decision: tool-call, prompt-get, elicitation-response, or broker. |
+| `mcp-router.broker-passthrough` | Non-routed requests | Pass-through to broker (initialize, tools/list, prompts/list, notifications). |
 | `mcp-router.tool-call` | `tools/call` requests | Full tool call handling including session and server resolution. |
-| `mcp-router.broker.get-server-info` | Inside tool-call | Call out to broker to resolve which backend server owns the tool. |
-| `mcp-router.session-cache.get` | Inside tool-call | Call out to session cache to look up an existing backend session. |
-| `mcp-router.session-init` | Cache miss during tool-call | Hairpin initialize request through the gateway to the backend MCP server. |
-| `mcp-router.session-cache.store` | After session-init | Call out to session cache to store the new backend session. |
+| `mcp-router.broker.get-server-info` | Inside tool-call | Resolve which backend server owns the tool. |
+| `mcp-router.prompt-get` | `prompts/get` requests | Full prompt get handling including session and server resolution. |
+| `mcp-router.broker.get-server-info-by-prompt` | Inside prompt-get | Resolve which backend server owns the prompt. |
+| `mcp-router.elicitation-response` | Elicitation responses | Routes client elicitation responses to the correct backend server. |
+| `mcp-router.session-cache.get` | Inside tool-call or prompt-get | Look up an existing backend session in the cache. |
+| `mcp-router.session-init` | Cache miss | Hairpin initialize request through the gateway to the backend MCP server. |
+| `mcp-router.session-cache.store` | After session-init | Store the new backend session in the cache. |
+
+### MCP Broker Spans
+
+The MCP Broker emits spans for request handling, capability filtering, and upstream management.
+
+| Span | When | Description |
+|------|------|-------------|
+| `mcp-broker.handle-request` | Every MCP request to the broker | Wraps the full request lifecycle (initialize, tools/list, prompts/list, etc.). |
+| `mcp-broker.tools-list` | `tools/list` response filtering | Filters tools by authorization, virtual server, and removes gateway metadata. |
+| `mcp-broker.prompts-list` | `prompts/list` response filtering | Filters prompts by authorization, virtual server, and removes gateway metadata. |
+| `mcp-broker.upstream-manage` | Periodic health check tick | Backend connection management: connect, ping, tool/prompt discovery. |
 
 ### Span Hierarchy
 
 ```
 mcp-router.process
 ├── mcp-router.route-decision
-│   ├── mcp-router.broker-passthrough        (if initialize, tools/list, etc.)
-│   └── mcp-router.tool-call                (if tools/call)
-│       ├── mcp-router.broker.get-server-info
-│       ├── mcp-router.session-cache.get
-│       ├── mcp-router.session-init          (if cache miss)
-│       └── mcp-router.session-cache.store   (if cache miss)
+│   ├── mcp-router.broker-passthrough        (if initialize, tools/list, prompts/list, etc.)
+│   │   └── mcp-broker.handle-request        (broker-side)
+│   │       ├── mcp-broker.tools-list        (if tools/list)
+│   │       └── mcp-broker.prompts-list      (if prompts/list)
+│   ├── mcp-router.tool-call                 (if tools/call)
+│   │   ├── mcp-router.broker.get-server-info
+│   │   ├── mcp-router.session-cache.get
+│   │   ├── mcp-router.session-init          (if cache miss)
+│   │   └── mcp-router.session-cache.store   (if cache miss)
+│   ├── mcp-router.prompt-get                (if prompts/get)
+│   │   ├── mcp-router.broker.get-server-info-by-prompt
+│   │   ├── mcp-router.session-cache.get
+│   │   ├── mcp-router.session-init          (if cache miss)
+│   │   └── mcp-router.session-cache.store   (if cache miss)
+│   └── mcp-router.elicitation-response      (if elicitation response)
+
+mcp-broker.upstream-manage                   (periodic, not request-scoped)
 ```
 
 ### Span Attributes
@@ -95,7 +120,7 @@ Attributes follow the [OpenTelemetry MCP Semantic Conventions](https://opentelem
 | Attribute | Description |
 |-----------|-------------|
 | `mcp.method.name` | MCP method |
-| `mcp.route` | Routing decision: `tool-call` or `broker` |
+| `mcp.route` | Routing decision: `tool-call`, `prompt-get`, `elicitation-response`, or `broker` |
 
 #### Tool call span (`mcp-router.tool-call`)
 
@@ -106,13 +131,32 @@ Attributes follow the [OpenTelemetry MCP Semantic Conventions](https://opentelem
 | `mcp.server` | Resolved backend server name |
 | `mcp.server.hostname` | Resolved backend server hostname |
 
+#### Prompt get span (`mcp-router.prompt-get`)
+
+| Attribute | Description |
+|-----------|-------------|
+| `mcp.prompt.name` | Prompt name from the request |
+| `mcp.session.id` | Gateway session ID |
+| `mcp.server` | Resolved backend server name |
+| `mcp.server.hostname` | Resolved backend server hostname |
+
+#### Broker spans
+
+| Attribute | Span | Description |
+|-----------|------|-------------|
+| `mcp.method` | `handle-request` | MCP method being processed |
+| `mcp.session.id` | `handle-request`, `tools-list`, `prompts-list` | Gateway session ID |
+| `mcp.tools.count` | `tools-list` | Number of tools after filtering |
+| `mcp.prompts.count` | `prompts-list` | Number of prompts after filtering |
+| `mcp.server` | `upstream-manage` | Backend server name |
+
 #### Error attributes
 
 On error, spans include:
 
 | Attribute | Description |
 |-----------|-------------|
-| `error.type` | Error classification (e.g. `tool_not_found`, `invalid_session`, `session_cache_error`) |
+| `error.type` | Error classification (e.g. `tool_not_found`, `prompt_not_found`, `invalid_session`, `session_cache_error`) |
 | `error_source` | Component that generated the error (`ext-proc` or `backend`) |
 | `http.status_code` | HTTP status code returned |
 

--- a/examples/otel/istio-telemetry.yaml
+++ b/examples/otel/istio-telemetry.yaml
@@ -8,6 +8,9 @@ spec:
   - providers:
     - name: tempo-otlp
     randomSamplingPercentage: 100
+  accessLogging:
+  - providers:
+    - name: envoy
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -161,7 +161,7 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 			attribute.String("mcp.method", string(method)),
 		}
 		if sid := sessionIDFromContext(ctx); sid != "" {
-			attrs = append(attrs, attribute.String("mcp.session_id", sid))
+			attrs = append(attrs, attribute.String("mcp.session.id", sid))
 		}
 		spanTracker.start(ctx, id, "mcp-broker.handle-request", attrs...)
 		mcpBkr.logger.DebugContext(ctx, "processing request", "method", method)
@@ -177,10 +177,8 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		mcpBkr.logger.ErrorContext(ctx, "mcp server error", "method", method, "error", err)
 		span, ok := spanTracker.remove(id)
 		if ok {
-			if span.IsRecording() {
-				recordBrokerError(span, err)
-				span.SetAttributes(attribute.String("mcp.method", string(method)))
-			}
+			recordBrokerError(span, err)
+			span.SetAttributes(attribute.String("mcp.method", string(method)))
 			span.End()
 		}
 	})

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var _ config.Observer = &mcpBrokerImpl{}
@@ -144,24 +145,44 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	}
 
 	hooks := &server.Hooks{}
+	spanTracker := newRequestSpanTracker()
 
-	// Enhanced session registration to log gateway session assignment
-	hooks.AddOnRegisterSession(func(_ context.Context, session server.ClientSession) {
-		// Note that AddOnRegisterSession is for GET, not POST, for a session.
-		// https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server
-		mcpBkr.logger.Debug("gateway client session connected", "gatewaySessionID", session.SessionID())
+	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
+		mcpBkr.logger.DebugContext(ctx, "gateway client session connected", "gatewaySessionID", session.SessionID())
 	})
 
-	hooks.AddOnUnregisterSession(func(_ context.Context, session server.ClientSession) {
-		mcpBkr.logger.Debug("gateway client session unregistered", "gatewaySessionID", session.SessionID())
+	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
+		mcpBkr.logger.DebugContext(ctx, "gateway client session unregistered", "gatewaySessionID", session.SessionID())
 	})
 
-	hooks.AddBeforeAny(func(_ context.Context, _ any, method mcp.MCPMethod, _ any) {
-		mcpBkr.logger.Debug("processing request", "method", method)
+	hooks.AddBeforeAny(func(ctx context.Context, id any, method mcp.MCPMethod, _ any) {
+		attrs := []attribute.KeyValue{
+			brokerComponentAttr,
+			attribute.String("mcp.method", string(method)),
+		}
+		if sid := sessionIDFromContext(ctx); sid != "" {
+			attrs = append(attrs, attribute.String("mcp.session_id", sid))
+		}
+		spanTracker.start(ctx, id, "mcp-broker.handle-request", attrs...)
+		mcpBkr.logger.DebugContext(ctx, "processing request", "method", method)
 	})
 
-	hooks.AddOnError(func(_ context.Context, _ any, method mcp.MCPMethod, _ any, err error) {
-		mcpBkr.logger.Error("mcp server error", "method", method, "error", err)
+	hooks.AddOnSuccess(func(_ context.Context, id any, _ mcp.MCPMethod, _ any, _ any) {
+		if span, ok := spanTracker.remove(id); ok {
+			span.End()
+		}
+	})
+
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, _ any, err error) {
+		mcpBkr.logger.ErrorContext(ctx, "mcp server error", "method", method, "error", err)
+		span, ok := spanTracker.remove(id)
+		if ok {
+			if span.IsRecording() {
+				recordBrokerError(span, err)
+				span.SetAttributes(attribute.String("mcp.method", string(method)))
+			}
+			span.End()
+		}
 	})
 
 	hooks.AddAfterListTools(func(ctx context.Context, id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
@@ -188,7 +209,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	servers := conf.ListServers()
 	virtualServers := conf.ListVirtualServers()
 
-	m.logger.Debug("Broker OnConfigChange start", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(servers))
+	m.logger.DebugContext(ctx, "Broker OnConfigChange start", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(servers))
 	// unregister decommissioned servers
 	m.mcpLock.Lock()
 	defer m.mcpLock.Unlock()
@@ -197,9 +218,9 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		if !slices.ContainsFunc(servers, func(s *config.MCPServer) bool {
 			return serverID == s.ID()
 		}) {
-			m.logger.Info("un-register upstream server", "server id", serverID)
+			m.logger.InfoContext(ctx, "un-register upstream server", "server id", serverID)
 			if man, ok := m.mcpServers[serverID]; ok {
-				m.logger.Info("stopping manager for unregistered server", "server id", serverID)
+				m.logger.InfoContext(ctx, "stopping manager for unregistered server", "server id", serverID)
 				man.Stop()
 				delete(m.mcpServers, serverID)
 			}
@@ -210,24 +231,24 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 	for _, mcpServer := range servers {
 		man, ok := m.mcpServers[mcpServer.ID()]
 		if ok {
-			m.logger.Info("Server is registered", "mcpID", mcpServer.ID())
+			m.logger.InfoContext(ctx, "Server is registered", "mcpID", mcpServer.ID())
 			// already have a manger
 			if mcpServer.ConfigChanged(man.Config()) {
 				// todo prob could look at just updating the config
-				m.logger.Info("Server Config Changed removing manager", "mcpID", mcpServer.ID())
+				m.logger.InfoContext(ctx, "Server Config Changed removing manager", "mcpID", mcpServer.ID())
 				man.Stop()
 				delete(m.mcpServers, mcpServer.ID())
 			}
 		}
 		// check if we need to setup a new manager
 		if _, ok := m.mcpServers[mcpServer.ID()]; !ok {
-			m.logger.Info("starting new manager", "server id", mcpServer.ID())
+			m.logger.InfoContext(ctx, "starting new manager", "server id", mcpServer.ID())
 			manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
 			if err != nil {
-				m.logger.Error("failed to create manager", "server id", mcpServer.ID(), "error", err)
+				m.logger.ErrorContext(ctx, "failed to create manager", "server id", mcpServer.ID(), "error", err)
 				continue
 			}
-			m.logger.Info("Starting manager for", "mcpID", mcpServer.ID())
+			m.logger.InfoContext(ctx, "Starting manager for", "mcpID", mcpServer.ID())
 			m.mcpServers[mcpServer.ID()] = manager.Start(ctx)
 		}
 	}
@@ -237,7 +258,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		m.virtualServers[vs.Name] = vs
 	}
 	m.vsLock.Unlock()
-	m.logger.Debug("Broker OnConfigChange done", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(servers))
+	m.logger.DebugContext(ctx, "Broker OnConfigChange done", "Total managers for upstream mcp servers", len(m.mcpServers), "total servers", len(servers))
 }
 
 func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]upstream.ActiveMCPServer {

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -17,7 +17,7 @@ func (broker *mcpBrokerImpl) FilterPrompts(ctx context.Context, _ any, mcpReq *m
 	if sid := sessionIDFromContext(ctx); sid != "" {
 		attrs = append(attrs, attribute.String("mcp.session.id", sid))
 	}
-	_, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(attrs...))
+	ctx, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(attrs...))
 	defer span.End()
 
 	broker.logger.DebugContext(ctx, "FilterPrompts called", "input_prompts_count", len(mcpRes.Prompts))

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -20,7 +20,7 @@ func (broker *mcpBrokerImpl) FilterPrompts(ctx context.Context, _ any, mcpReq *m
 	_, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(attrs...))
 	defer span.End()
 
-	broker.logger.Debug("FilterPrompts called", "input_prompts_count", len(mcpRes.Prompts))
+	broker.logger.DebugContext(ctx, "FilterPrompts called", "input_prompts_count", len(mcpRes.Prompts))
 	prompts := mcpRes.Prompts
 	emptyPrompts := []mcp.Prompt{}
 	if len(mcpRes.Prompts) == 0 {

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -7,10 +7,19 @@ import (
 	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // FilterPrompts reduces the prompt set based on authorization headers.
-func (broker *mcpBrokerImpl) FilterPrompts(_ context.Context, _ any, mcpReq *mcp.ListPromptsRequest, mcpRes *mcp.ListPromptsResult) {
+func (broker *mcpBrokerImpl) FilterPrompts(ctx context.Context, _ any, mcpReq *mcp.ListPromptsRequest, mcpRes *mcp.ListPromptsResult) {
+	attrs := []attribute.KeyValue{brokerComponentAttr}
+	if sid := sessionIDFromContext(ctx); sid != "" {
+		attrs = append(attrs, attribute.String("mcp.session.id", sid))
+	}
+	_, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(attrs...))
+	defer span.End()
+
 	broker.logger.Debug("FilterPrompts called", "input_prompts_count", len(mcpRes.Prompts))
 	prompts := mcpRes.Prompts
 	emptyPrompts := []mcp.Prompt{}
@@ -22,6 +31,8 @@ func (broker *mcpBrokerImpl) FilterPrompts(_ context.Context, _ any, mcpReq *mcp
 	prompts = broker.applyAuthorizedCapabilitiesFilterForPrompts(mcpReq.Header, prompts)
 	prompts = broker.applyVirtualServerFilterForPrompts(mcpReq.Header, prompts)
 	prompts = broker.removeGatewayMetaFromPrompts(prompts)
+
+	span.SetAttributes(attribute.Int("mcp.prompts.count", len(prompts)))
 
 	if prompts == nil {
 		prompts = emptyPrompts

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/mark3labs/mcp-go/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var authorizedCapabilitiesHeader = http.CanonicalHeaderKey("x-mcp-authorized")
@@ -22,8 +24,15 @@ const allowedCapabilitiesClaimKey = "allowed-capabilities"
 
 // FilterTools reduces the tool set based on authorization headers.
 // Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
-func (broker *mcpBrokerImpl) FilterTools(_ context.Context, _ any, mcpReq *mcp.ListToolsRequest, mcpRes *mcp.ListToolsResult) {
-	broker.logger.Debug("FilterTools called", "input_tools_count", len(mcpRes.Tools))
+func (broker *mcpBrokerImpl) FilterTools(ctx context.Context, _ any, mcpReq *mcp.ListToolsRequest, mcpRes *mcp.ListToolsResult) {
+	attrs := []attribute.KeyValue{brokerComponentAttr}
+	if sid := sessionIDFromContext(ctx); sid != "" {
+		attrs = append(attrs, attribute.String("mcp.session_id", sid))
+	}
+	ctx, span := brokerTracer().Start(ctx, "mcp-broker.tools-list", trace.WithAttributes(attrs...))
+	defer span.End()
+
+	broker.logger.DebugContext(ctx, "FilterTools called", "input_tools_count", len(mcpRes.Tools))
 	tools := mcpRes.Tools
 	emptyTools := []mcp.Tool{}
 	if len(mcpRes.Tools) == 0 {
@@ -33,13 +42,17 @@ func (broker *mcpBrokerImpl) FilterTools(_ context.Context, _ any, mcpReq *mcp.L
 
 	// step 1: apply x-mcp-authorized filtering (JWT-based)
 	tools = broker.applyAuthorizedCapabilitiesFilter(mcpReq.Header, tools)
-	broker.logger.Debug("FilterTools authorized capabilities result", "output_tools_count", len(tools))
+	broker.logger.DebugContext(ctx, "FilterTools authorized capabilities result", "output_tools_count", len(tools))
 
 	// step 2: apply virtual server filtering
 	tools = broker.applyVirtualServerFilter(mcpReq.Header, tools)
 	// filter out any gateway specific meta data we are storing internally before sending to clients
 	tools = broker.removeGatewayMeta(tools)
-	broker.logger.Debug("FilterTools virtual server result", "output_tools_count", len(tools))
+	broker.logger.DebugContext(ctx, "FilterTools virtual server result", "output_tools_count", len(tools))
+
+	if span.IsRecording() {
+		span.SetAttributes(attribute.Int("mcp.tools.count", len(tools)))
+	}
 
 	// ensure we never return nil (would serialize as null instead of [])
 	if tools == nil {

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -27,7 +27,7 @@ const allowedCapabilitiesClaimKey = "allowed-capabilities"
 func (broker *mcpBrokerImpl) FilterTools(ctx context.Context, _ any, mcpReq *mcp.ListToolsRequest, mcpRes *mcp.ListToolsResult) {
 	attrs := []attribute.KeyValue{brokerComponentAttr}
 	if sid := sessionIDFromContext(ctx); sid != "" {
-		attrs = append(attrs, attribute.String("mcp.session_id", sid))
+		attrs = append(attrs, attribute.String("mcp.session.id", sid))
 	}
 	ctx, span := brokerTracer().Start(ctx, "mcp-broker.tools-list", trace.WithAttributes(attrs...))
 	defer span.End()
@@ -50,9 +50,7 @@ func (broker *mcpBrokerImpl) FilterTools(ctx context.Context, _ any, mcpReq *mcp
 	tools = broker.removeGatewayMeta(tools)
 	broker.logger.DebugContext(ctx, "FilterTools virtual server result", "output_tools_count", len(tools))
 
-	if span.IsRecording() {
-		span.SetAttributes(attribute.Int("mcp.tools.count", len(tools)))
-	}
+	span.SetAttributes(attribute.Int("mcp.tools.count", len(tools)))
 
 	// ensure we never return nil (would serialize as null instead of [])
 	if tools == nil {

--- a/internal/broker/tracing.go
+++ b/internal/broker/tracing.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"sync"
 
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
-const brokerTracerName = "mcp-broker"
+const brokerTracerName = mcpotel.BrokerTracerName
 
 var brokerComponentAttr = attribute.String("component", "mcp-broker")
 
@@ -59,8 +59,7 @@ func sessionIDFromContext(ctx context.Context) string {
 }
 
 func recordBrokerError(span trace.Span, err error) {
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
+	mcpotel.SpanError(span, err, err.Error())
 	span.SetAttributes(
 		attribute.String("error.type", fmt.Sprintf("%T", err)),
 		attribute.String("error_source", "broker"),

--- a/internal/broker/tracing.go
+++ b/internal/broker/tracing.go
@@ -1,0 +1,68 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const brokerTracerName = "mcp-broker"
+
+var brokerComponentAttr = attribute.String("component", "mcp-broker")
+
+func brokerTracer() trace.Tracer {
+	return otel.Tracer(brokerTracerName)
+}
+
+type requestSpanTracker struct {
+	mu    sync.Mutex
+	spans map[any]trace.Span
+}
+
+func newRequestSpanTracker() *requestSpanTracker {
+	return &requestSpanTracker{spans: make(map[any]trace.Span)}
+}
+
+func (t *requestSpanTracker) start(ctx context.Context, id any, spanName string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	opts := []trace.SpanStartOption{}
+	if len(attrs) > 0 {
+		opts = append(opts, trace.WithAttributes(attrs...))
+	}
+	ctx, span := brokerTracer().Start(ctx, spanName, opts...) //nolint:spancheck // span ended by requestSpanTracker.remove caller
+	t.mu.Lock()
+	t.spans[id] = span
+	t.mu.Unlock()
+	return ctx, span //nolint:spancheck // span ended by requestSpanTracker.remove caller
+}
+
+func (t *requestSpanTracker) remove(id any) (trace.Span, bool) {
+	t.mu.Lock()
+	span, ok := t.spans[id]
+	if ok {
+		delete(t.spans, id)
+	}
+	t.mu.Unlock()
+	return span, ok
+}
+
+func sessionIDFromContext(ctx context.Context) string {
+	if session := server.ClientSessionFromContext(ctx); session != nil {
+		return session.SessionID()
+	}
+	return ""
+}
+
+func recordBrokerError(span trace.Span, err error) {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.SetAttributes(
+		attribute.String("error.type", fmt.Sprintf("%T", err)),
+		attribute.String("error_source", "broker"),
+	)
+}

--- a/internal/broker/tracing_test.go
+++ b/internal/broker/tracing_test.go
@@ -1,0 +1,82 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func setupTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exporter
+}
+
+func findAttribute(attrs []attribute.KeyValue, key string) (attribute.KeyValue, bool) {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr, true
+		}
+	}
+	return attribute.KeyValue{}, false
+}
+
+func TestBrokerTracer(t *testing.T) {
+	tr := brokerTracer()
+	require.NotNil(t, tr)
+}
+
+func TestRecordBrokerError(t *testing.T) {
+	exporter := setupTestTracer(t)
+	_, span := brokerTracer().Start(context.Background(), "test-span")
+	testErr := fmt.Errorf("test broker error")
+	recordBrokerError(span, testErr)
+	span.End()
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	s := spans[0]
+	require.Equal(t, "test-span", s.Name)
+	require.NotEmpty(t, s.Events)
+	attr, found := findAttribute(s.Attributes, "error_source")
+	require.True(t, found, "expected error_source attribute")
+	require.Equal(t, "broker", attr.Value.AsString())
+}
+
+func TestRequestSpanTracker(t *testing.T) {
+	exporter := setupTestTracer(t)
+	tracker := newRequestSpanTracker()
+	tracker.start(context.Background(), "req-1", "mcp-broker.handle-request",
+		attribute.String("mcp.method", "tools/list"),
+	)
+	span, ok := tracker.remove("req-1")
+	require.True(t, ok)
+	require.NotNil(t, span)
+	span.End()
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Equal(t, "mcp-broker.handle-request", spans[0].Name)
+	attr, found := findAttribute(spans[0].Attributes, "mcp.method")
+	require.True(t, found)
+	require.Equal(t, "tools/list", attr.Value.AsString())
+}
+
+func TestRequestSpanTrackerEndMissing(t *testing.T) {
+	_ = setupTestTracer(t)
+	tracker := newRequestSpanTracker()
+	span, ok := tracker.remove("nonexistent")
+	require.False(t, ok)
+	require.Nil(t, span)
+}

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -17,11 +17,11 @@ import (
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -48,7 +48,6 @@ const (
 	notificationToolsListChanged   = "notifications/tools/list_changed"
 	notificationPromptsListChanged = "notifications/prompts/list_changed"
 	gatewayServerID                = "kuadrant/id"
-	brokerTracerName               = "mcp-broker"
 )
 
 type eventType int
@@ -289,7 +288,7 @@ func (man *MCPManager) registerCallbacks() func() {
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.logger.DebugContext(ctx, "managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
 
-	ctx, span := otel.Tracer(brokerTracerName).Start(ctx, "mcp-broker.upstream-manage",
+	ctx, span := otel.Tracer(mcpotel.BrokerTracerName).Start(ctx, "mcp-broker.upstream-manage",
 		trace.WithAttributes(
 			attribute.String("component", "mcp-broker"),
 			attribute.String("mcp.server", man.mcp.GetName()),
@@ -304,6 +303,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
 		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.mcp.ID(), err)
 		man.recordBackendError(span, err)
+		man.logger.ErrorContext(ctx, "connection failed", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.removeAllTools()
 		man.removeAllPrompts()
 		// we call disconnect here as we may have connected but failed to initialize
@@ -508,11 +508,7 @@ func (man *MCPManager) applyBackoff() {
 }
 
 func (man *MCPManager) recordBackendError(span trace.Span, err error) {
-	if !span.IsRecording() {
-		return
-	}
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
+	mcpotel.SpanError(span, err, err.Error())
 	span.SetAttributes(
 		attribute.String("error.type", fmt.Sprintf("%T", err)),
 		attribute.String("error_source", "backend"),

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -19,6 +19,10 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ToolsAdderDeleter defines the interface for interacting with the gateway directly
@@ -44,6 +48,7 @@ const (
 	notificationToolsListChanged   = "notifications/tools/list_changed"
 	notificationPromptsListChanged = "notifications/prompts/list_changed"
 	gatewayServerID                = "kuadrant/id"
+	brokerTracerName               = "mcp-broker"
 )
 
 type eventType int
@@ -217,13 +222,13 @@ func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 				man.logger.Debug("manager stopped", "upstream mcp server", man.mcp.ID())
 				return
 			case <-man.ticker.C:
-				man.logger.Debug("health check tick", "upstream mcp server", man.mcp.ID())
+				man.logger.DebugContext(ctx, "health check tick", "upstream mcp server", man.mcp.ID())
 				man.manage(ctx, eventTypeTimer)
 			case <-man.toolEvents:
-				man.logger.Debug("received tool notification", "upstream mcp server", man.mcp.ID())
+				man.logger.DebugContext(ctx, "received tool notification", "upstream mcp server", man.mcp.ID())
 				man.manage(ctx, eventTypeToolNotification)
 			case <-man.promptEvents:
-				man.logger.Debug("received prompt notification", "upstream mcp server", man.mcp.ID())
+				man.logger.DebugContext(ctx, "received prompt notification", "upstream mcp server", man.mcp.ID())
 				man.manage(ctx, eventTypePromptNotification)
 			}
 		}
@@ -282,14 +287,23 @@ func (man *MCPManager) registerCallbacks() func() {
 
 // manage should be the only entry point that triggers changes to tools
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
-	man.logger.Debug("managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
+	man.logger.DebugContext(ctx, "managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
+
+	ctx, span := otel.Tracer(brokerTracerName).Start(ctx, "mcp-broker.upstream-manage",
+		trace.WithAttributes(
+			attribute.String("component", "mcp-broker"),
+			attribute.String("mcp.server", man.mcp.GetName()),
+		),
+	)
+	defer span.End()
+
 	numberOfTools := len(man.tools)
 	numberOfPrompts := len(man.prompts)
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
-	man.logger.Debug("attempting to connect", "upstream mcp server", man.mcp.ID())
+	man.logger.DebugContext(ctx, "attempting to connect", "upstream mcp server", man.mcp.ID())
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
 		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.mcp.ID(), err)
-		man.logger.Error("connection failed", "upstream mcp server", man.mcp.ID(), "error", err)
+		man.recordBackendError(span, err)
 		man.removeAllTools()
 		man.removeAllPrompts()
 		// we call disconnect here as we may have connected but failed to initialize
@@ -301,7 +315,8 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	if err := man.mcp.Ping(ctx); err != nil {
 		// if we fail to ping we disconnect to ensure a fresh connection next time around
 		err = fmt.Errorf("upstream mcp failed to ping server %s removing tools : %w", man.mcp.ID(), err)
-		man.logger.Error("ping failed", "upstream mcp server", man.mcp.ID(), "error", err)
+		man.recordBackendError(span, err)
+		man.logger.ErrorContext(ctx, "ping failed", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.removeAllTools()
 		man.removeAllPrompts()
 		_ = man.mcp.Disconnect()
@@ -312,24 +327,26 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	var toolErr error
 	var invalidTools []InvalidToolInfo
 	if !man.shouldFetchTools(event) {
-		man.logger.Debug("not fetching tools", "event", event, "upstream mcp server", man.mcp.ID(), "waiting for notification", notificationToolsListChanged)
+		man.logger.DebugContext(ctx, "not fetching tools", "event", event, "upstream mcp server", man.mcp.ID(), "waiting for notification", notificationToolsListChanged)
 	} else {
-		man.logger.Debug("fetching tools", "upstream mcp server", man.mcp.ID())
+		man.logger.DebugContext(ctx, "fetching tools", "upstream mcp server", man.mcp.ID())
 		current, fetched, err := man.getTools(ctx)
 		if err != nil {
 			toolErr = fmt.Errorf("upstream mcp failed to list tools server %s : %w", man.mcp.ID(), err)
-			man.logger.Error("failed to list tools", "upstream mcp server", man.mcp.ID(), "error", toolErr)
+			man.recordBackendError(span, toolErr)
+			man.logger.ErrorContext(ctx, "failed to list tools", "upstream mcp server", man.mcp.ID(), "error", toolErr)
 		} else {
 			// validate fetched tools
 			validTools, invalids := ValidateTools(fetched)
 			if len(invalids) > 0 {
-				man.logger.Error("invalid tools detected", "upstream mcp server", man.mcp.ID(), "invalid", len(invalids), "valid", len(validTools))
+				man.logger.ErrorContext(ctx, "invalid tools detected", "upstream mcp server", man.mcp.ID(), "invalid", len(invalids), "valid", len(validTools))
 				for _, info := range invalids {
-					man.logger.Error("invalid tool", "upstream mcp server", man.mcp.ID(), "tool", info.Name, "errors", info.Errors)
+					man.logger.ErrorContext(ctx, "invalid tool", "upstream mcp server", man.mcp.ID(), "tool", info.Name, "errors", info.Errors)
 				}
 				invalidTools = invalids
 				if man.invalidToolPolicy == mcpv1alpha1.InvalidToolPolicyRejectServer {
 					toolErr = fmt.Errorf("upstream mcp %s rejected: %d invalid tools found", man.mcp.ID(), len(invalids))
+					man.recordBackendError(span, toolErr)
 					man.removeAllTools()
 				} else {
 					fetched = validTools
@@ -341,7 +358,8 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 				toAdd, toRemove := man.diffTools(current, fetched)
 				if conflictErr := man.findToolConflicts(toAdd); conflictErr != nil {
 					toolErr = fmt.Errorf("upstream mcp failed to add tools to gateway %s : %w", man.mcp.ID(), conflictErr)
-					man.logger.Error("tool conflict detected", "upstream mcp server", man.mcp.ID(), "error", toolErr)
+					man.recordBackendError(span, toolErr)
+					man.logger.ErrorContext(ctx, "tool conflict detected", "upstream mcp server", man.mcp.ID(), "error", toolErr)
 				} else {
 					man.toolsLock.Lock()
 					man.tools = fetched
@@ -359,14 +377,14 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 					man.serverTools = append(man.serverTools, toAdd...)
 					man.toolsLock.Unlock()
 
-					man.logger.Debug("updating gateway tools", "upstream mcp server", man.mcp.ID(), "adding", len(toAdd), "removing", len(toRemove))
+					man.logger.DebugContext(ctx, "updating gateway tools", "upstream mcp server", man.mcp.ID(), "adding", len(toAdd), "removing", len(toRemove))
 					if len(toRemove) > 0 {
 						man.gatewayServer.DeleteTools(toRemove...)
 					}
 					if len(toAdd) > 0 {
 						man.gatewayServer.AddTools(toAdd...)
 					}
-					man.logger.Debug("internal tools", "upstream mcp server", man.mcp.ID(), "total", len(man.serverTools))
+					man.logger.DebugContext(ctx, "internal tools", "upstream mcp server", man.mcp.ID(), "total", len(man.serverTools))
 				}
 			}
 		}
@@ -378,13 +396,14 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		currentPrompts, fetchedPrompts, listErr := man.getPrompts(ctx)
 		if listErr != nil {
 			promptErr = fmt.Errorf("upstream mcp failed to list prompts server %s : %w", man.mcp.ID(), listErr)
-			man.logger.Error("failed to list prompts", "upstream mcp server", man.mcp.ID(), "error", promptErr)
+			man.recordBackendError(span, promptErr)
+			man.logger.ErrorContext(ctx, "failed to list prompts", "upstream mcp server", man.mcp.ID(), "error", promptErr)
 		} else {
 			validPrompts, invalids := ValidatePrompts(fetchedPrompts)
 			if len(invalids) > 0 {
-				man.logger.Error("invalid prompts detected", "upstream mcp server", man.mcp.ID(), "invalid", len(invalids), "valid", len(validPrompts))
+				man.logger.ErrorContext(ctx, "invalid prompts detected", "upstream mcp server", man.mcp.ID(), "invalid", len(invalids), "valid", len(validPrompts))
 				for _, info := range invalids {
-					man.logger.Error("invalid prompt", "upstream mcp server", man.mcp.ID(), "prompt", info.Name, "errors", info.Errors)
+					man.logger.ErrorContext(ctx, "invalid prompt", "upstream mcp server", man.mcp.ID(), "prompt", info.Name, "errors", info.Errors)
 				}
 				invalidPrompts = invalids
 				fetchedPrompts = validPrompts
@@ -393,7 +412,8 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 			toAddPrompts, toRemovePrompts := man.diffPrompts(currentPrompts, fetchedPrompts)
 			if conflictErr := man.findPromptConflicts(toAddPrompts); conflictErr != nil {
 				promptErr = fmt.Errorf("upstream mcp failed to add prompts to gateway %s : %w", man.mcp.ID(), conflictErr)
-				man.logger.Error("prompt conflict detected", "upstream mcp server", man.mcp.ID(), "error", promptErr)
+				man.recordBackendError(span, promptErr)
+				man.logger.ErrorContext(ctx, "prompt conflict detected", "upstream mcp server", man.mcp.ID(), "error", promptErr)
 			} else {
 				man.toolsLock.Lock()
 				man.prompts = fetchedPrompts
@@ -411,7 +431,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 				man.serverPrompts = append(man.serverPrompts, toAddPrompts...)
 				man.toolsLock.Unlock()
 
-				man.logger.Debug("updating gateway prompts", "upstream mcp server", man.mcp.ID(), "adding", len(toAddPrompts), "removing", len(toRemovePrompts))
+				man.logger.DebugContext(ctx, "updating gateway prompts", "upstream mcp server", man.mcp.ID(), "adding", len(toAddPrompts), "removing", len(toRemovePrompts))
 				if len(toRemovePrompts) > 0 {
 					man.promptsServer.DeletePrompts(toRemovePrompts...)
 				}
@@ -485,6 +505,19 @@ func (man *MCPManager) applyBackoff() {
 	duration := man.backoff.Step()
 	man.logger.Debug("applying backoff", "duration", duration, "upstream mcp server", man.mcp.ID())
 	man.ticker.Reset(duration)
+}
+
+func (man *MCPManager) recordBackendError(span trace.Span, err error) {
+	if !span.IsRecording() {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.SetAttributes(
+		attribute.String("error.type", fmt.Sprintf("%T", err)),
+		attribute.String("error_source", "backend"),
+		attribute.String("mcp.server", man.mcp.GetName()),
+	)
 }
 
 func (man *MCPManager) findToolConflicts(mcpTools []server.ServerTool) error {

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -227,7 +227,7 @@ func (mr *MCPRequest) ToBytes() ([]byte, error) {
 
 // HandleRequestHeaders handles request headers minimally.
 func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, _ *eppb.HttpHeaders) ([]*eppb.ProcessingResponse, error) {
-	s.Logger.InfoContext(ctx, "Request Handler: HandleRequestHeaders called")
+	s.Logger.DebugContext(ctx, "Request Handler: HandleRequestHeaders called")
 	requestHeaders := NewHeaders()
 	response := NewResponse()
 	requestHeaders.WithAuthority(s.RoutingConfig.MCPGatewayExternalHostname)

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -225,8 +225,8 @@ func (mr *MCPRequest) ToBytes() ([]byte, error) {
 }
 
 // HandleRequestHeaders handles request headers minimally.
-func (s *ExtProcServer) HandleRequestHeaders(_ *eppb.HttpHeaders) ([]*eppb.ProcessingResponse, error) {
-	s.Logger.Info("Request Handler: HandleRequestHeaders called")
+func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, _ *eppb.HttpHeaders) ([]*eppb.ProcessingResponse, error) {
+	s.Logger.InfoContext(ctx, "Request Handler: HandleRequestHeaders called")
 	requestHeaders := NewHeaders()
 	response := NewResponse()
 	requestHeaders.WithAuthority(s.RoutingConfig.MCPGatewayExternalHostname)
@@ -237,6 +237,7 @@ func (s *ExtProcServer) HandleRequestHeaders(_ *eppb.HttpHeaders) ([]*eppb.Proce
 func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
 	ctx, span := tracer().Start(ctx, "mcp-router.route-decision",
 		trace.WithAttributes(
+			componentAttr,
 			attribute.String("mcp.method.name", mcpReq.Method),
 		),
 	)
@@ -277,6 +278,7 @@ func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) 
 
 	ctx, span := tracer().Start(ctx, "mcp-router.tool-call",
 		trace.WithAttributes(
+			componentAttr,
 			attribute.String("gen_ai.tool.name", toolName),
 			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
 		),
@@ -308,6 +310,7 @@ func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) 
 	{
 		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info",
 			trace.WithAttributes(
+				componentAttr,
 				attribute.String("gen_ai.tool.name", toolName),
 			),
 		)
@@ -417,6 +420,7 @@ func (s *ExtProcServer) HandlePromptGet(ctx context.Context, mcpReq *MCPRequest)
 
 	ctx, span := tracer().Start(ctx, "mcp-router.prompt-get",
 		trace.WithAttributes(
+			componentAttr,
 			attribute.String("mcp.prompt.name", promptName),
 			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
 		),
@@ -446,6 +450,7 @@ func (s *ExtProcServer) HandlePromptGet(ctx context.Context, mcpReq *MCPRequest)
 	{
 		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info-by-prompt",
 			trace.WithAttributes(
+				componentAttr,
 				attribute.String("mcp.prompt.name", promptName),
 			),
 		)
@@ -498,6 +503,7 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 	{
 		_, cacheSpan := tracer().Start(ctx, "mcp-router.session-cache.get",
 			trace.WithAttributes(
+				componentAttr,
 				attribute.String("mcp.session.id", mcpReq.GetSessionID()),
 			),
 		)
@@ -577,9 +583,19 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	ctx context.Context,
 	mcpReq *MCPRequest,
 ) []*eppb.ProcessingResponse {
+	ctx, span := tracer().Start(ctx, "mcp-router.elicitation-response",
+		trace.WithAttributes(
+			componentAttr,
+			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+		),
+	)
+	defer span.End()
+
 	response := NewResponse()
 
 	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
+		span.RecordError(sessionErr)
+		span.SetStatus(codes.Error, sessionErr.Error())
 		response.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
 		return response.Build()
 	}
@@ -589,16 +605,24 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	entry, ok, err := s.ElicitationMap.Lookup(ctx, gatewayID)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to lookup elicitation mapping", "error", err, "gatewayID", gatewayID)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "elicitation lookup failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
 	if !ok {
+		lookupErr := fmt.Errorf("elicitation response for unknown gateway ID: %s", gatewayID)
 		s.Logger.ErrorContext(ctx, "elicitation response for unknown gateway ID", "gatewayID", gatewayID)
+		span.RecordError(lookupErr)
+		span.SetStatus(codes.Error, "unknown elicitation ID")
 		response.WithImmediateResponse(400, "unknown elicitation ID")
 		return response.Build()
 	}
 	if entry.GatewaySessionID != mcpReq.GetSessionID() {
+		mismatchErr := fmt.Errorf("elicitation session mismatch: expected %s, got %s", entry.GatewaySessionID, mcpReq.GetSessionID())
 		s.Logger.ErrorContext(ctx, "elicitation session mismatch", "gatewayID", gatewayID, "expected", entry.GatewaySessionID, "got", mcpReq.GetSessionID())
+		span.RecordError(mismatchErr)
+		span.SetStatus(codes.Error, "session mismatch")
 		response.WithImmediateResponse(403, "session mismatch")
 		return response.Build()
 	}
@@ -609,6 +633,8 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(entry.ServerName)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "server not found for elicitation response", "server", entry.ServerName)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "server not found")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
@@ -620,6 +646,8 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	path, err := mcpServerConfig.Path()
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to parse url for backend", "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "path parse failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
@@ -628,6 +656,8 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	body, err := mcpReq.ToBytes()
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to get bytes for elicitation response", "mcpReqID", mcpReq.ID, "serverName", entry.ServerName)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "marshal failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
@@ -647,6 +677,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *MCPRequest) (string, error) {
 	ctx, initSpan := tracer().Start(ctx, "mcp-router.session-init",
 		trace.WithAttributes(
+			componentAttr,
 			attribute.String("mcp.server", mcpReq.serverName),
 			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
 		),
@@ -797,6 +828,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
 	ctx, span := tracer().Start(ctx, "mcp-router.broker-passthrough",
 		trace.WithAttributes(
+			componentAttr,
 			attribute.String("mcp.method.name", mcpReq.Method),
 		),
 	)

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"go.opentelemetry.io/otel/attribute"
@@ -296,8 +297,7 @@ func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) 
 	}
 	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
 		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
-		span.RecordError(sessionErr)
-		span.SetStatus(codes.Error, sessionErr.Error())
+		mcpotel.SpanError(span, sessionErr, sessionErr.Error())
 		span.SetAttributes(attribute.String("error.type", "invalid_session"))
 		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
 		return calculatedResponse.Build()
@@ -317,16 +317,14 @@ func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) 
 		var infoErr error
 		serverInfo, infoErr = s.Broker.GetServerInfo(toolName)
 		if infoErr != nil {
-			infoSpan.RecordError(infoErr)
-			infoSpan.SetStatus(codes.Error, "tool not found")
+			mcpotel.SpanError(infoSpan, infoErr, "tool not found")
 		}
 		infoSpan.End()
 		err = infoErr
 	}
 	if err != nil {
 		s.Logger.DebugContext(ctx, "no server for tool", "toolName", toolName)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "tool not found")
+		mcpotel.SpanError(span, err, "tool not found")
 		span.SetAttributes(attribute.String("error.type", "tool_not_found"))
 		calculatedResponse.WithImmediateJSONRPCResponse(200,
 			[]*corev3.HeaderValueOption{
@@ -378,8 +376,7 @@ func (s *ExtProcServer) HandleToolCall(ctx context.Context, mcpReq *MCPRequest) 
 	if s.ElicitationEnabled && serverInfo.TokenURLElicitation != nil {
 		elicitInfo, tokenErr := s.resolveUpstreamToken(ctx, mcpReq, serverInfo, headers)
 		if tokenErr != nil {
-			span.RecordError(tokenErr)
-			span.SetStatus(codes.Error, tokenErr.Error())
+			mcpotel.SpanError(span, tokenErr, tokenErr.Error())
 			var routerErr *RouterError
 			if errors.As(tokenErr, &routerErr) {
 				span.SetAttributes(attribute.String("error.type", "client_capability"))
@@ -437,8 +434,7 @@ func (s *ExtProcServer) HandlePromptGet(ctx context.Context, mcpReq *MCPRequest)
 	}
 	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
 		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
-		span.RecordError(sessionErr)
-		span.SetStatus(codes.Error, sessionErr.Error())
+		mcpotel.SpanError(span, sessionErr, sessionErr.Error())
 		span.SetAttributes(attribute.String("error.type", "invalid_session"))
 		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
 		return calculatedResponse.Build()
@@ -457,16 +453,14 @@ func (s *ExtProcServer) HandlePromptGet(ctx context.Context, mcpReq *MCPRequest)
 		var infoErr error
 		serverInfo, infoErr = s.Broker.GetServerInfoByPrompt(promptName)
 		if infoErr != nil {
-			infoSpan.RecordError(infoErr)
-			infoSpan.SetStatus(codes.Error, "prompt not found")
+			mcpotel.SpanError(infoSpan, infoErr, "prompt not found")
 		}
 		infoSpan.End()
 		err = infoErr
 	}
 	if err != nil {
 		s.Logger.DebugContext(ctx, "no server for prompt", "promptName", promptName)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "prompt not found")
+		mcpotel.SpanError(span, err, "prompt not found")
 		span.SetAttributes(attribute.String("error.type", "prompt_not_found"))
 		calculatedResponse.WithImmediateJSONRPCResponse(200,
 			[]*corev3.HeaderValueOption{
@@ -510,14 +504,12 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 		var cacheErr error
 		exists, cacheErr = s.SessionCache.GetSession(ctx, mcpReq.GetSessionID())
 		if cacheErr != nil {
-			cacheSpan.RecordError(cacheErr)
-			cacheSpan.SetStatus(codes.Error, "session cache get failed")
+			mcpotel.SpanError(cacheSpan, cacheErr, "session cache get failed")
 		}
 		cacheSpan.End()
 		if cacheErr != nil {
 			s.Logger.ErrorContext(ctx, "failed to get session from cache", "error", cacheErr)
-			span.RecordError(cacheErr)
-			span.SetStatus(codes.Error, "session cache error")
+			mcpotel.SpanError(span, cacheErr, "session cache error")
 			span.SetAttributes(attribute.String("error.type", "session_cache_error"))
 			calculatedResponse.WithImmediateResponse(500, "internal error")
 			return calculatedResponse.Build()
@@ -538,8 +530,7 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 				calculatedResponse.WithImmediateResponse(500, "internal error")
 			}
 			s.Logger.ErrorContext(ctx, "failed to get remote mcp server session id", "error", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "session initialization failed")
+			mcpotel.SpanError(span, err, "session initialization failed")
 			span.SetAttributes(attribute.String("error.type", "session_init_error"))
 			return calculatedResponse.Build()
 		}
@@ -552,8 +543,7 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 	body, err := mcpReq.ToBytes()
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to marshal body to bytes", "error", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "body marshal failed")
+		mcpotel.SpanError(span, err, "body marshal failed")
 		span.SetAttributes(attribute.String("error.type", "marshal_error"))
 		calculatedResponse.WithImmediateResponse(500, "internal error")
 		return calculatedResponse.Build()
@@ -561,8 +551,7 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 	path, err := serverInfo.Path()
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to parse url for backend", "error", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "path parse failed")
+		mcpotel.SpanError(span, err, "path parse failed")
 		span.SetAttributes(attribute.String("error.type", "path_parse_error"))
 		calculatedResponse.WithImmediateResponse(500, "internal error")
 		return calculatedResponse.Build()
@@ -594,8 +583,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	response := NewResponse()
 
 	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
-		span.RecordError(sessionErr)
-		span.SetStatus(codes.Error, sessionErr.Error())
+		mcpotel.SpanError(span, sessionErr, sessionErr.Error())
 		response.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
 		return response.Build()
 	}
@@ -605,24 +593,21 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	entry, ok, err := s.ElicitationMap.Lookup(ctx, gatewayID)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to lookup elicitation mapping", "error", err, "gatewayID", gatewayID)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "elicitation lookup failed")
+		mcpotel.SpanError(span, err, "elicitation lookup failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
 	if !ok {
 		lookupErr := fmt.Errorf("elicitation response for unknown gateway ID: %s", gatewayID)
 		s.Logger.ErrorContext(ctx, "elicitation response for unknown gateway ID", "gatewayID", gatewayID)
-		span.RecordError(lookupErr)
-		span.SetStatus(codes.Error, "unknown elicitation ID")
+		mcpotel.SpanError(span, lookupErr, "unknown elicitation ID")
 		response.WithImmediateResponse(400, "unknown elicitation ID")
 		return response.Build()
 	}
 	if entry.GatewaySessionID != mcpReq.GetSessionID() {
 		mismatchErr := fmt.Errorf("elicitation session mismatch: expected %s, got %s", entry.GatewaySessionID, mcpReq.GetSessionID())
 		s.Logger.ErrorContext(ctx, "elicitation session mismatch", "gatewayID", gatewayID, "expected", entry.GatewaySessionID, "got", mcpReq.GetSessionID())
-		span.RecordError(mismatchErr)
-		span.SetStatus(codes.Error, "session mismatch")
+		mcpotel.SpanError(span, mismatchErr, "session mismatch")
 		response.WithImmediateResponse(403, "session mismatch")
 		return response.Build()
 	}
@@ -633,8 +618,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(entry.ServerName)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "server not found for elicitation response", "server", entry.ServerName)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "server not found")
+		mcpotel.SpanError(span, err, "server not found")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
@@ -646,8 +630,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	path, err := mcpServerConfig.Path()
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to parse url for backend", "error", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "path parse failed")
+		mcpotel.SpanError(span, err, "path parse failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
@@ -656,8 +639,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	body, err := mcpReq.ToBytes()
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "failed to get bytes for elicitation response", "mcpReqID", mcpReq.ID, "serverName", entry.ServerName)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "marshal failed")
+		mcpotel.SpanError(span, err, "marshal failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
@@ -760,15 +742,13 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		initToken, err := s.JWTManager.GenerateBackendInitToken(mcpServerConfig.Hostname)
 		if err != nil {
 			s.Logger.ErrorContext(ctx, "failed to generate backend-init token", "error", err)
-			initSpan.RecordError(err)
-			initSpan.SetStatus(codes.Error, "failed to generate backend-init token")
+			mcpotel.SpanError(initSpan, err, "failed to generate backend-init token")
 			return "", NewRouterErrorf(500, "failed to generate backend-init token: %w", err)
 		}
 		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation)
 		if err != nil {
 			s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
-			initSpan.RecordError(err)
-			initSpan.SetStatus(codes.Error, "failed to initialize backend session")
+			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
 			return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 		}
 		var sessionCloser = func() {
@@ -801,8 +781,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			)
 			_, storeErr := s.SessionCache.AddSession(ctx, mcpReq.GetSessionID(), mcpServerConfig.Name, remoteSessionID)
 			if storeErr != nil {
-				storeSpan.RecordError(storeErr)
-				storeSpan.SetStatus(codes.Error, "session cache store failed")
+				mcpotel.SpanError(storeSpan, storeErr, "session cache store failed")
 			}
 			storeSpan.End()
 			if storeErr != nil {

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1317,7 +1317,7 @@ func TestHandleRequestHeaders(t *testing.T) {
 				},
 			}
 
-			responses, err := server.HandleRequestHeaders(headers)
+			responses, err := server.HandleRequestHeaders(context.Background(), headers)
 
 			require.NoError(t, err)
 			require.Len(t, responses, 1)

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -111,13 +111,14 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			span.End()
 			ctx, span = tracer().Start(ctx, "mcp-router.process", //nolint:spancheck // ended via defer closure
 				trace.WithAttributes(
+					componentAttr,
 					attribute.String("http.method", method),
 					attribute.String("http.path", requestPath),
 					attribute.String("http.request_id", requestID),
 				),
 			)
 
-			responses, _ := s.HandleRequestHeaders(r.RequestHeaders)
+			responses, _ := s.HandleRequestHeaders(ctx, r.RequestHeaders)
 			s.Logger.DebugContext(ctx, "[ext_proc ] Process: ProcessingRequest_RequestHeaders", "request id:", requestID, "path", requestPath, "method", method)
 			for _, response := range responses {
 				s.Logger.DebugContext(ctx, "sending header processing instructions to envoy", "response", response)

--- a/internal/mcp-router/tracing.go
+++ b/internal/mcp-router/tracing.go
@@ -13,6 +13,8 @@ import (
 
 const tracerName = "mcp-router"
 
+var componentAttr = attribute.String("component", "mcp-router")
+
 func tracer() trace.Tracer {
 	return otel.Tracer(tracerName)
 }
@@ -48,6 +50,7 @@ func extractTraceContext(ctx context.Context, headers *corev3.HeaderMap) context
 
 func spanAttributes(mcpReq *MCPRequest) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
+		componentAttr,
 		attribute.String("mcp.method.name", mcpReq.Method),
 		attribute.String("jsonrpc.protocol.version", mcpReq.JSONRPC),
 	}

--- a/internal/mcp-router/tracing.go
+++ b/internal/mcp-router/tracing.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -83,8 +83,7 @@ func spanAttributes(mcpReq *MCPRequest) []attribute.KeyValue {
 }
 
 func recordError(span trace.Span, err error, statusCode int32) {
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
+	mcpotel.SpanError(span, err, err.Error())
 	span.SetAttributes(
 		attribute.String("error.type", fmt.Sprintf("%T", err)),
 		attribute.String("error_source", "ext-proc"),

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -6,9 +6,20 @@ import (
 	"log/slog"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// BrokerTracerName is the OpenTelemetry tracer name for the broker component.
+const BrokerTracerName = "mcp-broker"
+
+// SpanError records an error on the span and sets its status to error.
+func SpanError(span trace.Span, err error, msg string) {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, msg)
+}
 
 // SetupOTelSDK initializes the OpenTelemetry SDK with tracing and logs support
 func SetupOTelSDK(ctx context.Context, gitSHA, dirty, version string, logger *slog.Logger) (shutdown func(context.Context) error, loggerProvider *sdklog.LoggerProvider, err error) {


### PR DESCRIPTION
Closes ## Broker & Router OTEL Tracing — Verification Guide

This guide walks through verifying that the MCP Broker and Router produce distributed tracing spans, structured logs with trace ID correlation, and immediate_response span events, following the observability plan in issues #596 and #428.

Section 0 deploys the full environment with Envoy and Authorino tracing enabled. Since `AUTH_TRACING=1` installs the auth stack, all requests require a Bearer token — section 0 fetches one that is reused throughout. Re-run the token command if requests start returning 401 (tokens expire after ~30 minutes).

## Prerequisites

- `kubectl`, `curl`, `jq`, `openssl` available locally

## 0. Deploy the environment with OTel stack

Deploy the Kind cluster, MCP Gateway, test servers, and the OTel observability stack (Tempo, Loki, Grafana, Collector) with Envoy and Authorino tracing:

```bash
make local-env-setup
make deploy-test-servers && make deploy-example
make otel ISTIO_TRACING=1 AUTH_TRACING=1
```

Verify all observability pods are running:

```bash
make otel-status
```

Expected: `otel-collector`, `tempo`, `loki`, and `grafana` pods in `Running` state in the `observability` namespace.

Port-forward Grafana for trace inspection:

```bash
make otel-forward &
```

Grafana is now available at http://localhost:3000.

Fetch a Keycloak token (used in all subsequent sections):

```bash
TOKEN=$(curl -sk -X POST "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token" \
  -d "grant_type=password" \
  -d "client_id=mcp-gateway" \
  -d "client_secret=secret" \
  -d "username=mcp" \
  -d "password=mcp" \
  -d "scope=openid groups roles" | jq -r '.access_token')
echo "Token: ${TOKEN:0:20}..."
```

> **Note:** Tokens expire after ~30 minutes. Re-run the command above if requests start returning 401.

## 1. Verify `mcp-broker.handle-request` span on tools/list

Initialize a session and send a `tools/list` request with a known trace ID:

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID: $TRACE_ID"

HEADERS=$(mktemp)
curl -sk -D "$HEADERS" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

SESSION_ID=$(grep -i "mcp-session-id:" "$HEADERS" | tr -d '\r' | awk '{print $2}')
echo "Session: $SESSION_ID"

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
```

Open Grafana -> Explore -> select **Tempo** datasource. Paste the printed Trace ID into the search.

Expected: a trace containing a `mcp-broker.handle-request` span with attributes:

- `component` = `mcp-broker`
- `mcp.method` = `tools/list`
- `mcp.session_id` = the gateway session ID from above

## 2. Verify `mcp-broker.tools-list` span with tool count

In the same trace from section 1, look for a `mcp-broker.tools-list` span.

Expected:
- The span is a child span in the same trace
- Attributes include:
  - `component` = `mcp-broker`
  - `mcp.session_id` = the gateway session ID
  - `mcp.tools.count` = number of tools returned (should match the tools/list response count)

## 3. Verify `mcp-router.tool-call` span on tools/call

Use the session from section 1 to call a tool. This verifies the router's tool-call tracing path (the broker is not involved — the router routes directly to the backend):

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID: $TRACE_ID"

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test1_greet","arguments":{"name":"reviewer"}}}'

echo ""
echo "Search Tempo for trace: $TRACE_ID"
```

Expected: a trace containing:

- `mcp-router.process` with `component=mcp-router`
- `mcp-router.route-decision` with `mcp.route=tool-call`
- `mcp-router.tool-call` with:
  - `component` = `mcp-router`
  - `gen_ai.tool.name` = `test1_greet`
  - `mcp.session.id` = the gateway session ID
  - `mcp.server` = server1's name
- `mcp-router.session-init` (on first call — lazy backend initialization)
- `mcp-router.session-cache.get` and `mcp-router.session-cache.store`

> **Note:** No `mcp-broker.handle-request` span appears — `tools/call` is routed directly to the backend server by the router, bypassing the broker entirely.

## 4. Verify `mcp-broker.handle-request` span on initialize

The `BeforeAny` / `OnSuccess` hook pair fires for every MCP method, including `initialize`:

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID: $TRACE_ID"

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

echo "Search Tempo for trace: $TRACE_ID"
```

Expected: a `mcp-broker.handle-request` span with:

- `component` = `mcp-broker`
- `mcp.method` = `initialize`
- Status: OK (no error)
- The span has a non-zero duration (wraps the full request processing, not just the hook)

## 5. Verify `error_source=broker` on error spans

Send a `tools/list` request with an invalid pagination cursor. The broker dispatches through `BeforeAny` (starting the span), then the handler fails on the bad cursor, then `OnError` fires (annotating and ending the span):

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID: $TRACE_ID"

HEADERS=$(mktemp)
curl -sk -D "$HEADERS" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

SESSION_ID=$(grep -i "mcp-session-id:" "$HEADERS" | tr -d '\r' | awk '{print $2}')

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":99,"method":"tools/list","params":{"cursor":"!!!not-valid-base64!!!"}}'

echo ""
echo "Search Tempo for trace: $TRACE_ID"
```

> **Note:** The invalid cursor passes JSON parsing (so `BeforeAny` fires), but fails base64 decoding inside `handleListTools` (so `OnError` fires with the span still active). Errors like unsupported methods or malformed JSON are rejected *before* `BeforeAny`, so no span is created for those — this is expected per mcp-go's hook contract.

Expected: a `mcp-broker.handle-request` span with:

- Status: **Error**
- `error_source` = `broker`
- `error.type` set
- `mcp.method` = `tools/list`
- An error event recorded on the span

## 6. Verify `error_source=backend` on upstream errors

The upstream manager creates `mcp-broker.upstream-manage` spans when connecting to backend servers. The broken-server is intentionally misconfigured to trigger connect/ping failures.

Deploy the broken server if not already:

```bash
kubectl apply -f config/test-servers/broken-server-deployment.yaml \
              -f config/test-servers/broken-server-service.yaml \
              -f config/test-servers/broken-server-httproute.yaml -n mcp-test
kubectl apply -f config/samples/mcpserverregistration-broken-server.yaml
kubectl wait --for=condition=Available deployment/mcp-test-broken-server -n mcp-test --timeout=60s
```

Wait for the manager tick (up to 60 seconds) or check broker logs for the connect attempt:

```bash
kubectl logs deployment/mcp-gateway -n mcp-system -c mcp-gateway | grep -i "broken\|failed to connect"
```

In Tempo, search for spans named `mcp-broker.upstream-manage`.

Expected: a span for the broken server with:

- `mcp.server` = the broken server's name
- Status: **Error**
- `error_source` = `backend`
- `error.type` set

For healthy servers (e.g., everything-server, server1), the same `mcp-broker.upstream-manage` span should show:

- `mcp.server` = the server name

## 7. Verify structured logging with trace_id correlation

Check that broker logs include `trace_id` and `span_id` fields when a span is active:

```bash
kubectl logs deployment/mcp-gateway -n mcp-system -c mcp-gateway | grep -E "trace_id|span_id" | head -10
```

Expected: JSON log lines containing `trace_id` and `span_id` fields, e.g.:

```json
{"time":"...","level":"DEBUG","msg":"processing request","method":"tools/list","trace_id":"abc123...","span_id":"def456..."}
```

For log-to-trace correlation in Grafana:
1. Open Grafana -> Explore -> select **Loki** datasource
2. Query: `{namespace="mcp-system", container="mcp-gateway"} | json`
3. Find a log line with a `trace_id` field
4. Click the trace ID link to jump directly to the trace in Tempo

Verify that logs from methods like `initialize`, `tools/list`, and `tools/call` all include trace context. Lifecycle logs without an active span (e.g., `manager stopped`, `removing tools from gateway`) should gracefully omit `trace_id`/`span_id` with no errors.

## 8. Verify `component` attribute on router spans

Send a tools/list request to verify router and broker spans have the correct `component` attribute:

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID: $TRACE_ID"

HEADERS=$(mktemp)
curl -sk -D "$HEADERS" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

SESSION_ID=$(grep -i "mcp-session-id:" "$HEADERS" | tr -d '\r' | awk '{print $2}')

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'

echo ""
echo "Search Tempo for trace: $TRACE_ID"
```

In Tempo, search by the printed Trace ID. Verify all router spans have `component=mcp-router`:

- `mcp-router.process`
- `mcp-router.route-decision`
- `mcp-router.broker-passthrough`

And all broker spans have `component=mcp-broker`:

- `mcp-broker.handle-request`
- `mcp-broker.tools-list`

## 9. Verify full end-to-end trace (Envoy -> Authorino -> Router -> Broker)

Since Envoy and Authorino tracing were enabled in section 0, the full trace chain should already be visible. Send a request with a known trace ID:

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID: $TRACE_ID"

HEADERS=$(mktemp)
curl -sk -D "$HEADERS" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

SESSION_ID=$(grep -i "mcp-session-id:" "$HEADERS" | tr -d '\r' | awk '{print $2}')

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'

echo ""
echo "Search Tempo for trace: $TRACE_ID"
```

In Tempo, search by Trace ID. Expected: a single trace showing the full chain:

- **Envoy** ingress span (from Istio)
- **Authorino** auth check span (ext-authz)
- **mcp-router.process** with `component=mcp-router`
- **mcp-router.route-decision** → **mcp-router.broker-passthrough**
- **mcp-broker.handle-request** with `component=mcp-broker`, `mcp.method=tools/list`
- **mcp-broker.tools-list** with `mcp.tools.count`

This is the "click one trace and see the full journey" outcome from the Phase 2 design.

## 10. Verify Envoy access logs with `response_code_details`

Envoy access logging is enabled by `make otel ISTIO_TRACING=1`. Each request through the gateway produces an access log line showing who caused the response status code.

Send a successful request and check the Envoy logs:

```bash
TOKEN=$(curl -sk -X POST "https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp/protocol/openid-connect/token" \
  -d "grant_type=password" -d "client_id=mcp-gateway" -d "client_secret=secret" \
  -d "username=mcp" -d "password=mcp" -d "scope=openid groups roles" | jq -r '.access_token') 2>/dev/null

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

sleep 1
kubectl logs deployment/mcp-gateway-istio -n gateway-system --since=10s | grep "POST /mcp"
```

Expected: an access log line containing:

- `response_code_details` — e.g., `via_upstream` (backend responded), `ext_authz_denied` (Authorino rejected), `route_not_found`
- `upstream_cluster` — e.g., `outbound|8080||mcp-gateway.mcp-system.svc.cluster.local`
- `x-request-id` — for correlating with traces

To verify an auth-denied response, send a request without a token:

```bash
curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

sleep 1
kubectl logs deployment/mcp-gateway-istio -n gateway-system --since=10s | grep "POST /mcp"
```

Expected: `401` with no upstream host (`"-"`) — showing the request never reached the backend. The `response_code_details` field may be empty (`-`) when the Kuadrant WASM filter handles the rejection directly. The key signal is the missing upstream host combined with the 401 status.

> **Note:** `response_code_details` is an Envoy-internal field not available to the ext-proc. It appears only in access logs, not in OTel spans. Use the `x-request-id` from the access log to correlate with traces in Tempo.

## 11. Verify graceful degradation without OTel (optional)

Remove the OTel environment variables from the gateway deployment:

```bash
kubectl set env deployment/mcp-gateway -n mcp-system \
  OTEL_EXPORTER_OTLP_ENDPOINT- OTEL_EXPORTER_OTLP_INSECURE-
kubectl rollout status deployment/mcp-gateway -n mcp-system --timeout=120s
```

Send a request (traceparent is still passed but won't be exported since OTel is off):

```bash
TRACE_ID=$(openssl rand -hex 16)
echo "Trace ID (should NOT appear in Tempo): $TRACE_ID"

HEADERS=$(mktemp)
curl -sk -D "$HEADERS" -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null

SESSION_ID=$(grep -i "mcp-session-id:" "$HEADERS" | tr -d '\r' | awk '{print $2}')

curl -sk -X POST "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "mcp-session-id: $SESSION_ID" \
  -H "traceparent: 00-${TRACE_ID}-$(openssl rand -hex 8)-01" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | jq '.result.tools | length'
```

Expected: the request succeeds and returns tools. No panics or errors in the logs:

```bash
kubectl logs deployment/mcp-gateway -n mcp-system -c mcp-gateway | grep -i "error\|panic"
```

Expected: no OTel-related errors. The `TracingHandler` gracefully skips trace context when tracing is inactive. Log lines should not contain `trace_id`/`span_id` fields.

Re-enable OTel:

```bash
make otel
```

## 12. Verify unit and integration tests pass

```bash
make test-unit
make test-controller-integration
```

All tests should pass.

## 13. Verify lint passes

```bash
make lint
```

Expected: 0 issues.

--------------------------------------------------

<img width="975" height="792" alt="image" src="https://github.com/user-attachments/assets/71122e3b-1410-4ae6-a487-a25b2fcffb94" />


This trace shows a tools/list request through the full MCP Gateway stack — 24 spans, two HTTP
  round-trips (initialize + tools/list).

  Each request follows the same pattern:

  1. Envoy ingress (mcp-gateway-istio.gateway-system) — receives the HTTP POST
  2. ext_proc (async envoy...ExternalProcessor.Process) — Envoy consults the router
  3. Broker (mcp-broker.handle-request) — processes the MCP method
  4. Router (mcp-router.process → route-decision → broker-passthrough) — parses the JSON-RPC body,
  decides it's broker-bound
  5. Auth (wasm-shim → authorino Check) — Kuadrant WASM filter sends the request to Authorino for
  JWT validation
  
  Why does the broker span appear before the router? Envoy works in phases — it forwards the request
   to the broker while simultaneously sending the body to the router's ext_proc. They run
  concurrently; Envoy orchestrates both.

  Why two identical patterns? The trace contains two requests on the same trace ID: initialize (top,
   41ms) and tools/list (bottom, 8ms — faster because auth config is cached).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-level OpenTelemetry tracing across broker, router, and upstream paths with propagated trace context and richer span attributes (session, component, counts).
  * Enhanced error recording to surface error type and source in traces.

* **Tests**
  * Added unit tests for tracing helpers and span tracking.

* **Documentation**
  * Expanded OpenTelemetry conventions and examples.

* **Chores**
  * Enabled access logging in Istio telemetry patch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->