### PR TITLE
docs: add prompt federation user guide

### DIFF
--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -4,10 +4,10 @@ This guide covers configuring fine-grained authorization and access control for 
 
 ## Overview
 
-Authorization in MCP Gateway controls which authenticated users can access specific MCP tools. This guide demonstrates using Kuadrant's AuthPolicy with Common Expression Language (CEL) to implement role-based access control.
+Authorization in MCP Gateway controls which authenticated users can access specific MCP tools and prompts. This guide demonstrates using Kuadrant's AuthPolicy with Common Expression Language (CEL) to implement role-based access control.
 
 Key concepts:
-- **Tool-Level Authorization**: Control access to individual MCP tools
+- **Tool and Prompt-Level Authorization**: Control access to individual MCP tools and prompts
 - **Role-Based Access**: Use Keycloak client roles and group bindings for permission decisions
 - **Self-contained ACL**: Access control lists stored in the signed JWT tokens
 - **CEL Expressions**: Define complex authorization logic using Common Expression Language
@@ -38,10 +38,10 @@ The issued OAuth token should include claims similar to:
 {
   "resource_access": {
     "mcp-ns/arithmetic-mcp-server": { // matches the namespaced name of the MCPServerRegistration CR
-      "roles": ["tool:add", "tool:sum", "tool:multiply", "tool:divide"] // roles prefixed with capability type
+      "roles": ["tool:add", "tool:sum", "tool:multiply", "tool:divide", "prompt:math_tutor"] // roles prefixed with capability type
     },
     "mcp-ns/geometry-mcp-server": {
-      "roles": ["tool:area", "tool:distance", "tool:volume"]
+      "roles": ["tool:area", "tool:distance", "tool:volume", "prompt:calculate_area"]
     }
   }
 }
@@ -49,9 +49,9 @@ The issued OAuth token should include claims similar to:
 
 > **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of the `accounting` group, which maps to specific tool permissions.
 
-## Step 2: Configure Tool-Level Authorization
+## Step 2: Configure Tool and Prompt Authorization
 
-Apply an AuthPolicy that enforces tool-level access control:
+Apply an AuthPolicy that enforces access control for both tools and prompts:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -73,10 +73,19 @@ spec:
           issuerUrl: https://keycloak.127-0-0-1.sslip.io:8002/realms/mcp
     authorization:
       'tool-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-toolname')"
         patternMatching:
           patterns:
             - predicate: |
                 ('tool:' + request.headers['x-mcp-toolname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
+      'prompt-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-promptname')"
+        patternMatching:
+          patterns:
+            - predicate: |
+                ('prompt:' + request.headers['x-mcp-promptname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
     response:
       unauthenticated:
         headers:
@@ -86,14 +95,14 @@ spec:
           value: |
             {
               "error": "Unauthorized",
-              "message": "MCP Tool Access denied: Authentication required."
+              "message": "MCP Access denied: Authentication required."
             }
       unauthorized:
         body:
           value: |
             {
               "error": "Forbidden",
-              "message": "MCP Tool Access denied: Insufficient permissions for this tool."
+              "message": "MCP Access denied: Insufficient permissions."
             }
 EOF
 ```
@@ -101,12 +110,41 @@ EOF
 **Key Configuration Explained:**
 
 - **Authentication**: Validates the JWT token using the configured issuer URL
-- **Authorization Logic**: CEL expression checks if user's roles allow access to the requested tool
+- **Authorization Logic**: CEL expressions check if the user's roles allow access to the requested tool or prompt. The appropriate check is triggered based on the presence of the `x-mcp-toolname` or `x-mcp-promptname` header.
 - **CEL Breakdown**:
-  - `request.headers['x-mcp-toolname']`: The name of the requested MCP tool (stripped from prefix)
+  - `request.headers['x-mcp-toolname']` / `x-mcp-promptname`: The name of the requested capability
   - `request.headers['x-mcp-servername']`: The namespaced name of the MCP server matching the MCPServerRegistration resource
-  - `auth.identity.resource_access`: The JWT claim containing roles prefixed by capability type (e.g. `tool:greet`), grouped by MCP server
+  - `auth.identity.resource_access`: The JWT claim containing roles prefixed by capability type (e.g. `tool:greet`, `prompt:math_tutor`), grouped by MCP server
 - **Response Handling**: Custom 401 and 403 responses for unauthenticated and unauthorized access attempts
+
+For more advanced policy examples covering token exchange and `tools/list` filtering, see the [Vault Token Exchange guide](./vault-token-exchange.md).
+
+You can also apply a policy that filters available tools and prompts during the `initialize` flow using an OPA rule:
+
+```yaml
+authorization:
+  'authorized-capabilities':
+    opa:
+      rego: |
+        allow = true
+        capabilities = {
+          "tools": { server: tools |
+            server := object.keys(input.auth.identity.resource_access)[_]
+            tools := [substring(r, count("tool:"), -1) |
+              r := input.auth.identity.resource_access[server].roles[_]
+              startswith(r, "tool:")
+            ]
+          },
+          "prompts": { server: prompts |
+            server := object.keys(input.auth.identity.resource_access)[_]
+            prompts := [substring(r, count("prompt:"), -1) |
+              r := input.auth.identity.resource_access[server].roles[_]
+              startswith(r, "prompt:")
+            ]
+          }
+        }
+      allValues: true
+```
 
 ## Step 3: Test Authorization
 

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -1,6 +1,16 @@
 # MCP Server Registration
 
-You must register your MCP servers to be discovered and routed by the MCP Gateway. To connect an MCP server to MCP Gateway, you must create an `HTTPRoute` that routes to your MCP server and an `MCPServerRegistration` resource that references the `HTTPRoute`.
+You must register your MCP servers to be discovered and routed by the MCP Gateway. When a server is registered, the gateway automatically discovers and federates its capabilities (tools and prompts), applying a prefix to avoid name collisions across multiple servers.
+
+## Overview
+
+MCP Gateway supports federating both MCP Tools and MCP Prompts.
+
+- **Discovery**: The gateway's broker automatically discovers available tools and prompts from registered upstream servers.
+- **Prefixing**: To prevent collisions between capabilities with the same name on different servers, the gateway applies the `prefix` defined in the `MCPServerRegistration` to each tool and prompt name (e.g., `greet` becomes `myserver_greet`).
+- **Routing**: When a client calls a tool or requests a prompt, the gateway identifies the target upstream server by the prefix, strips the prefix, and routes the request to the correct server.
+
+To connect an MCP server to MCP Gateway, you must create an `HTTPRoute` that routes to your MCP server and an `MCPServerRegistration` resource that references the `HTTPRoute`.
 
 ## Prerequisites
 
@@ -113,7 +123,7 @@ EOF
 
 ## Step 4: Verify Registration
 
-Wait for the MCPServerRegistration to become ready (the broker needs a moment to connect and discover tools):
+Wait for the MCPServerRegistration to become ready (the broker needs a moment to connect and discover tools and prompts):
 
 ```bash
 kubectl wait --for=condition=Ready mcpsr/my-mcp-server -n mcp-test --timeout=120s
@@ -159,12 +169,49 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
   -H "Content-Type: application/json" \
   -H "mcp-session-id: $SESSION_ID" \
   -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}'
+```
+
+You should now see your MCP server tools in the response, prefixed with your configured `prefix` (e.g., `myserver_`).
+
+## Step 6: Test Prompt Discovery
+
+Verify that your MCP server prompts are also available through the gateway:
+
+```bash
+# Use the same SESSION_ID from the previous step
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc": "2.0", "id": 3, "method": "prompts/list"}'
+```
+
+You should see your MCP server prompts in the response, also prefixed with your configured `prefix`.
+
+## Step 7: Getting a Prompt
+
+To retrieve a specific prompt, use the `prompts/get` method with the federated (prefixed) name:
+
+```bash
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "prompts/get",
+    "params": {
+      "name": "myserver_gh_pr_review",
+      "arguments": {
+        "pr_number": "42"
+      }
+    }
+  }'
 
 # Clean up
 rm -f /tmp/mcp_headers
 ```
 
-You should now see your MCP server tools in the response, prefixed with your configured `prefix` (e.g., `myserver_`).
+You should now see your MCP server tools and prompts in the response, prefixed with your configured `prefix` (e.g., `myserver_`).
 
 ## Next Steps
 

--- a/docs/guides/virtual-mcp-servers.md
+++ b/docs/guides/virtual-mcp-servers.md
@@ -4,16 +4,16 @@ This guide covers configuring virtual MCP servers to create focused, curated too
 
 ## Overview
 
-Virtual MCP servers solve a common problem when using MCP Gateway: while aggregating all your MCP tools centrally provides excellent benefits for authentication, authorization, and configuration management, it can overwhelm LLMs and AI agents with too many tools to choose from.
+Virtual MCP servers solve a common problem when using MCP Gateway: while aggregating all your MCP tools and prompts centrally provides excellent benefits for authentication, authorization, and configuration management, it can overwhelm LLMs and AI agents with too many capabilities to choose from.
 
 **Why use virtual MCP servers:**
-- **Focused Tool Sets**: Create specialized collections of tools for specific use cases
-- **Improved AI Performance**: Reduce cognitive load on LLMs by presenting fewer, more relevant tools
-- **Domain-Specific Interfaces**: Group tools by function (e.g., "development tools", "data analysis tools")
-- **Simplified Discovery**: Make it easier for users and agents to find the right tools
+- **Focused Capability Sets**: Create specialized collections of tools and prompts for specific use cases
+- **Improved AI Performance**: Reduce cognitive load on LLMs by presenting fewer, more relevant capabilities
+- **Domain-Specific Interfaces**: Group tools and prompts by function (e.g., "development", "data analysis")
+- **Simplified Discovery**: Make it easier for users and agents to find the right capabilities
 - **Layered Access Control**: Combine with authorization policies for fine-grained access management
 
-Virtual servers work by filtering the complete tool list based on a curated selection, accessed via HTTP headers.
+Virtual servers work by filtering the complete list of tools and prompts based on a curated selection, accessed via HTTP headers.
 
 ## Prerequisites
 
@@ -26,10 +26,11 @@ Virtual servers work by filtering the complete tool list based on a curated sele
 
 A virtual MCP server is defined by an `MCPVirtualServer` custom resource that specifies:
 - **Tool Selection**: Which tools from the aggregated pool to expose
+- **Prompt Selection**: Which prompts from the aggregated pool to expose (if omitted, all prompts are exposed)
 - **Description**: Human-readable description of the virtual server's purpose
 - **Access Method**: Accessed via `X-Mcp-Virtualserver` header with `namespace/name` format
 
-When a client includes the virtual server header, MCP Gateway filters responses to only include the specified tools.
+When a client includes the virtual server header, MCP Gateway filters responses to only include the specified tools and prompts.
 
 ## Step 1: Discover Available Tools
 
@@ -80,6 +81,8 @@ spec:
   - test2_time             # replace with your actual tool names
   - test3_dozen
   - test3_add
+  prompts:
+  - test2_data_summary     # optional: filter exposed prompts
 EOF
 ```
 
@@ -138,6 +141,19 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
 
 **Expected Response**: Only tools specified in the `data-tools` virtual server (the example tools you configured)
 
+### Test Prompt Filtering
+
+```bash
+# Request prompts from the data-tools virtual server
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -H "X-Mcp-Virtualserver: mcp-system/data-tools" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "prompts/list"}' | jq '.result.prompts[].name'
+```
+
+**Expected Response**: Only prompts specified in the `data-tools` virtual server (e.g. `test2_data_summary`)
+
 ### Test Without Virtual Server Header
 
 ```bash
@@ -160,14 +176,14 @@ You can also test virtual servers using MCP Inspector. Connect to your gateway a
 kubectl delete mcpvirtualserver dev-tools data-tools -n mcp-system
 ```
 
-## Authorization and Tool Filtering
+## Authorization and Capability Filtering
 
-Virtual MCP servers are a `tools/list` concept only. They filter which tools a client discovers, but do not affect `tools/call` routing or authorization.
+Virtual MCP servers are a discovery concept only. They filter which tools and prompts a client discovers, but do not affect routing or authorization.
 
-If you have [authentication](./authentication.md) and [user-based tool filtering](./user-based-tool-filter.md) configured, the broker applies two filters sequentially when handling a `tools/list` request with a virtual server header:
+If you have [authentication](./authentication.md) and [user-based tool filtering](./user-based-tool-filter.md) configured, the broker applies two filters sequentially when handling a tools/list or prompts/list request with a virtual server header:
 
-1. **Identity-based filtering** -- the `x-mcp-authorized` header carries a signed JWT with an `allowed-capabilities` claim that reduces the tool list to only the tools the user is authorized for
-2. **Virtual server filtering** -- the `X-Mcp-Virtualserver` header further reduces the list to only tools defined in the MCPVirtualServer resource
+1. **Identity-based filtering** -- the `x-mcp-authorized` header carries a signed JWT with an `allowed-capabilities` claim that reduces the list to only the capabilities (tools and prompts) the user is authorized for
+2. **Virtual server filtering** -- the `X-Mcp-Virtualserver` header further reduces the list to only those defined in the `MCPVirtualServer` resource
 
 The result is the intersection of both filters. For example, if the `accounting` virtual server lists `test1_greet` and `test3_add`, but the user's `x-mcp-authorized` JWT only grants access to `greet` on `mcp-test/test-server1`, they will only see `test1_greet`.
 


### PR DESCRIPTION
Adds user-facing documentation for the prompt federation feature.

- Incorporates prompt federation (discovery, prefixing, and routing) into the register-mcp-servers.md guide.
- Updates authorization.md to cover prompt-level RBAC (prompt:* roles and prompt-access-check AuthPolicy rules).
- Updates virtual-mcp-servers.md examples to include the new prompts filtering field.
- Removes redundant prompt-federation.md guide as requested by maintainers.

Related PR for docs.kuadrant.io nav: Kuadrant/docs.kuadrant.io#243

Closes #946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authorization guide to support both tool and prompt access, including JWT configuration examples for implementing role-based access control across tools and prompts
  * Enhanced virtual MCP servers documentation to include prompt filtering capabilities alongside tool filtering
  * Expanded registration guide with comprehensive prompt discovery and testing procedures for federated MCP servers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/973)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->