### PR TITLE
fix: protect MCPManager.status with statusMu to eliminate data race

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -129,6 +129,8 @@ type MCPManager struct {
 
 	// toolsLock protects tools, serverTools, prompts, serverPrompts
 	toolsLock sync.RWMutex
+	// statusMu protects status; kept separate from toolsLock to avoid contention
+	statusMu sync.RWMutex
 
 	logger *slog.Logger
 
@@ -452,12 +454,14 @@ func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
 }
 
 // GetStatus returns the current status of the MCP Server
-// no locking is done here as it is expected to be called multiple times
 func (man *MCPManager) GetStatus() ServerValidationStatus {
+	man.statusMu.RLock()
+	defer man.statusMu.RUnlock()
 	return man.status
 }
 
 func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo) {
+	man.statusMu.Lock()
 	man.status.ID = string(man.mcp.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()
@@ -468,12 +472,16 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
+		man.statusMu.Unlock()
+		man.applyBackoff()
 		return
 	}
 	man.status.TotalTools = toolCount
 	man.status.TotalPrompts = promptCount
 	man.status.Ready = true
 	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
+	man.statusMu.Unlock()
+	man.resetBackoff()
 }
 
 func (man *MCPManager) resetBackoff() {
@@ -571,6 +579,8 @@ func (man *MCPManager) SetToolsForTesting(tools []mcp.Tool) {
 // SetStatusForTesting sets the status directly for testing purposes.
 // This bypasses the normal status update flow and should only be used in tests.
 func (man *MCPManager) SetStatusForTesting(status ServerValidationStatus) {
+	man.statusMu.Lock()
+	defer man.statusMu.Unlock()
 	man.status = status
 }
 


### PR DESCRIPTION
While I was chasing the `singleflight` fix in #976 I kept `go test -race` running in the background and noticed it lighting up somewhere I hadn't looked yet; not in the session cache, not in the init path, but in the health check...

`MCPManager` runs an event loop in a background goroutine. Every 60 seconds (or whenever a `notifications/tools/list_changed` comes in) it calls `manage()`, which eventually calls `setStatus()`. That function writes eleven fields onto `man.status` one by one; including a `time.Time` and two slices; with no lock held.

Meanwhile, every Kubernetes readiness probe hits `/readyz`, which calls `IsReady()`, which calls `GetStatus()` on every registered manager. `GetStatus()` just does `return man.status` ; a bare struct copy, also with no lock. The comment even says "no locking is done here as it is expected to be called multiple times", as if frequency is the reason to skip synchronization rather than the reason to add it.

The struct copy and the field-by-field writes race. The `Ready` bool can flip the wrong way for one probe interval and cause Kubernetes to briefly drain the pod. The slice headers (`InvalidToolList`, `InvalidPromptList`) are 24 bytes each; a torn read gives a valid pointer with a stale length, and anything that iterates the result ; like the JSON encoder in `ValidateAllServers()` ; walks off the end.

The fix adds a dedicated `statusMu sync.RWMutex` (separate from `toolsLock` to keep the tools hot path unaffected), acquires it in `setStatus()` and `GetStatus()`, and covers `SetStatusForTesting()` too so race-detected test runs stay clean.