### PR TITLE
Per-client Notification Infrastructure Support

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -17,6 +17,7 @@ import (
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
+	"github.com/Kuadrant/mcp-gateway/internal/broker/authcapture"
 	"github.com/Kuadrant/mcp-gateway/internal/clients"
 	config "github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
@@ -356,7 +357,7 @@ func setUpHTTPServer(address string, mcpBroker broker.MCPBroker, sessionManager 
 
 	mux.HandleFunc("/status", mcpBroker.HandleStatusRequest)
 	mux.HandleFunc("/status/", mcpBroker.HandleStatusRequest)
-	mux.Handle("/mcp", streamableHTTPServer)
+	mux.Handle("/mcp", authcapture.InjectHeaders(streamableHTTPServer))
 
 	return httpSrv, streamableHTTPServer
 }

--- a/internal/broker/authcapture/middleware.go
+++ b/internal/broker/authcapture/middleware.go
@@ -1,0 +1,46 @@
+// Package authcapture provides HTTP middleware to capture client auth headers for
+// per-client backend SSE connections. Headers are injected into the request context
+// on GET /mcp so the OnRegisterSession hook can read them and open per-client connections.
+package authcapture
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+type contextKey struct{}
+
+// InjectHeaders wraps next and, on GET requests, stores a copy of the client's
+// headers in the request context. All headers are captured except:
+//   - HTTP/2 pseudo-headers (":authority", ":path", etc.) — not valid HTTP/1.1 headers
+//   - "mcp-session-id" — this is a gateway-assigned session identifier scoped to the
+//     client↔gateway connection; it must not be forwarded to backend servers because
+//     the backend has its own independent session with the broker
+//
+// This matches the passthrough policy applied by the router for tool calls.
+func InjectHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			headers := make(map[string]string, len(r.Header))
+			for k, vs := range r.Header {
+				k = strings.ToLower(k)
+				if strings.HasPrefix(k, ":") || k == "mcp-session-id" {
+					continue
+				}
+				if len(vs) > 0 {
+					headers[k] = vs[0]
+				}
+			}
+			r = r.WithContext(context.WithValue(r.Context(), contextKey{}, headers))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// ExtractHeaders reads the headers injected by InjectHeaders from the context.
+// Returns false if no headers were captured (e.g. on non-GET requests).
+func ExtractHeaders(ctx context.Context) (map[string]string, bool) {
+	headers, ok := ctx.Value(contextKey{}).(map[string]string)
+	return headers, ok
+}

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/broker/authcapture"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -84,6 +85,9 @@ type mcpBrokerImpl struct {
 
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy mcpv1alpha1.InvalidToolPolicy
+
+	// perClientNotifMgr manages per-client, per-server backend SSE connections
+	perClientNotifMgr *upstream.PerClientNotificationManager
 }
 
 // this ensures that mcpBrokerImpl implements the MCPBroker interface
@@ -135,15 +139,18 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 
 	hooks := &server.Hooks{}
 
-	// Enhanced session registration to log gateway session assignment
-	hooks.AddOnRegisterSession(func(_ context.Context, session server.ClientSession) {
-		// Note that AddOnRegisterSession is for GET, not POST, for a session.
-		// https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server
+	// Note that AddOnRegisterSession is for GET, not POST, for a session.
+	// https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server
+	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		mcpBkr.logger.Debug("gateway client session connected", "gatewaySessionID", session.SessionID())
+		if headers, ok := authcapture.ExtractHeaders(ctx); ok {
+			mcpBkr.perClientNotifMgr.OpenConnections(ctx, session.SessionID(), headers)
+		}
 	})
 
 	hooks.AddOnUnregisterSession(func(_ context.Context, session server.ClientSession) {
 		mcpBkr.logger.Debug("gateway client session unregistered", "gatewaySessionID", session.SessionID())
+		mcpBkr.perClientNotifMgr.TeardownSession(session.SessionID())
 	})
 
 	hooks.AddBeforeAny(func(_ context.Context, _ any, method mcp.MCPMethod, _ any) {
@@ -169,6 +176,17 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),
 	)
+
+	mcpBkr.perClientNotifMgr = upstream.NewPerClientNotificationManager(
+		mcpBkr.listeningMCPServer,
+		func() map[config.UpstreamMCPID]upstream.ActiveMCPServer {
+			mcpBkr.mcpLock.RLock()
+			defer mcpBkr.mcpLock.RUnlock()
+			return mcpBkr.mcpServers
+		},
+		logger.With("sub-component", "per-client-notif-mgr"),
+	)
+
 	return mcpBkr
 }
 

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -73,6 +73,8 @@ type ServerValidationStatus struct {
 type MCP interface {
 	GetName() string
 	SupportsToolsListChanged() bool
+	SupportsLogging() bool
+	SupportsResourceSubscribe() bool
 	GetConfig() config.MCPServer
 	ID() config.UpstreamMCPID
 	GetPrefix() string
@@ -98,6 +100,8 @@ type ActiveMCPServer interface {
 	GetManagedPrompts() []mcp.Prompt
 	GetServedManagedPrompt(promptName string) *mcp.Prompt
 	Config() config.MCPServer
+	SupportsLogging() bool
+	SupportsResourceSubscribe() bool
 }
 
 // MCPManager manages a single backend MCPServer for the broker. It does not act on behalf of clients. It is the only thing that should be connecting to the MCP Server for the broker. It handles tools updates, disconnection, notifications, liveness checks and updating the status for the MCP server. It is responsible for adding and removing tools to the broker. It is intended to be long lived and have 1:1 relationship with a backend MCP server.
@@ -252,6 +256,10 @@ func (a *activeMCP) GetServedManagedPrompt(p string) *mcp.Prompt {
 	return a.manager.GetServedManagedPrompt(p)
 }
 func (a *activeMCP) Config() config.MCPServer { return a.manager.mcp.GetConfig() }
+func (a *activeMCP) SupportsLogging() bool    { return a.manager.mcp.SupportsLogging() }
+func (a *activeMCP) SupportsResourceSubscribe() bool {
+	return a.manager.mcp.SupportsResourceSubscribe()
+}
 
 func (man *MCPManager) registerCallbacks() func() {
 	man.logger.Debug("registering callbacks", "upstream mcp server", man.mcp.ID())

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -69,6 +69,10 @@ func (m *MockMCP) SupportsToolsListChanged() bool {
 	return m.hasToolsCap
 }
 
+func (m *MockMCP) SupportsLogging() bool { return false }
+
+func (m *MockMCP) SupportsResourceSubscribe() bool { return false }
+
 func (m *MockMCP) Disconnect() error {
 	m.connected.Store(false)
 	return nil

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -72,7 +72,23 @@ func (up *MCPServer) SupportsToolsListChanged() bool {
 	if up.init == nil {
 		return false
 	}
-	return up.init.Capabilities.Tools.ListChanged
+	return up.init.Capabilities.Tools != nil && up.init.Capabilities.Tools.ListChanged
+}
+
+// SupportsLogging reports whether the backend advertises logging capability
+func (up *MCPServer) SupportsLogging() bool {
+	if up.init == nil {
+		return false
+	}
+	return up.init.Capabilities.Logging != nil
+}
+
+// SupportsResourceSubscribe reports whether the backend advertises resource subscription capability
+func (up *MCPServer) SupportsResourceSubscribe() bool {
+	if up.init == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources != nil && up.init.Capabilities.Resources.Subscribe
 }
 
 // Connect establishes a connection to the upstream MCP server. It creates a

--- a/internal/broker/upstream/per_client_manager.go
+++ b/internal/broker/upstream/per_client_manager.go
@@ -1,0 +1,124 @@
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// PerClientNotificationManager manages per-client, per-server backend SSE connections.
+// When a gateway client opens GET /mcp, OpenConnections creates one backend SSE
+// connection for each registered server that advertises per-client notification
+// capabilities (logging or resource subscriptions). Servers that do not advertise
+// these capabilities are skipped. Notifications received on per-client connections
+// are forwarded only to the specific client, never broadcast.
+//
+// The existing shared MCPManager broadcast path is untouched.
+type PerClientNotificationManager struct {
+	// connections maps sessionKey(gatewaySessionID, serverName) → context.CancelFunc
+	connections   sync.Map
+	gatewayServer *server.MCPServer
+	serverConfigs func() map[config.UpstreamMCPID]ActiveMCPServer
+	logger        *slog.Logger
+}
+
+// NewPerClientNotificationManager creates a manager. gatewayServer is the mcp-go
+// server used to deliver notifications to clients. serverConfigs is a closure that
+// returns the current set of upstream managers; it is evaluated at OpenConnections
+// time so newly registered backends are picked up automatically.
+func NewPerClientNotificationManager(
+	gatewayServer *server.MCPServer,
+	serverConfigs func() map[config.UpstreamMCPID]ActiveMCPServer,
+	logger *slog.Logger,
+) *PerClientNotificationManager {
+	return &PerClientNotificationManager{
+		gatewayServer: gatewayServer,
+		serverConfigs: serverConfigs,
+		logger:        logger,
+	}
+}
+
+// OpenConnections opens per-client backend SSE connections for all registered
+// servers that advertise per-client notification capabilities. It is called
+// eagerly from the OnRegisterSession hook when a client opens GET /mcp.
+// Each connection runs in its own goroutine and is tied to ctx; when ctx is
+// cancelled (client disconnects) all connections for this session stop.
+func (m *PerClientNotificationManager) OpenConnections(ctx context.Context, gatewaySessionID string, headers map[string]string) {
+	servers := m.serverConfigs()
+	for _, man := range servers {
+		if !man.SupportsLogging() && !man.SupportsResourceSubscribe() {
+			continue
+		}
+		cfg := man.Config()
+		key := sessionKey(gatewaySessionID, cfg.Name)
+
+		connCtx, cancel := context.WithCancel(ctx)
+		if _, loaded := m.connections.LoadOrStore(key, cancel); loaded {
+			// another goroutine already created this connection
+			cancel()
+			continue
+		}
+
+		pc := newPerClientMCPServer(cfg, gatewaySessionID, headers, m.logger.With(
+			"sub-component", "per-client-mcp",
+			"server", cfg.Name,
+			"gatewaySessionID", gatewaySessionID,
+		))
+
+		onNotification := m.notificationHandler(gatewaySessionID, cfg.Name)
+
+		go pc.run(connCtx, onNotification)
+
+		m.logger.Debug("opened per-client backend connection",
+			"server", cfg.Name,
+			"gatewaySessionID", gatewaySessionID,
+		)
+	}
+}
+
+// TeardownSession cancels all per-client backend connections for the given
+// gateway session. Called from the OnUnregisterSession hook.
+func (m *PerClientNotificationManager) TeardownSession(gatewaySessionID string) {
+	prefix := gatewaySessionID + ":"
+	m.connections.Range(func(k, v any) bool {
+		if strings.HasPrefix(k.(string), prefix) {
+			if cancel, ok := v.(context.CancelFunc); ok {
+				cancel()
+			}
+			m.connections.Delete(k)
+		}
+		return true
+	})
+}
+
+// notificationHandler returns the callback that routes backend notifications to
+// the specific gateway client identified by gatewaySessionID.
+func (m *PerClientNotificationManager) notificationHandler(gatewaySessionID, serverName string) func(mcp.JSONRPCNotification) {
+	return func(n mcp.JSONRPCNotification) {
+		switch n.Method {
+		case "notifications/tools/list_changed":
+			// suppress: the shared MCPManager already broadcasts this to all clients
+			return
+		}
+
+		params := n.Params.AdditionalFields
+		if err := m.gatewayServer.SendNotificationToSpecificClient(gatewaySessionID, n.Method, params); err != nil {
+			m.logger.Debug("failed to forward per-client notification",
+				"gatewaySessionID", gatewaySessionID,
+				"server", serverName,
+				"method", n.Method,
+				"error", err,
+			)
+		}
+	}
+}
+
+func sessionKey(gatewaySessionID, serverName string) string {
+	return fmt.Sprintf("%s:%s", gatewaySessionID, serverName)
+}

--- a/internal/broker/upstream/per_client_mcp.go
+++ b/internal/broker/upstream/per_client_mcp.go
@@ -1,0 +1,175 @@
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	perClientInitialBackoff = time.Second
+	perClientMaxBackoff     = 30 * time.Second
+)
+
+// PerClientMCPServer manages a single SSE backend connection for one
+// (gatewaySessionID × backendServer) pair. It uses the client's captured auth
+// headers rather than the shared broker credentials.
+type PerClientMCPServer struct {
+	cfg              config.MCPServer
+	gatewaySessionID string
+	headers          map[string]string
+	client           *client.Client
+	clientMu         sync.Mutex
+	logger           *slog.Logger
+}
+
+func newPerClientMCPServer(cfg config.MCPServer, gatewaySessionID string, headers map[string]string, logger *slog.Logger) *PerClientMCPServer {
+	return &PerClientMCPServer{
+		cfg:              cfg,
+		gatewaySessionID: gatewaySessionID,
+		headers:          headers,
+		logger:           logger,
+	}
+}
+
+// run manages the connection lifecycle with exponential backoff reconnection.
+// It blocks until ctx is cancelled. Called in a goroutine from OpenConnections.
+func (p *PerClientMCPServer) run(ctx context.Context, onNotification func(mcp.JSONRPCNotification)) {
+	backoff := perClientInitialBackoff
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.closeClient()
+			return
+		default:
+		}
+
+		lostCh := make(chan struct{}, 1)
+		err := p.connect(ctx, onNotification, func(_ error) {
+			select {
+			case lostCh <- struct{}{}:
+			default:
+			}
+		})
+
+		if err != nil {
+			p.logger.Debug("per-client backend connection failed, will retry",
+				"server", p.cfg.Name,
+				"gatewaySessionID", p.gatewaySessionID,
+				"backoff", backoff,
+				"error", err,
+			)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				backoff = min(backoff*2, perClientMaxBackoff)
+				continue
+			}
+		}
+
+		// connected — reset backoff and wait
+		backoff = perClientInitialBackoff
+		p.logger.Debug("per-client backend connected",
+			"server", p.cfg.Name,
+			"gatewaySessionID", p.gatewaySessionID,
+		)
+
+		select {
+		case <-ctx.Done():
+			p.closeClient()
+			return
+		case <-lostCh:
+			p.logger.Debug("per-client backend connection lost, reconnecting",
+				"server", p.cfg.Name,
+				"gatewaySessionID", p.gatewaySessionID,
+			)
+			p.closeClient()
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				backoff = min(backoff*2, perClientMaxBackoff)
+			}
+		}
+	}
+}
+
+// transportHeaders returns only the headers safe to forward on a backend connection.
+// Transport-level headers (accept, content-type, host, connection, transfer-encoding)
+// are excluded because mcp-go sets them itself; forwarding them overrides the correct
+// values and breaks the Streamable HTTP handshake.
+func transportHeaders(headers map[string]string) map[string]string {
+	skip := map[string]struct{}{
+		"accept":            {},
+		"content-type":      {},
+		"host":              {},
+		"connection":        {},
+		"transfer-encoding": {},
+		"user-agent":        {},
+	}
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		if _, blocked := skip[k]; !blocked {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func (p *PerClientMCPServer) connect(ctx context.Context, onNotification func(mcp.JSONRPCNotification), onConnectionLost func(error)) error {
+	options := []transport.StreamableHTTPCOption{
+		transport.WithContinuousListening(),
+		transport.WithHTTPHeaders(transportHeaders(p.headers)),
+	}
+
+	httpClient, err := client.NewStreamableHttpClient(p.cfg.URL, options...)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	p.clientMu.Lock()
+	p.client = httpClient
+	p.clientMu.Unlock()
+
+	// register handlers before Start so they are active for the first notification
+	httpClient.OnNotification(onNotification)
+	httpClient.OnConnectionLost(onConnectionLost)
+
+	if err := httpClient.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start client: %w", err)
+	}
+
+	_, err = httpClient.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			Capabilities:    mcp.ClientCapabilities{},
+			ClientInfo: mcp.Implementation{
+				Name:    "mcp-broker",
+				Version: "0.0.1",
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize with %s: %w", p.cfg.Name, err)
+	}
+
+	return nil
+}
+
+func (p *PerClientMCPServer) closeClient() {
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
+	if p.client != nil {
+		_ = p.client.Close()
+		p.client = nil
+	}
+}


### PR DESCRIPTION
## What

Adds per-client, per-server backend SSE connections to the broker a prerequisite for MCP Logging (#407) and Resource Subscriptions (#597).

## Why

The broker’s single shared GET connection per backend uses broker credentials and broadcasts to all clients. Logging and resource subscription notifications are session-scoped and must only reach the client that requested them. No per-client connection infrastructure exists today, which is why both issues are blocked.

## Changes

**New**
- `internal/broker/authcapture/middleware.go`: wraps `/mcp`; captures client auth headers into request context on GET so `OnRegisterSession` can read them.
- `internal/broker/upstream/per_client_mcp.go`: single SSE backend connection per `(gatewaySessionID × server)` using client auth; exponential backoff reconnect; transport-level headers filtered before forwarding.
- `internal/broker/upstream/per_client_manager.go`: registry that opens per-client connections eagerly on session register (capability-gated), tears them down on disconnect, and routes notifications to the specific client only.

**Modified**
- `internal/broker/upstream/manager.go`: added `SupportsLogging()` and `SupportsResourceSubscribe()` to the `MCP` interface and `ActiveMCPServer` type.
- `internal/broker/upstream/mcp.go`:  implemented both; fixed nil-pointer in `SupportsToolsListChanged` (`Tools` was dereferenced without nil check).
- `internal/broker/upstream/manager_test.go`: stub implementations on `MockMCP`.
- `internal/broker/broker.go`: wired auth capture and `OpenConnections` into `OnRegisterSession`; `TeardownSession` into `OnUnregisterSession`.
- `cmd/mcp-broker-router/main.go`: wrap `/mcp` with `authcapture.InjectHeaders`.

**Docs**
- Needs to be updated, in separate pr.

## Design decisions

**Eager + capability-gated.** Connections open when the client’s GET `/mcp` arrives, only for backends that advertise `logging` or `resources.subscribe` capability. Avoids spreading connection setup across feature handlers and closes the race where a notification fires before a lazy connection is established.

**Auth in-memory only.** Client credentials are never written to Redis. Cross-instance routing is deferred.

**Broadcast path untouched.** `notifications/tools/list_changed` via the shared `MCPManager` is unchanged; per-client connections suppress it to avoid double-delivery.

## Manual smoke test
**What you can verify now (infrastructure layer)**
Start the gateway with debug logging:
```bash
LOG_LEVEL=-4 ./mcp-broker-router
```
1. Register a backend that advertises `logging` or `resources.subscribe` in its `initialize` response (the TypeScript Everything Server or Conformance Server work).

2. Connect two MCP clients via `GET /mcp`. In the gateway logs look for:
   ```
   level=DEBUG msg="opened per-client backend connection" server=<name> gatewaySessionID=<id>
   ```
   One entry per qualifying backend, per client session.

3. Disconnect Client 1. Look for:
   ```
   level=DEBUG msg="gateway client session unregistered" gatewaySessionID=<id>
   ```
   Client 2's per-client connections must still be present (no teardown log for its session).

4. Trigger a `notifications/tools/list_changed` from the backend (add/remove a tool or restart the backend). Both clients should receive the broadcast, confirms the shared `MCPManager` path is untouched.

**What requires #407 or #597 before it can be tested**
- Issue `logging/setLevel` from Client 1 → backend emits `notifications/message` → only Client 1 receives it; Client 2 does not.
- Subscribe Client 1 to a resource → backend emits `notifications/resources/updated` → only Client 1 receives it.

## Testing
```bash
make lint
make test-unit
```
## Related
- Closes #599 
- Unblocks #407
- Unblocks #597
---
TO-DO:
- [ ] unit tests (it will make the pr huge difficult for review, raised in separate pr)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization headers from client requests are now captured and forwarded to MCP endpoints.
  * Per-client notification connections are now managed separately for each session.

* **Improvements**
  * Enhanced detection of upstream MCP server capabilities for more robust interactions.
  * Improved session lifecycle management with proper cleanup on disconnection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->