### PR TITLE
fix: correct broken ToC anchor links in flows.md

### DIFF
--- a/docs/design/flows.md
+++ b/docs/design/flows.md
@@ -8,7 +8,7 @@ This document captures the main request flows that involve the MCP Gateway.
 ## Table of Contents
 
 - [Components](#components)
-- [High Level Flow](#high-level-flows)
+- [High Level Flow](#high-level-flow)
 - [Initialize](#initialize)
 - [Aggregated Tools/List](#aggregated-toolslist)
 - [Tools/Call (no auth)](#toolscall-no-auth)
@@ -85,7 +85,7 @@ sequenceDiagram
   note left of MCPBroker: list is built via discovery phase. <br/> The MCPBroker applies filtering to this list. <br/> via signed x-authorised-tools header <br/> and client specified x-mcp-virtualserver headers.
 ```
 
-## Tools/Call
+## Tools/Call (no auth)
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
Two Table of Contents links in docs/design/flows.md pointed to non-existent anchors:

1. '#high-level-flows' → should be '#high-level-flow' (heading is singular 'High Level Flow', not 'High Level Flows')

2. '#toolscall-no-auth' → heading was '## Tools/Call' which renders as '#toolscall', not '#toolscall-no-auth'. Fixed by adding '(no auth)' to the heading to match the ToC link and distinguish it from the authenticated flows below.

Clicking either link in the rendered docs previously silently failed to navigate to the intended section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a table-of-contents anchor link in the flow documentation to point to the correct section.
  * Clarified the unauthenticated flow by renaming the section heading to "Tools/Call (no auth)".
  * Documentation-only edit; no functional changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->