### PR TITLE
Remove unnecessary span.IsRecording() guard guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Broker and router are hot paths. Avoid allocations in per-request code.
 - Use `for i := range` not `for _, v := range` on large structs in hot loops
 - Use structured logging (`logger.Info("msg", "key", val)`) not `fmt.Sprintf`
 - Use `logger.Debug` for per-request logging, `logger.Info` for lifecycle events only
-- Guard span attributes: `if span.IsRecording()` before `span.SetAttributes(...)`
+- Avoid expensive argument construction (e.g., `fmt.Sprintf`) in span attribute calls on hot paths; the OTel SDK already no-ops `SetAttributes` on non-recording spans
 - Use injected `logger`, never package-level `slog.Info`/`slog.Error`
 
 Profiling: pprof on port 6060. See `tests/perf/` for load testing scripts and methodology.

--- a/docs/design/performance.md
+++ b/docs/design/performance.md
@@ -20,9 +20,9 @@ The broker and router handle every MCP request. Allocations in these paths direc
 
 `slog.Info` acquires the handler's write mutex. At thousands of req/s this serialises concurrent callers. Use `logger.Debug` for per-request logging, `logger.Info` for lifecycle events only.
 
-### Unconditional span attribute writes
+### Expensive argument construction in span calls
 
-`span.SetAttributes(...)` allocates even when tracing is not configured. Guard with `if span.IsRecording()`.
+The OTel SDK already no-ops `SetAttributes` on [non-recording spans](https://github.com/open-telemetry/opentelemetry-go/blob/sdk/v1.43.0/sdk/trace/span.go#L632), so caller-side `IsRecording()` guards are unnecessary. However, arguments are evaluated before the call, so avoid expensive construction (e.g., `fmt.Sprintf`) in span attribute calls on hot paths.
 
 ### Package-level slog
 

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -213,9 +213,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			}
 			mcpRequest.Headers = localRequestHeaders.Headers
 			mcpRequest.Streaming = false
-			if span.IsRecording() {
-				span.SetAttributes(spanAttributes(mcpRequest)...)
-			}
+			span.SetAttributes(spanAttributes(mcpRequest)...)
 
 			routeResponses := s.RouteMCPRequest(ctx, mcpRequest)
 			for _, response := range routeResponses {


### PR DESCRIPTION
The OTel Go SDK already no-ops SetAttributes on non-recording spans and checks isRecording() internally
on recording spans, making caller-side guards redundant.

- Update CLAUDE.md and docs/design/performance.md to narrow guidance to avoiding expensive argument
construction (e.g., fmt.Sprintf) in span calls
- Remove existing IsRecording() guard in server.go

Context: closes #919 pattern at the source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified performance best practices for OpenTelemetry span attribute handling, explaining that the SDK optimizes attribute operations and emphasizing the importance of avoiding expensive argument construction on hot paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/969)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->