### PR TITLE
fix: return 401 Unauthorized for invalid/expired JWT session in validateSession

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -233,7 +233,7 @@ func (s *ExtProcServer) validateSession(sessionID string) *RouterError {
 	}
 	isInvalid, err := s.JWTManager.Validate(sessionID)
 	if err != nil || isInvalid {
-		return NewRouterError(404, fmt.Errorf("session no longer valid"))
+		return NewRouterError(401, fmt.Errorf("session no longer valid"))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #956

`validateSession` in `internal/mcp-router/request_handlers.go` was returning `404 Not Found` when a JWT session was invalid or expired. This is semantically incorrect — `404` signals that a resource does not exist, not that authentication has failed.

## Changes

- Changed `NewRouterError(404, ...)` to `NewRouterError(401, ...)` inside `validateSession()` for the case where the JWT is expired or has an invalid signature.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| `sessionID == ""` (missing) | `400 Bad Request` | `400 Bad Request` |
| JWT expired or invalid signature | `404 Not Found`  | `401 Unauthorized`  |

## Why This Matters

MCP clients receiving a `404` incorrectly assume they are hitting the wrong endpoint, breaking client retry and re-authentication logic. Clients are expected to re-call `initialize` upon receiving a `401`, so returning the correct status code is essential for proper session handling.

## Code Reference

**File:** `internal/mcp-router/request_handlers.go`  
**Function:** `validateSession()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP status code for invalid sessions to return 401 (Unauthorized) instead of 404 (Not Found), with updated error messaging to "session no longer valid."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/965)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->