### PR TITLE
fix: acquire manageMu in Stop() to prevent tool re-registration race

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -159,7 +159,12 @@ func (man *MCPManager) Start(ctx context.Context) {
 func (man *MCPManager) Stop() {
 	man.stopOnce.Do(func() {
 		man.ticker.Stop()
+		// Acquire manageMu to wait for any in-flight manage() call to complete before
+		// clearing tools. Without this, manage() can re-add tools via AddTools() after
+		// removeAllTools() has deleted them, leaving the broker with un-routable tools.
+		man.manageMu.Lock()
 		man.removeAllTools()
+		man.manageMu.Unlock()
 		if err := man.MCP.Disconnect(); err != nil {
 			man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.MCP.ID(), "error", err)
 		}


### PR DESCRIPTION
I was reading through the manager code and noticed something subtle with how `Stop()` and `manage()` interact.

When `Stop()` is called ; say, because a hot-reload removed a server; it grabs `toolsLock`, calls `removeAllTools()` to delete the tools from the broker, then disconnects and closes `done`. Clean enough on its own.

The problem is `manage()` doesn't know any of this is happening. It holds `manageMu` for its entire lifetime, but when it gets to the `getTools()` call it's just sitting there waiting on a network response from the backend. `Stop()` doesn't touch `manageMu` at all, so it runs right through ; clears the tools, releases `toolsLock`, disconnects the backend, closes `done`; and exits.

Then the network response comes back. `manage()` picks up where it left off, acquires `toolsLock` (nobody's holding it anymore), computes the diff between what it had before and what it just fetched, and calls `gatewayServer.AddTools()` with the result. The tools are back in `listeningMCPServer`.

But the manager itself is already deleted from `m.mcpServers` by `OnConfigChange`. So now `tools/list` shows those tools, but `GetServerInfo()` can't find the server config for them because it only looks in `m.mcpServers`. Every `tools/call` for those tools returns "Tool not found". And since no future code path will call `DeleteTools()` for a stopped, untracked manager, they stay there until the process restarts.

This is most likely to bite on a server's first `manage` cycle ; when `man.tools` is still empty, `toAdd` equals the full fetched list, so `AddTools()` always fires if the race hits.

The fix is small: `Stop()` acquires `manageMu` before calling `removeAllTools()`. It blocks until any running `manage()` finishes, then clears the tools. By that point the ticker is already stopped, `done` is about to close, so no new `manage()` can sneak in after. Three lines, no new fields, no new locks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition during shutdown that could cause tools to be improperly re-added after cleanup, improving overall shutdown reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/964)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->