### PR TITLE
broker: protect man.status with statusLock in MCPManager

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -146,6 +146,8 @@ type MCPManager struct {
 	toolEvents   chan struct{}
 	promptEvents chan struct{}
 	done         chan struct{} // closed when the event loop exits
+	// statusLock protects status
+	statusLock   sync.RWMutex
 	status       ServerValidationStatus
 }
 
@@ -472,12 +474,15 @@ func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
 }
 
 // GetStatus returns the current status of the MCP Server
-// no locking is done here as it is expected to be called multiple times
 func (man *MCPManager) GetStatus() ServerValidationStatus {
-	return man.status
+	man.statusLock.RLock()
+	defer man.statusLock.RUnlock()
+	return cloneStatus(man.status)
 }
 
 func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo) {
+	man.statusLock.Lock()
+	defer man.statusLock.Unlock()
 	man.status.ID = string(man.mcp.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()
@@ -600,7 +605,16 @@ func (man *MCPManager) SetToolsForTesting(tools []mcp.Tool) {
 // SetStatusForTesting sets the status directly for testing purposes.
 // This bypasses the normal status update flow and should only be used in tests.
 func (man *MCPManager) SetStatusForTesting(status ServerValidationStatus) {
-	man.status = status
+	man.statusLock.Lock()
+	defer man.statusLock.Unlock()
+	man.status = cloneStatus(status)
+}
+
+func cloneStatus(in ServerValidationStatus) ServerValidationStatus {
+	out := in
+	out.InvalidToolList = slices.Clone(in.InvalidToolList)
+	out.InvalidPromptList = slices.Clone(in.InvalidPromptList)
+	return out
 }
 
 // NewActiveForTesting wraps a manager as an ActiveMCPServer without starting

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1416,3 +1416,71 @@ func TestMCPManager_Backoff(t *testing.T) {
 	manager.manage(ctx, eventTypeTimer)
 	assert.True(t, manager.GetStatus().Ready)
 }
+
+func TestSetStatusForTestingNoRaceWithGetStatus(t *testing.T) {
+	man := &MCPManager{}
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			man.SetStatusForTesting(ServerValidationStatus{
+				Ready: true,
+			})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = man.GetStatus()
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestSetStatusForTestingNoRaceConcurrentWrites(t *testing.T) {
+	man := &MCPManager{}
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			man.SetStatusForTesting(ServerValidationStatus{
+				Ready: false,
+			})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			man.SetStatusForTesting(ServerValidationStatus{
+				Ready: true,
+			})
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestSetStatusForTestingValueIsVisible(t *testing.T) {
+	man := &MCPManager{}
+
+	expected := ServerValidationStatus{
+		Ready: true,
+	}
+
+	man.SetStatusForTesting(expected)
+	got := man.GetStatus()
+
+	if got.Ready != expected.Ready {
+		t.Errorf("expected Ready=%v, got Ready=%v", expected.Ready, got.Ready)
+	}
+}
+


### PR DESCRIPTION
## Problem

`GetStatus()`, `setStatus()`, and `SetStatusForTesting()` all access
`man.status` without synchronization.

- `setStatus()` runs in the manager's background event loop goroutine
- `GetStatus()` is called from HTTP handler goroutines via `ValidateAllServers` → `/status`
- `SetStatusForTesting()` is an unprotected write path with no lock, bypassing
  any lock invariant established by the other two methods

Furthermore, `ServerValidationStatus` contains slice headers (`[]InvalidToolInfo`, `[]InvalidPromptInfo`) that reference underlying backing arrays. A shallow copy exposes these arrays to outside mutations.

`go test -race` flags this as a DATA RACE.

Fixes #859
Fixes #1017

## Root Cause

After PR #943 (channel event loop refactor), `statusLock` does not exist in
`main`. No synchronization protects `man.status`. Three goroutines can access
it concurrently with no guards.

## Solution

Introduce `statusLock sync.RWMutex` on `MCPManager`. Protect all three access
paths consistently:

- `RLock` / `RUnlock` in `GetStatus()` — concurrent reads are safe
- `Lock` / `Unlock` in `setStatus()` — exclusive write from event loop
- `Lock` / `Unlock` in `SetStatusForTesting()` — exclusive write from tests

Additionally, implement `cloneStatus()` using `slices.Clone()` to perform a deep copy of all slice fields (`InvalidToolList`, `InvalidPromptList`) when returning status from `GetStatus()` and when accepting/storing status in `SetStatusForTesting()`.

## Changes

- `internal/broker/upstream/manager.go` — add `statusLock` and `cloneStatus()`, protect and deep-clone all three access paths
- `internal/broker/upstream/manager_test.go` — add three new unit tests

## Testing

Three new unit tests added to `manager_test.go`:

- `TestSetStatusForTestingNoRaceWithGetStatus` — concurrent reader and writer,
  catches reader-writer race
- `TestSetStatusForTestingNoRaceConcurrentWrites` — two concurrent writers,
  catches writer-writer race
- `TestSetStatusForTestingValueIsVisible` — confirms value written by
  `SetStatusForTesting` is correctly returned by `GetStatus()`

Verified local compilation:
`go test -c -o /dev/null ./internal/broker/upstream/...`

Race detector verification runs automatically in CI:
`go test -race ./internal/broker/upstream/...`

## Notes

Supersedes #860 (incomplete fix, SetStatusForTesting unprotected) and #1005.
This PR fixes all three access paths: GetStatus, setStatus, and SetStatusForTesting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for status handling by adding concurrency protections and safe-copy semantics, preventing race conditions and ensuring reliable, consistent status reads under concurrent operations.

* **Tests**
  * Added unit tests that exercise concurrent reads and writes of status to validate consistency and correctness under simultaneous access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->