### PR TITLE
automate k6 performance benchmarking pipeline with PR regression gating

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,9 @@
         "realm-import.yaml",
         "docs/plans/**",
         "docs/superpowers/**",
-        "catalog/mcp-gateway-catalog/**"
+        "catalog/mcp-gateway-catalog/**",
+        "out/**",
+        "GOTOOLCHAIN",  
+    "reqs"
     ]
 }

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -63,37 +63,9 @@ jobs:
       - name: Setup performance test environment
         run: make perf-ci-setup
 
-      # Apply the in-cluster k6 Job and wait for it to complete
-      - name: Run benchmark Job
-        run: |
-          kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
-          echo "Waiting for benchmark Job to complete..."
-          kubectl wait \
-            --for=condition=complete \
-            job/mcp-gateway-benchmark \
-            -n mcp-test \
-            --timeout=180s
-
-      # Copy the summary JSON out of the completed pod's results volume
-      - name: Extract benchmark results
-        run: |
-          POD=$(kubectl get pod \
-            -n mcp-test \
-            -l app=mcp-gateway-benchmark \
-            -o jsonpath='{.items[0].metadata.name}')
-          echo "Extracting results from pod: $POD"
-          kubectl cp "mcp-test/${POD}:/results/summary.json" ./k6-summary.json
-          echo "=== k6 summary ==="
-          cat ./k6-summary.json
-
-      # Convert k6 summary → customSmallerIsBetter JSON for benchmark-action
-      - name: Convert results to benchmark format
-        run: |
-          chmod +x tests/perf/scripts/convert-k6-to-benchmark.sh
-          tests/perf/scripts/convert-k6-to-benchmark.sh k6-summary.json \
-            > benchmark-results.json
-          echo "=== benchmark results ==="
-          cat benchmark-results.json
+      # Run the in-cluster k6 Job, extract the JSON via pod logs, and convert to benchmark format
+      - name: Run and extract benchmark
+        run: make perf-ci-run
 
       # Track results over time and gate on regression
       # Note: auto-push requires a gh-pages branch and GitHub Pages to be enabled.
@@ -103,7 +75,7 @@ jobs:
         with:
           name: MCP Gateway Performance
           tool: customSmallerIsBetter
-          output-file-path: benchmark-results.json
+          output-file-path: out/perf/benchmark-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Fail the workflow if any metric degrades by more than 30 %

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -1,0 +1,127 @@
+name: Performance Benchmark
+
+# Fulfills sub-issue #807: manually triggered CI job for benchmarking.
+#
+# Triggers:
+#   - workflow_dispatch: manually triggered from the Actions tab
+#   - pull_request: automatically on PRs that touch gateway internals or perf tests
+#
+# The workflow:
+#   1. Provisions a Kind cluster identical to the e2e CI cluster
+#   2. Deploys the full gateway stack via `make ci-setup`
+#   3. Deploys the perf mock server + k6 ConfigMap via `make perf-ci-setup`
+#   4. Runs the benchmark as an in-cluster Kubernetes Job
+#   5. Extracts the k6 summary JSON from the completed pod
+#   6. Converts it to customSmallerIsBetter format and feeds it to
+#      benchmark-action for historical tracking and regression detection
+#
+# Regression gate: the workflow fails (blocking merge/release) if any metric
+# exceeds 130 % of the stored baseline (i.e. a > 30 % performance degradation).
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/**'
+      - 'cmd/**'
+      - 'tests/perf/**'
+      - 'Dockerfile.k6'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      # Required by benchmark-action to push results to gh-pages and post PR comments
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      # Provision a Kind cluster using the same config as the standard e2e suite
+      - name: Create Kind cluster
+        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+
+      # Full gateway stack: Istio, gateway, controller, test servers
+      - name: Setup CI environment
+        run: make ci-setup
+
+      # Deploy perf mock server + create k6-ci-scenarios ConfigMap
+      - name: Setup performance test environment
+        run: make perf-ci-setup
+
+      # Apply the in-cluster k6 Job and wait for it to complete
+      - name: Run benchmark Job
+        run: |
+          kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
+          echo "Waiting for benchmark Job to complete..."
+          kubectl wait \
+            --for=condition=complete \
+            job/mcp-gateway-benchmark \
+            -n mcp-test \
+            --timeout=180s
+
+      # Copy the summary JSON out of the completed pod's results volume
+      - name: Extract benchmark results
+        run: |
+          POD=$(kubectl get pod \
+            -n mcp-test \
+            -l app=mcp-gateway-benchmark \
+            -o jsonpath='{.items[0].metadata.name}')
+          echo "Extracting results from pod: $POD"
+          kubectl cp "mcp-test/${POD}:/results/summary.json" ./k6-summary.json
+          echo "=== k6 summary ==="
+          cat ./k6-summary.json
+
+      # Convert k6 summary → customSmallerIsBetter JSON for benchmark-action
+      - name: Convert results to benchmark format
+        run: |
+          chmod +x tests/perf/scripts/convert-k6-to-benchmark.sh
+          tests/perf/scripts/convert-k6-to-benchmark.sh k6-summary.json \
+            > benchmark-results.json
+          echo "=== benchmark results ==="
+          cat benchmark-results.json
+
+      # Track results over time and gate on regression
+      # Note: auto-push requires a gh-pages branch and GitHub Pages to be enabled.
+      # See: https://github.com/benchmark-action/github-action-benchmark#readme
+      - name: Store and compare benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: MCP Gateway Performance
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Fail the workflow if any metric degrades by more than 30 %
+          fail-on-alert: true
+          alert-threshold: '130%'
+          comment-on-alert: true
+          # Post a summary comment on every PR (not just regressions)
+          summary-always: true
+
+      # Collect debug information on failure for easier diagnosis
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== k6 Job status ==="
+          kubectl describe job/mcp-gateway-benchmark -n mcp-test || true
+          echo "=== k6 pod logs ==="
+          kubectl logs \
+            -n mcp-test \
+            -l app=mcp-gateway-benchmark \
+            --tail=200 || true
+          make ci-debug-logs || true

--- a/Dockerfile.k6
+++ b/Dockerfile.k6
@@ -1,0 +1,33 @@
+# Build k6 with the xk6-infobip-mcp extension.
+# The resulting image is published to ghcr.io/kuadrant/mcp-gateway/k6-mcp
+# and used by the in-cluster performance benchmark Job.
+#
+# Build:  docker build -f Dockerfile.k6 -t ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest .
+# Push:   docker push ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
+
+FROM golang:1.24-alpine AS builder
+
+# Allow the Go toolchain to auto-download a newer version if a dependency
+# requires one (e.g. xk6 >= v1.4 requires Go 1.25+).
+# cspell:ignore GOTOOLCHAIN
+ENV GOTOOLCHAIN=auto
+
+RUN apk add --no-cache git
+
+# Install xk6 – the k6 extension builder
+RUN go install go.k6.io/xk6/cmd/xk6@latest
+
+
+# Build k6 with the MCP extension
+RUN xk6 build \
+    --with github.com/infobip/xk6-infobip-mcp \
+    --output /k6
+
+# ─────────────────────────────────────────────────────────────────────────────
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /k6 /usr/local/bin/k6
+
+ENTRYPOINT ["k6"]

--- a/build/perf.mk
+++ b/build/perf.mk
@@ -1,5 +1,8 @@
 ##@ Performance Testing
 
+# CI benchmark image (k6 + xk6-infobip-mcp extension)
+PERF_K6_IMG ?= ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
+
 PERF_MOCK_IMG ?= ghcr.io/kuadrant/mcp-gateway/perf-mock-server:latest
 PERF_USERS ?= 64
 PERF_MAX_USERS ?= 4096
@@ -135,3 +138,62 @@ perf-profile: ## Capture a one-off pprof snapshot from broker-router
 	@go tool pprof -proto -output out/profiles/mutex.pb.gz $(PERF_PPROF_URL)/debug/pprof/mutex
 	@echo "Profiles saved to out/profiles/"
 	@-pkill -f 'port-forward.*6060' 2>/dev/null || true
+
+##@ CI Performance Benchmarking
+
+.PHONY: perf-build-k6-image
+perf-build-k6-image: ## Build the k6-mcp Docker image (k6 + xk6-infobip-mcp)
+	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) \
+		-f Dockerfile.k6 \
+		-t $(PERF_K6_IMG) .
+
+.PHONY: perf-push-k6-image
+perf-push-k6-image: ## Push the k6-mcp image to the registry
+	$(CONTAINER_ENGINE) push $(PERF_K6_IMG)
+
+.PHONY: perf-ci-setup
+perf-ci-setup: kind perf-build-mock-server perf-build-k6-image ## Setup in-cluster CI benchmark environment (mock server + k6 ConfigMap)
+	@echo "Loading perf mock server image..."
+	$(call load-image,$(PERF_MOCK_IMG))
+	@echo "Loading k6-mcp image..."
+	$(call load-image,$(PERF_K6_IMG))
+	@echo "Applying default MCPGatewayExtension..."
+	kubectl apply -f config/mcp-gateway/base/mcpgatewayextension.yaml -n $(MCP_GATEWAY_NAMESPACE)
+	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --timeout=60s
+	kubectl apply -f config/test-servers/namespace.yaml
+	kubectl apply -f tests/perf/manifests/mock-server.yaml -n mcp-test
+	kubectl apply -f tests/perf/manifests/registration.yaml
+	@echo "Waiting for perf mock server..."
+	@kubectl wait --for=condition=Available deployment/perf-mock-server -n mcp-test --timeout=60s
+	@echo "Waiting for MCPServerRegistration..."
+	@kubectl wait --for=condition=Ready mcpsr/perf-mock-server -n mcp-test --timeout=120s
+	@echo "Creating k6 scenarios ConfigMap..."
+	kubectl create configmap k6-ci-scenarios \
+		--from-file=ci-benchmark.js=tests/perf/k6/ci-benchmark.js \
+		-n mcp-test \
+		--dry-run=client -o yaml | kubectl apply -f -
+	@echo "CI benchmark environment ready"
+
+.PHONY: perf-ci-run
+perf-ci-run: ## Run the in-cluster benchmark Job and extract results
+	@mkdir -p out/perf
+	@echo "Applying benchmark Job..."
+	kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
+	@echo "Waiting for Job to complete (timeout 180 s)..."
+	kubectl wait --for=condition=complete job/mcp-gateway-benchmark -n mcp-test --timeout=180s
+	@POD=$$(kubectl get pod -n mcp-test -l app=mcp-gateway-benchmark \
+		-o jsonpath='{.items[0].metadata.name}'); \
+	echo "Extracting results from pod logs: $$POD"; \
+	kubectl logs "$$POD" -n mcp-test | sed -n '/___K6_JSON_SUMMARY___/,/___K6_JSON_SUMMARY_END___/p' | grep -v '___K6_JSON_SUMMARY' > out/perf/k6-ci-summary.json
+	@chmod +x tests/perf/scripts/convert-k6-to-benchmark.sh
+	@tests/perf/scripts/convert-k6-to-benchmark.sh out/perf/k6-ci-summary.json \
+		> out/perf/benchmark-results.json
+	@echo "Results written to out/perf/benchmark-results.json"
+	@cat out/perf/benchmark-results.json
+
+.PHONY: perf-ci-clean
+perf-ci-clean: ## Remove in-cluster CI benchmark resources (Job + ConfigMap)
+	kubectl delete job/mcp-gateway-benchmark -n mcp-test --ignore-not-found
+	kubectl delete configmap/k6-ci-scenarios -n mcp-test --ignore-not-found
+	kubectl delete mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --ignore-not-found
+	kubectl delete mcpserverregistration/perf-mock-server --ignore-not-found

--- a/project-words.txt
+++ b/project-words.txt
@@ -427,3 +427,8 @@ deadbeefcafebabe
 myprompt
 promptname
 rescope
+forcetypeassert
+benchmarkaction
+customSmallerIsBetter
+ttlSecondsAfterFinished
+k6mcp

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -63,11 +63,14 @@ The `perf-run-ramp` target captures interval snapshots (goroutine, heap, CPU) ev
 |-|-|
 | `k6/concurrency-levels.js` | steady-state test at fixed VU count |
 | `k6/ramp-up.js` | ramp from 0 to N users to find failure point |
+| `k6/ci-benchmark.js` | short CI-optimised scenario for regression tracking |
 | `cmd/report/` | HTML report generator with comparison support |
 | `mock-server/` | 10-tool zero-latency MCP server for isolating gateway overhead |
 | `manifests/` | Kind deployment for mock server + MCPServerRegistration |
+| `manifests/k6-benchmark-job.yaml` | Kubernetes Job that runs k6 in-cluster |
 | `scripts/collect-resources.sh` | polls broker CPU/memory/goroutines during tests |
 | `scripts/capture-profiles.sh` | captures pprof snapshots at intervals |
+| `scripts/convert-k6-to-benchmark.sh` | converts k6 summary JSON to benchmark-action format |
 
 ## Makefile targets
 
@@ -79,3 +82,89 @@ The `perf-run-ramp` target captures interval snapshots (goroutine, heap, CPU) ev
 | `perf-run-steady` | run steady-state concurrency test |
 | `perf-run-ramp` | run ramp-up test with profiling |
 | `perf-profile` | capture a one-off pprof snapshot |
+| `perf-build-k6-image` | build the `k6-mcp` Docker image |
+| `perf-push-k6-image` | push the `k6-mcp` image to ghcr.io |
+| `perf-ci-setup` | load images + deploy mock server + create k6 ConfigMap |
+| `perf-ci-run` | apply Job, wait, extract results, convert to benchmark format |
+| `perf-ci-clean` | remove CI benchmark Job and ConfigMap |
+
+---
+
+## CI Benchmarking (Issue #305 / Sub-issue #807)
+
+The CI benchmark suite tracks gateway performance from release to release using a
+k6 load generator deployed as a Kubernetes Job **inside** the cluster. Running
+k6 in-cluster eliminates external network jitter and gives accurate baseline
+metrics for regression detection.
+
+### How it works
+
+```
+GitHub Actions
+  └─ kind create cluster
+  └─ make ci-setup         # Istio, gateway, controller, test servers
+  └─ make perf-ci-setup    # loads k6-mcp image + deploys mock server + ConfigMap
+  └─ kubectl apply k6-benchmark-job.yaml
+  └─ kubectl wait --for=condition=complete job/mcp-gateway-benchmark
+  └─ kubectl cp <pod>:/results/summary.json
+  └─ convert-k6-to-benchmark.sh → benchmark-results.json
+  └─ benchmark-action       # stores history + comments on PR + blocks on regression
+```
+
+### Triggering the workflow
+
+**Manually** (from the Actions tab — fulfils sub-issue #807):
+1. Navigate to **Actions → Performance Benchmark**.
+2. Click **Run workflow** and select the branch.
+3. The workflow provisions a fresh Kind cluster and posts results as a PR comment.
+
+**Automatically**: the workflow runs on every PR that touches `internal/`,
+`cmd/`, or `tests/perf/`.
+
+### Regression gating
+
+`benchmark-action` stores historical metrics on the `gh-pages` branch and
+compares each run against the stored baseline. If any metric degrades by more
+than **30 %** (threshold: `130%`), the workflow fails and blocks the PR from
+merging. A summary comment is posted on every run showing the trend.
+
+Metrics tracked (all smaller-is-better):
+
+| Metric | Description |
+|-|-|
+| `p95_tool_call_ms` | 95th-percentile MCP tool-call latency |
+| `p99_tool_call_ms` | 99th-percentile MCP tool-call latency |
+| `avg_tool_call_ms` | average MCP tool-call latency |
+| `tool_error_rate` | percentage of failed tool calls |
+| `session_fail_rate` | percentage of failed MCP session opens |
+
+### Running the CI benchmark locally
+
+Requires a running Kind cluster with the gateway deployed:
+
+```bash
+# One-time: build the k6-mcp image (already done if using the published image)
+make perf-build-k6-image
+
+# Setup: load images + deploy mock server + create ConfigMap
+make ci-setup
+make perf-ci-setup
+
+# Run: apply Job, wait, extract, and convert results
+make perf-ci-run
+# Results written to out/perf/benchmark-results.json
+
+# Cleanup
+make perf-ci-clean
+```
+
+### Pre-requisites for CI
+
+* The `k6-mcp` image must be published to
+  `ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest` before the first CI run:
+  ```bash
+  make perf-build-k6-image
+  make perf-push-k6-image
+  ```
+* GitHub Pages must be enabled on the repository (`gh-pages` branch) for
+  `benchmark-action` to persist historical data.

--- a/tests/perf/k6/ci-benchmark.js
+++ b/tests/perf/k6/ci-benchmark.js
@@ -1,0 +1,115 @@
+// CI benchmark scenario for the MCP gateway.
+// Designed to run as an in-cluster Kubernetes Job and produce stable,
+// comparable metrics suitable for regression tracking via benchmark-action.
+//
+// Key differences from the local development scenarios:
+//   - Short fixed duration (30 s) and low VU count suited to CI runners
+//   - Targets the gateway via in-cluster DNS (configurable via TARGET_URL)
+//   - Writes a --summary-export JSON used by the convert-k6-to-benchmark.sh
+//     converter before being fed to benchmark-action
+//
+// Usage (in-cluster Job):
+//   k6 run /scenarios/ci-benchmark.js \
+//       --summary-export /results/summary.json
+//
+// Usage (local, against a running Kind cluster):
+//   TARGET_URL=http://localhost:8001/mcp PREFIX=mock_ \
+//     ./bin/k6 run tests/perf/k6/ci-benchmark.js \
+//       --summary-export out/ci-summary.json
+
+import mcp from 'k6/x/infobip_mcp';
+import { check, sleep } from 'k6';
+import { Counter, Trend, Rate } from 'k6/metrics';
+
+// ─── configuration ────────────────────────────────────────────────────────────
+// Default URL targets the Istio gateway service via in-cluster DNS.
+// Override with TARGET_URL env var when running locally.
+const TARGET_URL = __ENV.TARGET_URL
+    || 'http://mcp-gateway-istio.gateway-system.svc.cluster.local/mcp';
+const PREFIX     = __ENV.PREFIX   || 'mock_';
+const VUS        = parseInt(__ENV.VUS      || '10');
+const DURATION   = __ENV.DURATION || '30s';
+const TIMEOUT    = parseInt(__ENV.TIMEOUT  || '10');
+
+// ─── custom metrics ───────────────────────────────────────────────────────────
+const mcpSessionsOpened   = new Counter('mcp_sessions_opened');
+const mcpSessionOpenFail  = new Rate('mcp_session_open_fail');
+const mcpSessionDuration  = new Trend('mcp_session_duration', true);
+
+const mcpToolCalls        = new Counter('mcp_tool_calls');
+const mcpToolCallDuration = new Trend('mcp_tool_call_duration', true);
+const mcpToolCallFails    = new Counter('mcp_tool_call_fails');
+const mcpToolCallFailRate = new Rate('mcp_tool_call_fail_rate');
+
+// ─── scenario options ─────────────────────────────────────────────────────────
+export const options = {
+    scenarios: {
+        ci_steady: {
+            executor: 'constant-vus',
+            vus:      VUS,
+            duration: DURATION,
+        },
+    },
+    thresholds: {
+        // CI gates: fail the Job (and therefore the workflow) if these are breached
+        mcp_tool_call_fail_rate: ['rate<0.01'],          // < 1 % errors
+        mcp_tool_call_duration:  ['p(95)<200'],           // p95 < 200 ms
+        mcp_session_open_fail:   ['rate<0.01'],           // < 1 % session failures
+    },
+};
+
+// Tools exposed by the perf-mock-server (10 zero-latency tools)
+const TOOLS = [
+    'alpha', 'bravo', 'charlie', 'delta', 'echo',
+    'foxtrot', 'golf', 'hotel', 'india', 'juliet',
+];
+
+// ─── default function (one VU iteration) ─────────────────────────────────────
+export default function () {
+    const sessionStart = Date.now();
+
+    // Open an MCP session
+    let client;
+    try {
+        client = mcp.NewClient({
+            endpoint: TARGET_URL,
+            timeout:  TIMEOUT,
+            isSSE:    false,
+        });
+        mcpSessionsOpened.add(1);
+        mcpSessionOpenFail.add(false);
+    } catch (e) {
+        mcpSessionOpenFail.add(true);
+        sleep(1);
+        return;
+    }
+
+    // Exercise a fixed set of tool calls per iteration (5 calls, ~0.5 s each)
+    try {
+        for (let i = 0; i < 5; i++) {
+            const toolName = `${PREFIX}${TOOLS[i % TOOLS.length]}`;
+            const start    = Date.now();
+            try {
+                const result  = client.callTool(toolName, { input: 'bench' });
+                const elapsed = Date.now() - start;
+                mcpToolCalls.add(1);
+                mcpToolCallDuration.add(elapsed);
+                const ok = result.length > 0;
+                mcpToolCallFailRate.add(!ok);
+                if (!ok) {
+                    mcpToolCallFails.add(1);
+                }
+                check(result, { 'tool call returned data': (r) => r.length > 0 });
+            } catch (e) {
+                mcpToolCalls.add(1);
+                mcpToolCallFailRate.add(true);
+                mcpToolCallFails.add(1);
+                mcpToolCallDuration.add(Date.now() - start);
+            }
+            sleep(0.1 + Math.random() * 0.2);
+        }
+    } finally {
+        mcpSessionDuration.add(Date.now() - sessionStart);
+        client.closeConnection();
+    }
+}

--- a/tests/perf/manifests/k6-benchmark-job.yaml
+++ b/tests/perf/manifests/k6-benchmark-job.yaml
@@ -1,0 +1,75 @@
+---
+# Kubernetes Job that runs the CI benchmark scenario in-cluster.
+#
+# The scenario script is mounted from the k6-ci-scenarios ConfigMap
+# (created by `make perf-ci-setup` or `kubectl create configmap`).
+#
+# Results are written to an emptyDir volume and extracted with
+# `kubectl cp` before the pod is garbage-collected.
+#
+# Apply:   kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
+# Wait:    kubectl wait --for=condition=complete job/mcp-gateway-benchmark --timeout=180s
+# Extract: kubectl cp <pod>:/results/summary.json ./k6-summary.json
+# Clean:   kubectl delete job/mcp-gateway-benchmark
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mcp-gateway-benchmark
+  namespace: mcp-test
+  labels:
+    app: mcp-gateway-benchmark
+    component: performance
+spec:
+  # Keep the completed pod alive for 5 minutes so metrics can be extracted
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: mcp-gateway-benchmark
+        component: performance
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              k6 run /scenarios/ci-benchmark.js --summary-export /results/summary.json && \
+              echo "___K6_JSON_SUMMARY___" && \
+              cat /results/summary.json && \
+              echo "" && \
+              echo "___K6_JSON_SUMMARY_END___"
+          env:
+            # In-cluster DNS for the Istio gateway service.
+            # Override when running in a different topology.
+            - name: TARGET_URL
+              value: "http://mcp-gateway-istio.gateway-system.svc.cluster.local:8080/mcp"
+            - name: PREFIX
+              value: "mock_"
+            - name: VUS
+              value: "10"
+            - name: DURATION
+              value: "30s"
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          volumeMounts:
+            - name: scenarios
+              mountPath: /scenarios
+              readOnly: true
+            - name: results
+              mountPath: /results
+      volumes:
+        - name: scenarios
+          configMap:
+            name: k6-ci-scenarios
+        - name: results
+          emptyDir: {}

--- a/tests/perf/scripts/convert-k6-to-benchmark.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# convert-k6-to-benchmark.sh
+#
+# Converts a k6 --summary-export JSON file into the customSmallerIsBetter
+# format expected by benchmark-action/github-action-benchmark.
+#
+# Usage:
+#   ./tests/perf/scripts/convert-k6-to-benchmark.sh <summary.json> > benchmark-results.json
+#
+# Input format (k6 --summary-export):
+#   {
+#     "metrics": {
+#       "http_req_duration": { "values": { "avg": 20.1, "p(95)": 45.2, "p(99)": 98.3 } },
+#       "mcp_tool_call_duration": { "values": { "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0 } },
+#       "mcp_tool_call_fail_rate": { "values": { "rate": 0.001 } },
+#       "mcp_session_open_fail":   { "values": { "rate": 0.000 } },
+#       ...
+#     }
+#   }
+#
+# Output format (customSmallerIsBetter):
+#   [
+#     { "name": "p95_tool_call_ms",  "unit": "ms",      "value": 42.1 },
+#     { "name": "p99_tool_call_ms",  "unit": "ms",      "value": 95.0 },
+#     { "name": "avg_tool_call_ms",  "unit": "ms",      "value": 18.4 },
+#     { "name": "tool_error_rate",   "unit": "percent", "value": 0.1  },
+#     { "name": "session_fail_rate", "unit": "percent", "value": 0.0  }
+#   ]
+
+set -euo pipefail
+
+SUMMARY_FILE="${1:-}"
+
+if [[ -z "$SUMMARY_FILE" ]]; then
+    echo "Usage: $0 <k6-summary.json>" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SUMMARY_FILE" ]]; then
+    echo "Error: file not found: $SUMMARY_FILE" >&2
+    exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed." >&2
+    exit 1
+fi
+
+jq '
+[
+  # MCP tool call p95 latency (primary regression signal)
+  {
+    name:  "p95_tool_call_ms",
+    unit:  "ms",
+    value: (.metrics.mcp_tool_call_duration["p(95)"] // 0)
+  },
+  # MCP tool call p99 latency
+  {
+    name:  "p99_tool_call_ms",
+    unit:  "ms",
+    value: (.metrics.mcp_tool_call_duration["p(99)"] // 0)
+  },
+  # MCP tool call average latency
+  {
+    name:  "avg_tool_call_ms",
+    unit:  "ms",
+    value: (.metrics.mcp_tool_call_duration.avg // 0)
+  },
+  # MCP tool call error rate (as a percentage)
+  {
+    name:  "tool_error_rate",
+    unit:  "percent",
+    value: ((.metrics.mcp_tool_call_fail_rate.rate // 0) * 100)
+  },
+  # MCP session open failure rate (as a percentage)
+  {
+    name:  "session_fail_rate",
+    unit:  "percent",
+    value: ((.metrics.mcp_session_open_fail.rate // 0) * 100)
+  }
+]
+| map(select(.value != null))
+' "$SUMMARY_FILE"


### PR DESCRIPTION
fixes #305
### Key Changes
* **Custom k6 Load Tester**: Added a `Dockerfile.k6` to build a custom `k6` image equipped with the `xk6-infobip-mcp` extension.
* **In-Cluster Benchmark Suite**: Created a robust `ci-benchmark.js` script to execute load tests against 10 zero-latency mock tools. The tests are executed directly inside the cluster via a Kubernetes Job (`k6-benchmark-job.yaml`) targeting the internal Istio ingress gateway (`mcp-gateway-istio:8080`).
* **CI Regression Gating**: Implemented a new GitHub Actions workflow (`performance-benchmark.yml`) that automatically runs the load test on PRs. It uses a custom shell script (`convert-k6-to-benchmark.sh`) to extract p95 latency and error rates, automatically commenting on the PR with the results.
* **Fail-Fast Thresholds**: The CI workflow is configured to fail the build if the new p95 latency degrades by more than 130% compared to the baseline on `main`.
* **Clean Environments**: Updated `build/perf.mk` targets (`perf-ci-setup`, `perf-ci-run`, `perf-ci-clean`) to correctly manage `MCPGatewayExtension` isolation, ensuring that running local performance tests does not break or conflict with the standard E2E test suite. 

### Testing Instructions
You can run this full CI benchmarking pipeline locally to test it:
```bash
make ci-setup
make perf-ci-setup
make perf-ci-run
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI performance benchmarking: in-cluster k6 runs with automated regression gating, diagnostics, and a packaged k6 runtime for CI.

* **Documentation**
  * Expanded performance testing docs with CI workflow, tracked metrics, usage, and local run guidance.

* **Chores**
  * Added CI build/publish and lifecycle targets, in-cluster benchmark orchestration, conversion script for benchmark-action, and updated spellcheck dictionary/ignore paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->