### PR TITLE
design: add protocol-neutral upstream config groundwork for A2A support

### DIFF
--- a/docs/design/multi-protocol-config.md
+++ b/docs/design/multi-protocol-config.md
@@ -1,0 +1,183 @@
+# Multi-Protocol Broker Config Model for A2A Upstreams
+
+This document details the architectural design and implementation plan for decoupling the MCP Gateway broker configuration from Model Context Protocol (MCP) specific structures, paving the way for future Agent-to-Agent (A2A) protocol support.
+
+> [!IMPORTANT]
+> **Scope Disclaimer**: This design represents foundational architectural groundwork only. It defines the interface boundaries and core structural modeling to support multi-protocol configurations in a backward-compatible manner. It does NOT implement full A2A routing, controller reconciliation, or runtime proxying, which remain part of the future development direction.
+
+
+## Overview & Background
+
+The MCP Gateway was originally designed exclusively for Model Context Protocol (MCP) backends. As a result, the broker's configuration schemas, runtime lookup mechanisms, and internal routing maps are tightly coupled to MCP terminology (e.g., `MCPServer`, `MCPServersConfig`, `UpstreamMCPID`).
+
+With the evolution of the ecosystem, there is an active need to support other backend protocols, such as **Agent-to-Agent (A2A)** upstreams. Forcing A2A upstreams into MCP-specific models results in awkward abstraction leaks, high maintenance overhead, and developer friction. 
+
+This architectural change introduces a **protocol-neutral configuration and runtime interface** layer that is fully backward compatible, extremely lightweight, and directly supports the future integration of A2A upstreams.
+
+---
+
+## Architectural Objectives
+
+1. **Decouple the Core**: Extract protocol-agnostic concepts (name, prefix, hostname, URL, enabled status, registry lookups) into clean, high-level interfaces.
+2. **Backward Compatibility (No Regressions)**: Do not break existing configurations, Kubernetes Secrets serialization, or any existing controller/broker/router runtime lookup structures.
+3. **Clean Extensibility**: Provide concrete, type-safe structures for A2A configurations (`A2AServer`) and demonstrate how they align with the protocol-neutral config models.
+
+---
+
+## The Protocol-Neutral Model
+
+```mermaid
+classDiagram
+    direction TB
+    class UpstreamServer {
+        <<interface>>
+        +GetName() string
+        +GetProtocol() Protocol
+        +GetURL() string
+        +GetHostname() string
+        +GetPrefix() string
+        +IsEnabled() bool
+        +GetID() UpstreamID
+    }
+    
+    class UpstreamRegistry {
+        <<interface>>
+        +ListUpstreams() []UpstreamServer
+        +GetUpstreamByName(name) (UpstreamServer, error)
+        +GetExternalHostname() string
+    }
+
+    class MCPServer {
+        +Name string
+        +URL string
+        +Hostname string
+        +Prefix string
+        +Enabled bool
+        +ID() UpstreamMCPID
+    }
+
+    class A2AServer {
+        +Name string
+        +URL string
+        +Hostname string
+        +Prefix string
+        +Enabled bool
+        +AgentID string
+    }
+
+    class MCPServersConfig {
+        +Servers []*MCPServer
+        +VirtualServers []*VirtualServer
+        +GetServerConfigByName(name) (*MCPServer, error)
+    }
+
+    UpstreamServer <|.. MCPServer : implements
+    UpstreamServer <|.. A2AServer : implements
+    UpstreamRegistry <|.. MCPServersConfig : implements
+```
+
+### 1. Protocol-Neutral Abstractions (`internal/config/types.go`)
+
+We define the protocol enum and generic upstream identifiers:
+
+```go
+// UpstreamID is a generic identifier for any upstream server (MCP, A2A, etc.)
+type UpstreamID string
+
+// Protocol represents the communication protocol of an upstream server
+type Protocol string
+
+const (
+	// ProtocolMCP represents the Model Context Protocol
+	ProtocolMCP Protocol = "mcp"
+	// ProtocolA2A represents the Agent-to-Agent protocol
+	ProtocolA2A Protocol = "a2a"
+)
+```
+
+### 2. The `UpstreamServer` Interface
+
+Rather than controllers and broker runners relying directly on the concrete `*MCPServer` struct, they can consume the generic `UpstreamServer` interface:
+
+```go
+// UpstreamServer represents the interface that any upstream server config must satisfy,
+// regardless of the protocol (MCP, A2A, etc.)
+type UpstreamServer interface {
+	GetName() string
+	GetProtocol() Protocol
+	GetURL() string
+	GetHostname() string
+	GetPrefix() string
+	IsEnabled() bool
+	GetID() UpstreamID
+}
+```
+
+### 3. The `UpstreamRegistry` Interface
+
+The runtime lookup paths are generalized through `UpstreamRegistry` to abstract the underling storage (ConfigMap, Secret, or memory):
+
+```go
+// UpstreamRegistry represents a protocol-neutral registry for looking up upstream servers
+type UpstreamRegistry interface {
+	ListUpstreams() []UpstreamServer
+	GetUpstreamByName(name string) (UpstreamServer, error)
+	GetExternalHostname() string
+}
+```
+
+---
+
+## Backward Compatibility & Integration Path
+
+### MCPServer Compatibility
+By implementing the methods of the `UpstreamServer` interface directly on `*MCPServer`, the existing structure satisfies the interface implicitly with **zero code modifications required for existing consumers**:
+
+```go
+func (mcpServer *MCPServer) GetName() string     { return mcpServer.Name }
+func (mcpServer *MCPServer) GetProtocol() Protocol { return ProtocolMCP }
+func (mcpServer *MCPServer) GetURL() string      { return mcpServer.URL }
+func (mcpServer *MCPServer) GetHostname() string { return mcpServer.Hostname }
+func (mcpServer *MCPServer) GetPrefix() string   { return mcpServer.Prefix }
+func (mcpServer *MCPServer) IsEnabled() bool     { return mcpServer.Enabled }
+func (mcpServer *MCPServer) GetID() UpstreamID   { return UpstreamID(mcpServer.ID()) }
+```
+
+### Extensible A2AServer Scaffolding
+A2A configurations are modeled alongside MCP inside the parsed configuration structures. The struct fields and JSON/YAML annotations allow seamless integration inside the shared Kubernetes config Secrets without conflicts:
+
+```go
+type A2AServer struct {
+	Name            string            `json:"name"                      yaml:"name"`
+	URL             string            `json:"url"                       yaml:"url"`
+	Hostname        string            `json:"hostname,omitempty"        yaml:"hostname,omitempty"`
+	Prefix          string            `json:"prefix,omitempty"          yaml:"prefix,omitempty"`
+	Auth            *AuthConfig       `json:"auth,omitempty"            yaml:"auth,omitempty"`
+	Enabled         bool              `json:"enabled"                   yaml:"enabled"`
+	AgentID         string            `json:"agentId,omitempty"         yaml:"agentId,omitempty"`
+	AgentCardURL    string            `json:"agentCardUrl,omitempty"    yaml:"agentCardUrl,omitempty"`
+	TaskEndpoint    string            `json:"taskEndpoint,omitempty"    yaml:"taskEndpoint,omitempty"`
+	ProtocolBinding string            `json:"protocolBinding,omitempty" yaml:"protocolBinding,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"        yaml:"metadata,omitempty"`
+}
+```
+
+### Extensible `BrokerConfig` Structure
+We expanded the global parsed configuration structure `BrokerConfig` to support `A2AServers` as an optional section:
+
+```go
+type BrokerConfig struct {
+	Servers        []MCPServer           `json:"servers"                  yaml:"servers"`
+	A2AServers     []A2AServer           `json:"a2aServers,omitempty"     yaml:"a2aServers,omitempty"`
+	VirtualServers []VirtualServerConfig `json:"virtualServers,omitempty" yaml:"virtualServers,omitempty"`
+}
+```
+
+Existing controllers writing to the Kubernetes configuration secret will simply marshal and unmarshal the A2A servers seamlessly if they are added in the future, with no runtime schema validation errors or deployment friction.
+
+---
+
+## Architectural Rationale & Future Work
+
+1. **Interface-Based Routing**: In future phases, the Envoy external processor and router can perform target lookup using `UpstreamRegistry.GetUpstreamByName()`, making it simple to fetch and handle custom properties for non-MCP protocols without mutating core routing engines.
+2. **Kubernetes CRD Harmonization**: In a later step, a new `A2AServerRegistration` Custom Resource Definition (CRD) can be introduced. The gateway controller will reconcile it exactly like `MCPServerRegistration` and upsert the result into the same `BrokerConfig` secret using `A2AServers` block, preserving all security validation features.

--- a/internal/config/mcpservers_test.go
+++ b/internal/config/mcpservers_test.go
@@ -462,3 +462,87 @@ func TestMCPServersConfig_Notify(t *testing.T) {
 	require.Equal(t, config, observer.receivedConf)
 	observer.mu.Unlock()
 }
+
+func TestMultiProtocolConfigModel(t *testing.T) {
+	t.Run("MCPServer implements UpstreamServer", func(t *testing.T) {
+		mcpServer := &MCPServer{
+			Name:     "weather",
+			URL:      "http://weather-service/mcp",
+			Hostname: "weather.mcp.local",
+			Prefix:   "weather_",
+			Enabled:  true,
+		}
+
+		var upstream UpstreamServer = mcpServer
+
+		require.Equal(t, "weather", upstream.GetName())
+		require.Equal(t, ProtocolMCP, upstream.GetProtocol())
+		require.Equal(t, "http://weather-service/mcp", upstream.GetURL())
+		require.Equal(t, "weather.mcp.local", upstream.GetHostname())
+		require.Equal(t, "weather_", upstream.GetPrefix())
+		require.True(t, upstream.IsEnabled())
+		require.Equal(t, UpstreamID("weather:weather_:weather.mcp.local"), upstream.GetID())
+	})
+
+	t.Run("A2AServer implements UpstreamServer", func(t *testing.T) {
+		a2aServer := &A2AServer{
+			Name:            "agent1",
+			URL:             "http://agent-service/a2a",
+			Hostname:        "agent.a2a.local",
+			Prefix:          "agent_",
+			Enabled:         true,
+			AgentID:         "agent-xyz-987",
+			AgentCardURL:    "http://agent-service/card.json",
+			TaskEndpoint:    "http://agent-service/tasks",
+			ProtocolBinding: "http-sse",
+			Metadata:        map[string]string{"version": "1.0"},
+		}
+
+		var upstream UpstreamServer = a2aServer
+
+		require.Equal(t, "agent1", upstream.GetName())
+		require.Equal(t, ProtocolA2A, upstream.GetProtocol())
+		require.Equal(t, "http://agent-service/a2a", upstream.GetURL())
+		require.Equal(t, "agent.a2a.local", upstream.GetHostname())
+		require.Equal(t, "agent_", upstream.GetPrefix())
+		require.True(t, upstream.IsEnabled())
+		require.Equal(t, UpstreamID("agent1:agent_:agent.a2a.local"), upstream.GetID())
+
+		// Verify A2A-specific fields are correctly accessible on concrete struct
+		require.Equal(t, "agent-xyz-987", a2aServer.AgentID)
+		require.Equal(t, "http://agent-service/card.json", a2aServer.AgentCardURL)
+		require.Equal(t, "http://agent-service/tasks", a2aServer.TaskEndpoint)
+		require.Equal(t, "http-sse", a2aServer.ProtocolBinding)
+		require.Equal(t, "1.0", a2aServer.Metadata["version"])
+	})
+
+	t.Run("MCPServersConfig implements UpstreamRegistry", func(t *testing.T) {
+		servers := []*MCPServer{
+			{Name: "server1", URL: "http://server1/mcp", Enabled: true},
+			{Name: "server2", URL: "http://server2/mcp", Enabled: false},
+		}
+
+		mcpConfig := &MCPServersConfig{
+			Servers:                    servers,
+			MCPGatewayExternalHostname: "gateway.public.host",
+		}
+
+		var registry UpstreamRegistry = mcpConfig
+
+		require.Equal(t, "gateway.public.host", registry.GetExternalHostname())
+
+		upstreams := registry.ListUpstreams()
+		require.Len(t, upstreams, 2)
+		require.Equal(t, "server1", upstreams[0].GetName())
+		require.Equal(t, "server2", upstreams[1].GetName())
+
+		upstream1, err := registry.GetUpstreamByName("server1")
+		require.NoError(t, err)
+		require.Equal(t, "server1", upstream1.GetName())
+		require.True(t, upstream1.IsEnabled())
+
+		_, err = registry.GetUpstreamByName("nonexistent")
+		require.Error(t, err)
+	})
+}
+

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -11,6 +11,48 @@ import (
 // UpstreamMCPID is used as type for identifying individual upstreams
 type UpstreamMCPID string
 
+// UpstreamID is a generic identifier for any upstream server (MCP, A2A, etc.)
+type UpstreamID string
+
+// Protocol represents the communication protocol of an upstream server
+type Protocol string
+
+const (
+	// ProtocolMCP represents the Model Context Protocol
+	ProtocolMCP Protocol = "mcp"
+	// ProtocolA2A represents the Agent-to-Agent protocol
+	ProtocolA2A Protocol = "a2a"
+)
+
+// UpstreamServer represents the interface that any upstream server config must satisfy,
+// regardless of the protocol (MCP, A2A, etc.)
+type UpstreamServer interface {
+	// GetName returns the unique name of the upstream server
+	GetName() string
+	// GetProtocol returns the protocol type (e.g., "mcp", "a2a")
+	GetProtocol() Protocol
+	// GetURL returns the backend endpoint URL
+	GetURL() string
+	// GetHostname returns the target hostname
+	GetHostname() string
+	// GetPrefix returns the prefix used for resource/tool naming isolation
+	GetPrefix() string
+	// IsEnabled returns true if the server is active
+	IsEnabled() bool
+	// GetID returns a unique UpstreamID
+	GetID() UpstreamID
+}
+
+// UpstreamRegistry represents a protocol-neutral registry for looking up upstream servers
+type UpstreamRegistry interface {
+	// ListUpstreams returns all registered upstream servers across all protocols
+	ListUpstreams() []UpstreamServer
+	// GetUpstreamByName retrieves an upstream server by its unique name
+	GetUpstreamByName(name string) (UpstreamServer, error)
+	// GetExternalHostname returns the public hostname of the gateway
+	GetExternalHostname() string
+}
+
 // MCPServersConfig holds server configuration
 type MCPServersConfig struct {
 	lock sync.RWMutex
@@ -85,6 +127,26 @@ func (config *MCPServersConfig) GetServerConfigByName(serverName string) (*MCPSe
 	return nil, fmt.Errorf("unknown server")
 }
 
+// ListUpstreams returns all registered upstream servers across all protocols
+func (config *MCPServersConfig) ListUpstreams() []UpstreamServer {
+	config.lock.RLock()
+	defer config.lock.RUnlock()
+	out := make([]UpstreamServer, len(config.Servers))
+	for i, server := range config.Servers {
+		out[i] = server
+	}
+	return out
+}
+
+// GetUpstreamByName retrieves an upstream server by its unique name
+func (config *MCPServersConfig) GetUpstreamByName(name string) (UpstreamServer, error) {
+	server, err := config.GetServerConfigByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
 // MCPServer represents a server
 type MCPServer struct {
 	Name                string                     `json:"name"                              yaml:"name"`
@@ -105,6 +167,92 @@ type TokenURLElicitationConfig struct {
 // ID returns a unique id for the a registered server
 func (mcpServer *MCPServer) ID() UpstreamMCPID {
 	return UpstreamMCPID(fmt.Sprintf("%s:%s:%s", mcpServer.Name, mcpServer.Prefix, mcpServer.Hostname))
+}
+
+// GetName returns the unique name of the upstream server
+func (mcpServer *MCPServer) GetName() string {
+	return mcpServer.Name
+}
+
+// GetProtocol returns the protocol type (always ProtocolMCP for MCPServer)
+func (mcpServer *MCPServer) GetProtocol() Protocol {
+	return ProtocolMCP
+}
+
+// GetURL returns the backend endpoint URL
+func (mcpServer *MCPServer) GetURL() string {
+	return mcpServer.URL
+}
+
+// GetHostname returns the target hostname
+func (mcpServer *MCPServer) GetHostname() string {
+	return mcpServer.Hostname
+}
+
+// GetPrefix returns the prefix used for resource/tool naming isolation
+func (mcpServer *MCPServer) GetPrefix() string {
+	return mcpServer.Prefix
+}
+
+// IsEnabled returns true if the server is active
+func (mcpServer *MCPServer) IsEnabled() bool {
+	return mcpServer.Enabled
+}
+
+// GetID returns a unique UpstreamID
+func (mcpServer *MCPServer) GetID() UpstreamID {
+	return UpstreamID(mcpServer.ID())
+}
+
+// A2AServer represents the configuration for an Agent-to-Agent (A2A) upstream server.
+// It implements the UpstreamServer interface.
+type A2AServer struct {
+	Name            string            `json:"name"                      yaml:"name"`
+	URL             string            `json:"url"                       yaml:"url"`
+	Hostname        string            `json:"hostname,omitempty"        yaml:"hostname,omitempty"`
+	Prefix          string            `json:"prefix,omitempty"          yaml:"prefix,omitempty"`
+	Auth            *AuthConfig       `json:"auth,omitempty"            yaml:"auth,omitempty"`
+	Enabled         bool              `json:"enabled"                   yaml:"enabled"`
+	AgentID         string            `json:"agentId,omitempty"         yaml:"agentId,omitempty"`
+	AgentCardURL    string            `json:"agentCardUrl,omitempty"    yaml:"agentCardUrl,omitempty"`
+	TaskEndpoint    string            `json:"taskEndpoint,omitempty"    yaml:"taskEndpoint,omitempty"`
+	ProtocolBinding string            `json:"protocolBinding,omitempty" yaml:"protocolBinding,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"        yaml:"metadata,omitempty"`
+}
+
+// GetName returns the unique name of the upstream server
+func (a2aServer *A2AServer) GetName() string {
+	return a2aServer.Name
+}
+
+// GetProtocol returns the protocol type (always ProtocolA2A for A2AServer)
+func (a2aServer *A2AServer) GetProtocol() Protocol {
+	return ProtocolA2A
+}
+
+// GetURL returns the backend endpoint URL
+func (a2aServer *A2AServer) GetURL() string {
+	return a2aServer.URL
+}
+
+// GetHostname returns the target hostname
+func (a2aServer *A2AServer) GetHostname() string {
+	return a2aServer.Hostname
+}
+
+// GetPrefix returns the prefix used for resource/tool naming isolation
+func (a2aServer *A2AServer) GetPrefix() string {
+	return a2aServer.Prefix
+}
+
+// IsEnabled returns true if the server is active
+func (a2aServer *A2AServer) IsEnabled() bool {
+	return a2aServer.Enabled
+}
+
+// GetID returns a unique UpstreamID
+func (a2aServer *A2AServer) GetID() UpstreamID {
+	return UpstreamID(fmt.Sprintf("%s:%s:%s", a2aServer.Name, a2aServer.Prefix, a2aServer.Hostname))
 }
 
 // ConfigChanged checks if a server's config has changed in a way that will affect the gateway.
@@ -150,7 +298,8 @@ type Observer interface {
 
 // BrokerConfig holds broker configuration
 type BrokerConfig struct {
-	Servers        []MCPServer           `json:"servers" yaml:"servers"`
+	Servers        []MCPServer           `json:"servers"                  yaml:"servers"`
+	A2AServers     []A2AServer           `json:"a2aServers,omitempty"     yaml:"a2aServers,omitempty"`
 	VirtualServers []VirtualServerConfig `json:"virtualServers,omitempty" yaml:"virtualServers,omitempty"`
 }
 


### PR DESCRIPTION
This PR introduces a small set of protocol-neutral config abstractions to prepare the broker config model for future A2A upstream support without changing the current MCP behavior.

The existing config and runtime flow is heavily MCP-oriented today. Instead of forcing future A2A concepts into MCP-specific structures, this change introduces lightweight shared abstractions that can support multiple upstream protocols cleanly over time.

 What changed ?

1.  added generic upstream protocol and ID types
2.  introduced `UpstreamServer` and `UpstreamRegistry` interfaces
3.  extended existing `MCPServer` and `MCPServersConfig` implementations to satisfy the new interfaces
4.  added an initial `A2AServer` structure for future protocol support
5.  extended `BrokerConfig` with optional A2A upstream configuration support
6.  added tests covering interface compatibility and multi-protocol behavior
7.  added a design document describing the motivation, scope, and future integration direction

 Notes :-

This PR is intentionally limited in scope.

It does not implement :-

1.  A2A routing
2.  controller reconciliation
3.  runtime proxying
4.  protocol execution logic

The goal here is only to establish safer abstraction boundaries and reduce MCP-specific coupling before larger A2A work begins.

Testing

1.   go test ./...
2.   added coverage for protocol-neutral interface compatibility and registry behavior
