### PR TITLE
chore: enable CodeRabbit auto-labeling for review effort and risk

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,8 +16,31 @@ reviews:
   assess_linked_issues: true
   related_issues: true
   related_prs: true
-  suggested_labels: false
-  auto_apply_labels: false
+  suggested_labels: true
+  auto_apply_labels: true
+  labeling_instructions:
+    - label: review-effort/small
+      instructions: >
+        Apply when the estimated review effort is 1-2. Typical indicators:
+        single file changed, straightforward logic, config-only, docs-only,
+        or generated code updates.
+    - label: review-effort/medium
+      instructions: >
+        Apply when the estimated review effort is 3. Typical indicators:
+        a few files changed across one subsystem, moderate logic changes,
+        new tests accompanying a small feature.
+    - label: review-effort/large
+      instructions: >
+        Apply when the estimated review effort is 4-5. Typical indicators:
+        many files changed, cross-cutting concerns, complex logic,
+        new components or significant refactors.
+    - label: high-risk
+      instructions: >
+        Apply when changes touch concurrency primitives (mutexes, channels,
+        singleflight), authentication or session management, CRD schema
+        changes, ext_proc request/response handling, or the Envoy routing
+        path. Also apply when the PR modifies security-sensitive code such
+        as JWT handling, credential management, or auth policies.
   suggested_reviewers: false
   auto_assign_reviewers: false
 


### PR DESCRIPTION
## Summary
- Enables suggested_labels and auto_apply_labels in .coderabbit.yaml
- Adds labeling instructions for review-effort/small, review-effort/medium, review-effort/large, and high-risk
- Labels already created in the repo

Lets reviewers quickly see which PRs need the most attention by scanning labels instead of opening each one.

## Test plan
- [ ] Merge this PR, then open a subsequent PR and verify CodeRabbit applies the appropriate effort/risk labels
- [ ] If auto_apply_labels does not work reliably, verify labels still appear as suggestions in the walkthrough comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced review automation: enabled suggested labels and automatic label application.
  * Added multi-category labeling that maps estimated review effort to review-effort/small, review-effort/medium, and review-effort/large.
  * Introduced a high-risk label that flags changes related to security/auth, concurrency, CRD schema, routing, and request/response processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->