### PR TITLE
test: enable x-mcp-authorized JWT header e2e test

### DIFF
--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -737,9 +737,74 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 	})
 
 	It("[Happy] should filter tools based on x-mcp-authorized JWT header", func() {
-		if !IsTrustedHeadersEnabled(ctx) {
-			Skip("trusted headers public key not configured - skipping x-mcp-authorized test")
+		By("Ensuring trusted headers key is configured")
+
+		// create the secret if it doesn't exist
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "trusted-headers-public-key",
+				Namespace: SystemNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"key": []byte(GetTestHeaderPublicKey()),
+			},
 		}
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, secret))).To(Succeed())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+		})
+
+		// Patch MCPGatewayExtension
+		// Get current deployment generation before patching
+		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
+		Expect(err).NotTo(HaveOccurred())
+
+		ext := &mcpv1alpha1.MCPGatewayExtension{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: MCPExtensionName, Namespace: SystemNamespace,
+		}, ext)).To(Succeed())
+
+		patch := client.MergeFrom(ext.DeepCopy())
+		ext.Spec.TrustedHeadersKey = &mcpv1alpha1.TrustedHeadersKey{
+			SecretName: "trusted-headers-public-key",
+		}
+		Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
+
+		DeferCleanup(func() {
+			By("Cleaning up: removing trustedHeadersKey from MCPGatewayExtension")
+
+			// Get current deployment generation before cleanup
+			gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
+			Expect(err).NotTo(HaveOccurred())
+
+			ext := &mcpv1alpha1.MCPGatewayExtension{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: MCPExtensionName, Namespace: SystemNamespace,
+			}, ext)
+			if err == nil {
+				patch := client.MergeFrom(ext.DeepCopy())
+				ext.Spec.TrustedHeadersKey = nil
+				Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
+
+				// Wait for deployment spec to be updated
+				Eventually(func(g Gomega) {
+					g.Expect(IsTrustedHeadersEnabled(ctx)).To(BeFalse())
+				}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+				// Wait for deployment to roll out
+				Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
+			}
+		})
+
+		// Wait for deployment to be updated with the env var
+		Eventually(func(g Gomega) {
+			g.Expect(IsTrustedHeadersEnabled(ctx)).To(BeTrue())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		// Wait for deployment to roll out with new pods
+		Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
 
 		By("Creating an MCPServerRegistration with tools")
 		registration := NewMCPServerResourcesWithDefaults("authorized-capabilities-test", k8sClient).Build()

--- a/tests/e2e/jwt_helpers.go
+++ b/tests/e2e/jwt_helpers.go
@@ -18,9 +18,20 @@ AwEHoUQDQgAE7WdMdvC8hviEAL4wcebqaYbLEtVOVEiyi/nozagw7BaWXmzbOWyy
 95gZLirTkhUb1P4Z4lgKLU2rD5NCbGPHAA==
 -----END EC PRIVATE KEY-----`
 
+// testHeaderPublicKey is the EC public key corresponding to testHeaderSigningKey
+const testHeaderPublicKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7WdMdvC8hviEAL4wcebqaYbLEtVO
+VEiyi/nozagw7BaWXmzbOWyy95gZLirTkhUb1P4Z4lgKLU2rD5NCbGPHAA==
+-----END PUBLIC KEY-----`
+
 // GetTestHeaderSigningKey returns the EC private key for signing test headers
 func GetTestHeaderSigningKey() string {
 	return testHeaderSigningKey
+}
+
+// GetTestHeaderPublicKey returns the EC public key for verifying test header JWTs
+func GetTestHeaderPublicKey() string {
+	return testHeaderPublicKey
 }
 
 // CreateAuthorizedCapabilitiesJWT creates a signed JWT for the x-mcp-authorized header


### PR DESCRIPTION
### Summary
Enables the previously skipped e2e test for JWT-based tool filtering via the `X-Mcp-Authorized` header. The test now sets up its own infrastructure (secret + MCPGatewayExtension configuration) and cleans up afterward, making it runnable in any test environment.

Without this change the test is always skipped because MCPGatewayExtension CR is removed and recreated by e2e test suite without configuration required by this test.

### Changes
  - **`tests/e2e/jwt_helpers.go`**: 
    - Added `testHeaderPublicKey` constant (EC public key)
    - Added `GetTestHeaderPublicKey()` function to expose the public key for secret creation
    
  - **`tests/e2e/happy_path_test.go`**:
    - Removed `Skip()` call that was blocking test execution
    - Added secret creation with `IgnoreAlreadyExists` pattern
    - Added MCPGatewayExtension patching to enable trusted headers if not already configured
    - Added proper `DeferCleanup` to restore MCPGatewayExtension and delete secret
    - Wait for deployment rollout after configuration changes

The secret handling follows the same pattern used in "Redis session cache" e2e test.

### Verification
It's probably enough to check that the test was executed by e2e PR check.

But you can run the e2e test suite yourself: `make test-e2e`.
Or you can run just this single test:
`./ginkgo -v --tags=e2e --timeout=15m --focus=".*x-mcp-authorized JWT header.*" ./tests/e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end JWT header filtering tests to work in environments without preconfigured trusted-header support by dynamically provisioning the required public-key secret, enabling proper setup/teardown, and ensuring the gateway is rolled during test setup and cleanup.
  * Added a test helper to expose the public EC key so tests can perform full signing and verification flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->