### PR TITLE
fix: removing MCPVirtualServer entry from config on deletion

### DIFF
--- a/internal/controller/mcpvirtualserver_controller.go
+++ b/internal/controller/mcpvirtualserver_controller.go
@@ -55,7 +55,19 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		logger.Info("mcpvirtualserver is being deleted", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
 		if controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
 			logger.Info("deleting mcpvirtualserver", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
-			// TODO remove from config
+			logger.V(1).Info("mcpvirtualserver generating config for deletion")
+			vsConfig, err := r.generateVirtualServerConfig(ctx)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to generate virtual server config during deletion %w", err)
+			}
+			logger.V(1).Info("mcpvirtualserver writing config for deletion")
+			if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, config.DefaultNamespaceName); err != nil {
+				if errors.IsConflict(err) {
+					logger.Info("mcpvirtualserver conflict on updating the config during deletion will retry")
+					return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
+				}
+				return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to write virtual server config during deletion %w", err)
+			}
 			controllerutil.RemoveFinalizer(mcpVS, mcpGatewayFinalizer)
 			if err := r.Update(ctx, mcpVS); err != nil {
 				return ctrl.Result{}, err


### PR DESCRIPTION
## Summary 
- Resolves a TODO in the codebase for removing the MCPVirtualServer entry from config on deletion.
- When an MCPVirtualServer is deleted, the controller now regenerates and writes the config (excluding the deleted resource) to the shared secret before removing the finalizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual server configurations are now properly generated and written before resource deletion, ensuring complete and reliable cleanup of all associated configurations throughout the system.
  * Enhanced conflict resolution during deletion operations with automatic retry logic for transient failures, improving system reliability and stability during resource removal and cleanup processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->