### PR TITLE
Add e2e tests for prompt federation

### DIFF
--- a/tests/e2e/prompt_test.go
+++ b/tests/e2e/prompt_test.go
@@ -1,0 +1,335 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("MCP Gateway Prompt Federation", func() {
+	var (
+		testResources []client.Object
+		headers       map[string]string
+	)
+
+	BeforeEach(func() {
+		testResources = []client.Object{}
+		headers = make(map[string]string)
+	})
+
+	AfterEach(func() {
+		for i := len(testResources) - 1; i >= 0; i-- {
+			CleanupResource(ctx, k8sClient, testResources[i])
+		}
+	})
+
+	It("[Happy] prompts/list returns federated prompts with prefixes", func() {
+		By("Registering server1 with prompts")
+		reg1 := NewTestResources("prompt-list-prefix", k8sClient).
+			ForInternalService(sharedMCPTestServer1, 9090).
+			WithPrefix("test1_").
+			Build()
+		testResources = append(testResources, reg1.GetObjects()...)
+		server1 := reg1.Register(ctx)
+
+		By("Waiting for MCPServerRegistration to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Initializing a session")
+		sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		By("Verifying prompts/list returns prefixed prompts")
+		Eventually(func(g Gomega) {
+			status, prompts, err := mcpListPrompts(ctx, gatewayURL, sessionID, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal(http.StatusOK))
+			g.Expect(prompts).To(ContainElement("test1_greet"))
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[Happy] Multi-server prompt aggregation", func() {
+		By("Registering server1 with prefix s1_")
+		reg1 := NewTestResources("prompt-agg-s1", k8sClient).
+			ForInternalService(sharedMCPTestServer1, 9090).
+			WithPrefix("s1_").
+			Build()
+		testResources = append(testResources, reg1.GetObjects()...)
+		server1 := reg1.Register(ctx)
+
+		By("Registering everything-server with prefix e_")
+		reg2 := NewTestResources("prompt-agg-e", k8sClient).
+			ForInternalService("everything-server", 9090).
+			WithPrefix("e_").
+			Build()
+		testResources = append(testResources, reg2.GetObjects()...)
+		server2 := reg2.Register(ctx)
+
+		By("Waiting for MCPServerRegistrations to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server2.Name, server2.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Initializing a session")
+		sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		By("Verifying prompts/list returns prompts from both servers")
+		Eventually(func(g Gomega) {
+			status, prompts, err := mcpListPrompts(ctx, gatewayURL, sessionID, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal(http.StatusOK))
+			g.Expect(prompts).To(ContainElement("s1_greet"))
+			// everything-server usually has several prompts
+			found := false
+			for _, p := range prompts {
+				if strings.HasPrefix(p, "e_") {
+					found = true
+					break
+				}
+			}
+			g.Expect(found).To(BeTrue(), "should have at least one prompt from everything-server")
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[Happy] prompts/get routes to the correct upstream server", func() {
+		By("Registering server1 with prompts")
+		reg1 := NewTestResources("prompt-get-route", k8sClient).
+			ForInternalService(sharedMCPTestServer1, 9090).
+			WithPrefix("test1_").
+			Build()
+		testResources = append(testResources, reg1.GetObjects()...)
+		server1 := reg1.Register(ctx)
+
+		By("Waiting for MCPServerRegistration to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Initializing a session")
+		sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		By("Invoking prompts/get for test1_greet")
+		Eventually(func(g Gomega) {
+			status, messages, err := mcpGetPrompt(ctx, gatewayURL, sessionID, "test1_greet", map[string]string{"name": "e2e"}, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal(http.StatusOK))
+			g.Expect(messages).NotTo(BeEmpty())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[Happy] VirtualServer filters prompts", func() {
+		By("Registering server1 with prompts")
+		reg1 := NewTestResources("prompt-vs-filter", k8sClient).
+			ForInternalService(sharedMCPTestServer1, 9090).
+			WithPrefix("test1_").
+			Build()
+		testResources = append(testResources, reg1.GetObjects()...)
+		server1 := reg1.Register(ctx)
+
+		By("Waiting for MCPServerRegistration to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Creating an MCPVirtualServer with a subset of prompts")
+		vs := NewMCPVirtualServerBuilder("prompt-vs", TestServerNameSpace).
+			WithPrompts([]string{"test1_greet"}).
+			Build()
+		testResources = append(testResources, vs)
+		Expect(k8sClient.Create(ctx, vs)).To(Succeed())
+
+		By("Initializing a session with X-Mcp-Virtualserver header")
+		headers["X-Mcp-Virtualserver"] = fmt.Sprintf("%s/%s", vs.Namespace, vs.Name)
+		sessionID, err := mcpInitialize(ctx, gatewayURL, headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, headers)).To(Succeed())
+
+		By("Verifying prompts/list is filtered")
+		Eventually(func(g Gomega) {
+			status, prompts, err := mcpListPrompts(ctx, gatewayURL, sessionID, headers)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal(http.StatusOK))
+			g.Expect(prompts).To(Equal([]string{"test1_greet"}))
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[Happy] VirtualServer with no prompts field exposes all prompts", func() {
+		By("Registering server1 with prompts")
+		reg1 := NewTestResources("prompt-vs-no-field", k8sClient).
+			ForInternalService(sharedMCPTestServer1, 9090).
+			WithPrefix("test1_").
+			Build()
+		testResources = append(testResources, reg1.GetObjects()...)
+		server1 := reg1.Register(ctx)
+
+		By("Waiting for MCPServerRegistration to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Creating an MCPVirtualServer with no prompts field")
+		// NewMCPVirtualServerBuilder doesn't set Prompts by default
+		vs := NewMCPVirtualServerBuilder("prompt-vs-empty", TestServerNameSpace).Build()
+		testResources = append(testResources, vs)
+		Expect(k8sClient.Create(ctx, vs)).To(Succeed())
+
+		By("Initializing a session with X-Mcp-Virtualserver header")
+		headers["X-Mcp-Virtualserver"] = fmt.Sprintf("%s/%s", vs.Namespace, vs.Name)
+		sessionID, err := mcpInitialize(ctx, gatewayURL, headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, headers)).To(Succeed())
+
+		By("Verifying prompts/list returns all prompts")
+		Eventually(func(g Gomega) {
+			status, prompts, err := mcpListPrompts(ctx, gatewayURL, sessionID, headers)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal(http.StatusOK))
+			g.Expect(prompts).To(ContainElement("test1_greet"))
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[Happy] prompts/get for nonexistent prompt returns error", func() {
+		By("Initializing a session")
+		sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		By("Invoking prompts/get for non_existent_prompt")
+		status, _, err := mcpGetPrompt(ctx, gatewayURL, sessionID, "non_existent_prompt", nil, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("-32602"))
+		Expect(status).To(Equal(http.StatusOK)) // JSON-RPC errors still return 200 OK
+	})
+
+	Context("Auth tests", func() {
+		BeforeEach(func() {
+			if !IsAuthPolicyConfigured(ctx) {
+				Skip("auth not configured - skipping prompt auth tests")
+			}
+		})
+
+		It("[Auth] JWT-filtered prompts/list with Keycloak", func() {
+			By("Registering servers matching Keycloak client IDs")
+			reg1 := NewTestResources("auth-prompt-s1", k8sClient).
+				ForInternalService(sharedMCPTestServer1, 9090).
+				WithPrefix("test1_").
+				WithRegistrationName("test-server1").
+				Build()
+			testResources = append(testResources, reg1.GetObjects()...)
+			server1 := reg1.Register(ctx)
+
+			By("Waiting for MCPServerRegistration to become ready")
+			Eventually(func(g Gomega) {
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+			}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+			By("Obtaining a token from Keycloak")
+			token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+			Expect(err).NotTo(HaveOccurred())
+			headers["Authorization"] = "Bearer " + token
+
+			By("Initializing a session")
+			sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+
+			By("Verifying prompts/list is filtered by user roles")
+			// mcp user in accounting group has prompt:* for test-server1
+			Eventually(func(g Gomega) {
+				status, prompts, err := mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status).To(Equal(http.StatusOK))
+				g.Expect(prompts).To(ContainElement("test1_greet"))
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		})
+
+		It("[Auth] prompts/get with auth as first request (hairpin test)", func() {
+			By("Registering servers matching Keycloak client IDs")
+			reg1 := NewTestResources("auth-hairpin-prompt", k8sClient).
+				ForInternalService(sharedMCPTestServer1, 9090).
+				WithPrefix("test1_").
+				WithRegistrationName("test-server1").
+				Build()
+			testResources = append(testResources, reg1.GetObjects()...)
+			server1 := reg1.Register(ctx)
+
+			By("Waiting for MCPServerRegistration to become ready")
+			Eventually(func(g Gomega) {
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+			}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+			By("Obtaining a token from Keycloak")
+			token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+			Expect(err).NotTo(HaveOccurred())
+			headers["Authorization"] = "Bearer " + token
+
+			By("Invoking prompts/get as the first request (no prior session)")
+			// gatewayURL is used here but maybe it should be authGatewayURL
+			// Hairpin test implies it's the first thing called, so gateway will do lazy init
+			Eventually(func(g Gomega) {
+				status, messages, err := mcpGetPrompt(ctx, authGatewayURL, "", "test1_greet", map[string]string{"name": "e2e"}, headers)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status).To(Equal(http.StatusOK))
+				g.Expect(messages).NotTo(BeEmpty())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		})
+
+		It("[Auth] Combined JWT + VirtualServer prompt filtering", func() {
+			By("Registering servers matching Keycloak client IDs")
+			reg1 := NewTestResources("auth-vs-prompt", k8sClient).
+				ForInternalService(sharedMCPTestServer1, 9090).
+				WithPrefix("test1_").
+				WithRegistrationName("test-server1").
+				Build()
+			testResources = append(testResources, reg1.GetObjects()...)
+			server1 := reg1.Register(ctx)
+
+			By("Waiting for MCPServerRegistration to become ready")
+			Eventually(func(g Gomega) {
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+			}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+			By("Creating an MCPVirtualServer that allows a DIFFERENT prompt (which doesn't exist on server1)")
+			vs := NewMCPVirtualServerBuilder("prompt-vs-combined", TestServerNameSpace).
+				WithPrompts([]string{"test1_non_existent"}).
+				Build()
+			testResources = append(testResources, vs)
+			Expect(k8sClient.Create(ctx, vs)).To(Succeed())
+
+			By("Obtaining a token from Keycloak")
+			token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+			Expect(err).NotTo(HaveOccurred())
+			headers["Authorization"] = "Bearer " + token
+			headers["X-Mcp-Virtualserver"] = fmt.Sprintf("%s/%s", vs.Namespace, vs.Name)
+
+			By("Initializing a session")
+			sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+
+			By("Verifying prompts/list is empty (intersection of test1_greet and test1_non_existent)")
+			Eventually(func(g Gomega) {
+				status, prompts, err := mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status).To(Equal(http.StatusOK))
+				g.Expect(prompts).To(BeEmpty())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		})
+	})
+})

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -126,6 +126,42 @@ func mcpListTools(ctx context.Context, url, sessionID string, headers map[string
 	return resp.StatusCode, names, nil
 }
 
+func mcpListPrompts(ctx context.Context, url, sessionID string, headers map[string]string) (int, []string, error) {
+	body := `{"jsonrpc":"2.0","id":2,"method":"prompts/list"}`
+	resp, err := mcpPost(ctx, url, sessionID, []byte(body), headers)
+	if err != nil {
+		return 0, nil, fmt.Errorf("prompts/list failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return resp.StatusCode, nil, fmt.Errorf("prompts/list returned status %d (body unreadable: %w)", resp.StatusCode, readErr)
+		}
+		return resp.StatusCode, nil, fmt.Errorf("prompts/list returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	result, err := readJSONRPCResult(resp)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+
+	var listResult struct {
+		Prompts []struct {
+			Name string `json:"name"`
+		} `json:"prompts"`
+	}
+	if err := json.Unmarshal(result, &listResult); err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("failed to parse prompts/list result: %w: %s", err, string(result))
+	}
+	names := make([]string, len(listResult.Prompts))
+	for i, p := range listResult.Prompts {
+		names[i] = p.Name
+	}
+	return resp.StatusCode, names, nil
+}
+
 func mcpCallTool(ctx context.Context, url, sessionID, toolName string, args map[string]any, headers map[string]string) (int, []toolContent, error) {
 	params := map[string]any{"name": toolName}
 	if len(args) > 0 {
@@ -170,6 +206,50 @@ func mcpCallTool(ctx context.Context, url, sessionID, toolName string, args map[
 	return resp.StatusCode, callResult.Content, nil
 }
 
+func mcpGetPrompt(ctx context.Context, url, sessionID, promptName string, args map[string]string, headers map[string]string) (int, []promptMessage, error) {
+	params := map[string]any{"name": promptName}
+	if len(args) > 0 {
+		params["arguments"] = args
+	}
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "prompts/get",
+		"params":  params,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to marshal prompts/get: %w", err)
+	}
+
+	resp, err := mcpPost(ctx, url, sessionID, body, headers)
+	if err != nil {
+		return 0, nil, fmt.Errorf("prompts/get failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return resp.StatusCode, nil, fmt.Errorf("prompts/get returned status %d (body unreadable: %w)", resp.StatusCode, readErr)
+		}
+		return resp.StatusCode, nil, fmt.Errorf("prompts/get returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	result, err := readJSONRPCResult(resp)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+
+	var getResult struct {
+		Messages []promptMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(result, &getResult); err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("failed to parse prompt result: %w: %s", err, string(result))
+	}
+	return resp.StatusCode, getResult.Messages, nil
+}
+
 func mcpRawPost(ctx context.Context, url, sessionID string, body []byte, headers map[string]string) (int, string, http.Header, error) {
 	resp, err := mcpPost(ctx, url, sessionID, body, headers)
 	if err != nil {
@@ -186,6 +266,11 @@ func mcpRawPost(ctx context.Context, url, sessionID string, body []byte, headers
 type toolContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
+}
+
+type promptMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
 }
 
 // extractBackendSession finds the backend Mcp-Session-Id from tool content

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -148,13 +148,51 @@
 
 - When an MCPServerRegistration is registered with a backend MCP server that has prompts (e.g., server1 with a "greet" prompt), the gateway should discover and serve those prompts with the server's prefix applied. A prompts/list request should return the prompt with the prefixed name. A prompts/get request using the prefixed prompt name should return the prompt's messages. When the MCPServerRegistration is deleted, the prompt should no longer appear in prompts/list.
 
+
 ### [Happy] Multi-server prompt aggregation
 
 - When multiple MCPServerRegistration resources are created pointing to servers with prompts and different prefixes, a prompts/list request should return prompts from all registered servers, each prefixed with the corresponding server's prefix. For example, two registrations of server1 with prefixes "s1a_" and "s1b_" should produce "s1a_greet" and "s1b_greet" in the prompts list.
 
+
 ### [Happy] MCPVirtualServer filters prompts
 
 - When an MCPVirtualServer resource specifies a subset of prompt names in its `prompts` field, a client using the `X-Mcp-Virtualserver` header should only see the specified prompts in a prompts/list response. A client without the header should still see all prompts.
+
+
+### [Happy] prompts/list returns federated prompts with prefixes
+
+- When a client sends a `prompts/list` request through the gateway, all prompts from registered upstream servers should be returned with their server prefix applied (e.g., `test1_greet`). Prompt metadata should not expose internal `kuadrant/id` fields.
+
+
+### [Happy] prompts/get routes to the correct upstream server
+
+- When a client sends a `prompts/get` request with a prefixed prompt name (e.g., `test1_greet`), the gateway should strip the prefix, route to the correct upstream server, perform lazy session initialization, and return the prompt messages.
+
+
+### [Happy] VirtualServer with no prompts field exposes all prompts
+
+- When a VirtualServer omits the `prompts` field, all federated prompts should be returned (same behavior as tools).
+
+
+### [Happy] prompts/get for nonexistent prompt returns error
+
+- When a client sends a `prompts/get` request with a prompt name that doesn't match any registered server, the gateway should return a JSON-RPC error with code `-32602`.
+
+
+### [Auth] JWT-filtered prompts/list with Keycloak
+
+- When a client authenticates via Keycloak and sends a `prompts/list` request, only prompts the user has `prompt:*` roles for should be returned. The `mcp` user in the `accounting` group should see `test1_greet` but not everything-server prompts.
+
+
+### [Auth] prompts/get with auth as first request (hairpin test)
+
+- When a client sends a `prompts/get` request as the first request to a server (no prior `tools/call`), the hairpin initialize should pass through the AuthPolicy correctly and return prompt messages.
+
+
+### [Auth] Combined JWT + VirtualServer prompt filtering
+
+- When a client sends a `prompts/list` request with both a valid auth token and an `x-mcp-virtualserver` header, the result should be the intersection of both filters.
+
 
 ### [Happy] Elicitation accept flow
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive end-to-end (e2e) test coverage for prompt federation, fulfilling the requirements of issue #945. It follows the patterns established in existing e2e tests and adds new infrastructure to support prompt-related JSON-RPC methods.

## Changes
- **Infrastructure**: Added `mcpListPrompts` and `mcpGetPrompt` helper functions to `tests/e2e/raw_mcp_http.go` to facilitate direct HTTP-based MCP interactions for prompts.
- **New Tests**: Created `tests/e2e/prompt_test.go` with the following test cases:
    - **[Happy] prompts/list**: Verifies that federated prompts are returned with correct server prefixes (e.g., `test1_greet`).
    - **[Happy] prompts/get**: Confirms correct routing to upstream servers and lazy session initialization.
    - **[Happy] Multi-server aggregation**: Ensures prompts from multiple servers are correctly aggregated and prefixed.
    - **[Happy] VirtualServer Filtering**: Tests that `MCPVirtualServer` correctly filters prompts when the `X-Mcp-Virtualserver` header is present.
    - **[Happy] VirtualServer Default**: Verifies that all prompts are exposed when the `prompts` field is omitted in `MCPVirtualServer`.
    - **[Happy] Error Handling**: Ensures a `-32602` error code is returned for nonexistent prompts.
    - **[Auth] Role-based Filtering**: Validates that prompt listing is filtered based on Keycloak user roles.
    - **[Auth] Hairpin Test**: Confirms that `prompts/get` works correctly as the first request through AuthPolicy.
    - **[Auth] Combined Filtering**: Tests the intersection of JWT and VirtualServer filters.
- **Documentation**: Updated `tests/e2e/test_cases.md` to include descriptions for the new prompt federation test cases.

## Verification
- Compiled tests with `go build -tags=e2e ./tests/e2e/...`.
- Manual verification instructions: `make test-e2e` 

Closes #945