### PR TITLE
fix: hold mcpLock.RLock in findServerByName to prevent concurrent map panic

### DIFF
--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -170,6 +170,8 @@ func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []strin
 }
 
 func (broker *mcpBrokerImpl) findServerByName(name string) upstream.ActiveMCPServer {
+	broker.mcpLock.RLock()
+	defer broker.mcpLock.RUnlock()
 	for _, upstream := range broker.mcpServers {
 		if upstream.MCPName() == name {
 			return upstream


### PR DESCRIPTION
While the race detector was still running from #1005 I noticed one more unguarded `mcpServers` access that follows the same pattern as #922.

Every method that touches `broker.mcpServers` holds `mcpLock` first; `GetServerInfo`, `GetServerInfoByPrompt`, `ToolAnnotations`, `ValidateAllServers`, all of them. `findServerByName` in `filtered_tools_handler.go` is the single exception. It does a bare `for range broker.mcpServers` with nothing around it, and it's called from the `x-mcp-authorized` JWT filtering path whenever a `tools/list` request carries that header (the Authorino/Keycloak tool AuthZ setup).

`OnConfigChange` writes to that same map under `mcpLock.Lock()` during every config reload; which in Kubernetes means every time the controller reconciles an `MCPServerRegistration`. If a `tools/list` lands while the reload is mid-write, you get a concurrent map iteration + write and Go panics with `fatal error: concurrent map read and map write`. No error log beforehand, just a pod restart.

Fix is one `RLock`/`RUnlock` in `findServerByName`, same as every other reader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by protecting concurrent access to upstream server listings, preventing intermittent crashes and race conditions when querying available servers.
  * Reduced chance of inconsistent server lookup results under concurrent load.
  * Improved reliability of server discovery during high-concurrency operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->