### PR TITLE
fix defer func in happy path tests to unblock CI tests

### DIFF
--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -967,7 +967,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			"X-Mcp-Virtualserver": virtualServerHeader,
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer virtualServerClient.Close()
+		defer func() { _ = virtualServerClient.Close() }()
 
 		By("Verifying only the allowed prompt is returned via virtual server")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
The e2e test at line 970 called defer virtualServerClient.Close() without checking the error return value. Go's errcheck linter flags this. Line 428 in the same file already had the correct pattern: defer func() { _ = virtualServerClient.Close() }() — which explicitly discards the error.   The fix makes line 970 match.

This was missed in  yesterdays #841 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test cleanup procedures.

---

*Note: This release contains internal test infrastructure improvements with no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/978)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->