### PR TITLE
Replace sleep based reconciliation in TLS controller integration tests

### DIFF
--- a/internal/controller/mcpserverregistration_controller_integration_test.go
+++ b/internal/controller/mcpserverregistration_controller_integration_test.go
@@ -383,13 +383,19 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			// reconcile multiple times to get past finalizer addition
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// first reconcile to add finalizer
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
+
+			// second reconcile to process
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1alpha1.MCPServerRegistration{}
@@ -430,13 +436,19 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			// reconcile multiple times to get past finalizer addition
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// first reconcile to add finalizer
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
+
+			// second reconcile to process
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1alpha1.MCPServerRegistration{}
@@ -492,13 +504,19 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			// reconcile multiple times to get past finalizer addition
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// first reconcile to add finalizer
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
+
+			// second reconcile to process
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1alpha1.MCPServerRegistration{}


### PR DESCRIPTION
The TLS integration tests were using a retry loop with time.Sleep() to drive reconciliation and wait for cache updates. While it worked it relied on timing assumptions and could become flaky depending on execution speed.

This change switches those tests to the same reconciliation pattern already used elsewhere in the integration suite :-

1. reconcile once to add the finalizer
2. wait for the cache to observe the update
3. reconcile again to process the resource

The overall test behavior remains the same but the tests no longer depends on arbitrary sleeps or retry counts.

Fixes #1040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing timing-dependent test behavior with deterministic reconciliation sequences in integration tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->