### PR TITLE
collecting manual test cases for release

### DIFF
--- a/.claude/rules/e2e-tests.md
+++ b/.claude/rules/e2e-tests.md
@@ -4,3 +4,5 @@
 - Use direct port-forwards to `deployment/mcp-gateway`
 - Clean up resources before creating them
 - Test servers live in `tests/servers/` — create new ones for specific scenarios
+- Test server images are built and pushed in `.github/workflows/test-images.yaml`
+- When e2e coverage is insufficient, consider manual test cases (see `manual-test-cases.md` for criteria)

--- a/.claude/rules/manual-test-cases.md
+++ b/.claude/rules/manual-test-cases.md
@@ -1,0 +1,19 @@
+# Manual Test Cases
+
+Manual test cases in `tests/manual-testcases/<upcoming-release>.md` are expensive and should be used sparingly. Create the file if it does not exist.
+
+Manual test cases are needed:
+
+- Features requiring external infrastructure impractical for e2e (real cloud providers, third-party SaaS)
+- Complex observability verification (distributed tracing across multiple systems, Grafana dashboards)
+- Bug fixes that cannot be adequately covered by automated tests due to infrastructure constraints
+- Features with critical browser/UI interaction that cannot be automated
+- Brand new guide added to `docs/guides/` that introduces a complete workflow not previously documented
+
+Manual test cases are not needed:
+
+- Demo code in `demos/`
+- Example configurations in `config/samples/`
+- Documentation updates, improvements or new sections added to existing guides in `docs/guides`
+- Test improvements
+- Features/Bug fixes with adequate e2e or integration test coverage

--- a/.claude/rules/upstream-features.md
+++ b/.claude/rules/upstream-features.md
@@ -9,3 +9,4 @@ When adding new upstream/broker features:
 - Update config types in `internal/config/types.go` if new config fields needed
 - Add unit tests alongside the implementation
 - Add e2e test in `tests/e2e/`
+- Add manual test scenarios not sufficiently covered by tests to `tests/manual-testcases/<upcoming-release>.md` (see `manual-test-cases.md` for criteria)

--- a/docs/release-notes/0.7.0.md
+++ b/docs/release-notes/0.7.0.md
@@ -1,4 +1,4 @@
-# Release Notes — 0.0.7
+# Release Notes — 0.7.0
 
 ## Security Advisories
 

--- a/tests/manual-testcases/0.7.0.md
+++ b/tests/manual-testcases/0.7.0.md
@@ -1,0 +1,46 @@
+# Manual Test Cases — 0.7.0
+
+## HTTPS Gateway Listener
+
+### Hairpin initialization with HTTPS listener
+
+**Related PR**: [#942](https://github.com/Kuadrant/mcp-gateway/pull/942)
+**Why manual**: Bug fix for HTTPS hairpin scheme handling. Only unit tests; no e2e coverage. Requires real HTTPS Gateway listener.
+
+- [ ] Deploy Gateway with HTTPS listener on port 443
+- [ ] Register MCPServerRegistration
+- [ ] Call a tool (triggers hairpin backend initialization)
+- [ ] Verify tool call succeeds (hairpin correctly uses `https://` not `http://`)
+- [ ] Check deployment has `--mcp-gateway-private-host=https://...`
+
+## Observability
+
+### OpenTelemetry distributed tracing
+
+**Related PR**: [#955](https://github.com/Kuadrant/mcp-gateway/pull/955)
+**Why manual**: Requires real OTel infrastructure (Tempo, Grafana, Loki). Distributed trace propagation and UI verification can't be fully automated.
+
+Follow the verification guide in [#955](https://github.com/Kuadrant/mcp-gateway/pull/955) (sections 1-11):
+- [ ] Deploy OTel stack: `make otel ISTIO_TRACING=1 AUTH_TRACING=1`
+- [ ] Verify broker spans appear in Tempo (`mcp-broker.handle-request`, `mcp-broker.tools-list`)
+- [ ] Verify router spans appear in Tempo (`mcp-router.tool-call`, `mcp-router.route-decision`)
+- [ ] Verify full trace chain: Envoy → Authorino → Router → Broker
+- [ ] Verify log-to-trace correlation in Grafana (click trace_id in Loki → jumps to Tempo)
+- [ ] Verify error spans with correct `error_source` (broker vs backend)
+
+### Auditing guide validation
+
+**Related PR**: [#1023](https://github.com/Kuadrant/mcp-gateway/pull/1023)
+**Why manual**: New user-facing guide. No e2e coverage. Requires full auth stack (Keycloak) and Istio Telemetry API configuration to validate end-to-end.
+
+Follow the complete auditing guide (`docs/guides/auditing.md`):
+- [ ] Set up local environment: `make local-env-setup-olm && make auth-example-setup-no-vault`
+- [ ] Step 1: Configure AuthPolicy for both `mcp` and `mcps` listeners
+- [ ] Verify identity injection: call `test1_headers` tool and confirm `x-auth-identity` header is present
+- [ ] Step 2: Add MeshConfig extension provider (`mcp-json-access-log`)
+- [ ] Step 3: Create Telemetry resource in gateway-system namespace
+- [ ] Step 4: Make authenticated tool call and verify JSON access log entry appears in gateway pod logs
+- [ ] Verify all MCP fields are captured: `mcp_method`, `mcp_tool_name`, `mcp_server_name`, `mcp_session_id`, `mcp_user_id`
+- [ ] Test example queries from guide (filter by user, tool, server, duration, response code)
+- [ ] Verify logs work without authentication (identity field empty but other fields populated)
+


### PR DESCRIPTION
### Summary
Collecting manual test cases for a release, similarly to collecting information for release notes. Adds comprehensive guidance in CLAUDE.md for when manual testing is justified vs
  when automated tests are sufficient, with the principle "manual tests are costly, aim for ideally zero."

### Changes
  - Fix version reference in CLAUDE.md (0.0.7 → 0.7.0)
  - Rename release notes file to match correct version (0.7.0)
  - Add comprehensive test coverage validation guidelines to CLAUDE.md
  - Create manual test cases file for 0.7.0 release
  - Document manual test cases for HTTPS hairpin (#942) and OTel tracing (#955)

### Verification
Not quite sure how to validate changes like this. I am a bit afraid that there will be influx of manual tests cases but we will see how it goes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Version 0.7.0 release notes published with detailed documentation
  * Manual test case documentation added for 0.7.0 with comprehensive test procedures and validation checklists

* **Tests**
  * Testing guidelines and procedures documentation updated

* **Chores**
  * Updated end-to-end testing infrastructure documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->