### PR TITLE
feat(router): negotiate MCP sampling capability

### DIFF
--- a/config/mcp-gateway/base/mcpgatewayextension.yaml
+++ b/config/mcp-gateway/base/mcpgatewayextension.yaml
@@ -3,6 +3,7 @@ kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway-extension
 spec:
+  httpRouteManagement: Disabled
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -128,6 +128,7 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 					ListChanged: true,
 				},
 				Elicitation: &mcp.ElicitationCapability{},
+				Sampling:    &struct{}{},
 			},
 			ClientInfo: mcp.Implementation{
 				Name:    "mcp-broker",

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -32,7 +32,7 @@ func buildHairpinURL(gatewayHost, mcpPath string) string {
 // Initialize will create a new initialize and initialized request and return the associated http client for connection management
 // This method makes a request back to the gateway setting the target mcp server to initialize. We hairpin through the gateway to ensure any Auth applied to that host is triggered for the call.
 // The initToken is a short-lived JWT bound to conf.Hostname that the router will validate when the hairpin request re-enters the gateway.
-func Initialize(ctx context.Context, gatewayHost, initToken string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool) (*client.Client, error) {
+func Initialize(ctx context.Context, gatewayHost, initToken string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation, clientSampling bool) (*client.Client, error) {
 	// force the initialize to hairpin back through envoy with a token that
 	// proves the request originated from the gateway's own router.
 	passThroughHeaders[mcprouter.RoutingKey] = initToken
@@ -55,6 +55,9 @@ func Initialize(ctx context.Context, gatewayHost, initToken string, conf *config
 	caps := mcp.ClientCapabilities{}
 	if clientElicitation {
 		caps.Elicitation = &mcp.ElicitationCapability{}
+	}
+	if clientSampling {
+		caps.Sampling = &struct{}{}
 	}
 	if _, err := httpClient.Initialize(ctx, mcp.InitializeRequest{
 		Params: mcp.InitializeParams{

--- a/internal/clients/clients_test.go
+++ b/internal/clients/clients_test.go
@@ -84,7 +84,7 @@ func TestInitialize(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, err := Initialize(context.Background(), tc.gatewayHost, tc.routerKey, tc.conf, tc.passThroughHeaders, false)
+			client, err := Initialize(context.Background(), tc.gatewayHost, tc.routerKey, tc.conf, tc.passThroughHeaders, false, false)
 			if tc.expectedError {
 				require.Error(t, err)
 				return

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1330,6 +1330,23 @@ func TestBuildGatewayHTTPRoute(t *testing.T) {
 			if parentRef.SectionName == nil || string(*parentRef.SectionName) != tt.mcpExt.Spec.TargetRef.SectionName {
 				t.Errorf("parentRef sectionName = %v, want %q", parentRef.SectionName, tt.mcpExt.Spec.TargetRef.SectionName)
 			}
+			if len(route.Spec.Rules) != 2 {
+				t.Fatalf("rules len = %d, want 2", len(route.Spec.Rules))
+			}
+
+			gotPaths := map[string]bool{}
+			for _, rule := range route.Spec.Rules {
+				if len(rule.Matches) == 0 || rule.Matches[0].Path == nil || rule.Matches[0].Path.Value == nil {
+					t.Fatalf("rule missing path match: %+v", rule)
+				}
+				gotPaths[*rule.Matches[0].Path.Value] = true
+			}
+			if !gotPaths["/mcp"] {
+				t.Errorf("missing /mcp rule")
+			}
+			if !gotPaths["/.well-known/oauth-protected-resource"] {
+				t.Errorf("missing /.well-known/oauth-protected-resource rule")
+			}
 		})
 	}
 }

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -92,6 +92,7 @@ type MCPRequest struct {
 	serverName        string            `json:"-"`
 	backendSessionID  string            `json:"-"`
 	clientElicitation bool              `json:"-"`
+	clientSampling    bool              `json:"-"`
 }
 
 // GetSingleHeaderValue returns a single header value
@@ -155,6 +156,23 @@ func (mr *MCPRequest) clientSupportsElicitation() bool {
 	}
 	_, hasElicitation := capsMap["elicitation"]
 	return hasElicitation
+}
+
+// clientSupportsSampling checks if an initialize request declares sampling support
+func (mr *MCPRequest) clientSupportsSampling() bool {
+	if mr.Method != methodInitialize || mr.Params == nil {
+		return false
+	}
+	caps, ok := mr.Params["capabilities"]
+	if !ok {
+		return false
+	}
+	capsMap, ok := caps.(map[string]any)
+	if !ok {
+		return false
+	}
+	_, hasSampling := capsMap["sampling"]
+	return hasSampling
 }
 
 func (mr *MCPRequest) isSamplingResponse() bool {
@@ -781,6 +799,16 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			mcpReq.clientElicitation = clientElicitation
 		}
 
+		// check if the original client declared sampling support
+		if !mcpReq.clientSampling {
+			clientSampling, sErr := s.SessionCache.GetClientSampling(ctx, mcpReq.GetSessionID())
+			if sErr != nil {
+				s.Logger.ErrorContext(ctx, "failed to get client sampling flag", "error", sErr, "session", mcpReq.GetSessionID())
+				return "", NewRouterErrorf(500, "failed to read client sampling flag: %w", sErr)
+			}
+			mcpReq.clientSampling = clientSampling
+		}
+
 		// mint a short-lived JWT bound to the target hostname; the router validates
 		// this token when the hairpin request re-enters the gateway in
 		// HandleNoneToolCall so we can never be tricked into routing to an
@@ -791,7 +819,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			mcpotel.SpanError(initSpan, err, "failed to generate backend-init token")
 			return "", NewRouterErrorf(500, "failed to generate backend-init token: %w", err)
 		}
-		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation)
+		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation, mcpReq.clientSampling)
 		if err != nil {
 			s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
 			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
+	"github.com/Kuadrant/mcp-gateway/internal/idmap"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
 	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -73,6 +74,9 @@ const (
 	elicitationActionAccept  = "accept"
 	elicitationActionDecline = "decline"
 	elicitationActionCancel  = "cancel"
+
+	samplingResultRole    = "role"
+	samplingResultContent = "content"
 )
 
 // MCPRequest encapsulates a mcp protocol request to the gateway
@@ -81,7 +85,7 @@ type MCPRequest struct {
 	JSONRPC           string            `json:"jsonrpc"`
 	Method            string            `json:"method,omitempty"`
 	Params            map[string]any    `json:"params,omitempty"`
-	Result            map[string]any    `json:"result,omitempty"` // set in elicitation responses (which are a request from the client)
+	Result            map[string]any    `json:"result,omitempty"` // set in elicitation/sampling responses (which are a request from the client)
 	Headers           *corev3.HeaderMap `json:"-"`
 	Streaming         bool              `json:"-"`
 	sessionID         string            `json:"-"`
@@ -111,8 +115,8 @@ func (mr *MCPRequest) Validate() (bool, error) {
 	if mr.JSONRPC != "2.0" {
 		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("json rpc version invalid"))
 	}
-	// elicitation responses (sent as a request to the server) do not have the method set
-	if mr.Method == "" && !mr.isElicitationResponse() {
+	// elicitation/sampling responses (sent as a request to the server) do not have the method set
+	if mr.Method == "" && !mr.isElicitationResponse() && !mr.isSamplingResponse() {
 		return false, errors.Join(ErrInvalidRequest, fmt.Errorf("no method set in json rpc payload"))
 	}
 	if mr.ID == nil && !mr.isNotificationRequest() {
@@ -151,6 +155,19 @@ func (mr *MCPRequest) clientSupportsElicitation() bool {
 	}
 	_, hasElicitation := capsMap["elicitation"]
 	return hasElicitation
+}
+
+func (mr *MCPRequest) isSamplingResponse() bool {
+	if mr.Method != "" || mr.Result == nil {
+		return false
+	}
+	if _, ok := mr.Result[samplingResultRole].(string); !ok {
+		return false
+	}
+	if _, ok := mr.Result[samplingResultContent]; !ok {
+		return false
+	}
+	return true
 }
 
 func (mr *MCPRequest) isElicitationResponse() bool {
@@ -249,6 +266,9 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	case mcpReq.isElicitationResponse():
 		span.SetAttributes(attribute.String("mcp.route", "elicitation-response"))
 		return s.HandleElicitationResponse(ctx, mcpReq)
+	case mcpReq.isSamplingResponse():
+		span.SetAttributes(attribute.String("mcp.route", "sampling-response"))
+		return s.HandleSamplingResponse(ctx, mcpReq)
 	case mcpReq.Method == methodToolCall:
 		span.SetAttributes(attribute.String("mcp.route", "tool-call"))
 		return s.HandleToolCall(ctx, mcpReq)
@@ -579,7 +599,27 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	ctx context.Context,
 	mcpReq *MCPRequest,
 ) []*eppb.ProcessingResponse {
-	ctx, span := tracer().Start(ctx, "mcp-router.elicitation-response",
+	return s.handleServerInitiatedResponse(ctx, mcpReq, s.ElicitationMap, "elicitation")
+}
+
+// HandleSamplingResponse routes a sampling/createMessage response from the client to the correct backend server
+func (s *ExtProcServer) HandleSamplingResponse(
+	ctx context.Context,
+	mcpReq *MCPRequest,
+) []*eppb.ProcessingResponse {
+	return s.handleServerInitiatedResponse(ctx, mcpReq, s.SamplingMap, "sampling")
+}
+
+// handleServerInitiatedResponse routes a client response for a server-initiated request
+// (elicitation/create or sampling/createMessage) back to the correct backend server using
+// the supplied id map.
+func (s *ExtProcServer) handleServerInitiatedResponse(
+	ctx context.Context,
+	mcpReq *MCPRequest,
+	idMap idmap.Map,
+	kind string,
+) []*eppb.ProcessingResponse {
+	ctx, span := tracer().Start(ctx, "mcp-router."+kind+"-response",
 		trace.WithAttributes(
 			componentAttr,
 			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
@@ -597,23 +637,23 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	gatewayID := fmt.Sprint(mcpReq.ID)
 
-	entry, ok, err := s.ElicitationMap.Lookup(ctx, gatewayID)
+	entry, ok, err := idMap.Lookup(ctx, gatewayID)
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to lookup elicitation mapping", "error", err, "gatewayID", gatewayID)
-		mcpotel.SpanError(span, err, "elicitation lookup failed")
+		s.Logger.ErrorContext(ctx, "failed to lookup "+kind+" mapping", "error", err, "gatewayID", gatewayID)
+		mcpotel.SpanError(span, err, kind+" lookup failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
 	}
 	if !ok {
-		lookupErr := fmt.Errorf("elicitation response for unknown gateway ID: %s", gatewayID)
-		s.Logger.ErrorContext(ctx, "elicitation response for unknown gateway ID", "gatewayID", gatewayID)
-		mcpotel.SpanError(span, lookupErr, "unknown elicitation ID")
-		response.WithImmediateResponse(400, "unknown elicitation ID")
+		lookupErr := fmt.Errorf("%s response for unknown gateway ID: %s", kind, gatewayID)
+		s.Logger.ErrorContext(ctx, kind+" response for unknown gateway ID", "gatewayID", gatewayID)
+		mcpotel.SpanError(span, lookupErr, "unknown "+kind+" ID")
+		response.WithImmediateResponse(400, "unknown "+kind+" ID")
 		return response.Build()
 	}
 	if entry.GatewaySessionID != mcpReq.GetSessionID() {
-		mismatchErr := fmt.Errorf("elicitation session mismatch: expected %s, got %s", entry.GatewaySessionID, mcpReq.GetSessionID())
-		s.Logger.ErrorContext(ctx, "elicitation session mismatch", "gatewayID", gatewayID, "expected", entry.GatewaySessionID, "got", mcpReq.GetSessionID())
+		mismatchErr := fmt.Errorf("%s session mismatch: expected %s, got %s", kind, entry.GatewaySessionID, mcpReq.GetSessionID())
+		s.Logger.ErrorContext(ctx, kind+" session mismatch", "gatewayID", gatewayID, "expected", entry.GatewaySessionID, "got", mcpReq.GetSessionID())
 		mcpotel.SpanError(span, mismatchErr, "session mismatch")
 		response.WithImmediateResponse(403, "session mismatch")
 		return response.Build()
@@ -624,7 +664,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(entry.ServerName)
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "server not found for elicitation response", "server", entry.ServerName)
+		s.Logger.ErrorContext(ctx, "server not found for "+kind+" response", "server", entry.ServerName)
 		mcpotel.SpanError(span, err, "server not found")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
@@ -632,7 +672,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	headers := NewHeaders()
 	headers.WithAuthority(mcpServerConfig.Hostname)
-	headers.WithMCPSession(entry.SessionID) // entry.SessionID contains the backend session id from when the elicitation request was made
+	headers.WithMCPSession(entry.SessionID) // backend session id captured when the server-initiated request was made
 	headers.WithMCPServerName(entry.ServerName)
 	path, err := mcpServerConfig.Path()
 	if err != nil {
@@ -645,7 +685,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 
 	body, err := mcpReq.ToBytes()
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to get bytes for elicitation response", "mcpReqID", mcpReq.ID, "serverName", entry.ServerName)
+		s.Logger.ErrorContext(ctx, "failed to get bytes for "+kind+" response", "mcpReqID", mcpReq.ID, "serverName", entry.ServerName)
 		mcpotel.SpanError(span, err, "marshal failed")
 		response.WithImmediateResponse(500, "internal error")
 		return response.Build()
@@ -654,8 +694,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	headers.WithContentLength(len(body))
 	response.WithRequestBodyHeadersAndBodyResponse(headers.Build(), body)
 
-	// remove the mapping only after the response was successfully built
-	s.ElicitationMap.Remove(ctx, gatewayID)
+	idMap.Remove(ctx, gatewayID)
 
 	return response.Build()
 }

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -181,7 +181,7 @@ func TestHandleRequestBody(t *testing.T) {
 	require.True(t, sessionAdded)
 
 	// Mock InitForClient - should not be called since session exists
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _, _ bool) (*client.Client, error) {
 		// This should not be called in this test since session exists in cache
 		return nil, fmt.Errorf("InitForClient should not be called when session exists")
 	}
@@ -1209,7 +1209,7 @@ func TestInitializeMCPSeverSession_PassThroughHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	var captured map[string]string
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, headers map[string]string, _ bool) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, headers map[string]string, _, _ bool) (*client.Client, error) {
 		captured = make(map[string]string, len(headers))
 		for k, v := range headers {
 			captured[k] = v
@@ -1429,7 +1429,7 @@ func TestHandlePromptGet(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, sessionAdded)
 
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _, _ bool) (*client.Client, error) {
 		return nil, fmt.Errorf("InitForClient should not be called when session exists")
 	}
 
@@ -1532,7 +1532,7 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 		JWTManager:   jwtManager,
 		Logger:       logger,
 		SessionCache: cache,
-		InitForClient: func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+		InitForClient: func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _, _ bool) (*client.Client, error) {
 			return nil, fmt.Errorf("should not be called")
 		},
 		Broker:              newMockBroker(serverConfigs, toolMap),

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -23,14 +23,22 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 		responseHeaderBuilder.WithMCPSession(gatewaySessionID)
 	}
 
-	// on initialize responses, record whether the client declared elicitation support.
-	// only store for direct client inits (no mcp-init-host), not hairpin backend inits.
-	if req != nil && req.Method == "initialize" && req.clientSupportsElicitation() {
+	// on initialize responses, record whether the client declared elicitation or
+	// sampling support. only store for direct client inits (no mcp-init-host), not
+	// hairpin backend inits.
+	if req != nil && req.Method == "initialize" {
 		initHost := getSingleValueHeader(requestHeaders.Headers, "mcp-init-host")
 		if initHost == "" {
 			if sid := getSingleValueHeader(responseHeaders.Headers, sessionHeader); sid != "" {
-				if err := s.SessionCache.SetClientElicitation(ctx, sid); err != nil {
-					s.Logger.ErrorContext(ctx, "failed to store client elicitation flag", "error", err)
+				if req.clientSupportsElicitation() {
+					if err := s.SessionCache.SetClientElicitation(ctx, sid); err != nil {
+						s.Logger.ErrorContext(ctx, "failed to store client elicitation flag", "error", err)
+					}
+				}
+				if req.clientSupportsSampling() {
+					if err := s.SessionCache.SetClientSampling(ctx, sid); err != nil {
+						s.Logger.ErrorContext(ctx, "failed to store client sampling flag", "error", err)
+					}
 				}
 			}
 		}

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -34,6 +34,8 @@ type SessionCache interface {
 	SetUserToken(ctx context.Context, sessionID, serverName, token string) error
 	GetUserToken(ctx context.Context, sessionID, serverName string) (string, bool, error)
 	DeleteUserToken(ctx context.Context, sessionID, serverName string) error
+	SetClientSampling(ctx context.Context, gatewaySessionID string) error
+	GetClientSampling(ctx context.Context, gatewaySessionID string) (bool, error)
 }
 
 // InitForClient defines a function for initializing an MCP server for a client.
@@ -50,6 +52,7 @@ type ExtProcServer struct {
 	SessionCache        SessionCache
 	ElicitationMap      idmap.Map
 	TokenElicitationMap elicitation.Map
+	SamplingMap         idmap.Map
 	MaxRequestBodySize  int
 	ElicitationEnabled  bool
 	//TODO this should not be needed

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -41,7 +41,7 @@ type SessionCache interface {
 // InitForClient defines a function for initializing an MCP server for a client.
 // initToken is a short-lived JWT minted by the router and validated again when
 // the hairpin request re-enters the gateway.
-type InitForClient func(ctx context.Context, gatewayHost, initToken string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool) (*client.Client, error)
+type InitForClient func(ctx context.Context, gatewayHost, initToken string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation, clientSampling bool) (*client.Client, error)
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -10,7 +10,10 @@ import (
 	redis "github.com/redis/go-redis/v9"
 )
 
-const clientElicitationPrefix = "clientelicitation:"
+const (
+	clientElicitationPrefix = "clientelicitation:"
+	clientSamplingPrefix    = "clientsampling:"
+)
 
 const userTokenFieldPrefix = "token:"
 
@@ -59,12 +62,13 @@ func (c *Cache) DeleteSessions(ctx context.Context, key ...string) error {
 		for _, k := range key {
 			c.inmemory.Delete(k)
 			c.inmemory.Delete(clientElicitationPrefix + k)
+			c.inmemory.Delete(clientSamplingPrefix + k)
 		}
 		return nil
 	}
-	allKeys := make([]string, 0, len(key)*2)
+	allKeys := make([]string, 0, len(key)*3)
 	for _, k := range key {
-		allKeys = append(allKeys, k, clientElicitationPrefix+k)
+		allKeys = append(allKeys, k, clientElicitationPrefix+k, clientSamplingPrefix+k)
 	}
 	return c.extClient.Del(ctx, allKeys...).Err()
 }
@@ -229,6 +233,33 @@ func (c *Cache) DeleteUserToken(ctx context.Context, sessionID, serverName strin
 		return nil
 	}
 	return c.extClient.HDel(ctx, sessionID, field).Err()
+}
+
+// SetClientSampling records that the client for this gateway session supports sampling
+func (c *Cache) SetClientSampling(ctx context.Context, gatewaySessionID string) error {
+	key := clientSamplingPrefix + gatewaySessionID
+	if c.inmemory != nil {
+		c.inmemory.Store(key, true)
+		return nil
+	}
+	return c.extClient.Set(ctx, key, "1", 0).Err()
+}
+
+// GetClientSampling returns whether the client for this gateway session supports sampling
+func (c *Cache) GetClientSampling(ctx context.Context, gatewaySessionID string) (bool, error) {
+	key := clientSamplingPrefix + gatewaySessionID
+	if c.inmemory != nil {
+		_, ok := c.inmemory.Load(key)
+		return ok, nil
+	}
+	val, err := c.extClient.Get(ctx, key).Result()
+	if errors.Is(err, redis.Nil) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return val == "1", nil
 }
 
 // NewCache returns a new cache. Pass WithRedisClient to use an external redis


### PR DESCRIPTION
## Description

Phase 2 of MCP Sampling support capability negotiation. 
This PR makes the gateway advertise the sampling capability to backend MCP servers when the originating client supports it, and records that support per gateway session.

SSE rewriting of `sampling/createMessage` will follow in a later PR.


## Fixes

Fixes (part of):

* #949

Based on :
* #953 

## Changes

- Updates `Initialize` to accept a `clientSampling` argument.
- Sets the Sampling capability on the hairpinned backend initialize request when enabled.
- Extends the `InitForClient` function type signature to carry `clientSampling`.
- Adds the `MCPRequest.clientSampling` field.
- Adds the `clientSupportsSampling()` predicate.
- Reads `GetClientSampling` from the session cache during lazy session initialization.
- Passes the sampling flag through to `InitForClient`.
- Stores client sampling support via `SetClientSampling` on initialize responses.
- Mirrors the existing elicitation handling behavior.
- Applies only to direct client initializes, not hairpin backend initializes.
- Broker upstream initialize now advertises the Sampling capability.

### Tests

- `internal/clients/clients_test.go`
-  `internal/mcp-router/request_handlers_test.go`

- Updates call sites and mock `InitForClient` signatures for the new argument.


## Why

For a backend MCP server to issue `sampling/createMessage`, the gateway must advertise the sampling capability on the backend connection but only when the real client behind the gateway can actually service sampling requests.

- Captures the client’s declared sampling support during initialize.
- Persists sampling capability per session.
- Replays the capability onto backend initialize requests during lazy session initialization.

The implementation intentionally mirrors the existing elicitation capability flow to keep both server-initiated request paths symmetric.

## Follow-ups (not in this PR)

### Phase 3

- Extend `sseRewriter` to match `sampling/createMessage`.
- Set `STREAMED` response mode for sampling-capable tool calls.
- Construct `SamplingMap` in `cmd/mcp-broker-router/main.go`.

### Phase 4

- Add a test server emitting `sampling/createMessage`.
- Add end-to-end and unit tests.
- Add optional per-`MCPServerRegistration` opt-in support.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests where applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MCP sampling capability, allowing clients to advertise and utilize sampling functionality.

* **Tests**
  * Enhanced test coverage for HTTPRoute rule validation and sampling parameter handling.

* **Chores**
  * Updated MCPGatewayExtension configuration for HTTP route management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->