### PR TITLE
chore: fix methodInitialized constant spelling and use it in isInitializeRequest

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -62,7 +62,7 @@ func NewRouterErrorf(code int32, format string, args ...any) *RouterError {
 const (
 	methodToolCall    = "tools/call"
 	methodInitialize  = "initialize"
-	methodInitialized = "notification/initialized"
+	methodInitialized = "notifications/initialized"
 
 	elicitationResultAction  = "action"
 	elicitationActionAccept  = "accept"
@@ -128,7 +128,7 @@ func (mr *MCPRequest) isToolCall() bool {
 
 // isInitializeRequest returns true if the method is initialize or initialized
 func (mr *MCPRequest) isInitializeRequest() bool {
-	return mr.Method == "initialize" || mr.Method == "notifications/initialized"
+	return mr.Method == methodInitialize || mr.Method == methodInitialized
 }
 
 // clientSupportsElicitation checks if an initialize request declares elicitation support


### PR DESCRIPTION
## Summary

Fixes #958

The constant `methodInitialized` in `internal/mcp-router/request_handlers.go` was defined with the wrong MCP spec method name (`"notification/initialized"` — singular), and was never referenced in the codebase. `isInitializeRequest()` bypassed the constant entirely by hardcoding the correct string directly.

## Changes

1. Fixed the constant value from `"notification/initialized"` to `"notifications/initialized"` (plural, per MCP spec).
2. Updated `isInitializeRequest()` to use `methodInitialized` instead of the hardcoded string literal.

## Before / After

**Constant:**
```go
// Before
const methodInitialized = "notification/initialized"   // wrong — singular

// After
const methodInitialized = "notifications/initialized"  // correct — plural
```

**Function:**
```go
// Before
func (mr *MCPRequest) isInitializeRequest() bool {
    return mr.Method == "initialize" || mr.Method == "notifications/initialized"
}

// After
func (mr *MCPRequest) isInitializeRequest() bool {
    return mr.Method == methodInitialize || mr.Method == methodInitialized
}
```

## Why This Matters

The constant exists to prevent silent string-mismatch bugs. With the old misspelled value, any future code using `methodInitialized` directly would silently fail to match. This fix ensures the constant is both correct and actively used, making the codebase safer to extend.

## Code Reference

**File:** `internal/mcp-router/request_handlers.go`  
**Constant:** `methodInitialized`  
**Function:** `isInitializeRequest()`