### PR TITLE
feat: add MCP resource federation support

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -31,6 +31,9 @@ type MCPBroker interface {
 	// Returns server info for a given prompt name
 	GetServerInfoByPrompt(prompt string) (*config.MCPServer, error)
 
+	// Returns server info for a given resource URI
+	GetServerInfoByResource(resourceURI string) (*config.MCPServer, error)
+
 	// MCPServer gets an MCP server that federates the upstreams known to this MCPBroker
 	MCPServer() *server.MCPServer
 
@@ -172,12 +175,17 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		mcpBkr.FilterPrompts(ctx, id, message, result)
 	})
 
+	hooks.AddAfterListResources(func(ctx context.Context, id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult) {
+		mcpBkr.FilterResources(ctx, id, message, result)
+	})
+
 	mcpBkr.listeningMCPServer = server.NewMCPServer(
 		"Kuadrant MCP Gateway",
 		"0.0.1",
 		server.WithHooks(hooks),
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),
+		server.WithResourceCapabilities(false, true),
 	)
 	return mcpBkr
 }
@@ -222,7 +230,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		// check if we need to setup a new manager
 		if _, ok := m.mcpServers[mcpServer.ID()]; !ok {
 			m.logger.Info("starting new manager", "server id", mcpServer.ID())
-			manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
+			manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
 			if err != nil {
 				m.logger.Error("failed to create manager", "server id", mcpServer.ID(), "error", err)
 				continue
@@ -313,6 +321,27 @@ func (m *mcpBrokerImpl) GetServerInfoByPrompt(prompt string) (*config.MCPServer,
 	}
 
 	return nil, fmt.Errorf("prompt name %q doesn't match any configured server", prompt)
+}
+
+// GetServerInfoByResource implements MCPBroker by providing a lookup of the server that implements a resource.
+func (m *mcpBrokerImpl) GetServerInfoByResource(resourceURI string) (*config.MCPServer, error) {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+
+	for _, upstream := range m.mcpServers {
+		r := upstream.GetServedManagedResource(resourceURI)
+		if r != nil {
+			cfg := upstream.Config()
+			m.logger.Debug("found matching server for resource",
+				"resourceURI", resourceURI,
+				"serverPrefix", cfg.Prefix,
+				"serverName", upstream.MCPName())
+			retval := cfg
+			return &retval, nil
+		}
+	}
+
+	return nil, fmt.Errorf("resource URI %q doesn't match any configured server", resourceURI)
 }
 
 func (m *mcpBrokerImpl) Shutdown(_ context.Context) error {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -227,6 +227,43 @@ func TestGetServerInfo(t *testing.T) {
 	require.Nil(t, svr)
 }
 
+func TestGetServerInfoByResource(t *testing.T) {
+	b := NewBroker(logger)
+
+	// Attach phony tools/resources to the upstreams
+	bImpl, ok := b.(*mcpBrokerImpl)
+	require.True(t, ok)
+
+	m1 := createTestManager(t, "test1", "", nil)
+	m1.SetResourcesForTesting([]mcp.Resource{
+		{URI: "file://settings"},
+	})
+	bImpl.mcpServers["test1"] = upstream.NewActiveForTesting(m1)
+
+	m2 := createTestManager(t, "test2", "t_", nil)
+	m2.SetResourcesForTesting([]mcp.Resource{
+		{URI: "file://settings"},
+	})
+	bImpl.mcpServers["test2"] = upstream.NewActiveForTesting(m2)
+
+	// Direct lookup for server 1 (no prefix)
+	svr, err := b.GetServerInfoByResource("file://settings")
+	require.NoError(t, err)
+	require.NotNil(t, svr)
+	require.Equal(t, "test1", svr.Name)
+
+	// Prefixed lookup for server 2
+	svr, err = b.GetServerInfoByResource("t_file://settings")
+	require.NoError(t, err)
+	require.NotNil(t, svr)
+	require.Equal(t, "test2", svr.Name)
+
+	// Unregistered resource URI
+	svr, err = b.GetServerInfoByResource("file://unregistered")
+	require.Error(t, err)
+	require.Nil(t, svr)
+}
+
 func TestToolAnnotations(t *testing.T) {
 	b := NewBroker(logger,
 		WithEnforceCapabilityFilter(true),

--- a/internal/broker/filtered_prompts_handler_test.go
+++ b/internal/broker/filtered_prompts_handler_test.go
@@ -19,7 +19,7 @@ func createPromptTestManager(t *testing.T, serverName, prefix string, prompts []
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	manager.SetPromptsForTesting(prompts)
 	return manager
 }

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -1,0 +1,144 @@
+package broker
+
+import (
+	"context"
+	"net/http"
+	"slices"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// FilterResources reduces the resource set based on authorization headers.
+// Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
+func (broker *mcpBrokerImpl) FilterResources(_ context.Context, _ any, mcpReq *mcp.ListResourcesRequest, mcpRes *mcp.ListResourcesResult) {
+	broker.logger.Debug("FilterResources called", "input_resources_count", len(mcpRes.Resources))
+	resources := mcpRes.Resources
+	emptyResources := []mcp.Resource{}
+	if len(mcpRes.Resources) == 0 {
+		mcpRes.Resources = emptyResources
+		return
+	}
+
+	// step 1: apply x-mcp-authorized filtering (JWT-based)
+	resources = broker.applyAuthorizedResourcesFilter(mcpReq.Header, resources)
+	broker.logger.Debug("FilterResources authorized capabilities result", "output_resources_count", len(resources))
+
+	// step 2: apply virtual server filtering
+	resources = broker.applyVirtualServerResourcesFilter(mcpReq.Header, resources)
+	// filter out any gateway specific meta data we are storing internally before sending to clients
+	resources = broker.removeGatewayMetaResources(resources)
+	broker.logger.Debug("FilterResources virtual server result", "output_resources_count", len(resources))
+
+	// ensure we never return nil (would serialize as null instead of [])
+	if resources == nil {
+		resources = emptyResources
+	}
+	mcpRes.Resources = resources
+}
+
+func (broker *mcpBrokerImpl) removeGatewayMetaResources(resources []mcp.Resource) []mcp.Resource {
+	broker.logger.Debug("removing gateway specific meta from resources")
+	for i := range resources {
+		if resources[i].Meta != nil {
+			delete(resources[i].Meta.AdditionalFields, "kuadrant/id")
+			if len(resources[i].Meta.AdditionalFields) == 0 {
+				resources[i].Meta = nil
+			}
+		}
+	}
+	return resources
+}
+
+// applyAuthorizedResourcesFilter filters resources based on x-mcp-authorized JWT header.
+// Returns original resources if header not present and enforcement is off.
+// Returns empty slice if header validation fails or enforcement is on without header.
+func (broker *mcpBrokerImpl) applyAuthorizedResourcesFilter(headers http.Header, resources []mcp.Resource) []mcp.Resource {
+	headerValues, present := headers[authorizedCapabilitiesHeader]
+
+	if !present {
+		broker.logger.Debug("no x-mcp-authorized header for resources", "enforced", broker.enforceCapabilityFilter)
+		if broker.enforceCapabilityFilter {
+			return []mcp.Resource{}
+		}
+		return resources
+	}
+
+	capabilities, err := broker.parseAuthorizedCapabilitiesJWT(headerValues)
+	if err != nil {
+		broker.logger.Error("failed to parse x-mcp-authorized header for resources", "error", err)
+		return []mcp.Resource{}
+	}
+
+	allowedResources, hasResources := capabilities["resources"]
+	if !hasResources {
+		broker.logger.Debug("no resources key in capabilities")
+		if broker.enforceCapabilityFilter {
+			return []mcp.Resource{}
+		}
+		return resources
+	}
+
+	return broker.filterResourcesByServerMap(allowedResources)
+}
+
+// filterResourcesByServerMap filters resources based on a map of server name to allowed resource URIs.
+func (broker *mcpBrokerImpl) filterResourcesByServerMap(allowedResources map[string][]string) []mcp.Resource {
+	var filtered []mcp.Resource
+
+	for serverName, resourceURIs := range allowedResources {
+		upstreamServer := broker.findServerByName(serverName)
+		if upstreamServer == nil {
+			broker.logger.Error("upstream not found", "server", serverName)
+			continue
+		}
+		resList := upstreamServer.GetManagedResources()
+		if resList == nil {
+			broker.logger.Debug("no resources registered for upstream server", "server", upstreamServer.MCPName)
+			continue
+		}
+
+		for _, res := range resList {
+			broker.logger.Debug("checking access for resource", "uri", res.URI, "against", resourceURIs)
+			if slices.Contains(resourceURIs, res.URI) {
+				broker.logger.Debug("access granted for resource", "uri", res.URI)
+				res.URI = upstream.PrefixURI(res.URI, upstreamServer.Config().Prefix)
+				filtered = append(filtered, res)
+			}
+		}
+	}
+
+	return filtered
+}
+
+// applyVirtualServerResourcesFilter filters resources to only those specified in the virtual server.
+func (broker *mcpBrokerImpl) applyVirtualServerResourcesFilter(headers http.Header, resources []mcp.Resource) []mcp.Resource {
+	headerValues, ok := headers[virtualMCPHeader]
+	if !ok || len(headerValues) != 1 {
+		return resources
+	}
+
+	virtualServerID := headerValues[0]
+	broker.logger.Debug("applying virtual server filter to resources", "virtualServer", virtualServerID)
+
+	vs, err := broker.GetVirtualSeverByHeader(virtualServerID)
+	if err != nil {
+		broker.logger.Error("failed to get virtual server for resources", "error", err)
+		return resources
+	}
+
+	// build a set of allowed resource URIs for O(1) lookup
+	filteredSet := make(map[string]struct{}, len(vs.Resources))
+	for _, name := range vs.Resources {
+		filteredSet[name] = struct{}{}
+	}
+
+	var filtered []mcp.Resource
+	for _, res := range resources {
+		if _, inFilter := filteredSet[res.URI]; inFilter {
+			filtered = append(filtered, res)
+		}
+	}
+
+	return filtered
+}

--- a/internal/broker/filtered_resources_handler_test.go
+++ b/internal/broker/filtered_resources_handler_test.go
@@ -1,0 +1,141 @@
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func createResourceTestManager(t *testing.T, serverName, prefix string, resources []mcp.Resource) *upstream.MCPManager {
+	t.Helper()
+	mcpServer := upstream.NewUpstreamMCP(&config.MCPServer{
+		Name:   serverName,
+		Prefix: prefix,
+		URL:    "http://test.local/mcp",
+	})
+	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager.SetResourcesForTesting(resources)
+	return manager
+}
+
+func TestFilterResources(t *testing.T) {
+	testCases := []struct {
+		Name                 string
+		FullResourceList     *mcp.ListResourcesResult
+		RegisteredMCPServers map[config.UpstreamMCPID]upstream.ActiveMCPServer
+		enforceFilterList    bool
+		ExpectedResources    []string
+	}{
+		{
+			Name: "returns all resources when no headers and enforce is false",
+			FullResourceList: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test_resource1"},
+				{URI: "test_resource2"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
+			enforceFilterList:    false,
+			ExpectedResources:    []string{"test_resource1", "test_resource2"},
+		},
+		{
+			Name: "returns empty resources when no headers and enforce is true",
+			FullResourceList: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test_resource1"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
+			enforceFilterList:    true,
+			ExpectedResources:    []string{},
+		},
+		{
+			Name:                 "returns empty slice for nil resources input",
+			FullResourceList:     &mcp.ListResourcesResult{Resources: nil},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
+			enforceFilterList:    false,
+			ExpectedResources:    []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mcpBroker := &mcpBrokerImpl{
+				enforceCapabilityFilter: tc.enforceFilterList,
+				trustedHeadersPublicKey: testPublicKey,
+				logger:                  slog.Default(),
+				mcpServers:              tc.RegisteredMCPServers,
+			}
+
+			request := &mcp.ListResourcesRequest{Header: http.Header{}}
+			mcpBroker.FilterResources(context.TODO(), 1, request, tc.FullResourceList)
+
+			if len(tc.ExpectedResources) != len(tc.FullResourceList.Resources) {
+				t.Fatalf("expected %d resources but got %d: %v", len(tc.ExpectedResources), len(tc.FullResourceList.Resources), tc.FullResourceList.Resources)
+			}
+		})
+	}
+}
+
+func TestFilterResources_JWTFiltering(t *testing.T) {
+	jwtToken := createTestJWTWithCapabilities(t, map[string]map[string][]string{
+		"resources": {"mcp-test/test-server1": {"file://settings"}},
+	})
+
+	mcpBroker := &mcpBrokerImpl{
+		enforceCapabilityFilter: true,
+		trustedHeadersPublicKey: testPublicKey,
+		logger:                  slog.Default(),
+		mcpServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			"mcp-test/test-server1:test_:http://test.local/mcp": upstream.NewActiveForTesting(createResourceTestManager(t,
+				"mcp-test/test-server1",
+				"test_",
+				[]mcp.Resource{{URI: "file://settings"}},
+			)),
+		},
+	}
+
+	result := &mcp.ListResourcesResult{Resources: []mcp.Resource{
+		{URI: "test_file://settings"},
+		{URI: "test_file://other"},
+	}}
+
+	request := &mcp.ListResourcesRequest{Header: http.Header{
+		"X-Mcp-Authorized": []string{jwtToken},
+	}}
+
+	mcpBroker.FilterResources(context.TODO(), 1, request, result)
+
+	require.Len(t, result.Resources, 1)
+	require.Equal(t, "test_file://settings", result.Resources[0].URI)
+}
+
+func TestFilterResources_VirtualServerFiltering(t *testing.T) {
+	mcpBroker := &mcpBrokerImpl{
+		enforceCapabilityFilter: false,
+		logger:                  slog.Default(),
+		virtualServers: map[string]*config.VirtualServer{
+			"mcp-test/my-virtual-server": {
+				Name:      "mcp-test/my-virtual-server",
+				Resources: []string{"test_file://settings"},
+			},
+		},
+	}
+
+	result := &mcp.ListResourcesResult{Resources: []mcp.Resource{
+		{URI: "test_file://settings"},
+		{URI: "test_file://other"},
+	}}
+
+	request := &mcp.ListResourcesRequest{Header: http.Header{
+		"X-Mcp-Virtualserver": []string{"mcp-test/my-virtual-server"},
+	}}
+
+	mcpBroker.FilterResources(context.TODO(), 1, request, result)
+
+	require.Len(t, result.Resources, 1)
+	require.Equal(t, "test_file://settings", result.Resources[0].URI)
+}

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -59,7 +59,7 @@ func createTestManager(t *testing.T, serverName, prefix string, tools []mcp.Tool
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	// populate tools directly for testing (this requires accessing internal state)
 	manager.SetToolsForTesting(tools)

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -34,7 +34,7 @@ func createTestManagerForStatus(t *testing.T, serverName string, tools []mcp.Too
 		Prefix: "test_",
 		URL:    "http://test.local/mcp",
 	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)
 	manager.SetStatusForTesting(upstream.ServerValidationStatus{

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -40,10 +42,18 @@ type PromptsAdderDeleter interface {
 	ListPrompts() map[string]*server.ServerPrompt
 }
 
+// ResourcesAdderDeleter defines the interface for managing resources on the gateway server
+type ResourcesAdderDeleter interface {
+	AddResources(resources ...server.ServerResource)
+	DeleteResources(names ...string)
+	ListResources() map[string]*server.ServerResource
+}
+
 const (
-	notificationToolsListChanged   = "notifications/tools/list_changed"
-	notificationPromptsListChanged = "notifications/prompts/list_changed"
-	gatewayServerID                = "kuadrant/id"
+	notificationToolsListChanged     = "notifications/tools/list_changed"
+	notificationPromptsListChanged   = "notifications/prompts/list_changed"
+	notificationResourcesListChanged = "notifications/resources/list_changed"
+	gatewayServerID                  = "kuadrant/id"
 )
 
 type eventType int
@@ -52,6 +62,7 @@ const (
 	eventTypeTimer eventType = iota
 	eventTypeToolNotification
 	eventTypePromptNotification
+	eventTypeResourceNotification
 )
 
 // ServerValidationStatus contains the validation results for an upstream MCP server
@@ -63,6 +74,7 @@ type ServerValidationStatus struct {
 	Ready             bool                `json:"ready"`
 	TotalTools        int                 `json:"totalTools"`
 	TotalPrompts      int                 `json:"totalPrompts"`
+	TotalResources    int                 `json:"totalResources"`
 	InvalidTools      int                 `json:"invalidTools"`
 	InvalidToolList   []InvalidToolInfo   `json:"invalidToolList,omitempty"`
 	InvalidPrompts    int                 `json:"invalidPrompts"`
@@ -80,8 +92,11 @@ type MCP interface {
 	Disconnect() error
 	ListTools(context.Context, mcp.ListToolsRequest) (*mcp.ListToolsResult, error)
 	ListPrompts(context.Context, mcp.ListPromptsRequest) (*mcp.ListPromptsResult, error)
+	ListResources(context.Context, mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error)
 	SupportsPrompts() bool
 	SupportsPromptsListChanged() bool
+	SupportsResources() bool
+	SupportsResourcesListChanged() bool
 	OnNotification(func(notification mcp.JSONRPCNotification))
 	OnConnectionLost(func(err error))
 	Ping(context.Context) error
@@ -97,6 +112,8 @@ type ActiveMCPServer interface {
 	GetServedManagedTool(toolName string) *mcp.Tool
 	GetManagedPrompts() []mcp.Prompt
 	GetServedManagedPrompt(promptName string) *mcp.Prompt
+	GetManagedResources() []mcp.Resource
+	GetServedManagedResource(resourceURI string) *mcp.Resource
 	Config() config.MCPServer
 }
 
@@ -127,7 +144,15 @@ type MCPManager struct {
 	promptsMap       map[string]*mcp.Prompt
 	servedPromptsMap map[string]*mcp.Prompt
 
-	// toolsLock protects tools, serverTools, prompts, serverPrompts
+	resourcesServer ResourcesAdderDeleter
+	// serverResources is an internal copy with prefixed names
+	serverResources []server.ServerResource
+	// resources is the original set from MCP server with no prefix
+	resources          []mcp.Resource
+	resourcesMap       map[string]*mcp.Resource
+	servedResourcesMap map[string]*mcp.Resource
+
+	// toolsLock protects tools, serverTools, prompts, serverPrompts, resources, serverResources
 	toolsLock sync.RWMutex
 
 	logger *slog.Logger
@@ -139,10 +164,11 @@ type MCPManager struct {
 	// Separate channels with buffer of 1 each ensure a tool notification cannot
 	// block a prompt notification (or vice versa) while still coalescing rapid
 	// same-type notifications.
-	toolEvents   chan struct{}
-	promptEvents chan struct{}
-	done         chan struct{} // closed when the event loop exits
-	status       ServerValidationStatus
+	toolEvents     chan struct{}
+	promptEvents   chan struct{}
+	resourceEvents chan struct{}
+	done           chan struct{} // closed when the event loop exits
+	status         ServerValidationStatus
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
@@ -151,7 +177,15 @@ const DefaultTickerInterval = time.Minute * 1
 // NewUpstreamMCPManager creates a new MCPManager for managing a single upstream MCP server.
 // The addTools and removeTools callbacks are used to update the gateway's tool registry.
 // The tickerInterval controls how often the manager checks backend health (use 0 for default).
-func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, promptsServer PromptsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) (*MCPManager, error) {
+func NewUpstreamMCPManager(
+	upstream MCP,
+	gatewayServer ToolsAdderDeleter,
+	promptsServer PromptsAdderDeleter,
+	resourcesServer ResourcesAdderDeleter,
+	logger *slog.Logger,
+	tickerInterval time.Duration,
+	policy mcpv1alpha1.InvalidToolPolicy,
+) (*MCPManager, error) {
 	if gatewayServer == nil {
 		return nil, fmt.Errorf("gateway server is required for upstream MCP manager")
 	}
@@ -168,24 +202,32 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 	}
 
 	return &MCPManager{
-		mcp:               upstream,
-		gatewayServer:     gatewayServer,
-		promptsServer:     promptsServer,
-		tickerInterval:    tickerInterval,
-		ticker:            time.NewTicker(tickerInterval),
-		backoff:           bo,
-		baseBackoff:       bo,
-		logger:            logger,
-		invalidToolPolicy: policy,
-		toolEvents:        make(chan struct{}, 1),
-		promptEvents:      make(chan struct{}, 1),
-		done:              make(chan struct{}),
-		toolsMap:          map[string]*mcp.Tool{},
-		servedToolsMap:    map[string]*mcp.Tool{},
-		serverTools:       []server.ServerTool{},
-		promptsMap:        map[string]*mcp.Prompt{},
-		servedPromptsMap:  map[string]*mcp.Prompt{},
-		serverPrompts:     []server.ServerPrompt{},
+		mcp:                upstream,
+		gatewayServer:      gatewayServer,
+		promptsServer:      promptsServer,
+		resourcesServer:    resourcesServer,
+		tickerInterval:     tickerInterval,
+		ticker:             time.NewTicker(tickerInterval),
+		backoff:            bo,
+		baseBackoff:        bo,
+		logger:             logger,
+		invalidToolPolicy:  policy,
+		toolEvents:         make(chan struct{}, 1),
+		promptEvents:       make(chan struct{}, 1),
+		resourceEvents:     make(chan struct{}, 1),
+		done:               make(chan struct{}),
+		toolsMap:           map[string]*mcp.Tool{},
+		servedToolsMap:     map[string]*mcp.Tool{},
+		serverTools:        []server.ServerTool{},
+		tools:              []mcp.Tool{},
+		promptsMap:         map[string]*mcp.Prompt{},
+		servedPromptsMap:   map[string]*mcp.Prompt{},
+		serverPrompts:      []server.ServerPrompt{},
+		prompts:            []mcp.Prompt{},
+		resourcesMap:       map[string]*mcp.Resource{},
+		servedResourcesMap: map[string]*mcp.Resource{},
+		serverResources:    []server.ServerResource{},
+		resources:          []mcp.Resource{},
 	}, nil
 }
 
@@ -212,6 +254,7 @@ func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 				}
 				man.removeAllPrompts()
 				man.removeAllTools()
+				man.removeAllResources()
 
 				close(man.done)
 				man.logger.Debug("manager stopped", "upstream mcp server", man.mcp.ID())
@@ -225,6 +268,9 @@ func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 			case <-man.promptEvents:
 				man.logger.Debug("received prompt notification", "upstream mcp server", man.mcp.ID())
 				man.manage(ctx, eventTypePromptNotification)
+			case <-man.resourceEvents:
+				man.logger.Debug("received resource notification", "upstream mcp server", man.mcp.ID())
+				man.manage(ctx, eventTypeResourceNotification)
 			}
 		}
 	}()
@@ -251,6 +297,10 @@ func (a *activeMCP) GetManagedPrompts() []mcp.Prompt { return a.manager.GetManag
 func (a *activeMCP) GetServedManagedPrompt(p string) *mcp.Prompt {
 	return a.manager.GetServedManagedPrompt(p)
 }
+func (a *activeMCP) GetManagedResources() []mcp.Resource { return a.manager.GetManagedResources() }
+func (a *activeMCP) GetServedManagedResource(r string) *mcp.Resource {
+	return a.manager.GetServedManagedResource(r)
+}
 func (a *activeMCP) Config() config.MCPServer { return a.manager.mcp.GetConfig() }
 
 func (man *MCPManager) registerCallbacks() func() {
@@ -270,6 +320,12 @@ func (man *MCPManager) registerCallbacks() func() {
 				case man.promptEvents <- struct{}{}:
 				default:
 				}
+			case notificationResourcesListChanged:
+				man.logger.Debug("received notification", "upstream mcp server", man.mcp.ID(), "notification", notification.Method)
+				select {
+				case man.resourceEvents <- struct{}{}:
+				default:
+				}
 			}
 		})
 
@@ -285,6 +341,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.logger.Debug("managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
 	numberOfTools := len(man.tools)
 	numberOfPrompts := len(man.prompts)
+	numberOfResources := len(man.resources)
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
 	man.logger.Debug("attempting to connect", "upstream mcp server", man.mcp.ID())
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
@@ -292,9 +349,10 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.logger.Error("connection failed", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.removeAllTools()
 		man.removeAllPrompts()
+		man.removeAllResources()
 		// we call disconnect here as we may have connected but failed to initialize
 		_ = man.mcp.Disconnect()
-		man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+		man.setStatus(err, numberOfTools, numberOfPrompts, numberOfResources, nil, nil, nil)
 		return
 	}
 	// there may be an active client so we also ping
@@ -304,8 +362,9 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.logger.Error("ping failed", "upstream mcp server", man.mcp.ID(), "error", err)
 		man.removeAllTools()
 		man.removeAllPrompts()
+		man.removeAllResources()
 		_ = man.mcp.Disconnect()
-		man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+		man.setStatus(err, numberOfTools, numberOfPrompts, numberOfResources, nil, nil, nil)
 		return
 	}
 
@@ -421,8 +480,63 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 			}
 		}
 	}
-	jointErr := errors.Join(toolErr, promptErr)
-	man.setStatus(jointErr, numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
+
+	var resourceErr error
+	var invalidResources []InvalidResourceInfo
+	if man.resourcesServer != nil && man.mcp.SupportsResources() && man.shouldFetchResources(event) {
+		currentResources, fetchedResources, listErr := man.getResources(ctx)
+		if listErr != nil {
+			resourceErr = fmt.Errorf("upstream mcp failed to list resources server %s : %w", man.mcp.ID(), listErr)
+			man.logger.Error("failed to list resources", "upstream mcp server", man.mcp.ID(), "error", resourceErr)
+		} else {
+			validResources, invalids := ValidateResources(fetchedResources)
+			if len(invalids) > 0 {
+				man.logger.Error("invalid resources detected", "upstream mcp server", man.mcp.ID(), "invalid", len(invalids), "valid", len(validResources))
+				for _, info := range invalids {
+					man.logger.Error("invalid resource", "upstream mcp server", man.mcp.ID(), "resourceName", info.Name, "errors", info.Errors)
+				}
+				invalidResources = invalids
+				fetchedResources = validResources
+			}
+
+			toAddResources, toRemoveResources := man.diffResources(currentResources, fetchedResources)
+			if conflictErr := man.findResourceConflicts(toAddResources); conflictErr != nil {
+				resourceErr = fmt.Errorf("upstream mcp failed to add resources to gateway %s : %w", man.mcp.ID(), conflictErr)
+				man.logger.Error("resource conflict detected", "upstream mcp server", man.mcp.ID(), "error", resourceErr)
+			} else {
+				man.toolsLock.Lock()
+				man.resources = fetchedResources
+				numberOfResources = len(fetchedResources)
+				man.resourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
+				man.servedResourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
+				for i := range fetchedResources {
+					man.resourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
+					prefixedURI := PrefixURI(fetchedResources[i].URI, man.mcp.GetPrefix())
+					man.servedResourcesMap[prefixedURI] = &fetchedResources[i]
+				}
+				man.serverResources = slices.DeleteFunc(man.serverResources, func(res server.ServerResource) bool {
+					return slices.Contains(toRemoveResources, res.Resource.URI)
+				})
+				man.serverResources = append(man.serverResources, toAddResources...)
+				man.toolsLock.Unlock()
+
+				man.logger.Debug("updating gateway resources", "upstream mcp server", man.mcp.ID(), "adding", len(toAddResources), "removing", len(toRemoveResources))
+				if len(toRemoveResources) > 0 {
+					man.resourcesServer.DeleteResources(toRemoveResources...)
+				}
+				if len(toAddResources) > 0 {
+					man.resourcesServer.AddResources(toAddResources...)
+				}
+			}
+		}
+	} else {
+		man.toolsLock.RLock()
+		numberOfResources = len(man.resources)
+		man.toolsLock.RUnlock()
+	}
+
+	jointErr := errors.Join(toolErr, promptErr, resourceErr)
+	man.setStatus(jointErr, numberOfTools, numberOfPrompts, numberOfResources, invalidTools, invalidPrompts, invalidResources)
 	if jointErr != nil {
 		man.applyBackoff()
 	} else {
@@ -451,13 +565,23 @@ func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
 	return event == eventTypeTimer && len(man.serverPrompts) == 0
 }
 
+func (man *MCPManager) shouldFetchResources(event eventType) bool {
+	if !man.mcp.SupportsResourcesListChanged() {
+		return true
+	}
+	if event == eventTypeResourceNotification {
+		return true
+	}
+	return event == eventTypeTimer && len(man.serverResources) == 0
+}
+
 // GetStatus returns the current status of the MCP Server
 // no locking is done here as it is expected to be called multiple times
 func (man *MCPManager) GetStatus() ServerValidationStatus {
 	return man.status
 }
 
-func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo) {
+func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, resourceCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo, invalidResources []InvalidResourceInfo) {
 	man.status.ID = string(man.mcp.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()
@@ -472,8 +596,9 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	}
 	man.status.TotalTools = toolCount
 	man.status.TotalPrompts = promptCount
+	man.status.TotalResources = resourceCount
 	man.status.Ready = true
-	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
+	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d. Total resources added %d", toolCount, promptCount, resourceCount)
 }
 
 func (man *MCPManager) resetBackoff() {
@@ -776,4 +901,195 @@ func (man *MCPManager) SetPromptsForTesting(prompts []mcp.Prompt) {
 		man.promptsMap[prompts[i].Name] = &prompts[i]
 		man.servedPromptsMap[prefixedName(man.mcp.GetPrefix(), prompts[i].Name)] = &prompts[i]
 	}
+}
+
+// PrefixURI prepends a prefix to the scheme of a resource URI.
+func PrefixURI(uriStr string, prefix string) string {
+	if prefix == "" {
+		return uriStr
+	}
+	u, err := url.Parse(uriStr)
+	if err != nil || u.Scheme == "" {
+		return prefix + uriStr
+	}
+	u.Scheme = prefix + u.Scheme
+	return u.String()
+}
+
+// StripURIPrefix removes a prefix from the scheme of a resource URI.
+func StripURIPrefix(uriStr string, prefix string) string {
+	if prefix == "" {
+		return uriStr
+	}
+	u, err := url.Parse(uriStr)
+	if err != nil || u.Scheme == "" {
+		if strings.HasPrefix(uriStr, prefix) {
+			return uriStr[len(prefix):]
+		}
+		return uriStr
+	}
+	if strings.HasPrefix(u.Scheme, prefix) {
+		u.Scheme = u.Scheme[len(prefix):]
+		return u.String()
+	}
+	return uriStr
+}
+
+type InvalidResourceInfo struct {
+	Name   string   `json:"name"`
+	Errors []string `json:"errors"`
+}
+
+// ValidateResources validates resource fields.
+func ValidateResources(resources []mcp.Resource) ([]mcp.Resource, []InvalidResourceInfo) {
+	var valid []mcp.Resource
+	var invalid []InvalidResourceInfo
+	for _, res := range resources {
+		var errs []string
+		if res.URI == "" {
+			errs = append(errs, "uri is required")
+		}
+		if res.Name == "" {
+			errs = append(errs, "name is required")
+		}
+		if len(errs) > 0 {
+			invalid = append(invalid, InvalidResourceInfo{Name: res.Name, Errors: errs})
+		} else {
+			valid = append(valid, res)
+		}
+	}
+	return valid, invalid
+}
+
+func (man *MCPManager) resourceToServerResource(newResource mcp.Resource) server.ServerResource {
+	newResource.URI = PrefixURI(newResource.URI, man.mcp.GetPrefix())
+	newResource.Meta = mcp.NewMetaFromMap(map[string]any{
+		gatewayServerID: string(man.mcp.ID()),
+	})
+	return server.ServerResource{
+		Resource: newResource,
+		Handler: func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			return nil, fmt.Errorf("Kagenti MCP Broker doesn't forward resource reads")
+		},
+	}
+}
+
+func (man *MCPManager) diffResources(oldResources, newResources []mcp.Resource) ([]server.ServerResource, []string) {
+	oldResourceMap := make(map[string]mcp.Resource)
+	for _, oldRes := range oldResources {
+		oldResourceMap[oldRes.URI] = oldRes
+	}
+
+	newResourceMap := make(map[string]mcp.Resource)
+	for _, newRes := range newResources {
+		newResourceMap[newRes.URI] = newRes
+	}
+
+	addedResources := make([]server.ServerResource, 0)
+	for _, newRes := range newResourceMap {
+		_, ok := oldResourceMap[newRes.URI]
+		if !ok {
+			addedResources = append(addedResources, man.resourceToServerResource(newRes))
+		}
+	}
+
+	removedResources := make([]string, 0)
+	for _, oldRes := range oldResourceMap {
+		if _, ok := newResourceMap[oldRes.URI]; !ok {
+			removedResources = append(removedResources, PrefixURI(oldRes.URI, man.mcp.GetPrefix()))
+		}
+	}
+
+	return addedResources, removedResources
+}
+
+func (man *MCPManager) getResources(ctx context.Context) ([]mcp.Resource, []mcp.Resource, error) {
+	man.toolsLock.RLock()
+	resources := make([]mcp.Resource, len(man.resources))
+	copy(resources, man.resources)
+	man.toolsLock.RUnlock()
+
+	res, err := man.mcp.ListResources(ctx, mcp.ListResourcesRequest{})
+	if err != nil {
+		return resources, resources, fmt.Errorf("failed to get resources: %w", err)
+	}
+	return resources, res.Resources, nil
+}
+
+func (man *MCPManager) findResourceConflicts(mcpResources []server.ServerResource) error {
+	if man.resourcesServer == nil {
+		return nil
+	}
+	gatewayServerResources := man.resourcesServer.ListResources()
+	var conflictingResourceURIs []string
+	for _, res := range mcpResources {
+		for existingResourceURI, existingResourceInfo := range gatewayServerResources {
+			existingResource := existingResourceInfo.Resource
+			if existingResource.Meta == nil || existingResource.Meta.AdditionalFields == nil {
+				man.logger.Error("unable to check conflict, resource meta is nil", "upstream mcp server", man.mcp.ID(), "resource", existingResourceURI)
+				continue
+			}
+			existingResourceID, ok := existingResource.Meta.AdditionalFields[gatewayServerID]
+			if !ok {
+				man.logger.Error("unable to check conflict, resource id is missing", "upstream mcp server", man.mcp.ID())
+				continue
+			}
+			resourceID, is := existingResourceID.(string)
+			if !is {
+				man.logger.Error("unable to check conflict, resource id is not a string", "upstream mcp server", man.mcp.ID(), "type", reflect.TypeOf(existingResourceID))
+				continue
+			}
+			if existingResourceURI == res.Resource.URI && resourceID != string(man.mcp.ID()) {
+				conflictingResourceURIs = append(conflictingResourceURIs, res.Resource.URI)
+			}
+		}
+	}
+	if len(conflictingResourceURIs) > 0 {
+		return fmt.Errorf("conflicting resources discovered. conflicting resource URIs %v", conflictingResourceURIs)
+	}
+	return nil
+}
+
+// GetManagedResources returns a copy of all resources discovered from the upstream server.
+func (man *MCPManager) GetManagedResources() []mcp.Resource {
+	man.toolsLock.RLock()
+	result := make([]mcp.Resource, len(man.resources))
+	copy(result, man.resources)
+	man.toolsLock.RUnlock()
+	return result
+}
+
+// GetServedManagedResource returns the resource if present that is being served by the gateway.
+func (man *MCPManager) GetServedManagedResource(resourceURI string) *mcp.Resource {
+	man.toolsLock.RLock()
+	defer man.toolsLock.RUnlock()
+	return man.servedResourcesMap[resourceURI]
+}
+
+// SetResourcesForTesting sets resources directly for testing purposes.
+func (man *MCPManager) SetResourcesForTesting(resources []mcp.Resource) {
+	man.toolsLock.Lock()
+	defer man.toolsLock.Unlock()
+	man.resources = resources
+	for i := range resources {
+		man.resourcesMap[resources[i].URI] = &resources[i]
+		man.servedResourcesMap[PrefixURI(resources[i].URI, man.mcp.GetPrefix())] = &resources[i]
+	}
+}
+
+func (man *MCPManager) removeAllResources() {
+	if man.resourcesServer == nil {
+		return
+	}
+	man.toolsLock.Lock()
+	resourcesToRemove := make([]string, 0, len(man.serverResources))
+	for _, res := range man.serverResources {
+		resourcesToRemove = append(resourcesToRemove, res.Resource.URI)
+	}
+	man.serverResources = []server.ServerResource{}
+	man.resources = []mcp.Resource{}
+	man.resourcesMap = map[string]*mcp.Resource{}
+	man.servedResourcesMap = map[string]*mcp.Resource{}
+	man.toolsLock.Unlock()
+	man.resourcesServer.DeleteResources(resourcesToRemove...)
 }

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -31,9 +31,12 @@ type MockMCP struct {
 	listToolsDelay      time.Duration
 	prompts             []mcp.Prompt
 	listPromptsErr      error
+	resources           []mcp.Resource
+	listResourcesErr    error
 	protocolVersion     string
 	hasToolsCap         bool
 	hasPromptsCap       bool
+	hasResourcesCap     bool
 	connected           atomic.Bool
 	notificationHandler func(mcp.JSONRPCNotification)
 }
@@ -101,6 +104,21 @@ func (m *MockMCP) ListPrompts(_ context.Context, _ mcp.ListPromptsRequest) (*mcp
 		return nil, m.listPromptsErr
 	}
 	return &mcp.ListPromptsResult{Prompts: m.prompts}, nil
+}
+
+func (m *MockMCP) SupportsResources() bool {
+	return m.hasResourcesCap
+}
+
+func (m *MockMCP) SupportsResourcesListChanged() bool {
+	return false
+}
+
+func (m *MockMCP) ListResources(_ context.Context, _ mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	if m.listResourcesErr != nil {
+		return nil, m.listResourcesErr
+	}
+	return &mcp.ListResourcesResult{Resources: m.resources}, nil
 }
 
 func (m *MockMCP) OnNotification(handler func(notification mcp.JSONRPCNotification)) {
@@ -204,7 +222,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP(tc.name, "")
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedInterval, manager.tickerInterval)
 		})
@@ -214,7 +232,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 func TestMCPManager_MCPName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("my-test-server", "prefix_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-test-server", manager.MCPName())
@@ -223,7 +241,7 @@ func TestMCPManager_MCPName(t *testing.T) {
 func TestMCPManager_GetStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	expectedStatus := ServerValidationStatus{
@@ -247,7 +265,7 @@ func TestMCPManager_GetManagedTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tools := []mcp.Tool{
@@ -267,7 +285,7 @@ func TestMCPManager_GetManagedTools_ReturnsCopy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tools := []mcp.Tool{validTool("tool1")}
@@ -322,7 +340,7 @@ func TestMCPManager_GetServedManagedTool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tc.prefix)
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 			manager.SetToolsForTesting(tc.tools)
 
@@ -369,11 +387,11 @@ func TestMCPManager_setStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
-			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 			manager.serverTools = make([]server.ServerTool, tc.numServerTools)
 
-			manager.setStatus(tc.err, tc.totalTools, 0, nil, nil)
+			manager.setStatus(tc.err, tc.totalTools, 0, 0, nil, nil, nil)
 
 			assert.Equal(t, string(mock.id), manager.status.ID)
 			assert.Equal(t, "test-server", manager.status.Name)
@@ -424,7 +442,7 @@ func TestPrefixedName(t *testing.T) {
 func TestMCPManager_toolToServerTool(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tool := mcp.Tool{
@@ -453,7 +471,7 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	active := manager.Start(context.Background())
@@ -472,7 +490,7 @@ func TestMCPManager_manage_ConnectError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.connectErr = fmt.Errorf("connection refused")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -487,7 +505,7 @@ func TestMCPManager_manage_PingError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.pingErr = fmt.Errorf("ping timeout")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -503,7 +521,7 @@ func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	mock.listToolsErr = fmt.Errorf("list tools failed")
 	mock.hasToolsCap = false // ensure we try to list tools
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -519,7 +537,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false // ensure we list tools every time
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -537,7 +555,7 @@ func TestMCPManager_manage_Success(t *testing.T) {
 func TestDiffTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -719,7 +737,7 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = tt.supportsToolsListChange
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			if tt.hasExistingTools {
@@ -739,7 +757,7 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true // supports tools list change notifications
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	// First call with notification - should fetch and add tools
@@ -821,7 +839,7 @@ func TestMCPManager_manage_OnlyCallsAddDeleteWhenNeeded(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = false // ensure we fetch tools on every manage call
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			// first manage call - establish initial tools
@@ -915,7 +933,7 @@ func TestServerToolsManagement(t *testing.T) {
 			mockMCP := newMockMCP("test-server", tt.prefix)
 			mockMCP.hasToolsCap = false // ensure we fetch tools on every manage call
 			mockGateway := NewMockGatewayServer()
-			manager, err := NewUpstreamMCPManager(mockMCP, mockGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mockMCP, mockGateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			// First manage call - establish initial tools
@@ -966,7 +984,7 @@ func TestMCPManager_manage_FilterOutPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -990,7 +1008,7 @@ func TestMCPManager_manage_FilterOutPolicy_AllInvalid(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -1011,7 +1029,7 @@ func TestMCPManager_manage_RejectServerPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -1029,7 +1047,7 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -1045,7 +1063,7 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 func TestMCPManager_NewUpstreamMCPManager_nilGateway(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	_, err := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	_, err := NewUpstreamMCPManager(mock, nil, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gateway server is required")
 }
@@ -1056,7 +1074,7 @@ func TestMCPManager_EventChannel_NotificationRoutesThrough(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true
 	gateway := NewMockGatewayServer()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1090,7 +1108,7 @@ func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -1136,7 +1154,7 @@ func TestMCPManager_StopDuringManage(t *testing.T) {
 	// slow down ListTools so manage() is mid-flight when Stop() fires
 	mock.listToolsDelay = 100 * time.Millisecond
 	gateway := NewMockGatewayServer()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	active := manager.Start(context.Background())
@@ -1198,6 +1216,48 @@ func (m *MockPromptsAdderDeleter) ListPrompts() map[string]*server.ServerPrompt 
 	return result
 }
 
+// MockResourcesAdderDeleter implements ResourcesAdderDeleter for testing
+type MockResourcesAdderDeleter struct {
+	resources map[string]*server.ServerResource
+	addCalls  int
+	delCalls  int
+	mu        sync.Mutex
+}
+
+func newMockResourcesAdderDeleter() *MockResourcesAdderDeleter {
+	return &MockResourcesAdderDeleter{
+		resources: make(map[string]*server.ServerResource),
+	}
+}
+
+func (m *MockResourcesAdderDeleter) AddResources(resources ...server.ServerResource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.addCalls++
+	for i := range resources {
+		m.resources[resources[i].Resource.URI] = &resources[i]
+	}
+}
+
+func (m *MockResourcesAdderDeleter) DeleteResources(names ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.delCalls++
+	for _, name := range names {
+		delete(m.resources, name)
+	}
+}
+
+func (m *MockResourcesAdderDeleter) ListResources() map[string]*server.ServerResource {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]*server.ServerResource, len(m.resources))
+	for k, v := range m.resources {
+		result[k] = v
+	}
+	return result
+}
+
 func TestMCPManager_promptToServerPrompt(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
@@ -1215,7 +1275,7 @@ func TestMCPManager_promptToServerPrompt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tt.prefix)
-			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			serverPrompt := manager.promptToServerPrompt(mcp.Prompt{Name: tt.promptName, Description: tt.promptDesc})
@@ -1238,7 +1298,7 @@ func TestMCPManager_promptToServerPrompt(t *testing.T) {
 func TestMCPManager_diffPrompts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1290,7 +1350,7 @@ func TestMCPManager_diffPrompts(t *testing.T) {
 func TestMCPManager_GetManagedPrompts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	prompts := []mcp.Prompt{
@@ -1308,7 +1368,7 @@ func TestMCPManager_GetManagedPrompts(t *testing.T) {
 func TestMCPManager_GetServedManagedPrompt(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetPromptsForTesting([]mcp.Prompt{{Name: "myprompt", Description: "My Prompt"}})
 
@@ -1329,7 +1389,7 @@ func TestMCPManager_manage_PromptsSuccess(t *testing.T) {
 	mock.hasPromptsCap = true
 	gateway := newMockToolsAdderDeleter()
 	promptsGateway := newMockPromptsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, promptsGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, promptsGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -1352,7 +1412,7 @@ func TestMCPManager_manage_PromptsNilServer(t *testing.T) {
 	mock.prompts = []mcp.Prompt{{Name: "prompt1"}}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	manager.manage(context.Background(), eventTypeTimer)
@@ -1371,7 +1431,7 @@ func TestMCPManager_Backoff(t *testing.T) {
 
 	// Set a long ticker interval
 	tickerInterval := time.Minute
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, slog.Default(), tickerInterval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, slog.Default(), tickerInterval, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	// 1. Simulate failure (Connect)

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -225,3 +225,33 @@ func (up *MCPServer) ListTools(ctx context.Context, req mcp.ListToolsRequest) (*
 	}
 	return up.client.ListTools(ctx, req)
 }
+
+// SupportsResources checks if the upstream server declared resource capabilities
+func (up *MCPServer) SupportsResources() bool {
+	if up.init == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources != nil
+}
+
+// SupportsResourcesListChanged validates the mcp server supports resources/list_changed notifications
+func (up *MCPServer) SupportsResourcesListChanged() bool {
+	if up.init == nil {
+		return false
+	}
+	if up.init.Capabilities.Resources == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources.ListChanged
+}
+
+// ListResources retrieves the list of available resources from the upstream MCP server
+func (up *MCPServer) ListResources(ctx context.Context, req mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+
+	if up.client == nil {
+		return nil, fmt.Errorf("client not connected")
+	}
+	return up.client.ListResources(ctx, req)
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -138,9 +138,10 @@ func (mcpServer *MCPServer) Path() (string, error) {
 
 // VirtualServer represents a virtual server configuration
 type VirtualServer struct {
-	Name    string
-	Tools   []string
-	Prompts []string
+	Name      string
+	Tools     []string
+	Prompts   []string
+	Resources []string
 }
 
 // Observer provides an interface to implement in order to register as an Observer of config changes
@@ -164,7 +165,8 @@ type AuthConfig struct {
 
 // VirtualServerConfig represents virtual server config
 type VirtualServerConfig struct {
-	Name    string   `json:"name"    yaml:"name"`
-	Tools   []string `json:"tools"   yaml:"tools"`
-	Prompts []string `json:"prompts,omitempty" yaml:"prompts,omitempty"`
+	Name      string   `json:"name"    yaml:"name"`
+	Tools     []string `json:"tools"   yaml:"tools"`
+	Prompts   []string `json:"prompts,omitempty" yaml:"prompts,omitempty"`
+	Resources []string `json:"resources,omitempty" yaml:"resources,omitempty"`
 }

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -11,6 +11,7 @@ const (
 	toolAnnotationsHeader = "x-mcp-annotation-hints"
 	toolHeader            = "x-mcp-toolname"
 	promptHeader          = "x-mcp-promptname"
+	resourceHeader        = "x-mcp-resourceuri"
 	methodHeader          = "x-mcp-method"
 	sessionHeader         = "mcp-session-id"
 	authorityHeader       = ":authority"
@@ -143,6 +144,17 @@ func (hb *HeadersBuilder) WithMCPPromptName(promptName string) *HeadersBuilder {
 		Header: &basepb.HeaderValue{
 			Key:      promptHeader,
 			RawValue: []byte(promptName),
+		},
+	})
+	return hb
+}
+
+// WithMCPResourceURI will set the x-mcp-resourceuri header
+func (hb *HeadersBuilder) WithMCPResourceURI(resourceURI string) *HeadersBuilder {
+	hb.headers = append(hb.headers, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{
+			Key:      resourceHeader,
+			RawValue: []byte(resourceURI),
 		},
 	})
 	return hb

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
@@ -63,10 +64,11 @@ func NewRouterErrorf(code int32, format string, args ...any) *RouterError {
 }
 
 const (
-	methodToolCall    = "tools/call"
-	methodPromptGet   = "prompts/get"
-	methodInitialize  = "initialize"
-	methodInitialized = "notification/initialized"
+	methodToolCall     = "tools/call"
+	methodPromptGet    = "prompts/get"
+	methodResourceRead = "resources/read"
+	methodInitialize   = "initialize"
+	methodInitialized  = "notification/initialized"
 
 	elicitationResultAction  = "action"
 	elicitationActionAccept  = "accept"
@@ -219,6 +221,32 @@ func (mr *MCPRequest) ReWritePromptName(actualPrompt string) {
 	mr.Params["name"] = actualPrompt
 }
 
+// isResourceRead will check if the request is a resources/read request
+func (mr *MCPRequest) isResourceRead() bool {
+	return mr.Method == methodResourceRead
+}
+
+// ResourceURI returns the resource URI in a resources/read request
+func (mr *MCPRequest) ResourceURI() string {
+	if !mr.isResourceRead() {
+		return ""
+	}
+	uriVal, ok := mr.Params["uri"]
+	if !ok {
+		return ""
+	}
+	u, ok := uriVal.(string)
+	if !ok {
+		return ""
+	}
+	return u
+}
+
+// ReWriteResourceURI will allow re-setting the resource URI to remove prefix
+func (mr *MCPRequest) ReWriteResourceURI(actualURI string) {
+	mr.Params["uri"] = actualURI
+}
+
 // ToBytes marshals the data ready to send on
 func (mr *MCPRequest) ToBytes() ([]byte, error) {
 	return json.Marshal(mr)
@@ -253,6 +281,9 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	case mcpReq.Method == methodPromptGet:
 		span.SetAttributes(attribute.String("mcp.route", "prompt-get"))
 		return s.HandlePromptGet(ctx, mcpReq)
+	case mcpReq.Method == methodResourceRead:
+		span.SetAttributes(attribute.String("mcp.route", "resource-read"))
+		return s.HandleResourceRead(ctx, mcpReq)
 	default:
 		span.SetAttributes(attribute.String("mcp.route", "broker"))
 		return s.HandleNoneToolCall(ctx, mcpReq)
@@ -488,6 +519,88 @@ data: {"error":{"code":-32602,"message":"Prompt not found"},"jsonrpc":"2.0"}`)
 	upstreamPromptName, _ := strings.CutPrefix(promptName, serverInfo.Prefix)
 	headers.WithMCPPromptName(upstreamPromptName)
 	mcpReq.ReWritePromptName(upstreamPromptName)
+	headers.WithMCPServerName(serverInfo.Name)
+
+	return s.routeToUpstream(ctx, span, mcpReq, serverInfo, headers, calculatedResponse)
+}
+
+// HandleResourceRead handles an MCP resources/read request by routing to the correct upstream server
+func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
+	resourceURI := mcpReq.ResourceURI()
+
+	ctx, span := tracer().Start(ctx, "mcp-router.resource-read",
+		trace.WithAttributes(
+			attribute.String("mcp.resource.uri", resourceURI),
+			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+		),
+	)
+	defer span.End()
+
+	calculatedResponse := NewResponse()
+	if resourceURI == "" {
+		s.Logger.ErrorContext(ctx, "[EXT-PROC] HandleResourceRead no resource URI set in resources/read")
+		span.SetStatus(codes.Error, "no resource URI set")
+		span.SetAttributes(attribute.String("error.type", "missing_resource_uri"))
+		calculatedResponse.WithImmediateResponse(400, "no resource URI set")
+		return calculatedResponse.Build()
+	}
+	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
+		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
+		span.RecordError(sessionErr)
+		span.SetStatus(codes.Error, sessionErr.Error())
+		span.SetAttributes(attribute.String("error.type", "invalid_session"))
+		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
+		return calculatedResponse.Build()
+	}
+
+	headers := NewHeaders()
+	var serverInfo *config.MCPServer
+	var err error
+	{
+		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info-by-resource",
+			trace.WithAttributes(
+				attribute.String("mcp.resource.uri", resourceURI),
+			),
+		)
+		var infoErr error
+		serverInfo, infoErr = s.Broker.GetServerInfoByResource(resourceURI)
+		if infoErr != nil {
+			infoSpan.RecordError(infoErr)
+			infoSpan.SetStatus(codes.Error, "resource not found")
+		}
+		infoSpan.End()
+		err = infoErr
+	}
+	if err != nil {
+		s.Logger.DebugContext(ctx, "no server for resource", "resourceURI", resourceURI)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "resource not found")
+		span.SetAttributes(attribute.String("error.type", "resource_not_found"))
+		calculatedResponse.WithImmediateJSONRPCResponse(200,
+			[]*corev3.HeaderValueOption{
+				{
+					Header: &corev3.HeaderValue{
+						Key:   "mcp-session-id",
+						Value: mcpReq.GetSessionID(),
+					},
+				},
+			},
+			`
+event: message
+data: {"error":{"code":-32602,"message":"Resource not found"},"jsonrpc":"2.0"}`)
+		return calculatedResponse.Build()
+	}
+
+	span.SetAttributes(
+		attribute.String("mcp.server", serverInfo.Name),
+		attribute.String("mcp.server.hostname", serverInfo.Hostname),
+	)
+
+	headers.WithMCPMethod(mcpReq.Method)
+	mcpReq.serverName = serverInfo.Name
+	upstreamResourceURI := upstream.StripURIPrefix(resourceURI, serverInfo.Prefix)
+	headers.WithMCPResourceURI(upstreamResourceURI)
+	mcpReq.ReWriteResourceURI(upstreamResourceURI)
 	headers.WithMCPServerName(serverInfo.Name)
 
 	return s.routeToUpstream(ctx, span, mcpReq, serverInfo, headers, calculatedResponse)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1495,6 +1495,87 @@ func TestHandlePromptGet(t *testing.T) {
 	require.NotContains(t, string(body), `"name":"s_myprompt"`)
 }
 
+func TestHandleResourceRead(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	require.NoError(t, err)
+
+	validToken := jwtManager.Generate()
+
+	sessionAdded, err := cache.AddSession(context.Background(), validToken, "dummy", "mock-upstream-session-id")
+	require.NoError(t, err)
+	require.True(t, sessionAdded)
+
+	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+		return nil, fmt.Errorf("InitForClient should not be called when session exists")
+	}
+
+	serverConfigs := []*config.MCPServer{
+		{
+			Name:     "dummy",
+			URL:      "http://localhost:8080/mcp",
+			Prefix:   "s_",
+			Enabled:  true,
+			Hostname: "localhost",
+		},
+	}
+
+	testBroker := newMockBroker(serverConfigs, map[string]string{})
+	testBroker.(*mockBrokerImpl).resource2svr = map[string]string{
+		"s_myresource": "dummy",
+	}
+
+	srv := &ExtProcServer{
+		RoutingConfig: &config.MCPServersConfig{
+			Servers: serverConfigs,
+		},
+		JWTManager:    jwtManager,
+		Logger:        logger,
+		SessionCache:  cache,
+		InitForClient: mockInitForClient,
+		Broker:        testBroker,
+	}
+
+	data := &MCPRequest{
+		ID:      ptr.To(0),
+		JSONRPC: "2.0",
+		Method:  "resources/read",
+		Params: map[string]any{
+			"uri": "s_myresource",
+		},
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{
+					Key:      "mcp-session-id",
+					RawValue: []byte(validToken),
+				},
+			},
+		},
+	}
+
+	resp := srv.RouteMCPRequest(context.Background(), data)
+	require.Len(t, resp, 1)
+	require.IsType(t, &eppb.ProcessingResponse_RequestBody{}, resp[0].Response)
+	rb := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+	require.NotNil(t, rb.RequestBody.Response)
+
+	headers := rb.RequestBody.Response.HeaderMutation.SetHeaders
+	require.Equal(t, "x-mcp-method", headers[0].Header.Key)
+	require.Equal(t, []uint8("resources/read"), headers[0].Header.RawValue)
+	require.Equal(t, "x-mcp-resourceuri", headers[1].Header.Key)
+	require.Equal(t, []uint8("myresource"), headers[1].Header.RawValue)
+	require.Equal(t, "x-mcp-servername", headers[2].Header.Key)
+	require.Equal(t, []uint8("dummy"), headers[2].Header.RawValue)
+
+	body := rb.RequestBody.Response.BodyMutation.GetBody()
+	require.Contains(t, string(body), `"uri":"myresource"`)
+	require.NotContains(t, string(body), `"uri":"s_myresource"`)
+}
+
 func testBearerJWT(sub string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":"%s"}`, sub)))

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -20,9 +20,10 @@ import (
 )
 
 type mockBrokerImpl struct {
-	svrConfigs []*config.MCPServer
-	tool2svr   map[string]string
-	prompt2svr map[string]string
+	svrConfigs   []*config.MCPServer
+	tool2svr     map[string]string
+	prompt2svr   map[string]string
+	resource2svr map[string]string
 }
 
 func TestHandleResponseHeaders_ReturnsGatewaySessionID(t *testing.T) {
@@ -470,10 +471,24 @@ func TestHandleResponseHeaders_SkipsElicitationForHairpinInit(t *testing.T) {
 
 func newMockBroker(svrConfigs []*config.MCPServer, tool2svr map[string]string) broker.MCPBroker {
 	return &mockBrokerImpl{
-		svrConfigs: svrConfigs,
-		tool2svr:   tool2svr,
-		prompt2svr: map[string]string{},
+		svrConfigs:   svrConfigs,
+		tool2svr:     tool2svr,
+		prompt2svr:   map[string]string{},
+		resource2svr: map[string]string{},
 	}
+}
+
+func (m *mockBrokerImpl) GetServerInfoByResource(resourceURI string) (*config.MCPServer, error) {
+	svrName, ok := m.resource2svr[resourceURI]
+	if !ok {
+		return nil, fmt.Errorf("No server for resource %q", resourceURI)
+	}
+	for _, svrInfo := range m.svrConfigs {
+		if svrName == svrInfo.Name {
+			return svrInfo, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to get server %q for resource %q", svrName, resourceURI)
 }
 
 func (m *mockBrokerImpl) GetServerInfoByPrompt(prompt string) (*config.MCPServer, error) {


### PR DESCRIPTION
Summary

This PR adds support for federating MCP resources through the gateway.

Resources exposed by upstream MCP servers are now discovered by the broker, namespaced using the existing prefixing approach, and exposed through the gateway for clients using:

1. resources/list
2. resources/read

The router has also been updated to correctly route resource read requests to the owning upstream server.

What changed

Broker / Upstream

1. Added upstream resource discovery and federation
2. Added resource URI prefixing to avoid collisions across servers
3. Added resource capability filtering support
4. Added resource-to-server lookup support for routing

Router

Added handling for :-

1. resources/list
2. resources/read
3. Added prefix stripping before proxying requests upstream
4. Added routing/header handling for resource requests

Tests

Added unit tests covering :-

1.  resource routing
2.  prefix stripping
3.  multi-server resource collisions
4.  capability filtering

Notes
Resource subscription support (resources/subscribe, resources/unsubscribe, and update notifications) is intentionally out of scope for this PR and is tracked separately in #597.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource lookup API enabling the broker to resolve which server serves a given resource URI.
  * Enabled resource filtering based on authorization headers and virtual server configuration.
  * Resources can now be managed and configured similarly to tools and prompts.

* **Tests**
  * Added comprehensive test coverage for new resource lookup and filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->