### PR TITLE
Adopt RFC 0018 release branch naming (release-X.Y)

### DIFF
--- a/.github/workflows/controller-integration-tests.yaml
+++ b/.github/workflows/controller-integration-tests.yaml
@@ -3,7 +3,7 @@ name: Controller-Integration-Tests
 on:
   workflow_dispatch:
   push:
-    branches: ['main', 'release-v*']
+    branches: ['main', 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Unit-Tests
 on:
   workflow_dispatch:
   push:
-    branches: ['main', 'release-v*']
+    branches: ['main', 'release-*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,7 @@ The steps below document the same process manually, for reference or environment
 ```bash
 git checkout main
 git pull
-git checkout -b release-X.Y.Z
+git checkout -b release-X.Y
 ```
 
 Run the version update script with the full version including any RC suffix:
@@ -56,17 +56,17 @@ Commit and push:
 ```bash
 git add -u config/ charts/ docs/ bundle/
 git commit -s -m "Update version to X.Y.Z-rcN"
-git push -u origin release-X.Y.Z
+git push -u origin release-X.Y
 ```
 
 ### 2. Create GitHub Release
 
-Release branches use the full three-component format `release-X.Y.Z` (e.g. `release-0.6.0`), and all links, tags, and examples must use this format.
+Release branches use the minor-level format `release-X.Y` (e.g. `release-0.7`). One branch per minor version — all patches are tagged on the same branch.
 
 1. Go to [Releases](https://github.com/Kuadrant/mcp-gateway/releases)
 2. Click **Draft a new release**
 3. Click **Choose a tag** and create a new tag (e.g. `vX.Y.Z-rc1` or `vX.Y.Z`)
-4. Set **Target** to your `release-X.Y.Z` branch
+4. Set **Target** to your `release-X.Y` branch
 5. Set the release title (e.g. `vX.Y.Z-rc1` or `vX.Y.Z`)
 6. Click **Generate release notes**
 7. For release candidates: check **Set as a pre-release** (do not mark as latest)
@@ -102,7 +102,7 @@ After verifying all artifacts are published, create a test matrix issue to track
 1. Go to [New Issue](https://github.com/Kuadrant/mcp-gateway/issues/new/choose)
 2. Select the **RC Test Matrix** template
 3. Replace `vX.Y.Z-rcN` with the actual RC version in the title and body
-4. Replace `release-X.Y.Z` with the actual release branch name in all links
+4. Replace `release-X.Y` with the actual release branch name in all links
 5. Submit the issue and share with the team for testing
 
 Testing covers installation methods, E2E tests, integration tests, conformance tests, and documentation guide walkthroughs. See the [template](.github/ISSUE_TEMPLATE/rc-test-matrix.md) for the full checklist.


### PR DESCRIPTION
## Summary

Updates workflow triggers and release docs to use `release-X.Y` convention (no `v` prefix, minor-level only) per [RFC 0018](https://github.com/Kuadrant/architecture/blob/main/rfcs/0018-release-branch-naming.md).

## Changes

- `controller-integration-tests.yaml` — widen `release-v*` to `release-*`
- `tests.yaml` — widen `release-v*` to `release-*`
- `RELEASING.md` — update from `release-X.Y.Z` (per-patch) to `release-X.Y` (per-minor)

Part of Kuadrant/kuadrant-operator#1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration for release branch patterns.

* **Documentation**
  * Updated release process documentation to reflect changes in release branch naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->