### PR TITLE
test: add remaining e2e tests for prompt federation

### DIFF
--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -182,7 +182,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		var prompts []string
 		Eventually(func(g Gomega) {
 			var listErr error
-			prompts, listErr = mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
+			_, prompts, listErr = mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
 			g.Expect(listErr).NotTo(HaveOccurred())
 			g.Expect(prompts).NotTo(BeEmpty())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
@@ -208,16 +208,34 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 	})
 
 	It("[Auth] should return empty prompts for combined JWT + VirtualServer with no intersection", func() {
-		By("Creating a VirtualServer that allows only an everything-server prompt (user has no role for)")
+		By("Registering the everything-server so its prompts are federated")
+		evReg := NewTestResources("auth-everything", k8sClient).
+			ForInternalService("everything-server", 9090).
+			WithPrefix("everything_").
+			Build()
+		evObjects := evReg.GetObjects()
+		evServer := evReg.Register(ctx)
+		defer func() {
+			for i := len(evObjects) - 1; i >= 0; i-- {
+				CleanupResource(ctx, k8sClient, evObjects[i])
+			}
+			CleanupResource(ctx, k8sClient, evServer)
+		}()
+
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, evServer.Name, evServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Creating a VirtualServer that allows only the everything-server prompt (user has no JWT role for it)")
 		virtualServer := NewMCPVirtualServerBuilder("auth-prompt-combined-vs", TestServerNameSpace).
 			WithTools([]string{"test1_greet"}).
-			WithPrompts([]string{"everything_simple-prompt"}).Build()
+			WithPrompts([]string{"everything_simple_prompt"}).Build()
 		Expect(k8sClient.Create(ctx, virtualServer)).To(Succeed())
 		defer func() {
 			CleanupResource(ctx, k8sClient, virtualServer)
 		}()
 
-		By("Obtaining a token and initialising a session")
+		By("Obtaining a token and initialising a session with VirtualServer header")
 		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
 		Expect(err).NotTo(HaveOccurred())
 		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
@@ -230,9 +248,9 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
 
-		By("Listing prompts — JWT allows test1_greet, VirtualServer allows everything_simple-prompt, intersection is empty")
+		By("Listing prompts — JWT allows test1_greet, VirtualServer allows everything_simple_prompt, intersection is empty")
 		Eventually(func(g Gomega) {
-			prompts, listErr := mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
+			_, prompts, listErr := mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
 			g.Expect(listErr).NotTo(HaveOccurred())
 			g.Expect(prompts).To(BeEmpty(), "intersection of JWT and VirtualServer should be empty")
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())

--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -167,4 +167,74 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		Expect(callErr).To(HaveOccurred())
 		Expect(status).NotTo(Equal(http.StatusOK), "unauthorised tool call must not succeed")
 	})
+
+	It("[Auth] should filter prompts/list by JWT roles", func() {
+		By("Obtaining a token and initialising a session")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+		Expect(err).NotTo(HaveOccurred())
+		headers := map[string]string{"Authorization": "Bearer " + token}
+
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+
+		By("Listing prompts — accounting has prompt:greet on test-server1")
+		var prompts []string
+		Eventually(func(g Gomega) {
+			var listErr error
+			prompts, listErr = mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
+			g.Expect(listErr).NotTo(HaveOccurred())
+			g.Expect(prompts).NotTo(BeEmpty())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		Expect(prompts).To(ContainElement("test1_greet"), "accounting has prompt:greet for test-server1")
+	})
+
+	It("[Auth] should allow prompts/get with auth as first request to a server", func() {
+		By("Obtaining a token and initialising a session")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+		Expect(err).NotTo(HaveOccurred())
+		headers := map[string]string{"Authorization": "Bearer " + token}
+
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+
+		By("Calling prompts/get for test1_greet without any prior tool call (triggers hairpin init)")
+		status, respBody, err := mcpGetPrompt(ctx, authGatewayURL, sessionID, "test1_greet", map[string]string{"name": "reviewer"}, headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(200))
+		Expect(respBody).To(ContainSubstring("Say hi to reviewer"))
+	})
+
+	It("[Auth] should return empty prompts for combined JWT + VirtualServer with no intersection", func() {
+		By("Creating a VirtualServer that allows only an everything-server prompt (user has no role for)")
+		virtualServer := NewMCPVirtualServerBuilder("auth-prompt-combined-vs", TestServerNameSpace).
+			WithTools([]string{"test1_greet"}).
+			WithPrompts([]string{"everything_simple-prompt"}).Build()
+		Expect(k8sClient.Create(ctx, virtualServer)).To(Succeed())
+		defer func() {
+			CleanupResource(ctx, k8sClient, virtualServer)
+		}()
+
+		By("Obtaining a token and initialising a session")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+		Expect(err).NotTo(HaveOccurred())
+		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
+		headers := map[string]string{
+			"Authorization":       "Bearer " + token,
+			"X-Mcp-Virtualserver": virtualServerHeader,
+		}
+
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+
+		By("Listing prompts — JWT allows test1_greet, VirtualServer allows everything_simple-prompt, intersection is empty")
+		Eventually(func(g Gomega) {
+			prompts, listErr := mcpListPrompts(ctx, authGatewayURL, sessionID, headers)
+			g.Expect(listErr).NotTo(HaveOccurred())
+			g.Expect(prompts).To(BeEmpty(), "intersection of JWT and VirtualServer should be empty")
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
 })

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -955,6 +956,9 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(promptResult).NotTo(BeNil())
 		Expect(len(promptResult.Messages)).To(BeNumerically(">=", 1), "prompt should return at least one message")
+		content, ok := promptResult.Messages[0].Content.(mcp.TextContent)
+		Expect(ok).To(BeTrue(), "prompt message content should be TextContent")
+		Expect(content.Text).To(Equal("Say hi to e2e"))
 
 		By("Unregistering the MCPServerRegistration")
 		Expect(k8sClient.Delete(ctx, registeredServer)).To(Succeed())
@@ -1092,6 +1096,85 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 
+	It("[Happy] should send notifications to connected clients when server with prompts is registered", func() {
+		By("Creating clients with notification handlers")
+		client1Notification := false
+		client1, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
+			if strings.Contains(j.Method, "list_changed") {
+				GinkgoWriter.Println("client 1 received notification", j.Method)
+				client1Notification = true
+			}
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = client1.Close() }()
+
+		client2Notification := false
+		client2, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
+			if strings.Contains(j.Method, "list_changed") {
+				GinkgoWriter.Println("client 2 received notification", j.Method)
+				client2Notification = true
+			}
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = client2.Close() }()
+
+		By("Registering a new MCPServerRegistration with prompts")
+		registration := NewMCPServerResourcesWithDefaults("prompt-notification-test", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("pnotif_").Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Waiting for the server to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Waiting for prompts to show up")
+		WaitForPromptsWithPrefix(ctx, mcpGatewayClient, registeredServer.Spec.Prefix)
+
+		By("Verifying both clients received list_changed notifications")
+		Eventually(func(g Gomega) {
+			_, err := client1.ListPrompts(ctx, mcp.ListPromptsRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(client1Notification).To(BeTrue(), "client1 should have received a list_changed notification")
+			g.Expect(client2Notification).To(BeTrue(), "client2 should have received a list_changed notification")
+		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
+	})
+
+	It("[Happy] should report prompt conflicts in MCPServerRegistration status when same prefix is used", func() {
+		By("Creating first MCPServerRegistration with a specific prefix pointing to server1")
+		registration1 := NewMCPServerResources("prompt-conflict-1", "pconflict-s1.mcp.local", sharedMCPTestServer1, 9090, k8sClient).
+			WithPrefix("pconflict_").Build()
+		testResources = append(testResources, registration1.GetObjects()...)
+		server1 := registration1.Register(ctx)
+
+		By("Ensuring first server becomes ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Creating second MCPServerRegistration with the SAME prefix pointing to server1 via different hostname")
+		registration2 := NewMCPServerResources("prompt-conflict-2", "pconflict-s2.mcp.local", sharedMCPTestServer1, 9090, k8sClient).
+			WithPrefix("pconflict_").Build()
+		testResources = append(testResources, registration2.GetObjects()...)
+		server2 := registration2.Register(ctx)
+
+		By("Verifying at least one MCPServerRegistration reports conflict in status")
+		Eventually(func(g Gomega) {
+			msg1, err1 := GetMCPServerRegistrationStatusMessage(ctx, k8sClient, server1.Name, server1.Namespace)
+			msg2, err2 := GetMCPServerRegistrationStatusMessage(ctx, k8sClient, server2.Name, server2.Namespace)
+
+			g.Expect(err1).NotTo(HaveOccurred())
+			g.Expect(err2).NotTo(HaveOccurred())
+
+			GinkgoWriter.Println("Server1 status:", msg1)
+			GinkgoWriter.Println("Server2 status:", msg2)
+
+			hasConflict := strings.Contains(msg1, "conflict") || strings.Contains(msg2, "conflict")
+			g.Expect(hasConflict).To(BeTrue(), "expected at least one server to report prompt conflict")
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+	})
+
 	It("[Happy] should return error for prompts/get with nonexistent prompt", func() {
 		By("Creating MCPServerRegistration for server1")
 		registration := NewMCPServerResourcesWithDefaults("prompt-notfound", k8sClient).
@@ -1104,13 +1187,19 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
-		By("Calling GetPrompt with a nonexistent prompt name")
-		_, err := mcpGatewayClient.GetPrompt(ctx, mcp.GetPromptRequest{
-			Params: mcp.GetPromptParams{
-				Name: "nonexistent_prompt_that_does_not_exist",
-			},
-		})
-		Expect(err).To(HaveOccurred(), "prompts/get for nonexistent prompt should return an error")
+		By("Initialising a raw HTTP session for JSON-RPC error inspection")
+		sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		By("Calling prompts/get with a nonexistent prompt name")
+		status, body, err := mcpGetPrompt(ctx, gatewayURL, sessionID, "nonexistent_prompt_that_does_not_exist", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(http.StatusOK))
+
+		rpcErr, parseErr := parseSSEError(body)
+		Expect(parseErr).NotTo(HaveOccurred(), "expected a JSON-RPC error in SSE response")
+		Expect(rpcErr.Code).To(Equal(mcp.INVALID_PARAMS), "expected JSON-RPC invalid-params error code (-32602)")
 	})
 
 	It("[Happy] should resolve prefix conflicts by modifying MCPServer to add prefix", func() {

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -1043,6 +1043,76 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(PromptsListHasPrompt(promptsAll, expectedPrompt)).To(BeTrue())
 	})
 
+	It("[Happy] should expose all prompts when MCPVirtualServer omits prompts field", func() {
+		By("Creating MCPServerRegistration for server1 with prompts")
+		registration := NewMCPServerResourcesWithDefaults("prompt-vs-nofilter", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("nofilt_").Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Ensuring the gateway has registered the server")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Verifying prompts are available")
+		WaitForPromptsWithPrefix(ctx, mcpGatewayClient, registeredServer.Spec.Prefix)
+
+		By("Creating an MCPVirtualServer with tools only (no prompts field)")
+		allowedTool := fmt.Sprintf("%s%s", registeredServer.Spec.Prefix, "greet")
+		virtualServer := NewMCPVirtualServerBuilder("prompt-nofilter-vs", TestServerNameSpace).
+			WithTools([]string{allowedTool}).Build()
+		testResources = append(testResources, virtualServer)
+		Expect(k8sClient.Create(ctx, virtualServer)).To(Succeed())
+
+		By("Creating a client with X-Mcp-Virtualserver header")
+		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
+		virtualServerClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+			"X-Mcp-Virtualserver": virtualServerHeader,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = virtualServerClient.Close() }()
+
+		By("Verifying all prompts are returned (no prompts field = no filtering)")
+		Eventually(func(g Gomega) {
+			filteredPrompts, err := virtualServerClient.ListPrompts(ctx, mcp.ListPromptsRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(filteredPrompts).NotTo(BeNil())
+			expectedPrompt := fmt.Sprintf("%s%s", registeredServer.Spec.Prefix, "greet")
+			g.Expect(PromptsListHasPrompt(filteredPrompts, expectedPrompt)).To(BeTrueBecause("all prompts should be exposed when prompts field is omitted"))
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Verifying tools ARE filtered by the VirtualServer")
+		Eventually(func(g Gomega) {
+			filteredTools, err := virtualServerClient.ListTools(ctx, mcp.ListToolsRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(filteredTools).NotTo(BeNil())
+			g.Expect(len(filteredTools.Tools)).To(Equal(1), "expected exactly 1 tool from virtual server")
+			g.Expect(filteredTools.Tools[0].Name).To(Equal(allowedTool))
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+	})
+
+	It("[Happy] should return error for prompts/get with nonexistent prompt", func() {
+		By("Creating MCPServerRegistration for server1")
+		registration := NewMCPServerResourcesWithDefaults("prompt-notfound", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("notfound_").Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Ensuring the gateway has registered the server")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Calling GetPrompt with a nonexistent prompt name")
+		_, err := mcpGatewayClient.GetPrompt(ctx, mcp.GetPromptRequest{
+			Params: mcp.GetPromptParams{
+				Name: "nonexistent_prompt_that_does_not_exist",
+			},
+		})
+		Expect(err).To(HaveOccurred(), "prompts/get for nonexistent prompt should return an error")
+	})
+
 	It("[Happy] should resolve prefix conflicts by modifying MCPServer to add prefix", func() {
 		// server1 has: greet, time, slow, headers, add_tool
 		// server2 has: hello_world, time, headers, auth1234, slow, set_time, pour_chocolate_into_mold

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -92,20 +92,22 @@ func mcpNotifyInitialized(ctx context.Context, url, sessionID string, headers ma
 	return nil
 }
 
-func mcpListTools(ctx context.Context, url, sessionID string, headers map[string]string) (int, []string, error) { //nolint:unparam
-	body := `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`
+// mcpListNames posts a JSON-RPC list request (e.g. tools/list, prompts/list)
+// and extracts the name strings from the given result key.
+func mcpListNames(ctx context.Context, url, sessionID, method, resultKey string, headers map[string]string) (int, []string, error) {
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"%s"}`, method)
 	resp, err := mcpPost(ctx, url, sessionID, []byte(body), headers)
 	if err != nil {
-		return 0, nil, fmt.Errorf("tools/list failed: %w", err)
+		return 0, nil, fmt.Errorf("%s failed: %w", method, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
-			return resp.StatusCode, nil, fmt.Errorf("tools/list returned status %d (body unreadable: %w)", resp.StatusCode, readErr)
+			return resp.StatusCode, nil, fmt.Errorf("%s returned status %d (body unreadable: %w)", method, resp.StatusCode, readErr)
 		}
-		return resp.StatusCode, nil, fmt.Errorf("tools/list returned status %d: %s", resp.StatusCode, string(respBody))
+		return resp.StatusCode, nil, fmt.Errorf("%s returned status %d: %s", method, resp.StatusCode, string(respBody))
 	}
 
 	result, err := readJSONRPCResult(resp)
@@ -113,19 +115,22 @@ func mcpListTools(ctx context.Context, url, sessionID string, headers map[string
 		return resp.StatusCode, nil, err
 	}
 
-	var listResult struct {
-		Tools []struct {
-			Name string `json:"name"`
-		} `json:"tools"`
+	var parsed map[string][]struct {
+		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(result, &listResult); err != nil {
-		return resp.StatusCode, nil, fmt.Errorf("failed to parse tools/list result: %w: %s", err, string(result))
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("failed to parse %s result: %w: %s", method, err, string(result))
 	}
-	names := make([]string, len(listResult.Tools))
-	for i, t := range listResult.Tools {
-		names[i] = t.Name
+	items := parsed[resultKey]
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = item.Name
 	}
 	return resp.StatusCode, names, nil
+}
+
+func mcpListTools(ctx context.Context, url, sessionID string, headers map[string]string) (int, []string, error) {
+	return mcpListNames(ctx, url, sessionID, "tools/list", "tools", headers)
 }
 
 func mcpCallTool(ctx context.Context, url, sessionID, toolName string, args map[string]any, headers map[string]string) (int, []toolContent, error) {
@@ -172,40 +177,8 @@ func mcpCallTool(ctx context.Context, url, sessionID, toolName string, args map[
 	return resp.StatusCode, callResult.Content, nil
 }
 
-func mcpListPrompts(ctx context.Context, url, sessionID string, headers map[string]string) ([]string, error) {
-	body := `{"jsonrpc":"2.0","id":2,"method":"prompts/list"}`
-	resp, err := mcpPost(ctx, url, sessionID, []byte(body), headers)
-	if err != nil {
-		return nil, fmt.Errorf("prompts/list failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, readErr := io.ReadAll(resp.Body)
-		if readErr != nil {
-			return nil, fmt.Errorf("prompts/list returned status %d (body unreadable: %w)", resp.StatusCode, readErr)
-		}
-		return nil, fmt.Errorf("prompts/list returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	result, err := readJSONRPCResult(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var listResult struct {
-		Prompts []struct {
-			Name string `json:"name"`
-		} `json:"prompts"`
-	}
-	if err := json.Unmarshal(result, &listResult); err != nil {
-		return nil, fmt.Errorf("failed to parse prompts/list result: %w: %s", err, string(result))
-	}
-	names := make([]string, len(listResult.Prompts))
-	for i, p := range listResult.Prompts {
-		names[i] = p.Name
-	}
-	return names, nil
+func mcpListPrompts(ctx context.Context, url, sessionID string, headers map[string]string) (int, []string, error) {
+	return mcpListNames(ctx, url, sessionID, "prompts/list", "prompts", headers)
 }
 
 func mcpGetPrompt(ctx context.Context, url, sessionID, promptName string, args map[string]string, headers map[string]string) (int, string, error) {

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -172,6 +172,71 @@ func mcpCallTool(ctx context.Context, url, sessionID, toolName string, args map[
 	return resp.StatusCode, callResult.Content, nil
 }
 
+func mcpListPrompts(ctx context.Context, url, sessionID string, headers map[string]string) ([]string, error) {
+	body := `{"jsonrpc":"2.0","id":2,"method":"prompts/list"}`
+	resp, err := mcpPost(ctx, url, sessionID, []byte(body), headers)
+	if err != nil {
+		return nil, fmt.Errorf("prompts/list failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("prompts/list returned status %d (body unreadable: %w)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("prompts/list returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	result, err := readJSONRPCResult(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var listResult struct {
+		Prompts []struct {
+			Name string `json:"name"`
+		} `json:"prompts"`
+	}
+	if err := json.Unmarshal(result, &listResult); err != nil {
+		return nil, fmt.Errorf("failed to parse prompts/list result: %w: %s", err, string(result))
+	}
+	names := make([]string, len(listResult.Prompts))
+	for i, p := range listResult.Prompts {
+		names[i] = p.Name
+	}
+	return names, nil
+}
+
+func mcpGetPrompt(ctx context.Context, url, sessionID, promptName string, args map[string]string, headers map[string]string) (int, string, error) {
+	params := map[string]any{"name": promptName}
+	if len(args) > 0 {
+		params["arguments"] = args
+	}
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "prompts/get",
+		"params":  params,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to marshal prompts/get: %w", err)
+	}
+
+	resp, err := mcpPost(ctx, url, sessionID, body, headers)
+	if err != nil {
+		return 0, "", fmt.Errorf("prompts/get failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", fmt.Errorf("reading prompts/get response: %w", err)
+	}
+	return resp.StatusCode, string(respBody), nil
+}
+
 func mcpRawPost(ctx context.Context, url, sessionID string, body []byte, headers map[string]string) (int, string, http.Header, error) {
 	resp, err := mcpPost(ctx, url, sessionID, body, headers)
 	if err != nil {

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -167,7 +167,15 @@
 
 ### [Happy] prompts/get for nonexistent prompt returns error
 
-- When a client sends a prompts/get request with a prompt name that does not match any registered server, the gateway should return an error.
+- When a client sends a prompts/get request with a prompt name that does not match any registered server, the gateway should return a JSON-RPC error with code -32602 (Invalid params).
+
+### [Happy] Prompt notifications on registration
+
+- When an MCPServerRegistration is registered with a backend MCP server that has prompts, a `list_changed` notification should be sent to any clients connected to the MCP Gateway. Multiple connected clients should all receive the notification. The clients should receive these notifications within one minute of the MCPServerRegistration having reached a ready state.
+
+### [Happy] Prompt conflicts with same prefix
+
+- When two MCPServerRegistrations with the same prefix point to backends that both have prompts with the same name (e.g., both have a "greet" prompt producing "pconflict_greet"), at least one MCPServerRegistration should report a conflict in its status. This mirrors the tool conflict behavior where overlapping prefixed names cause a conflict.
 
 ### [Auth] JWT-filtered prompts/list with Keycloak
 
@@ -179,7 +187,7 @@
 
 ### [Auth] Combined JWT + VirtualServer prompt filtering
 
-- When a client sends a prompts/list request with both a valid auth token and an x-mcp-virtualserver header, the result should be the intersection of both filters. If the JWT allows `test1_greet` but the VirtualServer only allows `everything_simple-prompt`, the result should be empty.
+- When a client sends a prompts/list request with both a valid auth token and an `X-Mcp-Virtualserver` header, the result should be the intersection of both filters. The everything-server is registered with prefix `everything_` and its prompts are federated. If the JWT allows `test1_greet` but the VirtualServer only allows `everything_simple_prompt` (which the user has no JWT role for), the result should be empty.
 
 ### [Happy] Elicitation accept flow
 

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -161,6 +161,26 @@
 
 - When an MCPVirtualServer resource specifies a subset of prompt names in its `prompts` field, a client using the `X-Mcp-Virtualserver` header should only see the specified prompts in a prompts/list response. A client without the header should still see all prompts.
 
+### [Happy] VirtualServer with no prompts field exposes all prompts
+
+- When an MCPVirtualServer resource omits the `prompts` field, all federated prompts should be returned in a prompts/list response. Tools should still be filtered by the `tools` field. This matches the behavior where omitting a field means "no filtering" rather than "deny all".
+
+### [Happy] prompts/get for nonexistent prompt returns error
+
+- When a client sends a prompts/get request with a prompt name that does not match any registered server, the gateway should return an error.
+
+### [Auth] JWT-filtered prompts/list with Keycloak
+
+- When a client authenticates via Keycloak and sends a prompts/list request, only prompts the user has `prompt:*` roles for should be returned. The `mcp` user in the `accounting` group should see `test1_greet` but not prompts from servers where they have no prompt roles.
+
+### [Auth] prompts/get with auth as first request (hairpin test)
+
+- When a client sends a prompts/get request as the first request to a server (no prior tools/call), the hairpin initialize should pass through the AuthPolicy correctly and return prompt messages.
+
+### [Auth] Combined JWT + VirtualServer prompt filtering
+
+- When a client sends a prompts/list request with both a valid auth token and an x-mcp-virtualserver header, the result should be the intersection of both filters. If the JWT allows `test1_greet` but the VirtualServer only allows `everything_simple-prompt`, the result should be empty.
+
 ### [Happy] Elicitation accept flow
 
 - When a client connects to the gateway with an elicitation handler that accepts requests and provides user information, and calls a tool that triggers an elicitation request, the gateway should broker the elicitation between the upstream server and the client. The tool response should indicate that the user provided the requested information.


### PR DESCRIPTION
## Summary
- Adds 5 missing e2e test cases from #945 for prompt federation
- **[Happy] VirtualServer with no prompts field exposes all prompts** — verifies omitting `prompts` field returns all federated prompts
- **[Happy] prompts/get for nonexistent prompt returns error** — verifies error response for unknown prompt names
- **[Auth] JWT-filtered prompts/list with Keycloak** — verifies role-based prompt filtering via JWT claims
- **[Auth] prompts/get with auth as first request (hairpin test)** — verifies hairpin init works with auth on first prompt request
- **[Auth] Combined JWT + VirtualServer prompt filtering** — verifies intersection of JWT and VirtualServer filters
- Adds `mcpListPrompts` and `mcpGetPrompt` raw HTTP helpers to `raw_mcp_http.go`


Closes #945


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added E2E coverage for JWT role-based prompt filtering and combined JWT + virtual-server prompt access (including empty-intersection cases).
  * Added tests verifying prompt listing when a virtual server omits prompts (all federated prompts exposed) and that tools remain scoped.
  * Added tests for hairpin auth where prompts/get is the first request.
  * Added test for nonexistent prompt returning JSON-RPC INVALID_PARAMS (-32602).

* **Documentation**
  * Expanded E2E test scenarios documenting prompt/virtual-server/JWT behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->