### PR TITLE
chore(ci): add cspell words for GHSA advisory

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -404,3 +404,6 @@ usercred
 myprefix
 SIEM
 SIEMs
+GHSA
+hrpp
+deadbeefcafebabe


### PR DESCRIPTION
## Summary
- Adds `GHSA`, `hrpp`, and `deadbeefcafebabe` to the project dictionary so spell checks pass after the GHSA-g53w-w6mj-hrpp security advisory fix landed on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal word list with additional recognized terms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/962)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->