### PR TITLE
fix(controller): use resource namespace for mcpvirtualserver config i…

### DIFF
--- a/internal/controller/mcpvirtualserver_controller.go
+++ b/internal/controller/mcpvirtualserver_controller.go
@@ -50,12 +50,28 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
     }
     logger.Info("reconciling mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
 
+    targetNamespaceName := types.NamespacedName{
+        Namespace: mcpVS.Namespace,
+        Name:      config.DefaultNamespaceName.Name,
+    }
+
     // handle deletion
     if !mcpVS.DeletionTimestamp.IsZero() {
         logger.Info("mcpvirtualserver is being deleted", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
         if controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
-            logger.Info("deleting mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
-            // TODO remove from config
+            logger.Info("deleting mcpvirtualserver and updating config", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
+            
+            // Generate config (this automatically excludes the deleted item)
+            vsConfig, err := r.generateVirtualServerConfig(ctx, mcpVS.Namespace)
+            if err != nil {
+                return ctrl.Result{}, fmt.Errorf("failed to generate config during deletion %w", err)
+            }
+
+            // Write the updated config to completely remove the deleted server's footprint
+            if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, targetNamespaceName); err != nil {
+                return ctrl.Result{}, fmt.Errorf("failed to write config during deletion %w", err)
+            }
+
             controllerutil.RemoveFinalizer(mcpVS, mcpGatewayFinalizer)
             if err := r.Update(ctx, mcpVS); err != nil {
                 return ctrl.Result{}, err
@@ -63,6 +79,7 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
         }
         return ctrl.Result{}, nil
     }
+    
     // add finalizer if not present
     if !controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
         if controllerutil.AddFinalizer(mcpVS, mcpGatewayFinalizer) {
@@ -78,14 +95,9 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
     logger.V(1).Info("mcpvirtualserver generating config")
 
-    vsConfig, err := r.generateVirtualServerConfig(ctx)
+    vsConfig, err := r.generateVirtualServerConfig(ctx, mcpVS.Namespace)
     if err != nil {
         return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to generate virtual server config during reconcile %w", err)
-    }
-
-    targetNamespaceName := types.NamespacedName{
-        Namespace: mcpVS.Namespace,
-        Name:      config.DefaultNamespaceName.Name,
     }
 
     logger.V(1).Info("mcpvirtualserver writing config")
@@ -101,14 +113,18 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
     return ctrl.Result{}, nil
 }
 
-func (r *MCPVirtualServerReconciler) generateVirtualServerConfig(ctx context.Context) ([]config.VirtualServerConfig, error) {
+// Updated to accept namespace and scope the list query
+func (r *MCPVirtualServerReconciler) generateVirtualServerConfig(ctx context.Context, namespace string) ([]config.VirtualServerConfig, error) {
     log := log.FromContext(ctx)
     virtualServers := []config.VirtualServerConfig{}
     mcpVirtualServerList := &mcpv1alpha1.MCPVirtualServerList{}
-    if err := r.List(ctx, mcpVirtualServerList); err != nil {
+    
+    // Pass client.InNamespace to ensure we only pull configs for this specific tenant
+    if err := r.List(ctx, mcpVirtualServerList, client.InNamespace(namespace)); err != nil {
         log.Error(err, "Failed to list MCPVirtualServers")
         return virtualServers, err
     }
+    
     // generate the entire virtual server config fresh rather than merge etc (future optimization)
     for _, mcpVirtualServer := range mcpVirtualServerList.Items {
         if mcpVirtualServer.DeletionTimestamp != nil {

--- a/internal/controller/mcpvirtualserver_controller.go
+++ b/internal/controller/mcpvirtualserver_controller.go
@@ -1,36 +1,36 @@
 package controller
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
-	"time"
+    "context"
+    "fmt"
+    "log/slog"
+    "time"
 
-	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+    "github.com/go-logr/logr"
+    "k8s.io/apimachinery/pkg/api/errors"
+    "k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/apimachinery/pkg/types"
+    ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/client"
+    "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+    "sigs.k8s.io/controller-runtime/pkg/log"
 
-	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
-	"github.com/Kuadrant/mcp-gateway/internal/config"
+    mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+    "github.com/Kuadrant/mcp-gateway/internal/config"
 )
 
 // VirtualServerConfigReaderWriter interface to write virtual server config
 type VirtualServerConfigReaderWriter interface {
-	WriteVirtualServerConfig(ctx context.Context, virtualServers []config.VirtualServerConfig, namespaceName types.NamespacedName) error
+    WriteVirtualServerConfig(ctx context.Context, virtualServers []config.VirtualServerConfig, namespaceName types.NamespacedName) error
 }
 
 // MCPVirtualServerReconciler reconciles a MCPVirtualServer object
 type MCPVirtualServerReconciler struct {
-	client.Client
-	DirectAPIReader    client.Reader
-	Scheme             *runtime.Scheme
-	log                *slog.Logger
-	ConfigReaderWriter VirtualServerConfigReaderWriter
+    client.Client
+    DirectAPIReader    client.Reader
+    Scheme             *runtime.Scheme
+    log                *slog.Logger
+    ConfigReaderWriter VirtualServerConfigReaderWriter
 }
 
 var defaultRequeueTime = time.Second * 2
@@ -42,89 +42,94 @@ var defaultRequeueTime = time.Second * 2
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
+    logger := log.FromContext(ctx)
 
-	mcpVS := &mcpv1alpha1.MCPVirtualServer{}
-	if err := r.Get(ctx, req.NamespacedName, mcpVS); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-	logger.Info("reconciling mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
+    mcpVS := &mcpv1alpha1.MCPVirtualServer{}
+    if err := r.Get(ctx, req.NamespacedName, mcpVS); err != nil {
+        return ctrl.Result{}, client.IgnoreNotFound(err)
+    }
+    logger.Info("reconciling mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
 
-	// handle deletion
-	if !mcpVS.DeletionTimestamp.IsZero() {
-		logger.Info("mcpvirtualserver is being deleted", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
-		if controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
-			logger.Info("deleting mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
-			// TODO remove from config
-			controllerutil.RemoveFinalizer(mcpVS, mcpGatewayFinalizer)
-			if err := r.Update(ctx, mcpVS); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		return ctrl.Result{}, nil
-	}
-	// add finalizer if not present
-	if !controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
-		if controllerutil.AddFinalizer(mcpVS, mcpGatewayFinalizer) {
-			if err := r.Update(ctx, mcpVS); err != nil {
-				if errors.IsConflict(err) {
-					logger.V(1).Info("mcpvirtualserver conflict err requeuing")
-					return ctrl.Result{RequeueAfter: defaultRequeueTime}, err
-				}
-				return ctrl.Result{}, err
-			}
-		}
-	}
+    // handle deletion
+    if !mcpVS.DeletionTimestamp.IsZero() {
+        logger.Info("mcpvirtualserver is being deleted", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
+        if controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
+            logger.Info("deleting mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
+            // TODO remove from config
+            controllerutil.RemoveFinalizer(mcpVS, mcpGatewayFinalizer)
+            if err := r.Update(ctx, mcpVS); err != nil {
+                return ctrl.Result{}, err
+            }
+        }
+        return ctrl.Result{}, nil
+    }
+    // add finalizer if not present
+    if !controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
+        if controllerutil.AddFinalizer(mcpVS, mcpGatewayFinalizer) {
+            if err := r.Update(ctx, mcpVS); err != nil {
+                if errors.IsConflict(err) {
+                    logger.V(1).Info("mcpvirtualserver conflict err requeuing")
+                    return ctrl.Result{RequeueAfter: defaultRequeueTime}, err
+                }
+                return ctrl.Result{}, err
+            }
+        }
+    }
 
-	logger.V(1).Info("mcpvirtualserver generating config")
+    logger.V(1).Info("mcpvirtualserver generating config")
 
-	vsConfig, err := r.generateVirtualServerConfig(ctx)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to generate virtual server config during reconcile %w", err)
-	}
+    vsConfig, err := r.generateVirtualServerConfig(ctx)
+    if err != nil {
+        return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to generate virtual server config during reconcile %w", err)
+    }
 
-	logger.V(1).Info("mcpvirtualserver writing config")
-	if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, config.DefaultNamespaceName); err != nil {
-		if errors.IsConflict(err) {
-			logger.Info("mcpvirtualserver conflict on updating the config for virtual servers will retry in 5 seconds")
-			return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to write virtual server config during reconcile %w", err)
-	}
-	logger.V(1).Info("mcpvirtualserver reconcile complete", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
-	// update status of virtual server
-	return ctrl.Result{}, nil
+    targetNamespaceName := types.NamespacedName{
+        Namespace: mcpVS.Namespace,
+        Name:      config.DefaultNamespaceName.Name,
+    }
+
+    logger.V(1).Info("mcpvirtualserver writing config")
+    if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, targetNamespaceName); err != nil {
+        if errors.IsConflict(err) {
+            logger.Info("mcpvirtualserver conflict on updating the config for virtual servers will retry in 5 seconds")
+            return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
+        }
+        return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to write virtual server config during reconcile %w", err)
+    }
+    logger.V(1).Info("mcpvirtualserver reconcile complete", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
+    // update status of virtual server
+    return ctrl.Result{}, nil
 }
 
 func (r *MCPVirtualServerReconciler) generateVirtualServerConfig(ctx context.Context) ([]config.VirtualServerConfig, error) {
-	log := log.FromContext(ctx)
-	virtualServers := []config.VirtualServerConfig{}
-	mcpVirtualServerList := &mcpv1alpha1.MCPVirtualServerList{}
-	if err := r.List(ctx, mcpVirtualServerList); err != nil {
-		log.Error(err, "Failed to list MCPVirtualServers")
-		return virtualServers, err
-	}
-	// generate the entire virtual server config fresh rather than merge etc (future optimization)
-	for _, mcpVirtualServer := range mcpVirtualServerList.Items {
-		if mcpVirtualServer.DeletionTimestamp != nil {
-			continue
-		}
-		virtualServerName := fmt.Sprintf("%s/%s", mcpVirtualServer.Namespace, mcpVirtualServer.Name)
-		virtualServers = append(virtualServers, config.VirtualServerConfig{
-			Name:    virtualServerName,
-			Tools:   mcpVirtualServer.Spec.Tools,
-			Prompts: mcpVirtualServer.Spec.Prompts,
-		})
-	}
-	return virtualServers, nil
+    log := log.FromContext(ctx)
+    virtualServers := []config.VirtualServerConfig{}
+    mcpVirtualServerList := &mcpv1alpha1.MCPVirtualServerList{}
+    if err := r.List(ctx, mcpVirtualServerList); err != nil {
+        log.Error(err, "Failed to list MCPVirtualServers")
+        return virtualServers, err
+    }
+    // generate the entire virtual server config fresh rather than merge etc (future optimization)
+    for _, mcpVirtualServer := range mcpVirtualServerList.Items {
+        if mcpVirtualServer.DeletionTimestamp != nil {
+            continue
+        }
+        virtualServerName := fmt.Sprintf("%s/%s", mcpVirtualServer.Namespace, mcpVirtualServer.Name)
+        virtualServers = append(virtualServers, config.VirtualServerConfig{
+            Name:    virtualServerName,
+            Tools:   mcpVirtualServer.Spec.Tools,
+            Prompts: mcpVirtualServer.Spec.Prompts,
+        })
+    }
+    return virtualServers, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MCPVirtualServerReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
-	r.log = slog.New(logr.ToSlogHandler(mgr.GetLogger()))
+    r.log = slog.New(logr.ToSlogHandler(mgr.GetLogger()))
 
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&mcpv1alpha1.MCPVirtualServer{}).
-		Named("mcpvirtualserver").
-		Complete(r)
+    return ctrl.NewControllerManagedBy(mgr).
+        For(&mcpv1alpha1.MCPVirtualServer{}).
+        Named("mcpvirtualserver").
+        Complete(r)
 }

--- a/internal/controller/mcpvirtualserver_controller.go
+++ b/internal/controller/mcpvirtualserver_controller.go
@@ -59,15 +59,13 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
     if !mcpVS.DeletionTimestamp.IsZero() {
         logger.Info("mcpvirtualserver is being deleted", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
         if controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
-            logger.Info("deleting mcpvirtualserver and updating config", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
+            logger.Info("deleting mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
             
-            // Generate config (this automatically excludes the deleted item)
             vsConfig, err := r.generateVirtualServerConfig(ctx, mcpVS.Namespace)
             if err != nil {
                 return ctrl.Result{}, fmt.Errorf("failed to generate config during deletion %w", err)
             }
 
-            // Write the updated config to completely remove the deleted server's footprint
             if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, targetNamespaceName); err != nil {
                 return ctrl.Result{}, fmt.Errorf("failed to write config during deletion %w", err)
             }
@@ -86,7 +84,7 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
             if err := r.Update(ctx, mcpVS); err != nil {
                 if errors.IsConflict(err) {
                     logger.V(1).Info("mcpvirtualserver conflict err requeuing")
-                    return ctrl.Result{RequeueAfter: defaultRequeueTime}, err
+                    return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
                 }
                 return ctrl.Result{}, err
             }
@@ -103,7 +101,7 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
     logger.V(1).Info("mcpvirtualserver writing config")
     if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, targetNamespaceName); err != nil {
         if errors.IsConflict(err) {
-            logger.Info("mcpvirtualserver conflict on updating the config for virtual servers will retry in 5 seconds")
+            logger.Info("mcpvirtualserver conflict on updating the config for virtual servers, will retry")
             return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
         }
         return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to write virtual server config during reconcile %w", err)
@@ -113,13 +111,11 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
     return ctrl.Result{}, nil
 }
 
-// Updated to accept namespace and scope the list query
 func (r *MCPVirtualServerReconciler) generateVirtualServerConfig(ctx context.Context, namespace string) ([]config.VirtualServerConfig, error) {
     log := log.FromContext(ctx)
     virtualServers := []config.VirtualServerConfig{}
     mcpVirtualServerList := &mcpv1alpha1.MCPVirtualServerList{}
     
-    // Pass client.InNamespace to ensure we only pull configs for this specific tenant
     if err := r.List(ctx, mcpVirtualServerList, client.InNamespace(namespace)); err != nil {
         log.Error(err, "Failed to list MCPVirtualServers")
         return virtualServers, err


### PR DESCRIPTION
This PR fixes Issue #722.

The `MCPVirtualServerReconciler` was previously falling back to the hardcoded `config.DefaultNamespaceName` when writing configurations. To properly support the multi-tenant, isolated gateway deployments introduced in #436, this update maps the config writer target to the actual `Namespace` of the `MCPVirtualServer` being reconciled.

Closes #722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures virtual server configurations are written per-namespace, removes deleted servers' configuration footprints, and retries on write conflicts to prevent stale or missing configs.

* **Refactor**
  * Reworked reconciliation and finalizer handling so scoped configuration generation and cleanup are more reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->