### PR TITLE
feat: add OTel metrics for router, broker, session, and upstream manager

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -94,19 +94,19 @@ jobs:
 
       - name: Wait for conformance server to get ready
         run: |
-          echo "Waiting for Gateway to wire up the MCP routes and broker to fetch tools..."
-          for i in {1..30}; do
+          echo "Waiting for Envoy gateway to be programmed..."
+          kubectl wait --for=condition=Programmed gateway/mcp-gateway -n gateway-system --timeout=120s
+          echo "Waiting for MCP route to become active..."
+          for i in {1..60}; do
             HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" ${{ env.MCP_URL }})
             if [[ "$HTTP_STATUS" != "000" && "$HTTP_STATUS" != "0" && "$HTTP_STATUS" != "502" && "$HTTP_STATUS" != "503" ]]; then
               echo "Gateway route is active! HTTP Status: $HTTP_STATUS"
-              # Extra wait for broker to connect and fetch tools from the conformance server
-              sleep 10
               break
             fi
-            echo "Attempt $i/30: Gateway route not ready yet (Status: $HTTP_STATUS). Retrying in 2 seconds..."
+            echo "Attempt $i/60: Gateway route not ready yet (Status: $HTTP_STATUS). Retrying in 2 seconds..."
             sleep 2
-            if [ $i -eq 30 ]; then
-              echo "ERROR: Gateway routes failed to propagate after 60 seconds."
+            if [ $i -eq 60 ]; then
+              echo "ERROR: Gateway routes failed to propagate after 120 seconds."
               exit 1
             fi
           done

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "Waiting for Gateway to wire up the MCP routes and broker to fetch tools..."
           for i in {1..30}; do
-            HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" ${{ env.MCP_URL }} || echo "000")
+            HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" ${{ env.MCP_URL }})
             if [[ "$HTTP_STATUS" != "000" && "$HTTP_STATUS" != "0" && "$HTTP_STATUS" != "502" && "$HTTP_STATUS" != "503" ]]; then
               echo "Gateway route is active! HTTP Status: $HTTP_STATUS"
               # Extra wait for broker to connect and fetch tools from the conformance server

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -98,7 +98,7 @@ jobs:
           kubectl wait --for=condition=Programmed gateway/mcp-gateway -n gateway-system --timeout=120s
           echo "Waiting for MCP route to become active..."
           for i in {1..60}; do
-            HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" ${{ env.MCP_URL }})
+            HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" ${{ env.MCP_URL }} || true)
             if [[ "$HTTP_STATUS" != "000" && "$HTTP_STATUS" != "0" && "$HTTP_STATUS" != "502" && "$HTTP_STATUS" != "503" ]]; then
               echo "Gateway route is active! HTTP Status: $HTTP_STATUS"
               break

--- a/cmd/mcp-broker-router/router.go
+++ b/cmd/mcp-broker-router/router.go
@@ -24,5 +24,6 @@ func (a *app) createRouter() {
 		ElicitationEnabled:  cfg.enableURLElicitation,
 	}
 
+	a.router.InitMetrics()
 	extProcV3.RegisterExternalProcessorServer(a.grpcServer, a.router)
 }

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -24,6 +24,30 @@ The MCP Gateway leverages [OpenTelemetry](https://opentelemetry.io/) throughout 
 
 All components instrument their operations using OpenTelemetry, ensuring consistent observability data that can be collected and exported to various backends (e.g., Jaeger, Prometheus, Grafana, etc.).
 
+### Current Implementation Status
+
+Tracing and structured log export are implemented across the router and broker (see the [OpenTelemetry guide](../guides/opentelemetry.md)). Metrics export was added incrementally and currently covers an **operational** slice of the data path — instrumentation that helps operators reason about gateway health and capacity — rather than the per-tool-call analytics described in Journey 2 below.
+
+Implemented metrics (exported via OTLP when a metrics endpoint is configured):
+
+| Metric | Instrument | Component | Purpose |
+|--------|-----------|-----------|---------|
+| `mcp.router.stream.active` | UpDownCounter | router | active ext_proc gRPC streams |
+| `mcp.router.session.lookups` (`result=hit\|miss`) | Counter | router | session-cache hit/miss rate |
+| `mcp.router.session.inits` | Counter | router | backend session initializations on cache miss |
+| `mcp.session.op.duration` | Histogram | session | Redis session-store operation latency |
+| `mcp.broker.upstream.connections` (`mcp.server`) | UpDownCounter | broker | active upstream connections |
+| `mcp.broker.upstream.tool_fetch.duration` (`mcp.server`) | Histogram | broker | upstream tool-fetch latency |
+| `mcp.broker.config.reloads` | Counter | broker | config reload events |
+
+Still planned (not yet implemented):
+
+- Tool-call analytics metrics (`mcp_tool_calls_total`, `mcp_tool_call_duration_seconds`, `mcp_requests_total` by tool/server/status) — see Journey 2.
+- Component-level 404/error attribution metrics — see Journey 1.
+- Tool Call Graph signals — see Journey 3.
+
+The metric names in the journeys below are illustrative targets, not the names of the currently exported instruments. The user-facing reference for the implemented metrics lives in the [OpenTelemetry guide](../guides/opentelemetry.md).
+
 ### User Journeys
 
 #### Journey 1: Debugging 404 Errors ("What Went Wrong")
@@ -71,6 +95,8 @@ The trace flow will be more complex when statefulness comes into play with elici
 - Tool call patterns over time
 
 **Solution Requirements:**
+
+> **Note:** The tool-call metrics in this journey are **not yet implemented**. The current metrics export covers operational signals only (see Current Implementation Status above). The names below are proposed targets.
 
 - Metrics exported via OpenTelemetry metrics API
 - Key metrics:

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Integration
 
-This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing and log export. When enabled, the MCP Router (ext_proc) emits trace spans for every request and can export structured logs via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
+This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing, log export, and metrics. When enabled, the MCP Router (ext_proc) emits trace spans for every request, the router and broker export OTLP metrics about the gateway's internal data path, and structured logs can be exported via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
 
 ## Prerequisites
 
@@ -49,6 +49,7 @@ After enabling OTel, generate some traffic against the gateway (e.g., an `initia
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP endpoint for all signals | (none -- disabled) |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Override endpoint for traces only | Falls back to base |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Override endpoint for logs only | Falls back to base |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Override endpoint for metrics only | Falls back to base |
 | `OTEL_EXPORTER_OTLP_INSECURE` | Disable TLS verification | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces and logs | `mcp-gateway` |
 | `OTEL_SERVICE_VERSION` | Service version reported in traces and logs | Build version |
@@ -65,18 +66,19 @@ The endpoint URL scheme determines the transport protocol:
 
 When using `http://`, TLS is automatically disabled regardless of the `OTEL_EXPORTER_OTLP_INSECURE` setting. For `https://` and `rpc://`, set `OTEL_EXPORTER_OTLP_INSECURE=true` to skip TLS verification.
 
-## Sending Traces and Logs to Different Backends
+## Sending Signals to Different Backends
 
-Use signal-specific endpoint overrides to route traces and logs to different collectors or backends:
+Use signal-specific endpoint overrides to route traces, logs, and metrics to different collectors or backends:
 
 ```bash
 kubectl set env deployment/mcp-gateway -n mcp-system \
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://traces-collector:4318" \
   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://logs-collector:4318" \
+  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://metrics-collector:4318" \
   OTEL_EXPORTER_OTLP_INSECURE="true"
 ```
 
-To enable only traces (without log export), set only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. To enable only log export, set only `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`.
+Each signal is enabled independently by its own endpoint (or the base endpoint). To enable only traces, set only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`; to enable only metrics, set only `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`; and so on.
 
 ## What Gets Exported
 
@@ -112,6 +114,24 @@ On error, spans include `error.type`, `error_source`, and `http.status_code`.
 ### Logs
 
 When log export is enabled, all `slog` log lines are sent to the collector via OTLP in addition to stdout. Log lines emitted within a traced request automatically include `trace_id` and `span_id` fields, enabling log-to-trace correlation in backends like Grafana (Loki to Tempo).
+
+### Metrics
+
+When a metrics endpoint is configured, the MCP Router and MCP Broker export OTLP metrics on a 30-second interval. These are **operational** metrics about the gateway's internal data path — stream concurrency, session-cache behavior, upstream connection health, and config churn — rather than per-tool-call analytics.
+
+| Metric | Instrument | Unit | Attributes | Description |
+|--------|-----------|------|------------|-------------|
+| `mcp.router.stream.active` | UpDownCounter | `{stream}` | — | Active ext_proc gRPC streams currently open between Envoy and the router. |
+| `mcp.router.session.lookups` | Counter | `{lookup}` | `result` = `hit` \| `miss` | Session-cache lookups labeled by hit or miss (session-cache hit rate). |
+| `mcp.router.session.inits` | Counter | `{init}` | — | Backend session initializations (hairpin `initialize` requests) performed on a cache miss. |
+| `mcp.session.op.duration` | Histogram | `s` | `op` | Latency of Redis session-store operations. Emitted only when a Redis session store is configured; the in-memory store records nothing. |
+| `mcp.broker.upstream.connections` | UpDownCounter | `{connection}` | `mcp.server` | Active connections from the broker to each upstream MCP server. |
+| `mcp.broker.upstream.tool_fetch.duration` | Histogram | `s` | `mcp.server` | Time taken to fetch the tool list from each upstream MCP server. |
+| `mcp.broker.config.reloads` | Counter | `{reload}` | — | Config reload events processed by the broker. |
+
+Metrics are emitted only when an endpoint resolves (`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`). With no endpoint configured, no `MeterProvider` is installed and instrumentation is a no-op.
+
+> **Note:** Metric names use OTLP dotted notation. Exporters that target Prometheus normalize these to underscores (for example, `mcp.router.session.lookups` becomes `mcp_router_session_lookups_total`).
 
 ### Resource Attributes
 

--- a/go.mod
+++ b/go.mod
@@ -97,8 +97,11 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0 h1:deI9UQMoG
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0/go.mod h1:PFx9NgpNUKXdf7J4Q3agRxMs3Y07QhTCVipKmLsMKnU=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 h1:HIBTQ3VO5aupLKjC90JgMqpezVXwFuq6Ryjn0/izoag=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0/go.mod h1:ji9vId85hMxqfvICA0Jt8JqEdrXaAkcpkI9HPXya0ro=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0 h1:NOyNnS19BF2SUDApbOKbDtWZ0IK7b8FJ2uAGdIWOGb0=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0/go.mod h1:VL6EgVikRLcJa9ftukrHu/ZkkhFBSo1lzvdBC9CF1ss=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0 h1:9y5sHvAxWzft1WQ4BwqcvA+IFVUJ1Ya75mSAUnFEVwE=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0/go.mod h1:eQqT90eR3X5Dbs1g9YSM30RavwLF725Ris5/XSXWvqE=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 h1:QKdN8ly8zEMrByybbQgv8cWBcdAarwmIPZ6FThrWXJs=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0/go.mod h1:bTdK1nhqF76qiPoCCdyFIV+N/sRHYXYCTQc+3VCi3MI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 h1:DvJDOPmSWQHWywQS6lKL+pb8s3gBLOZUtw4N+mavW1I=

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,10 +15,13 @@ import (
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 var _ config.Observer = &mcpBrokerImpl{}
@@ -112,6 +115,8 @@ type mcpBrokerImpl struct {
 
 	// tagsToolsRegistered tracks whether list_tags/filter_tools_by_tags are currently registered
 	tagsToolsRegistered atomic.Bool
+
+	configReloads metric.Int64Counter
 }
 
 // this ensures that mcpBrokerImpl implements the MCPBroker interface
@@ -272,10 +277,18 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		mcpBkr.registerDiscoveryTools()
 	}
 
+	m := otel.GetMeterProvider().Meter(mcpotel.BrokerMeterName)
+	mcpBkr.configReloads, _ = m.Int64Counter(
+		mcpotel.MetricBrokerConfigReloads,
+		metric.WithDescription("total broker config reload events"),
+		metric.WithUnit("{reload}"),
+	)
+
 	return mcpBkr
 }
 
 func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServersConfig) {
+	m.configReloads.Add(ctx, 1)
 	// Take a consistent snapshot before acquiring mcpLock; LoadConfig may be
 	// concurrently replacing conf.Servers/VirtualServers under its own write lock.
 	servers := conf.ListServers()

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -278,11 +278,14 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	}
 
 	m := otel.GetMeterProvider().Meter(mcpotel.BrokerMeterName)
-	mcpBkr.configReloads, _ = m.Int64Counter(
+	var mErr error
+	if mcpBkr.configReloads, mErr = m.Int64Counter(
 		mcpotel.MetricBrokerConfigReloads,
 		metric.WithDescription("total broker config reload events"),
 		metric.WithUnit("{reload}"),
-	)
+	); mErr != nil {
+		logger.Error("failed to create config reloads counter", "error", mErr)
+	}
 
 	return mcpBkr
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -161,6 +162,9 @@ type MCPManager struct {
 	promptEvents chan struct{}
 	done         chan struct{} // closed when the event loop exits
 	status       ServerValidationStatus
+
+	connectionsActive metric.Int64UpDownCounter
+	toolFetchDuration metric.Float64Histogram
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
@@ -185,6 +189,19 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 		Cap:      tickerInterval,
 	}
 
+	m := otel.GetMeterProvider().Meter(mcpotel.BrokerMeterName)
+	connectionsActive, _ := m.Int64UpDownCounter(
+		mcpotel.MetricBrokerConnectionsActive,
+		metric.WithDescription("number of active upstream MCP server connections"),
+		metric.WithUnit("{connection}"),
+	)
+	toolFetchDuration, _ := m.Float64Histogram(
+		mcpotel.MetricBrokerToolFetchDuration,
+		metric.WithDescription("time taken to fetch tools from an upstream MCP server"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+	)
+
 	return &MCPManager{
 		mcp:               upstream,
 		gatewayServer:     gatewayServer,
@@ -204,6 +221,8 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 		promptsMap:        map[string]*mcp.Prompt{},
 		servedPromptsMap:  map[string]*mcp.Prompt{},
 		serverPrompts:     []server.ServerPrompt{},
+		connectionsActive: connectionsActive,
+		toolFetchDuration: toolFetchDuration,
 	}, nil
 }
 
@@ -218,6 +237,7 @@ func (man *MCPManager) MCPName() string {
 func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 	ctx, cancel := context.WithCancel(ctx)
 	man.ticker.Reset(man.tickerInterval)
+	man.connectionsActive.Add(ctx, 1, metric.WithAttributes(attribute.String("mcp.server", man.mcp.GetName())))
 
 	go func() {
 		man.manage(ctx, eventTypeTimer)
@@ -258,7 +278,11 @@ type activeMCP struct {
 	cancel  context.CancelFunc
 }
 
-func (a *activeMCP) Stop()                             { a.cancel(); <-a.manager.done }
+func (a *activeMCP) Stop() {
+	a.manager.connectionsActive.Add(context.Background(), -1, metric.WithAttributes(attribute.String("mcp.server", a.manager.mcp.GetName())))
+	a.cancel()
+	<-a.manager.done
+}
 func (a *activeMCP) MCPName() string                   { return a.manager.MCPName() }
 func (a *activeMCP) GetStatus() ServerValidationStatus { return a.manager.GetStatus() }
 func (a *activeMCP) GetManagedTools() []mcp.Tool       { return a.manager.GetManagedTools() }
@@ -361,13 +385,17 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		return
 	}
 
+	serverAttr := metric.WithAttributes(attribute.String("mcp.server", man.mcp.GetName()))
+
 	var toolErr error
 	var invalidTools []InvalidToolInfo
 	if !man.shouldFetchTools(event) {
 		man.logger.DebugContext(ctx, "not fetching tools", "event", event, "upstream mcp server", man.mcp.ID(), "waiting for notification", notificationToolsListChanged)
 	} else {
 		man.logger.DebugContext(ctx, "fetching tools", "upstream mcp server", man.mcp.ID())
+		fetchStart := time.Now()
 		current, fetched, err := man.getTools(ctx)
+		man.toolFetchDuration.Record(ctx, time.Since(fetchStart).Seconds(), serverAttr)
 		if err != nil {
 			toolErr = fmt.Errorf("upstream mcp failed to list tools server %s : %w", man.mcp.ID(), err)
 			man.recordBackendError(span, toolErr)

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -190,17 +190,23 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 	}
 
 	m := otel.GetMeterProvider().Meter(mcpotel.BrokerMeterName)
-	connectionsActive, _ := m.Int64UpDownCounter(
+	connectionsActive, err := m.Int64UpDownCounter(
 		mcpotel.MetricBrokerConnectionsActive,
 		metric.WithDescription("number of active upstream MCP server connections"),
 		metric.WithUnit("{connection}"),
 	)
-	toolFetchDuration, _ := m.Float64Histogram(
+	if err != nil {
+		logger.Error("failed to create connections active counter", "error", err)
+	}
+	toolFetchDuration, err := m.Float64Histogram(
 		mcpotel.MetricBrokerToolFetchDuration,
 		metric.WithDescription("time taken to fetch tools from an upstream MCP server"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
 	)
+	if err != nil {
+		logger.Error("failed to create tool fetch duration histogram", "error", err)
+	}
 
 	return &MCPManager{
 		mcp:               upstream,

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -17,6 +17,7 @@ import (
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -536,6 +537,11 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 	if id, ok := exists[mcpReq.serverName]; ok {
 		s.Logger.DebugContext(ctx, "found session in cache", "session id", mcpReq.GetSessionID(), "for server", serverInfo.Name, "remote session", id)
 		remoteMCPServerSession = id
+		if s.sessionLookups != nil {
+			s.sessionLookups.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "hit")))
+		}
+	} else if s.sessionLookups != nil {
+		s.sessionLookups.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "miss")))
 	}
 	if remoteMCPServerSession == "" {
 		id, err := s.initializeMCPServerSession(ctx, mcpReq)
@@ -825,6 +831,9 @@ func (s *ExtProcServer) initializeMCPServerSession(ctx context.Context, mcpReq *
 		}
 		// arm the cleanup timer only after the session is safely recorded in the cache
 		time.AfterFunc(ttl, sessionCloser)
+		if s.backendInits != nil {
+			s.backendInits.Add(ctx, 1)
+		}
 		return remoteSessionID, nil
 	})
 	if err != nil {

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -17,7 +17,6 @@ import (
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -538,10 +537,10 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 		s.Logger.DebugContext(ctx, "found session in cache", "session id", mcpReq.GetSessionID(), "for server", serverInfo.Name, "remote session", id)
 		remoteMCPServerSession = id
 		if s.sessionLookups != nil {
-			s.sessionLookups.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "hit")))
+			s.sessionLookups.Add(ctx, 1, s.sessionHitOpt)
 		}
 	} else if s.sessionLookups != nil {
-		s.sessionLookups.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "miss")))
+		s.sessionLookups.Add(ctx, 1, s.sessionMissOpt)
 	}
 	if remoteMCPServerSession == "" {
 		id, err := s.initializeMCPServerSession(ctx, mcpReq)

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -63,30 +63,42 @@ type ExtProcServer struct {
 	// pair, preventing concurrent tool calls from creating duplicate backend sessions.
 	initGroup singleflight.Group
 
-	streamsActive  metric.Int64UpDownCounter
-	sessionLookups metric.Int64Counter
-	backendInits   metric.Int64Counter
+	streamsActive    metric.Int64UpDownCounter
+	sessionLookups   metric.Int64Counter
+	backendInits     metric.Int64Counter
+	sessionHitOpt    metric.AddOption
+	sessionMissOpt   metric.AddOption
 }
 
 // InitMetrics initialises metric instruments from the global MeterProvider.
 // Must be called after otel.SetMeterProvider has been set (i.e. after SetupOTelSDK).
 func (s *ExtProcServer) InitMetrics() {
 	m := otel.GetMeterProvider().Meter(mcpotel.RouterMeterName)
-	s.streamsActive, _ = m.Int64UpDownCounter(
+	var err error
+	if s.streamsActive, err = m.Int64UpDownCounter(
 		mcpotel.MetricRouterStreamsActive,
 		metric.WithDescription("number of active ext_proc gRPC streams"),
 		metric.WithUnit("{stream}"),
-	)
-	s.sessionLookups, _ = m.Int64Counter(
+	); err != nil {
+		s.Logger.Error("failed to create streams active counter", "error", err)
+	}
+	if s.sessionLookups, err = m.Int64Counter(
 		mcpotel.MetricRouterSessionLookups,
 		metric.WithDescription("total session cache lookups"),
 		metric.WithUnit("{lookup}"),
-	)
-	s.backendInits, _ = m.Int64Counter(
+	); err != nil {
+		s.Logger.Error("failed to create session lookups counter", "error", err)
+	}
+	if s.backendInits, err = m.Int64Counter(
 		mcpotel.MetricRouterBackendInits,
 		metric.WithDescription("total backend session initialisations (hairpin requests)"),
 		metric.WithUnit("{init}"),
-	)
+	); err != nil {
+		s.Logger.Error("failed to create backend inits counter", "error", err)
+	}
+	// precompute to avoid per-request allocations on the hot path
+	s.sessionHitOpt = metric.WithAttributes(attribute.String("result", "hit"))
+	s.sessionMissOpt = metric.WithAttributes(attribute.String("result", "miss"))
 }
 
 // OnConfigChange is used to register the router for config changes

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -14,10 +14,13 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	extProcV3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/mark3labs/mcp-go/client"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
 )
@@ -59,6 +62,31 @@ type ExtProcServer struct {
 	// initGroup serializes backend session initialization per (gatewaySessionID, serverName)
 	// pair, preventing concurrent tool calls from creating duplicate backend sessions.
 	initGroup singleflight.Group
+
+	streamsActive  metric.Int64UpDownCounter
+	sessionLookups metric.Int64Counter
+	backendInits   metric.Int64Counter
+}
+
+// InitMetrics initialises metric instruments from the global MeterProvider.
+// Must be called after otel.SetMeterProvider has been set (i.e. after SetupOTelSDK).
+func (s *ExtProcServer) InitMetrics() {
+	m := otel.GetMeterProvider().Meter(mcpotel.RouterMeterName)
+	s.streamsActive, _ = m.Int64UpDownCounter(
+		mcpotel.MetricRouterStreamsActive,
+		metric.WithDescription("number of active ext_proc gRPC streams"),
+		metric.WithUnit("{stream}"),
+	)
+	s.sessionLookups, _ = m.Int64Counter(
+		mcpotel.MetricRouterSessionLookups,
+		metric.WithDescription("total session cache lookups"),
+		metric.WithUnit("{lookup}"),
+	)
+	s.backendInits, _ = m.Int64Counter(
+		mcpotel.MetricRouterBackendInits,
+		metric.WithDescription("total backend session initialisations (hairpin requests)"),
+		metric.WithUnit("{init}"),
+	)
 }
 
 // OnConfigChange is used to register the router for config changes
@@ -78,6 +106,10 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 		rewriter            *sseRewriter // nil until a tool call response arrives
 		bodyBuffer          []byte
 	)
+	if s.streamsActive != nil {
+		s.streamsActive.Add(ctx, 1)
+		defer s.streamsActive.Add(ctx, -1)
+	}
 	span := trace.SpanFromContext(ctx)
 	defer func() { span.End() }()
 	// ensure orphaned elicitation idmap entries are cleaned up on any exit path

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -63,11 +63,11 @@ type ExtProcServer struct {
 	// pair, preventing concurrent tool calls from creating duplicate backend sessions.
 	initGroup singleflight.Group
 
-	streamsActive    metric.Int64UpDownCounter
-	sessionLookups   metric.Int64Counter
-	backendInits     metric.Int64Counter
-	sessionHitOpt    metric.AddOption
-	sessionMissOpt   metric.AddOption
+	streamsActive  metric.Int64UpDownCounter
+	sessionLookups metric.Int64Counter
+	backendInits   metric.Int64Counter
+	sessionHitOpt  metric.AddOption
+	sessionMissOpt metric.AddOption
 }
 
 // InitMetrics initialises metric instruments from the global MeterProvider.

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -47,9 +47,22 @@ func (c *Config) LogsEndpoint() string {
 	return c.Endpoint
 }
 
+// MetricsEndpoint returns the endpoint for metrics, with signal-specific override support.
+func (c *Config) MetricsEndpoint() string {
+	if endpoint := env.GetString("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", ""); endpoint != "" {
+		return endpoint
+	}
+	return c.Endpoint
+}
+
 // TracesEnabled returns true if tracing is enabled
 func (c *Config) TracesEnabled() bool {
 	return c.TracesEndpoint() != ""
+}
+
+// MetricsEnabled returns true if metrics export is enabled
+func (c *Config) MetricsEnabled() bool {
+	return c.MetricsEndpoint() != ""
 }
 
 // LogsEnabled returns true if logs export is enabled
@@ -59,5 +72,5 @@ func (c *Config) LogsEnabled() bool {
 
 // Enabled returns true if any telemetry signal is enabled
 func (c *Config) Enabled() bool {
-	return c.TracesEnabled() || c.LogsEnabled()
+	return c.TracesEnabled() || c.LogsEnabled() || c.MetricsEnabled()
 }

--- a/internal/otel/logs.go
+++ b/internal/otel/logs.go
@@ -42,6 +42,7 @@ func NewLogsProvider(ctx context.Context, config *Config) (*LogsProvider, error)
 	}, nil
 }
 
+//nolint:dupl // each signal's exporter uses different option types; structural similarity is unavoidable
 func newLogExporter(ctx context.Context, endpoint string, insecure bool) (sdklog.Exporter, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {

--- a/internal/otel/metrics_provider.go
+++ b/internal/otel/metrics_provider.go
@@ -1,0 +1,90 @@
+package otel
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	otlpmetricgrpc "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	otlpmetrichttp "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// MetricsProvider wraps the OpenTelemetry MeterProvider and manages its lifecycle.
+type MetricsProvider struct {
+	meterProvider *sdkmetric.MeterProvider
+}
+
+// NewMetricsProvider creates a new OTLP metric provider using the same endpoint and
+// resource configuration as the trace provider.
+func NewMetricsProvider(ctx context.Context, config *Config) (*MetricsProvider, error) {
+	endpoint := config.MetricsEndpoint()
+	if endpoint == "" {
+		return nil, fmt.Errorf("metrics disabled: no endpoint configured")
+	}
+
+	res, err := NewResource(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	exporter, err := newMetricExporter(ctx, endpoint, config.Insecure)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP metric exporter: %w", err)
+	}
+
+	meterProvider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(30*time.Second))),
+	)
+
+	return &MetricsProvider{meterProvider: meterProvider}, nil
+}
+
+//nolint:dupl // each signal's exporter uses different option types; structural similarity is unavoidable
+func newMetricExporter(ctx context.Context, endpoint string, insecure bool) (sdkmetric.Exporter, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint URL: %w", err)
+	}
+
+	switch u.Scheme {
+	case "rpc":
+		opts := []otlpmetricgrpc.Option{
+			otlpmetricgrpc.WithEndpoint(u.Host),
+		}
+		if insecure {
+			opts = append(opts, otlpmetricgrpc.WithInsecure())
+		}
+		return otlpmetricgrpc.New(ctx, opts...)
+
+	case "http", "https":
+		opts := []otlpmetrichttp.Option{
+			otlpmetrichttp.WithEndpoint(u.Host),
+		}
+		if path := u.Path; path != "" {
+			opts = append(opts, otlpmetrichttp.WithURLPath(path))
+		}
+		if insecure || u.Scheme == "http" {
+			opts = append(opts, otlpmetrichttp.WithInsecure())
+		}
+		return otlpmetrichttp.New(ctx, opts...)
+
+	default:
+		return nil, fmt.Errorf("unsupported endpoint scheme: %s (use 'rpc', 'http', or 'https')", u.Scheme)
+	}
+}
+
+// MeterProvider returns the underlying MeterProvider.
+func (p *MetricsProvider) MeterProvider() *sdkmetric.MeterProvider {
+	return p.meterProvider
+}
+
+// Shutdown gracefully shuts down the meter provider.
+func (p *MetricsProvider) Shutdown(ctx context.Context) error {
+	if p.meterProvider == nil {
+		return nil
+	}
+	return p.meterProvider.Shutdown(ctx)
+}

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -12,6 +12,24 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// Meter names for each component.
+const (
+	RouterMeterName  = "mcp-router"
+	BrokerMeterName  = "mcp-broker"
+	SessionMeterName = "mcp-session"
+)
+
+// Metric instrument names.
+const (
+	MetricRouterStreamsActive     = "mcp.router.stream.active"
+	MetricRouterSessionLookups    = "mcp.router.session.lookups"
+	MetricRouterBackendInits      = "mcp.router.session.inits"
+	MetricSessionOpDuration       = "mcp.session.op.duration"
+	MetricBrokerConnectionsActive = "mcp.broker.upstream.connections"
+	MetricBrokerToolFetchDuration = "mcp.broker.upstream.tool_fetch.duration"
+	MetricBrokerConfigReloads     = "mcp.broker.config.reloads"
+)
+
 // BrokerTracerName is the OpenTelemetry tracer name for the broker component.
 const BrokerTracerName = "mcp-broker"
 
@@ -48,6 +66,16 @@ func SetupOTelSDK(ctx context.Context, gitSHA, dirty, version string, logger *sl
 		shutdownFuncs = append(shutdownFuncs, traceProvider.Shutdown)
 		otel.SetTracerProvider(traceProvider.TracerProvider())
 		logger.Info("OpenTelemetry tracing enabled", "endpoint", config.TracesEndpoint())
+	}
+
+	if config.MetricsEnabled() {
+		metricsProvider, err := NewMetricsProvider(ctx, config)
+		if err != nil {
+			return shutdown, nil, err
+		}
+		shutdownFuncs = append(shutdownFuncs, metricsProvider.Shutdown)
+		otel.SetMeterProvider(metricsProvider.MeterProvider())
+		logger.Info("OpenTelemetry metrics enabled", "endpoint", config.MetricsEndpoint())
 	}
 
 	if config.LogsEnabled() {

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	redis "github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,8 +18,6 @@ import (
 const clientElicitationPrefix = "clientelicitation:"
 
 const userTokenFieldPrefix = "token:"
-
-const sessionMeterName = "mcp-session"
 
 // Cache implements a cache
 type Cache struct {
@@ -274,10 +273,10 @@ func NewCache(opts ...func(*Cache)) (*Cache, error) {
 		opt(c)
 	}
 	if c.extClient != nil {
-		m := otel.GetMeterProvider().Meter(sessionMeterName)
+		m := otel.GetMeterProvider().Meter(mcpotel.SessionMeterName)
 		var err error
 		if c.opDuration, err = m.Float64Histogram(
-			"mcp.session.op.duration",
+			mcpotel.MetricSessionOpDuration,
 			metric.WithDescription("duration of Redis session store operations"),
 			metric.WithUnit("s"),
 			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -9,11 +9,16 @@ import (
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 const clientElicitationPrefix = "clientelicitation:"
 
 const userTokenFieldPrefix = "token:"
+
+const sessionMeterName = "mcp-session"
 
 // Cache implements a cache
 type Cache struct {
@@ -21,6 +26,17 @@ type Cache struct {
 	innerMu       sync.Mutex // serializes copy-on-write mutations on inner map[string]string values
 	extClient     *redis.Client
 	encryptionKey []byte
+	opDuration    metric.Float64Histogram
+}
+
+// recordOp records the duration of a Redis operation. No-op for in-memory caches.
+func (c *Cache) recordOp(ctx context.Context, op string, start time.Time) {
+	if c.opDuration == nil {
+		return
+	}
+	c.opDuration.Record(ctx, time.Since(start).Seconds(),
+		metric.WithAttributes(attribute.String("op", op)),
+	)
 }
 
 // KeyExists checks if a key exists in the cache
@@ -49,7 +65,10 @@ func (c *Cache) GetSession(ctx context.Context, key string) (map[string]string, 
 		}
 		return map[string]string{}, nil
 	}
-	return c.extClient.HGetAll(ctx, key).Result()
+	start := time.Now()
+	result, err := c.extClient.HGetAll(ctx, key).Result()
+	c.recordOp(ctx, "get_session", start)
+	return result, err
 }
 
 // DeleteSessions deletes sessions and associated metadata from the cache
@@ -88,12 +107,15 @@ func (c *Cache) AddSession(ctx context.Context, key, mcpServerID, mcpSession str
 		c.inmemory.Store(key, next)
 		return true, nil
 	}
+	start := time.Now()
 	pipe := c.extClient.Pipeline()
 	pipe.HSet(ctx, key, mcpServerID, mcpSession)
 	if ttl > 0 {
 		pipe.Expire(ctx, key, ttl)
 	}
-	if _, err := pipe.Exec(ctx); err != nil {
+	_, err := pipe.Exec(ctx)
+	c.recordOp(ctx, "add_session", start)
+	if err != nil {
 		return false, err
 	}
 	return true, nil
@@ -125,7 +147,10 @@ func (c *Cache) SetClientElicitation(ctx context.Context, gatewaySessionID strin
 		c.inmemory.Store(key, true)
 		return nil
 	}
-	return c.extClient.Set(ctx, key, "1", ttl).Err()
+	start := time.Now()
+	err := c.extClient.Set(ctx, key, "1", ttl).Err()
+	c.recordOp(ctx, "set_elicitation", start)
+	return err
 }
 
 // GetClientElicitation returns whether the client for this gateway session supports elicitation
@@ -135,7 +160,9 @@ func (c *Cache) GetClientElicitation(ctx context.Context, gatewaySessionID strin
 		_, ok := c.inmemory.Load(key)
 		return ok, nil
 	}
+	start := time.Now()
 	val, err := c.extClient.Get(ctx, key).Result()
+	c.recordOp(ctx, "get_elicitation", start)
 	if errors.Is(err, redis.Nil) {
 		return false, nil
 	}
@@ -247,6 +274,13 @@ func NewCache(opts ...func(*Cache)) (*Cache, error) {
 		opt(c)
 	}
 	if c.extClient != nil {
+		m := otel.GetMeterProvider().Meter(sessionMeterName)
+		c.opDuration, _ = m.Float64Histogram(
+			"mcp.session.op.duration",
+			metric.WithDescription("duration of Redis session store operations"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
+		)
 		return c, nil
 	}
 	c.inmemory = &sync.Map{}

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -275,12 +275,15 @@ func NewCache(opts ...func(*Cache)) (*Cache, error) {
 	}
 	if c.extClient != nil {
 		m := otel.GetMeterProvider().Meter(sessionMeterName)
-		c.opDuration, _ = m.Float64Histogram(
+		var err error
+		if c.opDuration, err = m.Float64Histogram(
 			"mcp.session.op.duration",
 			metric.WithDescription("duration of Redis session store operations"),
 			metric.WithUnit("s"),
 			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
-		)
+		); err != nil {
+			return nil, fmt.Errorf("failed to create session op duration histogram: %w", err)
+		}
 		return c, nil
 	}
 	c.inmemory = &sync.Map{}

--- a/project-words.txt
+++ b/project-words.txt
@@ -304,6 +304,7 @@ otlploghttp
 otlpmetric
 otlpmetricgrpc
 otlpmetrichttp
+sdkmetric
 otlptrace
 otlptracegrpc
 otlptracehttp

--- a/project-words.txt
+++ b/project-words.txt
@@ -297,9 +297,13 @@ operatorframework
 operatorgroup
 opm
 otelslog
+dupl
 otlplog
 otlploggrpc
 otlploghttp
+otlpmetric
+otlpmetricgrpc
+otlpmetrichttp
 otlptrace
 otlptracegrpc
 otlptracehttp


### PR DESCRIPTION
I opened #846 a while back to wire up metrics, but it only got as far as a single histogram on `HandleToolCall` before I got pulled into other things and it stalled.

Came back to it this week and decided to actually read through the full data path before writing another line; router, broker, session cache, upstream manager, the whole thing. Glad I did: traces and logs had full provider setup, but metrics had the OTel metric API sitting there as an indirect dep, completely unused. No `MeterProvider`, no instruments. You could run this in production for months with zero signal on what the gateway was doing internally.

So I closed #846 and started over. The metrics here are **operational**; aimed at operators and SREs running the gateway, not per-tool-call analytics (that's still future work, tracked in the observability design doc).

**Router** : active gRPC streams (`mcp.router.stream.active`), session cache lookups with hit/miss labels (`mcp.router.session.lookups`), backend session inits (`mcp.router.session.inits`).
- *As an operator, I want the session-cache hit/miss rate so I can decide whether scaling the session store (Redis) is worth it.*
- *As an SRE, I want active `ext_proc` stream counts so I can spot stream leaks or saturation between Envoy and the router.*

**Session store** : Redis op latency histogram (`mcp.session.op.duration`) with explicit buckets, Redis path only.
- *As an SRE, I want session-store operation latency so I can alert when Redis is degrading before it shows up as request failures.*

**Upstream manager** : connection tracking (`mcp.broker.upstream.connections`) and per-server tool-fetch duration (`mcp.broker.upstream.tool_fetch.duration`).
- *As an SRE, I want upstream tool-fetch latency per server so I can set alerts on degraded backends.*
- *As an operator, I want active upstream connection counts so I can confirm every registered MCP server is actually connected.*

**Broker** : config reload counter (`mcp.broker.config.reloads`).
- *As an operator, I want a config-reload count so I can correlate sudden behavior changes with a config push.*

The hit/miss attribute options are precomputed on `ExtProcServer` to avoid per-tool-call allocations on the hot path.

The `MetricsProvider` mirrors the existing logs/traces pattern exactly.., same URL scheme switching (`rpc://` for gRPC, `http://`/`https://` for HTTP), same 30-second periodic reader, same `Shutdown()` wired into `SetupOTelSDK`. Controlled via `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` with fallback to the base `OTEL_EXPORTER_OTLP_ENDPOINT`. User-facing reference added to `docs/guides/opentelemetry.md`.