### PR TITLE
e2e: add concurrent session init test

### DIFF
--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -251,6 +252,64 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 				Expect(textContent.Text).To(Not(ContainSubstring(mcpClient.GetSessionId())))
 			}
 		}
+	})
+
+	It("[Happy] concurrent tool calls on a fresh session should create only one backend session", func() {
+		By("Registering an MCPServerRegistration")
+		registration := NewMCPServerResourcesWithDefaults("concurrent-session", k8sClient).Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Ensuring the gateway has registered the server and tools are available")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+		WaitForToolsWithPrefix(ctx, mcpGatewayClient, registeredServer.Spec.Prefix)
+
+		By("Initializing a fresh raw HTTP session (no backend session exists yet)")
+		var sessionID string
+		Eventually(func(g Gomega) {
+			var initErr error
+			sessionID, initErr = mcpInitialize(ctx, gatewayURL, nil)
+			g.Expect(initErr).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		const concurrency = 8
+		type callResult struct {
+			backendSession string
+			err            error
+		}
+		results := make([]callResult, concurrency)
+		toolName := fmt.Sprintf("%s%s", registeredServer.Spec.Prefix, "headers")
+
+		By(fmt.Sprintf("Firing %d concurrent tool calls before any backend session exists", concurrency))
+		var wg sync.WaitGroup
+		for i := range concurrency {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				_, content, err := mcpCallTool(ctx, gatewayURL, sessionID, toolName, nil, nil)
+				if err != nil {
+					results[idx] = callResult{err: err}
+					return
+				}
+				results[idx] = callResult{backendSession: extractBackendSession(content)}
+			}(i)
+		}
+		wg.Wait()
+
+		By("Asserting all calls succeeded and all used the same backend session")
+		var firstSession string
+		for i, r := range results {
+			Expect(r.err).NotTo(HaveOccurred(), "concurrent call %d should succeed", i)
+			Expect(r.backendSession).NotTo(BeEmpty(), "concurrent call %d should return a backend session ID", i)
+			if firstSession == "" {
+				firstSession = r.backendSession
+			}
+			Expect(r.backendSession).To(Equal(firstSession), "concurrent call %d should share the same backend session", i)
+		}
+		GinkgoWriter.Printf("all %d concurrent calls used backend session: %s\n", concurrency, firstSession)
 	})
 
 	It("[Full] Redis session cache persists backend sessions across pod restarts", func() {

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -26,6 +26,11 @@
 - When a client makes multiple tool calls to the same backend MCP server, the gateway should reuse the same backend session for efficiency. The backend session ID should remain consistent across multiple calls from the same client. When a client disconnects and reconnects, a new backend session should be created.
 
 
+### [Happy] Concurrent tool calls on a fresh session create only one backend session
+
+- When multiple concurrent tool calls arrive for the same gateway session before any backend session has been established, the gateway should initialize exactly one backend session and all concurrent calls should complete successfully using that same backend session ID. No backend connections should be leaked regardless of how many concurrent callers race to trigger initialization.
+
+
 ### [Happy] Test MCPVirtualServer behaves as expected when defined
 
 - When a developer defines an MCPVirtualServer resource and specifies the value of the `X-Mcp-Virtualserver` header as the name in the format `namespace/name`, where the namespace and name come from the created MCPVirtualServer resource, they should only get the tools specified in the MCPVirtualServer resource when they do a tools/list request to the MCP Gateway host.


### PR DESCRIPTION
After the concurrent session init fix got merged (#976), the maintainer pointed out there was no e2e test actually proving the race doesn't happen anymore. So this adds one.

Closes: #989 

The test initializes a fresh gateway session (no backend session exists yet), then fires 8 concurrent `tools/call` requests at the same backend before any of them has had a chance to trigger initialization. If the `singleflight` fix is doing its job, all 8 should come back with the same backend `mcp-session-id`. If it isn't, you'd get different IDs or failures leaking through.

Used the raw HTTP helpers since I needed direct control over the session ID across goroutines; same pattern as the Redis session test. Also updated `test_cases.md` with the description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end test validating concurrent tool calls on fresh sessions. Ensures simultaneous requests establish exactly one backend session, with all calls completing successfully and using the same session ID.
  * Updated test documentation with new test case specification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->