### PR TITLE
fix: serialize concurrent manage() execution in MCPManager

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -130,6 +130,9 @@ type MCPManager struct {
 	// toolsLock protects tools, serverTools, prompts, serverPrompts
 	toolsLock sync.RWMutex
 
+	// manageMu protects against concurrent executions of manage()
+	manageMu sync.Mutex
+
 	logger *slog.Logger
 
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
@@ -282,6 +285,9 @@ func (man *MCPManager) registerCallbacks() func() {
 
 // manage should be the only entry point that triggers changes to tools
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
+	man.manageMu.Lock()
+	defer man.manageMu.Unlock()
+
 	man.logger.Debug("managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
 	numberOfTools := len(man.tools)
 	numberOfPrompts := len(man.prompts)
@@ -438,6 +444,8 @@ func (man *MCPManager) shouldFetchTools(event eventType) bool {
 	if event == eventTypeToolNotification {
 		return true
 	}
+	man.toolsLock.RLock()
+	defer man.toolsLock.RUnlock()
 	return event == eventTypeTimer && len(man.serverTools) == 0
 }
 
@@ -448,6 +456,8 @@ func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
 	if event == eventTypePromptNotification {
 		return true
 	}
+	man.toolsLock.RLock()
+	defer man.toolsLock.RUnlock()
 	return event == eventTypeTimer && len(man.serverPrompts) == 0
 }
 

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1125,6 +1125,38 @@ func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 	assert.NotEmpty(t, tools, "tools should be present after concurrent access")
 }
 
+// TestMCPManager_ConcurrentManageCalls verifies that concurrent manage() calls
+// are serialized safely and do not cause data races.
+func TestMCPManager_ConcurrentManageCalls(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	mock.hasToolsCap = false
+	gateway := newMockToolsAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	const concurrentCalls = 10
+
+	for i := range concurrentCalls {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			if id%2 == 0 {
+				mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
+			} else {
+				mock.tools = []mcp.Tool{validTool("tool1")}
+			}
+			manager.manage(ctx, eventTypeTimer)
+		}(i)
+	}
+
+	wg.Wait()
+	tools := manager.GetManagedTools()
+	assert.NotEmpty(t, tools, "tools should be present after concurrent manage calls")
+}
+
 // TestMCPManager_StopDuringManage starts the event loop, triggers a manage()
 // cycle via the events channel (with a slow ListTools), then calls Stop() while
 // manage() is in-flight. Verifies the shutdown path completes without deadlock.


### PR DESCRIPTION
This fixes a race condition in MCPManager where manage() could run concurrently from multiple goroutines.

The issue was happening because manage() could be triggered simultaneously by :-

1.  the periodic ticker loop
2.  upstream notification callbacks

Both paths were accessing and updating shared manager state (serverTools / serverPrompts) at the same time.

Changes

1. added a dedicated manageMu mutex to serialize manage() execution
2. synchronized reads in shouldFetchTools() and shouldFetchPrompts() using read locks
3. added a concurrent regression test covering overlapping manage() calls

Why this approach?

manage() performs multiple state update steps internally, so serializing the full execution path keeps the manager state consistent and avoids overlapping refresh cycles.

The lock is scoped per MCPManager instance, so different upstream servers continue operating independently without blocking each other.

Testing

Verified with :-

1. go test ./...
2. added concurrent regression coverage for repeated parallel manage() execution

Unable to run go test -race locally due to Windows CGO/GCC environment limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing race conditions during concurrent operations

* **Tests**
  * Added tests for concurrent operation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->