### PR TITLE
fix: rewrite elicitation IDs in sseRewriter.Flush() for final partial SSE lines

### DIFF
--- a/internal/mcp-router/elicitation.go
+++ b/internal/mcp-router/elicitation.go
@@ -61,6 +61,11 @@ func (w *sseRewriter) Process(ctx context.Context, chunk []byte) []byte {
 func (w *sseRewriter) Flush(ctx context.Context) []byte {
 	remaining := w.buf
 	w.buf = nil
+	if len(remaining) > 0 {
+		if bytes.HasPrefix(bytes.TrimSpace(remaining), dataPrefix) {
+			remaining = w.maybeRewriteElicitation(ctx, remaining)
+		}
+	}
 	for _, id := range w.gatewayIDs {
 		w.idMap.Remove(ctx, id) // tool request + response finished, no need to hold onto the mappings any more
 	}


### PR DESCRIPTION
## Summary

Fixes #957

`Flush()` in `internal/mcp-router/elicitation.go` was returning the leftover buffer raw, without passing it through `maybeRewriteElicitation()`. Since `Process()` is line-buffered and only handles complete lines (ending with `\n`), a final SSE chunk without a trailing newline would sit in `w.buf` unprocessed — and `Flush()` would return it with the raw backend ID unrewritten.

## Root Cause

`Process()` breaks out of its loop when `bytes.IndexByte(w.buf, '\n')` returns `-1`, leaving the partial line in `w.buf`. When Envoy signals `EndOfStream = true`, `Flush()` is called — but the original code returned `remaining` immediately without attempting a rewrite:

```go
// Before — raw return, no rewrite attempted
func (w *sseRewriter) Flush(ctx context.Context) []byte {
    remaining := w.buf
    w.buf = nil
    for _, id := range w.gatewayIDs {
        w.idMap.Remove(ctx, id)
    }
    return remaining
}
```

## Fix

Added the same `dataPrefix` guard already used in `Process()` before returning `remaining`, so the final partial line gets identical rewrite treatment:

```go
// After
func (w *sseRewriter) Flush(ctx context.Context) []byte {
    remaining := w.buf
    w.buf = nil
    if len(remaining) > 0 {
        if bytes.HasPrefix(bytes.TrimSpace(remaining), dataPrefix) {
            remaining = w.maybeRewriteElicitation(ctx, remaining)
        }
    }
    for _, id := range w.gatewayIDs {
        w.idMap.Remove(ctx, id)
    }
    return remaining
}
```

## Impact Without This Fix

If the backend sends a final SSE chunk without a trailing `\n` (e.g. `data: {"method":"elicitation/create","id":"backend-123"}`), the client receives the raw backend ID. When the client sends back an elicitation response using that ID, the gateway has no mapping for it and silently drops the response — breaking elicitation for the last event in any such stream.

## Code Reference

**File:** `internal/mcp-router/elicitation.go`  
**Functions:** `Flush()`, `Process()`