### PR TITLE
invalidate cached user token on 401 from upstream

### DIFF
--- a/docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md
+++ b/docs/design/gateway-url-token-elicitation/gateway-url-token-elicitation-design.md
@@ -119,7 +119,6 @@ sequenceDiagram
     participant Client as MCP Client
     participant Gateway as Envoy
     participant Router as MCP Router (ext_proc)
-    participant Broker as MCP Broker
     participant Cache as Session Cache
     participant Upstream as Upstream MCP Server
 
@@ -133,18 +132,22 @@ sequenceDiagram
     Upstream-->>Gateway: 401 Unauthorized
     Gateway->>Router: ext_proc response (401)
     Router->>Cache: DeleteUserToken(sessionID, "github")
-    Router->>Router: Route to broker /mcp/elicitation endpoint
-    Router-->>Gateway: Set path=/mcp/elicitation, add elicitation headers
-    Gateway->>Broker: POST /mcp/elicitation
-    Broker-->>Client: URLElicitationRequiredError (-32042) via SSE
-    Note over Client,Broker: Client prompts user to re-enter token
+    Router-->>Gateway: Pass 401 through to client
+    Gateway-->>Client: 401 Unauthorized
+
+    Note over Client: Client retries tool call
+    Client->>Gateway: POST /mcp tools/call (retry)
+    Gateway->>Router: ext_proc request
+    Router->>Cache: GetUserToken → empty (deleted)
+    Router->>Router: Cache miss → trigger elicitation
+    Note over Router,Client: Existing cache-miss flow returns -32042
 ```
 
 ### Component Responsibilities
 
 | Component | Role |
 |-----------|------|
-| **Router** | (1) If `Authorization` header present, use as-is for upstream routing. (2) If absent, check cache — inject cached token on hit. (3) On cache miss, route the request to the broker's `/mcp/elicitation` endpoint (setting `x-mcp-elicitation-id` and `x-mcp-request-id` headers) if client declares `elicitation.url` capability, otherwise return standard error. (4) On upstream 401, invalidate cached token and re-elicit or error per client capability. |
+| **Router** | (1) If `Authorization` header present, use as-is for upstream routing. (2) If absent, check cache — inject cached token on hit. (3) On cache miss, route the request to the broker's `/mcp/elicitation` endpoint (setting `x-mcp-elicitation-id` and `x-mcp-request-id` headers) if client declares `elicitation.url` capability, otherwise return standard error. (4) On upstream 401, invalidate cached token and pass 401 through — the client's next retry hits the cache-miss path (3) which triggers re-elicitation. |
 | **Broker** | (1) Hosts `/mcp/elicitation` endpoint — looks up the elicitation entry, resolves the server config, builds the token page URL, and returns the `-32042` SSE response. (2) Hosts `/tokens` page for token collection, writes token to cache. |
 | **Cache** | Shared storage for per-user, per-server tokens |
 | **Controller** | Propagates `tokenURLElicitation` from CRD to config. Includes `/tokens` path rule in the generated HTTPRoute alongside `/mcp`. |

--- a/docs/design/gateway-url-token-elicitation/tasks/e2e_test_cases.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/e2e_test_cases.md
@@ -32,7 +32,7 @@ tags: Happy,URLElicitation,Security
 
 ### [Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation
 
-- When the upstream MCP server returns a 401 Unauthorized response (e.g. because the cached token has expired or been revoked), the gateway should delete the cached token for that server and session, and return a -32042 URLElicitationRequiredError to the client. The client should be able to provide a new token via the broker page and retry successfully.
+- When the upstream MCP server returns a 401 Unauthorized response (e.g. because the cached token has expired or been revoked), the gateway should delete the cached token for that server and session and pass the 401 through to the client. On the client's next tool call retry, the cache miss triggers a -32042 URLElicitationRequiredError. The client should be able to provide a new token via the broker page and retry successfully.
 
 
 ### [URLElicitation] Non-elicitation-capable client gets standard error on missing token

--- a/docs/design/gateway-url-token-elicitation/tasks/tasks.md
+++ b/docs/design/gateway-url-token-elicitation/tasks/tasks.md
@@ -180,24 +180,23 @@ Depends on: Task 3. Independent of Task 4 — touches broker, not router.
 
 ---
 
-### Task 6: Router 401 invalidation + re-elicitation (CONNLINK-999)
+### Task 6: Router 401 invalidation (CONNLINK-999)
 
-Depends on: Task 4 (reuses the -32042 helper).
+Depends on: Task 4.
 
 **Files:**
 - `internal/mcp-router/response_handlers.go` — modify `HandleResponseHeaders` to handle 401:
   1. If status is 401 and server has `TokenURLElicitation` config and `--enable-url-elicitation`:
-     - Delete cached token via `UserTokenCache.DeleteUserToken`
-     - Check client capability via `SessionCache.GetClientElicitation(ctx, gatewaySessionID)` (same flow as Task 4)
-     - If client supports elicitation → return `-32042` immediate response (reuse helper from Task 4)
-     - If not → pass 401 through as-is
+     - Delete cached token via `SessionCache.DeleteUserToken`
+     - Pass the 401 through to the client as-is
+  2. On the client's next retry, the existing cache-miss path in `HandleToolCall` triggers `-32042` re-elicitation
 - `internal/mcp-router/response_handlers_test.go` — unit tests
 
 **Acceptance criteria:**
-- [ ] 401 from upstream with elicitation-configured server → token deleted + -32042 returned
-- [ ] 401 without elicitation capability → standard 401 pass-through
-- [ ] 401 from non-elicitation server → no change (existing behavior)
-- [ ] Feature flag disabled → 401 passed through as-is
+- [x] 401 from upstream with elicitation-configured server → token deleted, 401 passed through
+- [x] Next retry after 401 → cache miss triggers -32042 re-elicitation
+- [x] 401 from non-elicitation server → no change (existing behavior)
+- [x] Feature flag disabled → 401 passed through as-is, no token deletion
 
 **E2E test cases (from `e2e_test_cases.md`):**
 - `[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation`

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -5,6 +5,8 @@ import (
 
 	extprochttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // HandleResponseHeaders handles response headers for session ID reverse mapping
@@ -50,9 +52,19 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 	if status == "401" && req != nil && s.ElicitationEnabled {
 		serverInfo, cfgErr := s.RoutingConfig.GetServerConfigByName(req.serverName)
 		if cfgErr == nil && serverInfo.TokenURLElicitation != nil {
-			s.Logger.InfoContext(ctx, "received 401 from upstream, invalidating cached user token", "server", req.serverName)
+			span := trace.SpanFromContext(ctx)
+			span.SetAttributes(
+				attribute.String("http.upstream_status", "401"),
+				attribute.String("upstream.server", req.serverName),
+				attribute.Bool("token_elicitation.enabled", true),
+				attribute.Bool("token_invalidation.attempted", true),
+			)
+			s.Logger.DebugContext(ctx, "received 401 from upstream, invalidating cached user token", "server", req.serverName)
 			if err := s.SessionCache.DeleteUserToken(ctx, req.GetSessionID(), req.serverName); err != nil {
+				span.SetAttributes(attribute.String("token_invalidation.error", err.Error()))
 				s.Logger.ErrorContext(ctx, "failed to delete user token", "server", req.serverName, "session", req.GetSessionID(), "error", err)
+			} else {
+				span.SetAttributes(attribute.Bool("token_invalidation.succeeded", true))
 			}
 		}
 	}

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -45,6 +45,18 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 		}
 	}
 
+	// intercept 401 from backend: if the server uses URL token elicitation,
+	// delete the cached user token so the next tool call triggers re-elicitation
+	if status == "401" && req != nil && s.ElicitationEnabled {
+		serverInfo, cfgErr := s.RoutingConfig.GetServerConfigByName(req.serverName)
+		if cfgErr == nil && serverInfo.TokenURLElicitation != nil {
+			s.Logger.InfoContext(ctx, "received 401 from upstream, invalidating cached user token", "server", req.serverName)
+			if err := s.SessionCache.DeleteUserToken(ctx, req.GetSessionID(), req.serverName); err != nil {
+				s.Logger.ErrorContext(ctx, "failed to delete user token", "server", req.serverName, "session", req.GetSessionID(), "error", err)
+			}
+		}
+	}
+
 	responses := response.WithResponseHeaderResponse(responseHeaderBuilder.Build()).Build()
 
 	// for tool calls where the client supports elicitation, switch response body

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -62,7 +62,7 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 	// for tool calls where the client supports elicitation, switch response body
 	// mode to STREAMED so the ext_proc receives each SSE chunk and can rewrite
 	// elicitation request IDs.
-	if req != nil && req.isToolCall() && req.clientElicitation && len(responses) > 0 {
+	if req != nil && req.isToolCall() && req.clientElicitation && status == "200" && len(responses) > 0 {
 		responses[0].ModeOverride = &extprochttp.ProcessingMode{
 			RequestHeaderMode:   extprochttp.ProcessingMode_SEND,
 			ResponseHeaderMode:  extprochttp.ProcessingMode_SEND,

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -468,6 +468,230 @@ func TestHandleResponseHeaders_SkipsElicitationForHairpinInit(t *testing.T) {
 	require.False(t, val)
 }
 
+func TestHandleResponseHeaders_401DeletesUserToken(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	serverName := "elicit-server"
+	gatewaySessionID := "gateway-session-123"
+
+	routingConfig := &config.MCPServersConfig{
+		Servers: []*config.MCPServer{
+			{
+				Name:                serverName,
+				TokenURLElicitation: &config.TokenURLElicitationConfig{},
+			},
+		},
+	}
+
+	srv := &ExtProcServer{
+		Logger:             logger,
+		SessionCache:       cache,
+		Broker:             newMockBroker(nil, map[string]string{}),
+		RoutingConfig:      routingConfig,
+		ElicitationEnabled: true,
+	}
+
+	// store a user token in the cache
+	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "expired-token"))
+	tok, ok, err := cache.GetUserToken(context.Background(), gatewaySessionID, serverName)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "expired-token", tok)
+
+	requestHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "mcp-session-id", RawValue: []byte(gatewaySessionID)},
+			},
+		},
+	}
+	responseHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("401")},
+			},
+		},
+	}
+	mcpReq := &MCPRequest{
+		sessionID:  gatewaySessionID,
+		serverName: serverName,
+		Method:     "tools/call",
+	}
+
+	responses, err := srv.HandleResponseHeaders(context.Background(), responseHeaders, requestHeaders, mcpReq)
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+
+	// token should be deleted
+	_, ok, err = cache.GetUserToken(context.Background(), gatewaySessionID, serverName)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestHandleResponseHeaders_401SkipsTokenDeleteWhenNotApplicable(t *testing.T) {
+	tests := []struct {
+		name               string
+		serverName         string
+		elicitationConfig  *config.TokenURLElicitationConfig
+		elicitationEnabled bool
+	}{
+		{
+			name:               "no elicitation config on server",
+			serverName:         "plain-server",
+			elicitationConfig:  nil,
+			elicitationEnabled: true,
+		},
+		{
+			name:               "elicitation feature disabled",
+			serverName:         "elicit-server",
+			elicitationConfig:  &config.TokenURLElicitationConfig{},
+			elicitationEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+			cache, err := session.NewCache()
+			require.NoError(t, err)
+
+			gatewaySessionID := "gateway-session-123"
+			routingConfig := &config.MCPServersConfig{
+				Servers: []*config.MCPServer{
+					{Name: tt.serverName, TokenURLElicitation: tt.elicitationConfig},
+				},
+			}
+
+			srv := &ExtProcServer{
+				Logger:             logger,
+				SessionCache:       cache,
+				Broker:             newMockBroker(nil, map[string]string{}),
+				RoutingConfig:      routingConfig,
+				ElicitationEnabled: tt.elicitationEnabled,
+			}
+
+			require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, tt.serverName, "my-token"))
+
+			requestHeaders := &eppb.HttpHeaders{
+				Headers: &corev3.HeaderMap{
+					Headers: []*corev3.HeaderValue{
+						{Key: "mcp-session-id", RawValue: []byte(gatewaySessionID)},
+					},
+				},
+			}
+			responseHeaders := &eppb.HttpHeaders{
+				Headers: &corev3.HeaderMap{
+					Headers: []*corev3.HeaderValue{
+						{Key: ":status", RawValue: []byte("401")},
+					},
+				},
+			}
+			mcpReq := &MCPRequest{
+				sessionID:  gatewaySessionID,
+				serverName: tt.serverName,
+				Method:     "tools/call",
+			}
+
+			_, err = srv.HandleResponseHeaders(context.Background(), responseHeaders, requestHeaders, mcpReq)
+			require.NoError(t, err)
+
+			_, ok, err := cache.GetUserToken(context.Background(), gatewaySessionID, tt.serverName)
+			require.NoError(t, err)
+			require.True(t, ok, "token should NOT be deleted")
+		})
+	}
+}
+
+func TestHandleResponseHeaders_401WithNilRequestNoAction(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	srv := &ExtProcServer{
+		Logger:             logger,
+		SessionCache:       cache,
+		Broker:             newMockBroker(nil, map[string]string{}),
+		ElicitationEnabled: true,
+	}
+
+	requestHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "mcp-session-id", RawValue: []byte("gateway-session-123")},
+			},
+		},
+	}
+	responseHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("401")},
+			},
+		},
+	}
+
+	responses, err := srv.HandleResponseHeaders(context.Background(), responseHeaders, requestHeaders, nil)
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+}
+
+func TestHandleResponseHeaders_SuccessStatusDoesNotDeleteUserToken(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	serverName := "elicit-server"
+	gatewaySessionID := "gateway-session-123"
+
+	routingConfig := &config.MCPServersConfig{
+		Servers: []*config.MCPServer{
+			{
+				Name:                serverName,
+				TokenURLElicitation: &config.TokenURLElicitationConfig{},
+			},
+		},
+	}
+
+	srv := &ExtProcServer{
+		Logger:             logger,
+		SessionCache:       cache,
+		Broker:             newMockBroker(nil, map[string]string{}),
+		RoutingConfig:      routingConfig,
+		ElicitationEnabled: true,
+	}
+
+	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "valid-token"))
+
+	requestHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "mcp-session-id", RawValue: []byte(gatewaySessionID)},
+			},
+		},
+	}
+	responseHeaders := &eppb.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("200")},
+			},
+		},
+	}
+	mcpReq := &MCPRequest{
+		sessionID:  gatewaySessionID,
+		serverName: serverName,
+		Method:     "tools/call",
+	}
+
+	_, err = srv.HandleResponseHeaders(context.Background(), responseHeaders, requestHeaders, mcpReq)
+	require.NoError(t, err)
+
+	// token should still be present
+	_, ok, err := cache.GetUserToken(context.Background(), gatewaySessionID, serverName)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
 func newMockBroker(svrConfigs []*config.MCPServer, tool2svr map[string]string) broker.MCPBroker {
 	return &mockBrokerImpl{
 		svrConfigs: svrConfigs,

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -275,7 +275,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 					s.Logger.ErrorContext(ctx, "failed to check client elicitation", "error", elErr)
 				}
 				mcpRequest.clientElicitation = clientElicitation
-				if clientElicitation {
+				if clientElicitation && statusCode == "200" {
 					rewriter = &sseRewriter{
 						idMap:      s.ElicitationMap,
 						req:        mcpRequest,

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -328,7 +328,7 @@ func extractElicitationURL(sseErr *sseError) (string, error) {
 }
 
 // extractHiddenField extracts the value of a hidden input field from HTML
-func extractHiddenField(html, fieldName string) string {
+func extractHiddenField(html, fieldName string) string { //nolint:unparam
 	re := regexp.MustCompile(`<input[^>]+name="` + regexp.QuoteMeta(fieldName) + `"[^>]+value="([^"]*)"`)
 	m := re.FindStringSubmatch(html)
 	if len(m) < 2 {
@@ -357,7 +357,7 @@ func adaptElicitationURL(elicitationURL, gatewayBaseURL string) (string, error) 
 }
 
 // rawHTTPGetFull performs a GET and returns status, body, and response cookies
-func rawHTTPGetFull(targetURL string, headers map[string]string) (int, string, []*http.Cookie, error) {
+func rawHTTPGetFull(targetURL string, headers map[string]string) (int, string, []*http.Cookie, error) { //nolint:unparam
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, targetURL, nil)
 	if err != nil {
 		return 0, "", nil, err

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -191,7 +191,7 @@
 
 ### [Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation
 
-- When a client submits an invalid token via the token page and makes a tool call, the upstream server returns 401. The gateway should delete the cached token so the next tool call triggers a fresh -32042 elicitation error. The client can then submit the correct token and retry successfully. This verifies that expired or invalid upstream credentials don't persist until gateway session expiry.
+- When a client has a valid cached token and an established backend session, and the upstream server rejects a subsequent tool call with 401 (simulated via `X-Force-Auth-Reject` header on the api-key-server), the gateway should delete the cached token and pass the 401 through. The next tool call should trigger a fresh -32042 elicitation error. The client can then re-submit the correct token and retry successfully.
 
 ### [Happy,URLElicitation] Server without tokenURLElicitation is unaffected
 

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -189,6 +189,10 @@
 
 - When a client that did NOT declare `capabilities.elicitation` in its initialize request calls a tool on a server with `tokenURLElicitation` configured and no cached token, the gateway should return a tool result with `isError: true` and a message about elicitation (not a -32042 JSON-RPC error). The client should not receive a URL for token submission.
 
+### [Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation
+
+- When a client submits an invalid token via the token page and makes a tool call, the upstream server returns 401. The gateway should delete the cached token so the next tool call triggers a fresh -32042 elicitation error. The client can then submit the correct token and retry successfully. This verifies that expired or invalid upstream credentials don't persist until gateway session expiry.
+
 ### [Happy,URLElicitation] Server without tokenURLElicitation is unaffected
 
 - When an MCPServerRegistration does NOT have `tokenURLElicitation` configured and the backend does not require auth, tool calls should proceed without any token resolution or -32042 errors, regardless of whether the client declares elicitation capability.

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -262,7 +262,7 @@ var _ = Describe("URL Elicitation", func() {
 		Expect(body).NotTo(ContainSubstring("-32042"))
 	})
 
-	It("[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation", func() {
+	FIt("[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation", func() {
 		toolName := fmt.Sprintf("%shello_world", prefix)
 
 		By("Initializing with elicitation capability")
@@ -289,7 +289,7 @@ var _ = Describe("URL Elicitation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sseErr.Code).To(Equal(-32042))
 
-		By("Submitting a WRONG token via broker page")
+		By("Submitting the CORRECT token via broker page")
 		elicitURL, err := extractElicitationURL(sseErr)
 		Expect(err).NotTo(HaveOccurred())
 		testURL, err := adaptElicitationURL(elicitURL, gatewayURL)
@@ -306,7 +306,7 @@ var _ = Describe("URL Elicitation", func() {
 
 		formValues := url.Values{
 			"elicitation_id": {elicitationID},
-			"token":          {"Bearer wrong-token-value"},
+			"token":          {"Bearer test-api-key-secret-token"},
 			"csrf_token":     {csrfToken},
 		}
 		postStatus, _, postErr := rawHTTPPostForm(
@@ -318,19 +318,26 @@ var _ = Describe("URL Elicitation", func() {
 		Expect(postErr).NotTo(HaveOccurred())
 		Expect(postStatus).To(Equal(200))
 
-		By("Retrying tool call — upstream should reject with 401, gateway invalidates token")
-		retryStatus, _, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, map[string]any{"name": "retry1"}, nil)
+		By("Calling tool with correct token — should succeed and establish backend session")
+		successStatus, successContent, err := mcpCallTool(context.Background(), gatewayURL, sessionID, toolName, map[string]any{"name": "setup"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(successStatus).To(Equal(200))
+		Expect(successContent).NotTo(BeEmpty())
+		Expect(successContent[0].Text).To(ContainSubstring("Hello"))
+
+		By("Calling tool with X-Force-Auth-Reject — upstream returns 401, gateway invalidates token")
+		retryStatus, _, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, map[string]any{"name": "reject"}, map[string]string{"X-Force-Auth-Reject": "true"})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(retryStatus).To(Equal(401))
 
-		By("Retrying again — should get -32042 (token was invalidated)")
-		_, body2, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, map[string]any{"name": "retry2"}, nil)
+		By("Retrying — should get -32042 (token was invalidated)")
+		_, body2, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, map[string]any{"name": "retry"}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		sseErr2, err := parseSSEError(body2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sseErr2.Code).To(Equal(-32042))
 
-		By("Submitting the CORRECT token")
+		By("Submitting the correct token again")
 		elicitURL2, err := extractElicitationURL(sseErr2)
 		Expect(err).NotTo(HaveOccurred())
 		testURL2, err := adaptElicitationURL(elicitURL2, gatewayURL)

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -262,7 +262,7 @@ var _ = Describe("URL Elicitation", func() {
 		Expect(body).NotTo(ContainSubstring("-32042"))
 	})
 
-	FIt("[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation", func() {
+	It("[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation", func() {
 		toolName := fmt.Sprintf("%shello_world", prefix)
 
 		By("Initializing with elicitation capability")

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -262,6 +262,111 @@ var _ = Describe("URL Elicitation", func() {
 		Expect(body).NotTo(ContainSubstring("-32042"))
 	})
 
+	It("[Happy,URLElicitation] 401 from upstream invalidates cached token and re-triggers elicitation", func() {
+		toolName := fmt.Sprintf("%shello_world", prefix)
+
+		By("Initializing with elicitation capability")
+		var sessionID string
+		Eventually(func(g Gomega) {
+			var err error
+			sessionID, err = mcpInitializeWithElicitation(gatewayURL, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		Expect(mcpNotifyInitialized(context.Background(), gatewayURL, sessionID, nil)).To(Succeed())
+
+		By("Waiting for tools to be available")
+		Eventually(func(g Gomega) {
+			_, tools, err := mcpListTools(context.Background(), gatewayURL, sessionID, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(tools).To(ContainElement(toolName))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Calling tool — should get -32042 (no token yet)")
+		_, body, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		sseErr, err := parseSSEError(body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sseErr.Code).To(Equal(-32042))
+
+		By("Submitting a WRONG token via broker page")
+		elicitURL, err := extractElicitationURL(sseErr)
+		Expect(err).NotTo(HaveOccurred())
+		testURL, err := adaptElicitationURL(elicitURL, gatewayURL)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, htmlBody, cookies, err := rawHTTPGetFull(testURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		csrfToken := extractHiddenField(htmlBody, "csrf_token")
+		Expect(csrfToken).NotTo(BeEmpty())
+
+		parsed, err := url.Parse(testURL)
+		Expect(err).NotTo(HaveOccurred())
+		elicitationID := parsed.Query().Get("elicitation_id")
+
+		formValues := url.Values{
+			"elicitation_id": {elicitationID},
+			"token":          {"Bearer wrong-token-value"},
+			"csrf_token":     {csrfToken},
+		}
+		postStatus, _, postErr := rawHTTPPostForm(
+			strings.TrimSuffix(gatewayURL, "/mcp")+"/tokens",
+			formValues,
+			nil,
+			cookies...,
+		)
+		Expect(postErr).NotTo(HaveOccurred())
+		Expect(postStatus).To(Equal(200))
+
+		By("Retrying tool call — upstream should reject with 401, gateway invalidates token")
+		retryStatus, _, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, map[string]any{"name": "retry1"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(retryStatus).To(Equal(401))
+
+		By("Retrying again — should get -32042 (token was invalidated)")
+		_, body2, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, map[string]any{"name": "retry2"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		sseErr2, err := parseSSEError(body2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sseErr2.Code).To(Equal(-32042))
+
+		By("Submitting the CORRECT token")
+		elicitURL2, err := extractElicitationURL(sseErr2)
+		Expect(err).NotTo(HaveOccurred())
+		testURL2, err := adaptElicitationURL(elicitURL2, gatewayURL)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, htmlBody2, cookies2, err := rawHTTPGetFull(testURL2, nil)
+		Expect(err).NotTo(HaveOccurred())
+		csrfToken2 := extractHiddenField(htmlBody2, "csrf_token")
+		Expect(csrfToken2).NotTo(BeEmpty())
+
+		parsed2, err := url.Parse(testURL2)
+		Expect(err).NotTo(HaveOccurred())
+		elicitationID2 := parsed2.Query().Get("elicitation_id")
+
+		formValues2 := url.Values{
+			"elicitation_id": {elicitationID2},
+			"token":          {"Bearer test-api-key-secret-token"},
+			"csrf_token":     {csrfToken2},
+		}
+		postStatus2, _, postErr2 := rawHTTPPostForm(
+			strings.TrimSuffix(gatewayURL, "/mcp")+"/tokens",
+			formValues2,
+			nil,
+			cookies2...,
+		)
+		Expect(postErr2).NotTo(HaveOccurred())
+		Expect(postStatus2).To(Equal(200))
+
+		By("Final retry — should succeed with correct token")
+		finalStatus, finalContent, err := mcpCallTool(context.Background(), gatewayURL, sessionID, toolName, map[string]any{"name": "final"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalStatus).To(Equal(200))
+		Expect(finalContent).NotTo(BeEmpty())
+		Expect(finalContent[0].Text).To(ContainSubstring("Hello"))
+	})
+
 	It("[Happy,URLElicitation] Server without tokenURLElicitation is unaffected", func() {
 		By("Registering a server WITHOUT tokenURLElicitation or credentialRef")
 		registration2 := NewMCPServerResourcesWithDefaults("urlelicit-nocfg", k8sClient).

--- a/tests/servers/api-key-server/main.go
+++ b/tests/servers/api-key-server/main.go
@@ -38,6 +38,11 @@ type authMiddleware struct {
 }
 
 func (a authMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("X-Force-Auth-Reject") == "true" {
+		log.Printf("Auth force-rejected via X-Force-Auth-Reject header")
+		http.Error(w, `{"error": "Unauthorized: token revoked"}`, http.StatusUnauthorized)
+		return
+	}
 	if a.ExpectedAuth != "" {
 		auth := req.Header.Get("Authorization")
 		if auth != a.ExpectedAuth {


### PR DESCRIPTION
When a backend returns 401 for a server with tokenURLElicitation, delete the cached token so the next tool call re-triggers elicitation.

Closes #830 

We don't currently handle the elicitation config being removed where it was previously enabled. This is low impact as the sessions will timeout and be cleaned up but I will add a follow on issue for that use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway now invalidates cached user tokens when upstream returns 401 (with URL token elicitation enabled) and passes the 401 through to the client; SSE/streaming rewrites are only created for successful (200) tool responses.

* **Tests**
  * Added unit and end-to-end tests covering 401-driven token invalidation, skip conditions, nil-request safety, success-status (200) behavior, and an e2e flow that re-triggers elicitation after token invalidation.

* **Documentation**
  * Updated design and test-case docs to reflect 401 invalidation + re-elicitation-on-retry behavior.

* **Chores**
  * Added lint-suppression annotations to e2e test helpers; test server supports a header to simulate upstream 401.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->