### PR TITLE
fix(router): prevent duplicate backend sessions on concurrent tool calls

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -665,7 +665,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			}
 			passThroughHeaders["user-agent"] = "mcp-router"
 		}
-		s.Logger.DebugContext(ctx, "initializing target as no mcp-session-id found for client", "server ", mcpReq.serverName, "with passthrough headers", passThroughHeaders)
+		s.Logger.DebugContext(ctx, "initializing target as no mcp-session-id found for client", "server", mcpReq.serverName, "passthrough header count", len(passThroughHeaders))
 
 		// check if the original client declared elicitation support
 		if !mcpReq.clientElicitation {
@@ -714,7 +714,6 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			sessionCloser()
 			return "", NewRouterError(404, fmt.Errorf("invalid session"))
 		}
-		time.AfterFunc(time.Until(expiresAt), sessionCloser)
 		remoteSessionID := clientHandle.GetSessionId()
 		s.Logger.DebugContext(ctx, "got remote session id ", "mcp server", mcpServerConfig.Name, "session", remoteSessionID)
 		{
@@ -732,10 +731,15 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			storeSpan.End()
 			if storeErr != nil {
 				s.Logger.ErrorContext(ctx, "failed to add remote session to cache", "error", storeErr)
-				// again if this fails it is likely terminal due to a network connection error
+				// close the handle immediately; the timer is not yet armed so this is the only cleanup path
+				if cerr := clientHandle.Close(); cerr != nil {
+					s.Logger.DebugContext(ctx, "failed to close client connection on store error", "err", cerr)
+				}
 				return "", NewRouterError(500, fmt.Errorf("internal error"))
 			}
 		}
+		// arm the cleanup timer only after the session is safely recorded in the cache
+		time.AfterFunc(time.Until(expiresAt), sessionCloser)
 		return remoteSessionID, nil
 	})
 	if err != nil {

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -619,117 +619,129 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 	if err != nil {
 		return "", NewRouterErrorf(500, "failed check for server: %w", err)
 	}
-	exists, err := s.SessionCache.GetSession(ctx, mcpReq.GetSessionID())
-	if err != nil {
-		return "", NewRouterErrorf(500, "failed to check for existing session: %w", err)
-	}
-	if id, ok := exists[mcpReq.serverName]; ok {
-		s.Logger.DebugContext(ctx, "found session in cache", "session id", mcpReq.GetSessionID(), "for server", mcpServerConfig.Name, "remote session", id)
-		return id, nil
-	}
-	passThroughHeaders := map[string]string{}
-	if mcpReq.Headers != nil {
-		// We don't want to pass through any pseudo routing headers (:authority,
-		// :path, etc.), the gateway-bound mcp-session-id, or the router-internal
-		// headers (mcp-init-host, router-key) which we set ourselves below via
-		// clients.Initialize. Dropping the router-internal headers here is
-		// defense-in-depth so a client-supplied value can never reach the
-		// hairpin request even if the override in clients.Initialize is later
-		// refactored. Everything else is passed through for custom headers.
-		for _, h := range mcpReq.Headers.Headers {
-			key := strings.ToLower(h.Key)
-			if strings.HasPrefix(key, ":") ||
-				key == "mcp-session-id" ||
-				key == "mcp-init-host" ||
-				key == RoutingKey {
-				continue
+
+	// Serialize concurrent initialization for the same (gateway session, backend server) pair.
+	// Without this, N concurrent tool calls that all see an empty cache would each call
+	// clients.Initialize, creating N backend sessions and leaking N-1 connections until JWT expiry.
+	groupKey := mcpReq.GetSessionID() + "/" + mcpReq.serverName
+	result, err, _ := s.initGroup.Do(groupKey, func() (any, error) {
+		// Re-check the cache inside the singleflight: a previous call may have already
+		// stored a session while the current goroutine was waiting for the group lock.
+		exists, err := s.SessionCache.GetSession(ctx, mcpReq.GetSessionID())
+		if err != nil {
+			return "", NewRouterErrorf(500, "failed to check for existing session: %w", err)
+		}
+		if id, ok := exists[mcpReq.serverName]; ok {
+			s.Logger.DebugContext(ctx, "found session in cache", "session id", mcpReq.GetSessionID(), "for server", mcpServerConfig.Name, "remote session", id)
+			return id, nil
+		}
+		passThroughHeaders := map[string]string{}
+		if mcpReq.Headers != nil {
+			// We don't want to pass through any pseudo routing headers (:authority,
+			// :path, etc.), the gateway-bound mcp-session-id, or the router-internal
+			// headers (mcp-init-host, router-key) which we set ourselves below via
+			// clients.Initialize. Dropping the router-internal headers here is
+			// defense-in-depth so a client-supplied value can never reach the
+			// hairpin request even if the override in clients.Initialize is later
+			// refactored. Everything else is passed through for custom headers.
+			for _, h := range mcpReq.Headers.Headers {
+				key := strings.ToLower(h.Key)
+				if strings.HasPrefix(key, ":") ||
+					key == "mcp-session-id" ||
+					key == "mcp-init-host" ||
+					key == RoutingKey {
+					continue
+				}
+				passThroughHeaders[h.Key] = string(h.RawValue)
 			}
-			passThroughHeaders[h.Key] = string(h.RawValue)
+			// ensure these gateway headers are set
+			passThroughHeaders["x-mcp-method"] = mcpReq.Method
+			passThroughHeaders["x-mcp-servername"] = mcpReq.serverName
+			if toolName := mcpReq.ToolName(); toolName != "" {
+				passThroughHeaders["x-mcp-toolname"] = toolName
+			}
+			if promptName := mcpReq.PromptName(); promptName != "" {
+				passThroughHeaders["x-mcp-promptname"] = promptName
+			}
+			passThroughHeaders["user-agent"] = "mcp-router"
 		}
-		// ensure these gateway headers are set
-		passThroughHeaders["x-mcp-method"] = mcpReq.Method
-		passThroughHeaders["x-mcp-servername"] = mcpReq.serverName
-		if toolName := mcpReq.ToolName(); toolName != "" {
-			passThroughHeaders["x-mcp-toolname"] = toolName
-		}
-		if promptName := mcpReq.PromptName(); promptName != "" {
-			passThroughHeaders["x-mcp-promptname"] = promptName
-		}
-		passThroughHeaders["user-agent"] = "mcp-router"
-	}
-	s.Logger.DebugContext(ctx, "initializing target as no mcp-session-id found for client", "server ", mcpReq.serverName, "with passthrough headers", passThroughHeaders)
+		s.Logger.DebugContext(ctx, "initializing target as no mcp-session-id found for client", "server ", mcpReq.serverName, "with passthrough headers", passThroughHeaders)
 
-	// check if the original client declared elicitation support
-	if !mcpReq.clientElicitation {
-		clientElicitation, elErr := s.SessionCache.GetClientElicitation(ctx, mcpReq.GetSessionID())
-		if elErr != nil {
-			s.Logger.ErrorContext(ctx, "failed to get client elicitation flag", "error", elErr, "session", mcpReq.GetSessionID())
-			return "", NewRouterErrorf(500, "failed to read client elicitation flag: %w", elErr)
+		// check if the original client declared elicitation support
+		if !mcpReq.clientElicitation {
+			clientElicitation, elErr := s.SessionCache.GetClientElicitation(ctx, mcpReq.GetSessionID())
+			if elErr != nil {
+				s.Logger.ErrorContext(ctx, "failed to get client elicitation flag", "error", elErr, "session", mcpReq.GetSessionID())
+				return "", NewRouterErrorf(500, "failed to read client elicitation flag: %w", elErr)
+			}
+			mcpReq.clientElicitation = clientElicitation
 		}
-		mcpReq.clientElicitation = clientElicitation
-	}
 
-	// mint a short-lived JWT bound to the target hostname; the router validates
-	// this token when the hairpin request re-enters the gateway in
-	// HandleNoneToolCall so we can never be tricked into routing to an
-	// attacker-controlled host by a forged `mcp-init-host` header.
-	initToken, err := s.JWTManager.GenerateBackendInitToken(mcpServerConfig.Hostname)
+		// mint a short-lived JWT bound to the target hostname; the router validates
+		// this token when the hairpin request re-enters the gateway in
+		// HandleNoneToolCall so we can never be tricked into routing to an
+		// attacker-controlled host by a forged `mcp-init-host` header.
+		initToken, err := s.JWTManager.GenerateBackendInitToken(mcpServerConfig.Hostname)
+		if err != nil {
+			s.Logger.ErrorContext(ctx, "failed to generate backend-init token", "error", err)
+			initSpan.RecordError(err)
+			initSpan.SetStatus(codes.Error, "failed to generate backend-init token")
+			return "", NewRouterErrorf(500, "failed to generate backend-init token: %w", err)
+		}
+		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation)
+		if err != nil {
+			s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
+			initSpan.RecordError(err)
+			initSpan.SetStatus(codes.Error, "failed to initialize backend session")
+			return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
+		}
+		var sessionCloser = func() {
+			// use a fresh context: the request-scoped ctx is canceled long before this fires
+			cleanupCtx := context.Background()
+			s.Logger.DebugContext(cleanupCtx, "gateway session expired closing client", "Session ", mcpReq.GetSessionID())
+			if err := clientHandle.Close(); err != nil {
+				s.Logger.DebugContext(cleanupCtx, "failed to close client connection", "err", err)
+			}
+			if err := s.SessionCache.DeleteSessions(cleanupCtx, mcpReq.GetSessionID()); err != nil {
+				s.Logger.DebugContext(cleanupCtx, "failed to delete session", "session", mcpReq.GetSessionID(), "err", err)
+			}
+		}
+		// close connection with remote backend and delete any sessions when our gateway session expires
+		expiresAt, err := s.JWTManager.GetExpiresIn(mcpReq.GetSessionID())
+		if err != nil {
+			// this err would be caused by an invalid token so force a re-initialize
+			s.Logger.ErrorContext(ctx, "failed to get expires in value. Forcing session reset", "err", err)
+			sessionCloser()
+			return "", NewRouterError(404, fmt.Errorf("invalid session"))
+		}
+		time.AfterFunc(time.Until(expiresAt), sessionCloser)
+		remoteSessionID := clientHandle.GetSessionId()
+		s.Logger.DebugContext(ctx, "got remote session id ", "mcp server", mcpServerConfig.Name, "session", remoteSessionID)
+		{
+			_, storeSpan := tracer().Start(ctx, "mcp-router.session-cache.store",
+				trace.WithAttributes(
+					attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+					attribute.String("mcp.server", mcpServerConfig.Name),
+				),
+			)
+			_, storeErr := s.SessionCache.AddSession(ctx, mcpReq.GetSessionID(), mcpServerConfig.Name, remoteSessionID)
+			if storeErr != nil {
+				storeSpan.RecordError(storeErr)
+				storeSpan.SetStatus(codes.Error, "session cache store failed")
+			}
+			storeSpan.End()
+			if storeErr != nil {
+				s.Logger.ErrorContext(ctx, "failed to add remote session to cache", "error", storeErr)
+				// again if this fails it is likely terminal due to a network connection error
+				return "", NewRouterError(500, fmt.Errorf("internal error"))
+			}
+		}
+		return remoteSessionID, nil
+	})
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to generate backend-init token", "error", err)
-		initSpan.RecordError(err)
-		initSpan.SetStatus(codes.Error, "failed to generate backend-init token")
-		return "", NewRouterErrorf(500, "failed to generate backend-init token: %w", err)
+		return "", err
 	}
-	clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation)
-	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
-		initSpan.RecordError(err)
-		initSpan.SetStatus(codes.Error, "failed to initialize backend session")
-		return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
-	}
-	var sessionCloser = func() {
-		// use a fresh context: the request-scoped ctx is canceled long before this fires
-		cleanupCtx := context.Background()
-		s.Logger.DebugContext(cleanupCtx, "gateway session expired closing client", "Session ", mcpReq.GetSessionID())
-		if err := clientHandle.Close(); err != nil {
-			s.Logger.DebugContext(cleanupCtx, "failed to close client connection", "err", err)
-		}
-		if err := s.SessionCache.DeleteSessions(cleanupCtx, mcpReq.GetSessionID()); err != nil {
-			s.Logger.DebugContext(cleanupCtx, "failed to delete session", "session", mcpReq.GetSessionID(), "err", err)
-		}
-	}
-	// close connection with remote backend and delete any sessions when our gateway session expires
-	expiresAt, err := s.JWTManager.GetExpiresIn(mcpReq.GetSessionID())
-	if err != nil {
-		// this err would be caused by an invalid token so force a re-initialize
-		s.Logger.ErrorContext(ctx, "failed to get expires in value. Forcing session reset", "err", err)
-		sessionCloser()
-		return "", NewRouterError(404, fmt.Errorf("invalid session"))
-	}
-	time.AfterFunc(time.Until(expiresAt), sessionCloser)
-	remoteSessionID := clientHandle.GetSessionId()
-	s.Logger.DebugContext(ctx, "got remote session id ", "mcp server", mcpServerConfig.Name, "session", remoteSessionID)
-	{
-		_, storeSpan := tracer().Start(ctx, "mcp-router.session-cache.store",
-			trace.WithAttributes(
-				attribute.String("mcp.session.id", mcpReq.GetSessionID()),
-				attribute.String("mcp.server", mcpServerConfig.Name),
-			),
-		)
-		_, storeErr := s.SessionCache.AddSession(ctx, mcpReq.GetSessionID(), mcpServerConfig.Name, remoteSessionID)
-		if storeErr != nil {
-			storeSpan.RecordError(storeErr)
-			storeSpan.SetStatus(codes.Error, "session cache store failed")
-		}
-		storeSpan.End()
-		if storeErr != nil {
-			s.Logger.ErrorContext(ctx, "failed to add remote session to cache", "error", storeErr)
-			// again if this fails it is likely terminal due to a network connection error
-			return "", NewRouterError(500, fmt.Errorf("internal error"))
-		}
-	}
-	return remoteSessionID, nil
-
+	return result.(string), nil
 }
 
 // HandleNoneToolCall handles none tools calls such as initialize. The majority of these requests will be forwarded to the broker

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -732,8 +732,8 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			if storeErr != nil {
 				s.Logger.ErrorContext(ctx, "failed to add remote session to cache", "error", storeErr)
 				// close the handle immediately; the timer is not yet armed so this is the only cleanup path
-				if cerr := clientHandle.Close(); cerr != nil {
-					s.Logger.DebugContext(ctx, "failed to close client connection on store error", "err", cerr)
+				if closeErr := clientHandle.Close(); closeErr != nil {
+					s.Logger.DebugContext(ctx, "failed to close client connection on store error", "err", closeErr)
 				}
 				return "", NewRouterError(500, fmt.Errorf("internal error"))
 			}

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mark3labs/mcp-go/client"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 )
 
 var _ config.Observer = &ExtProcServer{}
@@ -46,6 +47,9 @@ type ExtProcServer struct {
 	MaxRequestBodySize int
 	//TODO this should not be needed
 	Broker broker.MCPBroker
+	// initGroup serializes backend session initialization per (gatewaySessionID, serverName)
+	// pair, preventing concurrent tool calls from creating duplicate backend sessions.
+	initGroup singleflight.Group
 }
 
 // OnConfigChange is used to register the router for config changes


### PR DESCRIPTION
While I was in `initializeMCPSeverSession` for #911, I was focused on the `sessionCloser` context leak and didn't look hard enough at the initialization path itself.

The cache check at line 622 is a bare `GetSession` read with nothing around it. Two goroutines on the same gateway session hitting the same backend for the first time both read an empty map, both clear the check, both fall into `InitForClient`. That call does a full TCP + MCP handshake; easily 50–200ms on any remote backend, so the race window is wide. Both goroutines race to `AddSession`; the copy-on-write there (#872) means no corruption, but last writer wins: the first `clientHandle` is now orphaned. Its mcp-go SSE reader goroutine stays alive, the backend session stays open, and the `time.AfterFunc` cleanup still fires; but so does the second goroutine's. Two timers, same `gatewaySessionID`. The first one to call `DeleteSessions` wipes the whole session map for that client.

The realistic trigger is any agent framework that fans out parallel tool calls on a fresh session before a backend session exists, which is basically every first-turn multi-tool call.

Fix wraps the creation block in `singleflight.Do` keyed on `gatewaySessionID + "/" + serverName`. Concurrent calls collapse into one; all callers get the same session ID back; exactly one `clientHandle`, one timer. `golang.org/x/sync` is already an indirect dep so no new module dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Backend session initialization now properly serializes concurrent requests per gateway session and backend server, preventing duplicate sessions and connection leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/976)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->