### PR TITLE
refactor(upstream): decouple backoff logic from status updates

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -421,7 +421,13 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 			}
 		}
 	}
-	man.setStatus(errors.Join(toolErr, promptErr), numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
+	jointErr := errors.Join(toolErr, promptErr)
+	man.setStatus(jointErr, numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
+	if jointErr != nil {
+		man.applyBackoff()
+	} else {
+		man.resetBackoff()
+	}
 }
 
 func (man *MCPManager) shouldFetchTools(event eventType) bool {
@@ -462,14 +468,12 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
-		man.applyBackoff()
 		return
 	}
 	man.status.TotalTools = toolCount
 	man.status.TotalPrompts = promptCount
 	man.status.Ready = true
 	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
-	man.resetBackoff()
 }
 
 func (man *MCPManager) resetBackoff() {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1374,41 +1374,45 @@ func TestMCPManager_Backoff(t *testing.T) {
 	manager, err := NewUpstreamMCPManager(mock, gateway, nil, slog.Default(), tickerInterval, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	// Initially, steps should be 10 (as configured in NewUpstreamMCPManager)
-	assert.Equal(t, 10, manager.backoff.Steps)
-
-	// 1. Simulate failure
+	// 1. Simulate failure (Connect)
 	mock.connectErr = fmt.Errorf("connect error")
 	manager.manage(ctx, eventTypeTimer)
 
-	// After failure, Steps should be 9
-	assert.Equal(t, 9, manager.backoff.Steps)
+	status := manager.GetStatus()
+	assert.False(t, status.Ready)
+	assert.Contains(t, status.Message, "connect error")
 
-	// 2. Simulate another failure
-	manager.manage(ctx, eventTypeTimer)
-	assert.Equal(t, 8, manager.backoff.Steps)
-
-	// 3. Simulate success
+	// 2. Simulate success
 	mock.connectErr = nil
 	manager.manage(ctx, eventTypeTimer)
 
-	// 4. Test Ping failure
+	status = manager.GetStatus()
+	assert.True(t, status.Ready)
+	assert.Contains(t, status.Message, "server added successfully")
+
+	// 3. Test Ping failure
 	mock.pingErr = fmt.Errorf("ping error")
 	manager.manage(ctx, eventTypeTimer)
-	assert.Equal(t, 9, manager.backoff.Steps)
+
+	status = manager.GetStatus()
+	assert.False(t, status.Ready)
+	assert.Contains(t, status.Message, "ping error")
 
 	// Reset
 	mock.pingErr = nil
 	manager.manage(ctx, eventTypeTimer)
-	assert.Equal(t, 10, manager.backoff.Steps)
+	assert.True(t, manager.GetStatus().Ready)
 
-	// 5. Test ListTools failure
+	// 4. Test ListTools failure
 	mock.listToolsErr = fmt.Errorf("list tools error")
 	manager.manage(ctx, eventTypeTimer)
-	assert.Equal(t, 9, manager.backoff.Steps)
+
+	status = manager.GetStatus()
+	assert.False(t, status.Ready)
+	assert.Contains(t, status.Message, "list tools error")
 
 	// Reset
 	mock.listToolsErr = nil
 	manager.manage(ctx, eventTypeTimer)
-	assert.Equal(t, 10, manager.backoff.Steps)
+	assert.True(t, manager.GetStatus().Ready)
 }


### PR DESCRIPTION
Follow up from #948.

Refactors the MCP manager status handling as requested:
- Move applyBackoff/resetBackoff from setStatus to manage() to keep setStatus as a pure status setter.
- Update TestMCPManager_Backoff to assert on status/readiness instead of internal wait.Backoff state for better robustness.