### PR TITLE
docs: fix broken TOC anchor links in flows.md

### DIFF
--- a/docs/design/flows.md
+++ b/docs/design/flows.md
@@ -8,7 +8,7 @@ This document captures the main request flows that involve the MCP Gateway.
 ## Table of Contents
 
 - [Components](#components)
-- [High Level Flow](#high-level-flows)
+- [High Level Flow](#high-level-flow)
 - [Initialize](#initialize)
 - [Aggregated Tools/List](#aggregated-toolslist)
 - [Tools/Call (no auth)](#toolscall-no-auth)
@@ -85,7 +85,7 @@ sequenceDiagram
   note left of MCPBroker: list is built via discovery phase. <br/> The MCPBroker applies filtering to this list. <br/> via signed x-authorised-tools header <br/> and client specified x-mcp-virtualserver headers.
 ```
 
-## Tools/Call
+## Tools/Call (no auth)
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
Summary

Fixes two broken links in the Table of Contents of docs/design/flows.md.

Changes

1. Corrected the `High Level Flow` anchor from `#high-level-flows` to #high-level-flow
2. Renamed the `Tools/Call` section heading to `Tools/Call (no auth)` so the generated anchor matches the existing ToC link

Fixes #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation organization with clarified section headers and corrected internal cross-references for better navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->