### PR TITLE
chore: add PR template with pre-review checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What does this PR do?
+
+<!-- One or two sentences. Link the issue if there is one. -->
+
+Fixes #
+
+## Pre-review checklist
+
+Before requesting review from a maintainer, confirm:
+
+- [ ] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
+- [ ] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
+- [ ] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
+- [ ] All CI checks pass, or failures have been investigated and explained below
+- [ ] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Fixes #
 
 ## Pre-review checklist
 
-Before requesting review from a maintainer, confirm:
+Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:
 
 - [ ] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
 - [ ] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate


### PR DESCRIPTION
## What does this PR do?

Adds a PR template that captures minimum expectations for PR authors before requesting maintainer review.

## Why?

We want to feel safer merging PRs faster. Shifting more quality work onto PR authors (before review) means maintainers spend less time on PRs that aren't ready. This opens a conversation about what those gates should be.

## Checklist items

1. Check CodeRabbit walkthrough for related issues and use Fixes/Closes syntax
2. Check CodeRabbit walkthrough for related PRs and confirm not a duplicate
3. Read, understand, and address or dismiss all CodeRabbit comments
4. All CI checks pass or failures explained
5. Ran the agent-skills:review skill and addressed valid recommendations

Items 1-3 leverage the CodeRabbit output we already get for free. Item 4 is basic hygiene. Item 5 is something new we want to introduce and details are TBD.

Open to feedback on what to add, remove, or reword.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standardized pull request template prompting a short PR description, issue linkage with a “Fixes #” placeholder, and a pre-review checklist to ensure checks pass and local verification is completed.

* **Documentation**
  * Clarified contributor guidance by adding explicit pre-submission verification items and review reminders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->