### PR TITLE
feat: add CRD validation for MCPServerRegistration prefix field

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -60,6 +60,7 @@ type MCPServerRegistrationSpec struct {
 	// For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="prefix is immutable once set"
+	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9_]*$`
 	Prefix string `json:"prefix,omitempty"`
 
 	// path specifies the URL path where the MCP server endpoint is exposed.

--- a/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -145,6 +145,7 @@ spec:
                   prefix is the prefix to add to all federated capabilities from referenced servers.
                   This helps avoid naming conflicts when aggregating tools from multiple sources.
                   For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                pattern: ^[a-z0-9][a-z0-9_]*$
                 type: string
                 x-kubernetes-validations:
                 - message: prefix is immutable once set

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -145,6 +145,7 @@ spec:
                   prefix is the prefix to add to all federated capabilities from referenced servers.
                   This helps avoid naming conflicts when aggregating tools from multiple sources.
                   For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                pattern: ^[a-z0-9][a-z0-9_]*$
                 type: string
                 x-kubernetes-validations:
                 - message: prefix is immutable once set

--- a/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -145,6 +145,7 @@ spec:
                   prefix is the prefix to add to all federated capabilities from referenced servers.
                   This helps avoid naming conflicts when aggregating tools from multiple sources.
                   For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                pattern: ^[a-z0-9][a-z0-9_]*$
                 type: string
                 x-kubernetes-validations:
                 - message: prefix is immutable once set

--- a/docs/release-notes/0.0.7.md
+++ b/docs/release-notes/0.0.7.md
@@ -108,6 +108,12 @@ The serialized server config in Kubernetes secrets changes the `toolPrefix` YAML
 
 The `ServerValidationStatus` JSON response from the broker `/status` endpoint changes the `toolPrefix` key to `prefix`. Monitoring or automation that parses this endpoint must update accordingly.
 
+### `prefix` field now enforces character validation
+
+The `prefix` field on MCPServerRegistration now only accepts lowercase letters (`a-z`), digits (`0-9`), and underscores (`_`). The value must start with a letter or digit. This is enforced at the CRD schema level.
+
+Existing MCPServerRegistration resources with non-conforming prefixes continue to function but cannot be updated. To update such resources, delete and recreate them with a conforming prefix.
+
 ## New Features
 
 ### Enable/disable MCPServerRegistration
@@ -115,6 +121,10 @@ The `ServerValidationStatus` JSON response from the broker `/status` endpoint ch
 MCPServerRegistration resources now support a `state` field (`Enabled` or `Disabled`, default `Enabled`). Setting `state: Disabled` tells the broker to disconnect from the upstream server and remove all its tools and prompts from the gateway. The registration is preserved and can be re-enabled at any time by setting the field back to `Enabled`, restoring the server's capabilities without recreating any resources.
 
 The status condition reason reflects the current state: `Ready`, `NotReady`, or `Disabled`.
+
+### Prompt federation
+
+The gateway now federates MCP prompts from upstream servers alongside tools. Prompts are prefixed with the same `prefix` value as tools and are accessible via `prompts/list` and `prompts/get` through the gateway. Authorization filtering supports prompts via the `"prompts"` key in the `allowed-capabilities` JWT claim. Virtual servers can scope prompts via the `spec.prompts` field on `MCPVirtualServer`.
 
 ### Generalized authorization header (`x-mcp-authorized`)
 

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -77,7 +77,7 @@ func TestOnConfigChange(t *testing.T) {
 	server1 := &config.MCPServer{
 		Name:   "test1",
 		URL:    MCPAddr,
-		Prefix: "_test1",
+		Prefix: "test1_",
 	}
 	virtualServer1 := &config.VirtualServer{
 		Name:  "test/test",

--- a/internal/controller/mcpserverregistration_controller_integration_test.go
+++ b/internal/controller/mcpserverregistration_controller_integration_test.go
@@ -936,4 +936,40 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			}, testTimeout, testRetryInterval).Should(Succeed())
 		})
 	})
+
+	Context("prefix field CRD validation", func() {
+		ctx := context.Background()
+
+		AfterEach(func() {
+			forceDeleteTestMCPServerRegistration(ctx, "prefix-valid", "default")
+		})
+
+		DescribeTable("rejects invalid prefix values",
+			func(prefix string) {
+				mcpsr := createTestMCPServerRegistration("prefix-invalid", "default", "some-route", prefix)
+				err := testK8sClient.Create(ctx, mcpsr)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsInvalid(err)).To(BeTrue(), "expected Invalid error, got: %v", err)
+			},
+			Entry("uppercase letters", "MyServer_"),
+			Entry("hyphen", "my-server"),
+			Entry("starts with underscore", "_test1"),
+			Entry("space", "my server"),
+			Entry("special characters", "test!@#"),
+			Entry("mixed case", "testServer"),
+		)
+
+		DescribeTable("accepts valid prefix values",
+			func(prefix string) {
+				mcpsr := createTestMCPServerRegistration("prefix-valid", "default", "some-route", prefix)
+				Expect(testK8sClient.Create(ctx, mcpsr)).To(Succeed())
+				forceDeleteTestMCPServerRegistration(ctx, "prefix-valid", "default")
+			},
+			Entry("lowercase with trailing underscore", "test_"),
+			Entry("alphanumeric with underscore", "server1_"),
+			Entry("single letter", "a"),
+			Entry("digits and underscores", "s1_prefix_"),
+			Entry("all lowercase", "weatherserver"),
+		)
+	})
 })

--- a/project-words.txt
+++ b/project-words.txt
@@ -430,3 +430,4 @@ myprompt
 promptname
 rescope
 selfsigned
+weatherserver


### PR DESCRIPTION
Enforce snake_case pattern (lowercase alphanumeric + underscores) on the prefix field via kubebuilder Pattern validation. Add release notes for prefix validation and prompt federation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * MCPServerRegistration `prefix` now enforces lowercase alphanumeric/underscore format (must start with a letter or digit). Non-conforming existing resources cannot be updated and must be deleted/recreated.

* **New Features**
  * Prompt federation: gateway exposes upstream MCP prompts via prompts/list and prompts/get with scoped authorization and per-virtual-server control.

* **Documentation**
  * Release notes updated to describe the new prefix validation and prompt federation.

* **Tests**
  * Added validation tests covering accepted and rejected prefix values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->