### PR TITLE
fix: complete jwtSigningKeyFlag rename missed in #971

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -195,7 +195,7 @@ func main() {
 	var sessionCacheOpts []func(*session.Cache)
 	sessionCacheOpts = append(sessionCacheOpts, session.WithRedisClient(redisClient))
 	if redisClient != nil {
-		encKey, encErr := session.DeriveEncryptionKey([]byte(jwtSigningKeyFlag))
+		encKey, encErr := session.DeriveEncryptionKey([]byte(gatewaySigningKeyFlag))
 		if encErr != nil {
 			panic("failed to derive encryption key: " + encErr.Error())
 		}


### PR DESCRIPTION
## Summary
- PR #971 renamed `jwtSigningKeyFlag` to `gatewaySigningKeyFlag` but missed one reference at `cmd/mcp-broker-router/main.go:198`
- This breaks the Docker build (and conformance CI) since the Dockerfile builds only `main.go`

## Test plan
- [x] `go build ./cmd/mcp-broker-router/` passes locally
- [x] Conformance CI passes