### PR TITLE
docs: document GATEWAY_SIGNING_KEY rename in release notes

### DIFF
--- a/docs/release-notes/0.0.7.md
+++ b/docs/release-notes/0.0.7.md
@@ -30,10 +30,15 @@ upstream MCP server.
 - The `--mcp-router-key` CLI flag and `MCP_ROUTER_API_KEY` environment
   variable have been **removed**. The controller no longer emits this flag
   and strips it from existing deployments on the next reconcile.
-- `GATEWAY_SIGNING_KEY` is now required for both the client session JWT
-  and the backend-init JWT. The broker/router panics on startup if it is
-  empty. In controller-managed deployments this is already generated and
-  injected automatically via `env.valueFrom.secretKeyRef`.
+- `JWT_SESSION_SIGNING_KEY` has been renamed to `GATEWAY_SIGNING_KEY`.
+  This key is now used for both JWT session signing and session cache
+  encryption key derivation. The old environment variable is still
+  accepted as a fallback but is deprecated. The broker/router panics on
+  startup if neither is set. In controller-managed deployments this is
+  already generated and injected automatically via
+  `env.valueFrom.secretKeyRef`.
+- The `--session-signing-key` CLI flag is now a deprecated alias for the
+  new `--gateway-signing-key` flag.
 - `JWTManager.Validate` now enforces `iss=mcp-gateway`, `aud=mcp-gateway`,
   and `alg=HS256`. Tokens signed with other algorithms or with different
   issuer/audience claims are rejected.


### PR DESCRIPTION
## Summary

- Documents the `JWT_SESSION_SIGNING_KEY` → `GATEWAY_SIGNING_KEY` rename in 0.0.7 release notes
- Notes the dual-purpose usage (JWT signing + cache encryption key derivation)
- Documents the deprecated `--session-signing-key` CLI flag alias

Follow-up to #971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security advisory documentation in release notes to clarify environment variable naming changes and their dual-purpose functionality.
  * Added details on deprecated command-line flag aliases and clarified startup behavior for incomplete configurations to assist with migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->