### PR TITLE
design: add initial multi-protocol config support for A2A upstreams

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -422,6 +422,15 @@ func LoadConfig(path string) {
 	if err != nil {
 		log.Fatalf("Unable to decode server config into struct: %s", err)
 	}
+
+	var newA2AServers []*config.A2AServer
+	if viper.IsSet("a2aServers") {
+		err = viper.UnmarshalKey("a2aServers", &newA2AServers)
+		if err != nil {
+			log.Fatal("Failed to parse a2aServers configuration", "error", err)
+		}
+	}
+
 	var newVirtualServers []*config.VirtualServer
 	// Load virtualServers if present - this is optional
 	if viper.IsSet("virtualServers") {
@@ -432,7 +441,7 @@ func LoadConfig(path string) {
 	} else {
 		logger.Debug("No virtualServers section found in configuration")
 	}
-	mcpConfig.SetServers(newServers, newVirtualServers)
+	mcpConfig.SetServers(newServers, newA2AServers, newVirtualServers)
 
 	logger.Debug("config successfully loaded", "# servers", len(newServers))
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -8,6 +8,32 @@ import (
 	"sync"
 )
 
+// UpstreamServer defines common properties for any upstream provider.
+type UpstreamServer interface {
+	ServerName() string
+	ServerURL() string
+	Protocol() string
+}
+
+// A2AServer represents a future Agent-to-Agent upstream configuration
+type A2AServer struct {
+	Name            string            `json:"name" yaml:"name"`
+	URL             string            `json:"url" yaml:"url"`
+	AgentCardURL    string            `json:"agentCardUrl,omitempty" yaml:"agentCardUrl,omitempty"`
+	TaskEndpoint    string            `json:"taskEndpoint,omitempty" yaml:"taskEndpoint,omitempty"`
+	ProtocolBinding string            `json:"protocolBinding,omitempty" yaml:"protocolBinding,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+func (a2aServer *A2AServer) ServerName() string { return a2aServer.Name }
+func (a2aServer *A2AServer) ServerURL() string  { return a2aServer.URL }
+func (a2aServer *A2AServer) Protocol() string {
+	if a2aServer.ProtocolBinding != "" {
+		return a2aServer.ProtocolBinding
+	}
+	return "a2a"
+}
+
 // UpstreamMCPID is used as type for identifying individual upstreams
 type UpstreamMCPID string
 
@@ -16,6 +42,7 @@ type MCPServersConfig struct {
 	lock sync.RWMutex
 
 	Servers        []*MCPServer
+	A2AServers     []*A2AServer
 	VirtualServers []*VirtualServer
 	observers      []Observer
 	//MCPGatewayExternalHostname is the accessible host of the gateway listener
@@ -32,10 +59,11 @@ func (config *MCPServersConfig) RegisterObserver(obs Observer) {
 }
 
 // SetServers atomically replaces the server and virtual-server lists.
-func (config *MCPServersConfig) SetServers(servers []*MCPServer, virtualServers []*VirtualServer) {
+func (config *MCPServersConfig) SetServers(servers []*MCPServer, a2aServers []*A2AServer, virtualServers []*VirtualServer) {
 	config.lock.Lock()
 	defer config.lock.Unlock()
 	config.Servers = servers
+	config.A2AServers = a2aServers
 	config.VirtualServers = virtualServers
 }
 
@@ -45,6 +73,15 @@ func (config *MCPServersConfig) ListServers() []*MCPServer {
 	defer config.lock.RUnlock()
 	out := make([]*MCPServer, len(config.Servers))
 	copy(out, config.Servers)
+	return out
+}
+
+// ListA2AServers returns a consistent snapshot of the current A2A server list.
+func (config *MCPServersConfig) ListA2AServers() []*A2AServer {
+	config.lock.RLock()
+	defer config.lock.RUnlock()
+	out := make([]*A2AServer, len(config.A2AServers))
+	copy(out, config.A2AServers)
 	return out
 }
 
@@ -96,6 +133,10 @@ type MCPServer struct {
 	Enabled             bool                       `json:"enabled"                           yaml:"enabled"`
 	TokenURLElicitation *TokenURLElicitationConfig `json:"tokenURLElicitation,omitempty" yaml:"tokenURLElicitation,omitempty"`
 }
+
+func (mcpServer *MCPServer) ServerName() string { return mcpServer.Name }
+func (mcpServer *MCPServer) ServerURL() string  { return mcpServer.URL }
+func (mcpServer *MCPServer) Protocol() string   { return "mcp" }
 
 // TokenURLElicitationConfig configures per-user token collection via URL elicitation.
 type TokenURLElicitationConfig struct {
@@ -151,6 +192,7 @@ type Observer interface {
 // BrokerConfig holds broker configuration
 type BrokerConfig struct {
 	Servers        []MCPServer           `json:"servers" yaml:"servers"`
+	A2AServers     []A2AServer           `json:"a2aServers,omitempty" yaml:"a2aServers,omitempty"`
 	VirtualServers []VirtualServerConfig `json:"virtualServers,omitempty" yaml:"virtualServers,omitempty"`
 }
 


### PR DESCRIPTION
Resolves #847

This PR adds the initial configuration groundwork needed for future A2A upstream support while keeping the current MCP flow unchanged.

The changes are intentionally small and additive so we can start introducing protocol-aware upstream configuration without forcing a larger refactor too early.

Changes included

1. added a lightweight UpstreamServer interface for shared upstream access patterns
2. introduced a minimal A2AServer config model
3. updated broker config loading to recognize a2aServers
4. extended config mapping without changing the existing MCP server flow
5. added coverage to ensure current config loading behavior still works as expected

Notes
The existing MCPServersConfig structure and Servers field were intentionally kept as-is to avoid unnecessary churn and preserve backward compatibility while the broader A2A work is still evolving.

The new A2A-related types are also intentionally minimal for now so the config model can evolve naturally alongside the routing and broker implementation work.

Validation

1. ran go fmt ./...
2. ran go test ./...
3. verified existing MCP configs continue to load without changes