### PR TITLE
Add grace period before removing backend tools

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -66,6 +66,7 @@ var (
 	sessionDurationInMins          int64
 	brokerWriteTimeoutSecs         int64
 	managerTickerIntervalSecs      int64
+	removeToolsGracePeriodSecs     int64
 	loglevel                       int
 	logFormat                      string
 	enforceCapabilityFilteringFlag bool
@@ -135,6 +136,7 @@ func main() {
 	flag.Int64Var(&sessionDurationInMins, "session-length", 60*24, "default session length with the gateway in minutes. Default 24h")
 	flag.Int64Var(&brokerWriteTimeoutSecs, "mcp-broker-write-timeout", 0, "HTTP write timeout in seconds for the broker. Default 0 (disabled) for SSE notification support. Set > 0 to enable timeout.")
 	flag.Int64Var(&managerTickerIntervalSecs, "mcp-check-interval", 60, "interval in seconds for MCP manager backend health checks. Default 60 seconds.")
+	flag.Int64Var(&removeToolsGracePeriodSecs, "remove-tools-grace-period", 60, "grace period in seconds to retain tools after backend checks fail. Default 60 seconds. Set 0 to remove immediately.")
 	flag.BoolVar(&enforceCapabilityFilteringFlag, "enforce-capability-filtering", false, "when enabled an x-mcp-authorized header will be needed to return any capabilities (tools, prompts)")
 	flag.StringVar(&invalidToolPolicyFlag, "invalid-tool-policy", "FilterOut", "policy for upstream tools with invalid schemas: FilterOut (default) or RejectServer")
 	flag.IntVar(&maxRequestBodySize, "max-request-body-size", 5242880, "max request body size in bytes for the ext_proc router. Default 5MB.")
@@ -214,10 +216,15 @@ func main() {
 	if managerTickerInterval <= 0 {
 		panic("flag mcp-check-interval cannot be 0 or less seconds")
 	}
+	removeToolsGracePeriod := time.Duration(removeToolsGracePeriodSecs) * time.Second
+	if removeToolsGracePeriod < 0 {
+		panic("flag remove-tools-grace-period cannot be less than 0 seconds")
+	}
 	mcpBroker := broker.NewBroker(logger.With("component", "broker"),
 		broker.WithEnforceCapabilityFilter(enforceCapabilityFilteringFlag),
 		broker.WithTrustedHeadersPublicKey(os.Getenv("TRUSTED_HEADER_PUBLIC_KEY")),
 		broker.WithManagerTickerInterval(managerTickerInterval),
+		broker.WithRemoveToolsGracePeriod(removeToolsGracePeriod),
 		broker.WithInvalidToolPolicy(invalidToolPolicy),
 	)
 	brokerServer, mcpServer := setUpHTTPServer(mcpBrokerAddrFlag, mcpBroker, jwtSessionMgr, brokerWriteTimeoutSecs)

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -73,6 +73,9 @@ type mcpBrokerImpl struct {
 	// managerTickerInterval is the interval for MCP manager backend health checks
 	managerTickerInterval time.Duration
 
+	// removeToolsGracePeriod is how long tools are retained after backend checks fail
+	removeToolsGracePeriod time.Duration
+
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy mcpv1alpha1.InvalidToolPolicy
 }
@@ -104,6 +107,13 @@ func WithManagerTickerInterval(interval time.Duration) Option {
 	}
 }
 
+// WithRemoveToolsGracePeriod sets the grace period before removing tools for an unreachable backend
+func WithRemoveToolsGracePeriod(period time.Duration) Option {
+	return func(mb *mcpBrokerImpl) {
+		mb.removeToolsGracePeriod = period
+	}
+}
+
 // WithInvalidToolPolicy sets the policy for handling upstream tools with invalid schemas
 func WithInvalidToolPolicy(policy mcpv1alpha1.InvalidToolPolicy) Option {
 	return func(mb *mcpBrokerImpl) {
@@ -114,10 +124,11 @@ func WithInvalidToolPolicy(policy mcpv1alpha1.InvalidToolPolicy) Option {
 // NewBroker creates a new MCPBroker accepts optional config functions such as WithEnforceCapabilityFilter
 func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	mcpBkr := &mcpBrokerImpl{
-		mcpServers:            map[config.UpstreamMCPID]*upstream.MCPManager{},
-		logger:                logger,
-		virtualServers:        map[string]*config.VirtualServer{},
-		managerTickerInterval: time.Second * 60,
+		mcpServers:             map[config.UpstreamMCPID]*upstream.MCPManager{},
+		logger:                 logger,
+		virtualServers:         map[string]*config.VirtualServer{},
+		managerTickerInterval:  time.Second * 60,
+		removeToolsGracePeriod: time.Minute,
 	}
 
 	for _, option := range opts {
@@ -193,7 +204,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		// check if we need to setup a new manager
 		if _, ok := m.mcpServers[mcpServer.ID()]; !ok {
 			m.logger.Info("starting new manager", "server id", mcpServer.ID())
-			manager := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
+			manager := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy, m.removeToolsGracePeriod)
 			m.mcpServers[mcpServer.ID()] = manager
 			go func() {
 				m.logger.Info("Starting manager for", "mcpID", mcpServer.ID())

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"testing"
+	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
@@ -58,7 +59,7 @@ func createTestManager(t *testing.T, serverName, prefix string, tools []mcp.Tool
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 	// populate tools directly for testing (this requires accessing internal state)
 	manager.SetToolsForTesting(tools)
 	return manager

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
@@ -34,7 +35,7 @@ func createTestManagerForStatus(t *testing.T, serverName string, tools []mcp.Too
 		Prefix: "test_",
 		URL:    "http://test.local/mcp",
 	})
-	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := upstream.NewUpstreamMCPManager(mcpServer, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 	manager.SetToolsForTesting(tools)
 	manager.SetStatusForTesting(upstream.ServerValidationStatus{
 		Name:  serverName,

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -76,7 +76,9 @@ type MCPManager struct {
 	ticker *time.Ticker
 	// tickerInterval is the interval between backend health checks
 	tickerInterval time.Duration
-	gatewayServer  ToolsAdderDeleter
+	// removeToolsGracePeriod is how long tools are retained after backend checks fail
+	removeToolsGracePeriod time.Duration
+	gatewayServer          ToolsAdderDeleter
 	// serverTools is an internal copy that contains the managed MCP's tools with prefixed names. It is these that are externally available via the gateway
 	serverTools []server.ServerTool
 	// tools is the original set from MCP server with no prefix
@@ -91,6 +93,9 @@ type MCPManager struct {
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy mcpv1alpha1.InvalidToolPolicy
 
+	// backendUnavailableSince records the first failed check while tools are retained.
+	backendUnavailableSince time.Time
+
 	stopOnce sync.Once     // ensures Stop() is only executed once
 	done     chan struct{} // triggers the exit of the select and routine
 	status   ServerValidationStatus
@@ -102,22 +107,24 @@ const DefaultTickerInterval = time.Minute * 1
 // NewUpstreamMCPManager creates a new MCPManager for managing a single upstream MCP server.
 // The addTools and removeTools callbacks are used to update the gateway's tool registry.
 // The tickerInterval controls how often the manager checks backend health (use 0 for default).
-func NewUpstreamMCPManager(upstream MCP, gatewaySever ToolsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) *MCPManager {
+// The removeToolsGracePeriod controls how long tools are retained after backend checks fail.
+func NewUpstreamMCPManager(upstream MCP, gatewaySever ToolsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy, removeToolsGracePeriod time.Duration) *MCPManager {
 	if tickerInterval <= 0 {
 		tickerInterval = DefaultTickerInterval
 	}
 
 	return &MCPManager{
-		MCP:               upstream,
-		gatewayServer:     gatewaySever,
-		tickerInterval:    tickerInterval,
-		ticker:            time.NewTicker(tickerInterval),
-		logger:            logger,
-		invalidToolPolicy: policy,
-		done:              make(chan struct{}),
-		toolsMap:          map[string]*mcp.Tool{},
-		servedToolsMap:    map[string]*mcp.Tool{},
-		serverTools:       []server.ServerTool{},
+		MCP:                    upstream,
+		gatewayServer:          gatewaySever,
+		tickerInterval:         tickerInterval,
+		removeToolsGracePeriod: removeToolsGracePeriod,
+		ticker:                 time.NewTicker(tickerInterval),
+		logger:                 logger,
+		invalidToolPolicy:      policy,
+		done:                   make(chan struct{}),
+		toolsMap:               map[string]*mcp.Tool{},
+		servedToolsMap:         map[string]*mcp.Tool{},
+		serverTools:            []server.ServerTool{},
 	}
 }
 
@@ -181,6 +188,27 @@ func (man *MCPManager) registerCallbacks(ctx context.Context) func() {
 	}
 }
 
+func (man *MCPManager) handleBackendUnavailable(err error) {
+	man.toolsLock.RLock()
+	toolCount := len(man.serverTools)
+	man.toolsLock.RUnlock()
+
+	if toolCount > 0 && man.removeToolsGracePeriod > 0 {
+		if man.backendUnavailableSince.IsZero() {
+			man.backendUnavailableSince = time.Now()
+		}
+		if time.Since(man.backendUnavailableSince) < man.removeToolsGracePeriod {
+			err = fmt.Errorf("%w; retaining existing tools during %s backend unavailable grace period", err, man.removeToolsGracePeriod)
+			man.setStatus(err, toolCount, nil)
+			return
+		}
+	}
+
+	err = fmt.Errorf("%w; removing tools", err)
+	man.removeAllTools()
+	man.setStatus(err, 0, nil)
+}
+
 // manage should be the only entry point that triggers changes to tools
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.logger.Debug("managing connection", "upstream mcp server", man.MCP.ID(), "event type", event)
@@ -188,26 +216,29 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
 	man.logger.Debug("attempting to connect", "upstream mcp server", man.MCP.ID())
 	if err := man.MCP.Connect(ctx, man.registerCallbacks(ctx)); err != nil {
-		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.MCP.ID(), err)
-		man.removeAllTools()
+		err = fmt.Errorf("failed to connect to upstream mcp %s: %w", man.MCP.ID(), err)
+		man.handleBackendUnavailable(err)
 		// we call disconnect here as we may have connected but failed to initialize
 		_ = man.MCP.Disconnect()
-		man.setStatus(err, numberOfTools, nil)
 		return
 	}
 	// there may be an active client so we also ping
 	if err := man.MCP.Ping(ctx); err != nil {
 		// if we fail to ping we disconnect to ensure a fresh connection next time around
-		err = fmt.Errorf("upstream mcp failed to ping server %s removing tools : %w", man.MCP.ID(), err)
+		err = fmt.Errorf("upstream mcp failed to ping server %s: %w", man.MCP.ID(), err)
 		man.logger.Error("ping failed", "upstream mcp server", man.MCP.ID(), "error", err)
-		man.removeAllTools()
+		man.handleBackendUnavailable(err)
 		_ = man.MCP.Disconnect()
-		man.setStatus(err, numberOfTools, nil)
 		return
 	}
+	man.backendUnavailableSince = time.Time{}
 
 	if !man.shouldFetchTools(event) {
 		man.logger.Debug("not fetching tools", "event", event, "upstream mcp server", man.MCP.ID(), "waiting for notification", notificationToolsListChanged)
+		man.toolsLock.RLock()
+		toolCount := len(man.serverTools)
+		man.toolsLock.RUnlock()
+		man.setStatus(nil, toolCount, nil)
 		return
 	}
 

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -173,7 +173,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP(tc.name, "")
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 			assert.Equal(t, tc.expectedInterval, manager.tickerInterval)
 		})
 	}
@@ -182,7 +182,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 func TestMCPManager_MCPName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("my-test-server", "prefix_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	assert.Equal(t, "my-test-server", manager.MCPName())
 }
@@ -190,7 +190,7 @@ func TestMCPManager_MCPName(t *testing.T) {
 func TestMCPManager_GetStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	expectedStatus := ServerValidationStatus{
 		ID:            "test-id",
@@ -213,7 +213,7 @@ func TestMCPManager_GetManagedTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	tools := []mcp.Tool{
 		{Name: "tool1", Description: "Tool 1", InputSchema: mcp.ToolInputSchema{Type: "object"}},
@@ -232,7 +232,7 @@ func TestMCPManager_GetManagedTools_ReturnsCopy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	tools := []mcp.Tool{validTool("tool1")}
 	manager.SetToolsForTesting(tools)
@@ -286,7 +286,7 @@ func TestMCPManager_GetServedManagedTool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tc.prefix)
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 			manager.SetToolsForTesting(tc.tools)
 
 			tool := manager.GetServedManagedTool(tc.lookupName)
@@ -332,7 +332,7 @@ func TestMCPManager_setStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
-			manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 			manager.serverTools = make([]server.ServerTool, tc.numServerTools)
 
 			manager.setStatus(tc.err, tc.totalTools, nil)
@@ -386,7 +386,7 @@ func TestPrefixedName(t *testing.T) {
 func TestMCPManager_toolToServerTool(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	tool := mcp.Tool{
 		Name:        "mytool",
@@ -414,7 +414,7 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	// calling Stop multiple times should not panic
 	manager.Stop()
@@ -430,7 +430,7 @@ func TestMCPManager_manage_ConnectError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.connectErr = fmt.Errorf("connection refused")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -444,7 +444,7 @@ func TestMCPManager_manage_PingError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.pingErr = fmt.Errorf("ping timeout")
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -459,7 +459,7 @@ func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	mock.listToolsErr = fmt.Errorf("list tools failed")
 	mock.hasToolsCap = false // ensure we try to list tools
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -468,13 +468,97 @@ func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	assert.Contains(t, status.Message, "list tools")
 }
 
+func TestMCPManager_manage_BackendUnavailableGracePeriodRetainsTools(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	gateway := newMockToolsAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Minute, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
+
+	manager.manage(context.Background(), eventTypeTimer)
+	assert.Contains(t, gateway.ListTools(), "test_mock_tool")
+
+	mock.pingErr = fmt.Errorf("ping timeout")
+	manager.manage(context.Background(), eventTypeTimer)
+
+	status := manager.GetStatus()
+	assert.False(t, status.Ready)
+	assert.Contains(t, status.Message, "ping timeout")
+	assert.Contains(t, status.Message, "retaining existing tools")
+	assert.Contains(t, gateway.ListTools(), "test_mock_tool")
+	assert.NotNil(t, manager.GetServedManagedTool("test_mock_tool"))
+}
+
+func TestMCPManager_manage_RemoveToolsGracePeriodZeroRemovesImmediately(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	gateway := newMockToolsAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Minute, mcpv1alpha1.InvalidToolPolicyFilterOut, 0)
+
+	manager.manage(context.Background(), eventTypeTimer)
+	assert.Contains(t, gateway.ListTools(), "test_mock_tool")
+
+	mock.pingErr = fmt.Errorf("ping timeout")
+	manager.manage(context.Background(), eventTypeTimer)
+
+	status := manager.GetStatus()
+	assert.False(t, status.Ready)
+	assert.Contains(t, status.Message, "removing tools")
+	assert.NotContains(t, gateway.ListTools(), "test_mock_tool")
+	assert.Nil(t, manager.GetServedManagedTool("test_mock_tool"))
+}
+
+func TestMCPManager_manage_BackendUnavailableGracePeriodRemovesToolsAfterExpiry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	gateway := newMockToolsAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Minute, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
+
+	manager.manage(context.Background(), eventTypeTimer)
+	assert.Contains(t, gateway.ListTools(), "test_mock_tool")
+
+	mock.pingErr = fmt.Errorf("ping timeout")
+	manager.manage(context.Background(), eventTypeTimer)
+	assert.Contains(t, gateway.ListTools(), "test_mock_tool")
+
+	manager.backendUnavailableSince = time.Now().Add(-manager.removeToolsGracePeriod - time.Second)
+	manager.manage(context.Background(), eventTypeTimer)
+
+	status := manager.GetStatus()
+	assert.False(t, status.Ready)
+	assert.Contains(t, status.Message, "removing tools")
+	assert.NotContains(t, gateway.ListTools(), "test_mock_tool")
+	assert.Nil(t, manager.GetServedManagedTool("test_mock_tool"))
+}
+
+func TestMCPManager_manage_BackendUnavailableRecoveryMarksReadyWithoutToolFetch(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	gateway := newMockToolsAdderDeleter()
+	manager := NewUpstreamMCPManager(mock, gateway, logger, time.Minute, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
+
+	manager.manage(context.Background(), eventTypeTimer)
+
+	mock.pingErr = fmt.Errorf("ping timeout")
+	manager.manage(context.Background(), eventTypeTimer)
+	assert.False(t, manager.GetStatus().Ready)
+
+	mock.pingErr = nil
+	manager.manage(context.Background(), eventTypeTimer)
+
+	status := manager.GetStatus()
+	assert.True(t, status.Ready)
+	assert.Equal(t, 1, status.TotalTools)
+	assert.True(t, manager.backendUnavailableSince.IsZero())
+	assert.Contains(t, gateway.ListTools(), "test_mock_tool")
+}
+
 func TestMCPManager_manage_Success(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	mock := newMockMCP("test-server", "test_")
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false // ensure we list tools every time
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -491,7 +575,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 func TestDiffTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	tests := []struct {
 		name            string
@@ -672,7 +756,7 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = tt.supportsToolsListChange
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 			if tt.hasExistingTools {
 				// set serverTools directly since shouldFetchTools checks this field
@@ -691,7 +775,7 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true // supports tools list change notifications
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	// First call with notification - should fetch and add tools
 	manager.manage(context.Background(), eventTypeNotification)
@@ -772,7 +856,7 @@ func TestMCPManager_manage_OnlyCallsAddDeleteWhenNeeded(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = false // ensure we fetch tools on every manage call
 			gateway := newMockToolsAdderDeleter()
-			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 			// first manage call - establish initial tools
 			mock.tools = tt.initialTools
@@ -865,7 +949,7 @@ func TestServerToolsManagement(t *testing.T) {
 			mockMCP := newMockMCP("test-server", tt.prefix)
 			mockMCP.hasToolsCap = false // ensure we fetch tools on every manage call
 			mockGateway := NewMockGatewayServer()
-			manager := NewUpstreamMCPManager(mockMCP, mockGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager := NewUpstreamMCPManager(mockMCP, mockGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 			// First manage call - establish initial tools
 			mockMCP.tools = tt.initialTools
@@ -915,7 +999,7 @@ func TestMCPManager_manage_FilterOutPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -938,7 +1022,7 @@ func TestMCPManager_manage_FilterOutPolicy_AllInvalid(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -958,7 +1042,7 @@ func TestMCPManager_manage_RejectServerPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 
@@ -975,7 +1059,7 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager := NewUpstreamMCPManager(mock, gateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut, time.Minute)
 
 	manager.manage(context.Background(), eventTypeTimer)
 


### PR DESCRIPTION
Fixes #463

Adds a configurable --remove-tools-grace-period before removing tools from an unavailable backend MCP server. Existing tools are retained during the grace period, removed after it expires, and recovery resets the unavailable state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools are now retained during a configurable grace period when upstream backends become unhealthy, providing resilience during transient failures.
  * Added `remove-tools-grace-period` CLI flag to customize the retention duration (default: 60 seconds).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->