### PR TITLE
docs: add design spec for gateway-level CA certificate bundle

### DIFF
--- a/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
+++ b/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
@@ -219,6 +219,10 @@ The current design uses a Secret for the CA bundle. A future enhancement could s
 
 The broker could parse the CA certificates and emit metrics or log warnings when certificates are near expiry. This would help operators detect upcoming CA rotations before they cause outages.
 
+### Per-Server CA Deduplication
+
+When a server's `caCertSecretRef` references the same CA that is already in the gateway `caCertBundleRef`, the CA PEM is stored twice in the config — once under `gatewayCACertPEM` and once inline in the server's `caCert` field. This is functionally correct (additive trust pools) but wastes space. A future optimization could skip embedding per-server CAs that match the gateway bundle. However, this introduces complexity: Secrets may be in different namespaces, and if one Secret is deleted, the CA disappears from config even though another Secret references the same CA. Given the low likelihood of users having many duplicate CAs without coordinating, this optimization is deferred.
+
 ## Execution
 
 See:

--- a/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
+++ b/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
@@ -17,7 +17,6 @@ Add a `caCertBundleRef` field to `MCPGatewayExtension` that references a shared 
 - Eliminate CA PEM duplication in the config secret when multiple servers share the same CA
 - Reduce operational burden for CA rotation to a single Secret update
 - Maintain backward compatibility — existing `caCertSecretRef` on `MCPServerRegistration` continues to work identically
-- Keep the CA PEM data out of the per-server config entries in the config secret
 
 ## Non-Goals
 
@@ -64,7 +63,7 @@ spec:
     sectionName: mcp
   caCertBundleRef:
     name: shared-ca-bundle
-    key: ca-bundle.crt    # optional, defaults to "ca-bundle.crt"
+    key: ca.crt    # optional, defaults to "ca.crt"
 ```
 
 ```go
@@ -88,65 +87,64 @@ type CACertBundleReference struct {
     Name string `json:"name,omitempty"`
 
     // key is the key within the Secret that contains the CA bundle PEM data.
-    // If not specified, defaults to "ca-bundle.crt".
+    // If not specified, defaults to "ca.crt".
     // +optional
-    // +default="ca-bundle.crt"
+    // +default="ca.crt"
     Key string `json:"key,omitempty"`
 }
 ```
 
-The default key is `ca-bundle.crt` (not `ca.crt`) to distinguish from per-server CA secrets and align with common Kubernetes conventions (e.g. OpenShift's `ca-bundle.crt` in ConfigMaps).
+The default key is `ca.crt` — the same default used by per-server `caCertSecretRef`. This means a user can promote an existing per-server CA Secret to gateway-level without creating a new Secret or changing keys.
 
 #### Config Type Changes
 
-`MCPServersConfig` in `internal/config/types.go` gains a field for the gateway-level CA bundle:
+`BrokerConfig` in `internal/config/types.go` gains a field for the gateway-level CA bundle:
 
 ```go
-type MCPServersConfig struct {
-    // ... existing fields ...
-
-    // GatewayCACertBundle is the PEM-encoded CA bundle from MCPGatewayExtension.
-    // Loaded once by the broker, not embedded per-server.
-    GatewayCACertBundle string
+type BrokerConfig struct {
+    Servers          []MCPServer           `json:"servers"          yaml:"servers"`
+    VirtualServers   []VirtualServerConfig `json:"virtualServers,omitempty" yaml:"virtualServers,omitempty"`
+    GatewayCACertPEM string                `json:"gatewayCACertPEM,omitempty" yaml:"gatewayCACertPEM,omitempty"`
 }
 ```
 
-This field is not serialized into the per-server config YAML — it is passed to the broker via a separate volume mount of the CA Secret, avoiding config secret bloat.
+The gateway CA bundle PEM is written once into the existing `mcp-gateway-config` Secret alongside the server list. The broker reads it from the same config source — no separate Secrets or volume mounts. Servers that share the gateway CA no longer need individual `CACert` entries, reducing the per-server duplication from N copies to 1.
 
 ### Architecture
 
 #### How the CA Bundle Reaches the Broker
 
+The gateway CA bundle uses the same config path as everything else — the `mcp-gateway-config` Secret:
+
 ```
-MCPGatewayExtension                Broker Pod
-┌──────────────────┐         ┌────────────────────────┐
-│ caCertBundleRef: │         │                        │
-│   name: shared-  │────────▶│  Volume Mount:         │
-│         ca-bundle│         │  /etc/mcp-gateway/ca/  │
-│   key: ca-bundle │         │    ca-bundle.crt       │
-│         .crt     │         │                        │
-└──────────────────┘         │  Broker reads at       │
-                             │  startup + watches     │
-                             │  for changes           │
-                             └────────────────────────┘
+MCPGatewayExtension              Controller                     Broker
+┌──────────────────┐     ┌──────────────────────┐     ┌────────────────────┐
+│ caCertBundleRef: │     │ Reads CA Secret,      │     │                    │
+│   name: shared-  │────▶│ validates PEM,        │────▶│ Reads config.yaml  │
+│         ca-bundle│     │ writes PEM into       │     │ extracts           │
+│   key: ca.crt    │     │ config.yaml under     │     │ gatewayCACertPEM,  │
+└──────────────────┘     │ gatewayCACertPEM key  │     │ builds base cert   │
+                         └──────────────────────┘     │ pool               │
+                                                      └────────────────────┘
 ```
 
 The MCPGatewayExtension controller:
 1. Validates the referenced CA Secret exists, has the required label, contains valid PEM, and is within size limits
-2. Adds the Secret as a volume mount on the broker-router Deployment
-3. Passes the mount path via a command-line flag `--ca-cert-bundle-path=/etc/mcp-gateway/ca/ca-bundle.crt`
+2. Writes the CA PEM into the `mcp-gateway-config` Secret's `config.yaml` under the `gatewayCACertPEM` key
+3. Existing config watcher detects the Secret update and calls `mcpConfig.Notify()` to trigger observers
 
 The broker:
-1. Reads the CA bundle PEM from the file at startup
-2. Builds a base `*x509.CertPool` from system roots + gateway CA bundle
+1. Receives config via `OnConfigChange()` (the existing observer pattern)
+2. Reads `GatewayCACertPEM` from the config, builds a base `*x509.CertPool` from system roots + gateway CA bundle
 3. For each upstream server, clones this base pool and appends any per-server CA from the config (if `CACert` is set on the `MCPServer`)
-4. Watches the file for changes (Kubernetes volume mount propagation) and rebuilds the pool on update
+
+Using the existing config Secret ensures **atomic updates** — the server list and CA bundle are always in sync. There is no timing window where the broker has a new server config but not yet the CA needed to connect.
 
 #### Trust Pool Construction
 
 ```
 System Root CAs (Go default)
-         ├── + Gateway CA Bundle (from caCertBundleRef)
+         ├── + Gateway CA Bundle (from gatewayCACertPEM in config)
          │        = Base Trust Pool (shared by all servers)
          │
          ├── Server A: uses base pool only (no caCertSecretRef)
@@ -182,32 +180,26 @@ The MCPGatewayExtension controller validates `caCertBundleRef` during reconcilia
 
 The size limit is 256 KiB (vs 64 KiB for per-server CAs) because a shared bundle typically contains multiple CA certificates (root + intermediates, or multiple issuer CAs).
 
-### Volume Mount Strategy
+### Config Secret Strategy
 
-The CA bundle Secret is mounted as a read-only volume, not embedded in the config secret. This:
+The CA bundle PEM is written into the existing `mcp-gateway-config` Secret as the `gatewayCACertPEM` field in `config.yaml`. This:
 
-1. **Avoids config bloat** — the CA PEM is not duplicated per-server in the config YAML
-2. **Enables hot reload** — Kubernetes propagates Secret updates to volume mounts (60-120s kubelet sync), and the broker watches the file for changes
-3. **Follows the existing pattern** — the aggregated credentials secret is already mounted as a volume on the broker-router Deployment
+1. **Atomic updates** — config and CA bundle are in the same Secret, so the broker always sees a consistent snapshot. No timing window where a server appears before its CA is available.
+2. **Single config source** — no separate Secrets or volume mounts to synchronize. The broker reads everything from one place.
+3. **Reduces per-server duplication** — the gateway CA is written once. Servers sharing it no longer embed individual `CACert` values, so the net effect is a reduction from N copies to 1.
 
-Mount details:
-- Volume name: `ca-cert-bundle`
-- Mount path: `/etc/mcp-gateway/ca/`
-- File: `ca-bundle.crt` (or the configured key)
-- Read-only: true
+The gateway bundle does add to the config Secret size, but since it replaces N per-server copies with 1, the net effect is always a reduction when multiple servers share the same CA. If the config Secret approaches the 1 MiB Kubernetes limit (e.g. many servers each with *different* CAs plus a large gateway bundle), operators can deploy multiple `MCPGatewayExtension` instances to partition servers across gateways.
 
 ### CA Bundle Rotation
 
 When the CA bundle Secret is updated:
 
 1. The MCPGatewayExtension controller detects the Secret update (via watch on labeled Secrets)
-2. The controller re-validates the PEM and updates the Deployment annotation hash to trigger a rollout (if the content changed)
-3. Kubernetes propagates the new Secret data to the volume mount (60-120s)
-4. The broker detects the file change, rebuilds the base trust pool, and re-registers all servers that use it
+2. The controller re-validates the PEM and writes the updated `gatewayCACertPEM` into the config Secret
+3. The config watcher detects the config Secret change and calls `mcpConfig.Notify()`
+4. The broker's `OnConfigChange()` observer rebuilds the base trust pool and re-registers servers
 
-End-to-end propagation: ~60-120 seconds (dominated by kubelet volume sync).
-
-**Alternative: file watch without rollout.** If rollout restarts are undesirable (they briefly interrupt all connections), the broker can use `fsnotify` to watch the mounted file and rebuild the cert pool in-place. This avoids pod restarts but relies on volume mount propagation being timely. Both strategies should be evaluated during implementation.
+End-to-end propagation: ~15-30 seconds (controller re-reconciliation + config watcher cycle). This is faster than the previous volume-mount approach since it does not depend on kubelet volume sync (60-120s).
 
 ## Security Considerations
 
@@ -215,6 +207,7 @@ End-to-end propagation: ~60-120 seconds (dominated by kubelet volume sync).
 - **No new trust** — the gateway CA bundle extends the system root pool, it does not replace it. Servers that work today with publicly-trusted CAs continue to work without changes
 - **Additive-only** — per-server CAs always append to the gateway bundle, never override. An operator cannot accidentally remove trust for a server by setting the gateway bundle
 - **Size limit** — 256 KiB prevents accidental inclusion of large files. This is generous enough for typical CA chains (~20-30 CAs at ~2 KiB each)
+- **Config Secret size** — the gateway CA bundle contributes to the 1 MiB Kubernetes Secret limit, but since it replaces N per-server copies with 1, the net size is always smaller when servers share a CA. For extreme cases, operators can partition servers across multiple gateways
 
 ## Future Considerations
 

--- a/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
+++ b/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
@@ -1,0 +1,234 @@
+# Gateway-Level CA Certificate Bundle
+
+## Problem
+
+With custom TLS support ([#659](https://github.com/Kuadrant/mcp-gateway/issues/659), [#1008](https://github.com/Kuadrant/mcp-gateway/pull/1008)), each `MCPServerRegistration` can reference its own CA certificate via `caCertSecretRef`. When many upstream servers share the same root or intermediate CA, this results in:
+
+- **Duplication** — the same CA PEM repeated N times across N registrations. Common in environments using OpenShift service-serving CA, a shared cert-manager issuer, or a corporate root CA.
+- **Config secret bloat** — each CA cert (up to 64 KiB per the `maxCACertSize` limit in the controller) is embedded per-server in the config YAML passed to the broker. The config is stored in a Kubernetes Secret (`mcp-gateway-config`), which is subject to the 1 MiB Secret limit. With 15 servers sharing the same 64 KiB CA bundle, the config consumes ~960 KiB on CA certs alone, leaving no room for actual configuration.
+- **Operational overhead** — CA rotation requires updating N Secrets and waiting for N re-reconciliations instead of one. Each `MCPServerRegistration` re-reconciles independently, creating a window where some servers use the old CA and some use the new one.
+
+## Summary
+
+Add a `caCertBundleRef` field to `MCPGatewayExtension` that references a shared CA certificate bundle Secret. The broker loads this bundle at startup as a base trust pool. Per-server `caCertSecretRef` on `MCPServerRegistration` appends additional CAs for backends with unique CAs. This mirrors how Kubernetes itself works — cluster-wide CA bundle plus per-resource overrides.
+
+## Goals
+
+- Eliminate CA PEM duplication in the config secret when multiple servers share the same CA
+- Reduce operational burden for CA rotation to a single Secret update
+- Maintain backward compatibility — existing `caCertSecretRef` on `MCPServerRegistration` continues to work identically
+- Keep the CA PEM data out of the per-server config entries in the config secret
+
+## Non-Goals
+
+- Replace `caCertSecretRef` on `MCPServerRegistration` (still needed for server-specific CAs)
+- Modify how Envoy/Gateway handles TLS (this only affects broker-to-upstream connections)
+- Implement mutual TLS (mTLS) between broker and upstream servers
+- Support non-PEM certificate formats
+
+## Job Stories
+
+### When I have many servers behind the same private CA
+
+When a platform engineer has 10+ upstream MCP servers behind the same OpenShift service-serving CA, they want to configure the CA once at the gateway level so that they don't need to create and maintain separate CA Secrets for each `MCPServerRegistration`.
+
+### When I need to rotate a shared CA certificate
+
+When a platform engineer needs to rotate the CA certificate used by all upstream servers (e.g. cert-manager issuer renewal), they want to update a single Secret and have all servers pick up the new CA within one reconciliation cycle, instead of updating N Secrets and waiting for N independent reconciliations.
+
+### When I have servers with unique CAs alongside a shared CA
+
+When a platform engineer has most servers behind a shared corporate CA but one or two servers using their own private CA, they want to set the shared CA at the gateway level and the unique CAs per-server, so that both types work without duplication.
+
+### When I want to avoid hitting the Kubernetes Secret size limit
+
+When a platform engineer registers many servers that each embed CA PEM data in the config secret, they want the shared CA to be loaded once by the broker (not embedded N times in the config), so that the config secret stays well under the 1 MiB Kubernetes limit.
+
+## Design
+
+### API Changes
+
+#### MCPGatewayExtension
+
+New optional field `caCertBundleRef` on `MCPGatewayExtensionSpec`:
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPGatewayExtension
+metadata:
+  name: mcp-gateway
+  namespace: mcp-system
+spec:
+  targetRef:
+    name: mcp-gateway
+    sectionName: mcp
+  caCertBundleRef:
+    name: shared-ca-bundle
+    key: ca-bundle.crt    # optional, defaults to "ca-bundle.crt"
+```
+
+```go
+// MCPGatewayExtensionSpec gains:
+type MCPGatewayExtensionSpec struct {
+    // ... existing fields ...
+
+    // caCertBundleRef references a Secret containing a PEM-encoded CA certificate
+    // bundle used as the base trust pool for all upstream MCP server connections.
+    // Per-server caCertSecretRef on MCPServerRegistration appends to this pool.
+    // The Secret must have the label mcp.kuadrant.io/secret=true.
+    // +optional
+    CACertBundleRef *CACertBundleReference `json:"caCertBundleRef,omitempty"`
+}
+
+// CACertBundleReference identifies a Secret containing a PEM-encoded CA bundle.
+type CACertBundleReference struct {
+    // name is the name of the Secret resource.
+    // +required
+    // +kubebuilder:validation:MinLength=1
+    Name string `json:"name,omitempty"`
+
+    // key is the key within the Secret that contains the CA bundle PEM data.
+    // If not specified, defaults to "ca-bundle.crt".
+    // +optional
+    // +default="ca-bundle.crt"
+    Key string `json:"key,omitempty"`
+}
+```
+
+The default key is `ca-bundle.crt` (not `ca.crt`) to distinguish from per-server CA secrets and align with common Kubernetes conventions (e.g. OpenShift's `ca-bundle.crt` in ConfigMaps).
+
+#### Config Type Changes
+
+`MCPServersConfig` in `internal/config/types.go` gains a field for the gateway-level CA bundle:
+
+```go
+type MCPServersConfig struct {
+    // ... existing fields ...
+
+    // GatewayCACertBundle is the PEM-encoded CA bundle from MCPGatewayExtension.
+    // Loaded once by the broker, not embedded per-server.
+    GatewayCACertBundle string
+}
+```
+
+This field is not serialized into the per-server config YAML — it is passed to the broker via a separate volume mount of the CA Secret, avoiding config secret bloat.
+
+### Architecture
+
+#### How the CA Bundle Reaches the Broker
+
+```
+MCPGatewayExtension                Broker Pod
+┌──────────────────┐         ┌────────────────────────┐
+│ caCertBundleRef: │         │                        │
+│   name: shared-  │────────▶│  Volume Mount:         │
+│         ca-bundle│         │  /etc/mcp-gateway/ca/  │
+│   key: ca-bundle │         │    ca-bundle.crt       │
+│         .crt     │         │                        │
+└──────────────────┘         │  Broker reads at       │
+                             │  startup + watches     │
+                             │  for changes           │
+                             └────────────────────────┘
+```
+
+The MCPGatewayExtension controller:
+1. Validates the referenced CA Secret exists, has the required label, contains valid PEM, and is within size limits
+2. Adds the Secret as a volume mount on the broker-router Deployment
+3. Passes the mount path via a command-line flag `--ca-cert-bundle-path=/etc/mcp-gateway/ca/ca-bundle.crt`
+
+The broker:
+1. Reads the CA bundle PEM from the file at startup
+2. Builds a base `*x509.CertPool` from system roots + gateway CA bundle
+3. For each upstream server, clones this base pool and appends any per-server CA from the config (if `CACert` is set on the `MCPServer`)
+4. Watches the file for changes (Kubernetes volume mount propagation) and rebuilds the pool on update
+
+#### Trust Pool Construction
+
+```
+System Root CAs (Go default)
+         ├── + Gateway CA Bundle (from caCertBundleRef)
+         │        = Base Trust Pool (shared by all servers)
+         │
+         ├── Server A: uses base pool only (no caCertSecretRef)
+         ├── Server B: uses base pool only (no caCertSecretRef)
+         └── Server C: base pool + per-server CA (caCertSecretRef set)
+                       = Server-specific pool
+```
+
+When `caCertBundleRef` is not set, behavior is identical to today — each server uses system roots + its own `caCertSecretRef` if set.
+
+### Interaction with Per-Server caCertSecretRef
+
+| Gateway `caCertBundleRef` | Server `caCertSecretRef` | Effective Trust Pool |
+|---------------------------|--------------------------|----------------------|
+| Not set                   | Not set                  | System roots only |
+| Not set                   | Set                      | System roots + server CA (current behavior) |
+| Set                       | Not set                  | System roots + gateway CA bundle |
+| Set                       | Set                      | System roots + gateway CA bundle + server CA |
+
+Per-server `caCertSecretRef` always **appends** — it never replaces the gateway bundle. This is additive-only, following the Kubernetes pattern where more-specific configuration adds to less-specific configuration rather than overriding it.
+
+### Validation
+
+The MCPGatewayExtension controller validates `caCertBundleRef` during reconciliation:
+
+| Check | Error |
+|-------|-------|
+| Secret exists | `CA bundle secret <name> not found` |
+| Secret has `mcp.kuadrant.io/secret=true` label | `CA bundle secret <name> missing required label` |
+| Key exists in Secret | `CA bundle secret <name> missing key <key>` |
+| PEM data is valid | `CA bundle in secret <name> is invalid: <reason>` |
+| Size ≤ 256 KiB | `CA bundle data exceeds maximum size` |
+
+The size limit is 256 KiB (vs 64 KiB for per-server CAs) because a shared bundle typically contains multiple CA certificates (root + intermediates, or multiple issuer CAs).
+
+### Volume Mount Strategy
+
+The CA bundle Secret is mounted as a read-only volume, not embedded in the config secret. This:
+
+1. **Avoids config bloat** — the CA PEM is not duplicated per-server in the config YAML
+2. **Enables hot reload** — Kubernetes propagates Secret updates to volume mounts (60-120s kubelet sync), and the broker watches the file for changes
+3. **Follows the existing pattern** — the aggregated credentials secret is already mounted as a volume on the broker-router Deployment
+
+Mount details:
+- Volume name: `ca-cert-bundle`
+- Mount path: `/etc/mcp-gateway/ca/`
+- File: `ca-bundle.crt` (or the configured key)
+- Read-only: true
+
+### CA Bundle Rotation
+
+When the CA bundle Secret is updated:
+
+1. The MCPGatewayExtension controller detects the Secret update (via watch on labeled Secrets)
+2. The controller re-validates the PEM and updates the Deployment annotation hash to trigger a rollout (if the content changed)
+3. Kubernetes propagates the new Secret data to the volume mount (60-120s)
+4. The broker detects the file change, rebuilds the base trust pool, and re-registers all servers that use it
+
+End-to-end propagation: ~60-120 seconds (dominated by kubelet volume sync).
+
+**Alternative: file watch without rollout.** If rollout restarts are undesirable (they briefly interrupt all connections), the broker can use `fsnotify` to watch the mounted file and rebuild the cert pool in-place. This avoids pod restarts but relies on volume mount propagation being timely. Both strategies should be evaluated during implementation.
+
+## Security Considerations
+
+- **Same label requirement** — the CA bundle Secret must have `mcp.kuadrant.io/secret=true`, consistent with per-server CA Secrets and credential Secrets
+- **No new trust** — the gateway CA bundle extends the system root pool, it does not replace it. Servers that work today with publicly-trusted CAs continue to work without changes
+- **Additive-only** — per-server CAs always append to the gateway bundle, never override. An operator cannot accidentally remove trust for a server by setting the gateway bundle
+- **Size limit** — 256 KiB prevents accidental inclusion of large files. This is generous enough for typical CA chains (~20-30 CAs at ~2 KiB each)
+
+## Future Considerations
+
+### ConfigMap Support
+
+The current design uses a Secret for the CA bundle. A future enhancement could support ConfigMaps, which are more natural for non-sensitive CA certificates and align with how OpenShift distributes the service-serving CA (`openshift-service-ca.crt` ConfigMap). This would require a union-type field or separate `caCertBundleConfigMapRef`.
+
+### Certificate Expiry Monitoring
+
+The broker could parse the CA certificates and emit metrics or log warnings when certificates are near expiry. This would help operators detect upcoming CA rotations before they cause outages.
+
+## Execution
+
+See:
+- [tasks/tasks.md](tasks/tasks.md) for the implementation plan
+- [tasks/e2e_test_cases.md](tasks/e2e_test_cases.md) for E2E test cases
+- [tasks/documentation.md](tasks/documentation.md) for documentation outline

--- a/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
+++ b/docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md
@@ -199,7 +199,7 @@ When the CA bundle Secret is updated:
 3. The config watcher detects the config Secret change and calls `mcpConfig.Notify()`
 4. The broker's `OnConfigChange()` observer rebuilds the base trust pool and re-registers servers
 
-End-to-end propagation: ~15-30 seconds (controller re-reconciliation + config watcher cycle). This is faster than the previous volume-mount approach since it does not depend on kubelet volume sync (60-120s).
+End-to-end propagation: ~60-120 seconds (dominated by kubelet volume sync of the config Secret to the broker pod).
 
 ## Security Considerations
 
@@ -210,14 +210,6 @@ End-to-end propagation: ~15-30 seconds (controller re-reconciliation + config wa
 - **Config Secret size** — the gateway CA bundle contributes to the 1 MiB Kubernetes Secret limit, but since it replaces N per-server copies with 1, the net size is always smaller when servers share a CA. For extreme cases, operators can partition servers across multiple gateways
 
 ## Future Considerations
-
-### ConfigMap Support
-
-The current design uses a Secret for the CA bundle. A future enhancement could support ConfigMaps, which are more natural for non-sensitive CA certificates and align with how OpenShift distributes the service-serving CA (`openshift-service-ca.crt` ConfigMap). This would require a union-type field or separate `caCertBundleConfigMapRef`.
-
-### Certificate Expiry Monitoring
-
-The broker could parse the CA certificates and emit metrics or log warnings when certificates are near expiry. This would help operators detect upcoming CA rotations before they cause outages.
 
 ### Per-Server CA Deduplication
 

--- a/docs/design/gateway-ca-cert-bundle/tasks/documentation.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/documentation.md
@@ -1,0 +1,62 @@
+# Gateway CA Certificate Bundle — Documentation Plan
+
+Documentation for the gateway-level CA certificate bundle, organized by user goals. Each section maps to a guide or doc update.
+
+## User-Facing Guide Update (`docs/guides/custom-ca-certificates.md`)
+
+### When I have many upstream servers behind the same private CA
+
+When a platform engineer has multiple upstream MCP servers behind a shared CA (e.g. OpenShift service-serving CA, a shared cert-manager issuer), they want to configure the CA once at the gateway level so they don't need to create and maintain separate CA Secrets for each MCPServerRegistration.
+
+**Cover:**
+- Adding `caCertBundleRef` to MCPGatewayExtension
+- Creating the CA bundle Secret with required label
+- How servers automatically trust the gateway-level CA
+- When to use gateway bundle vs per-server `caCertSecretRef`
+- Comparison table: gateway bundle vs per-server CA
+
+### When I need to rotate a shared CA certificate
+
+When a platform engineer needs to rotate the CA certificate used by all upstream servers, they want to update a single Secret and have all servers pick up the new CA.
+
+**Cover:**
+- Updating the CA bundle Secret
+- Propagation timing (60-120s kubelet sync + broker reload)
+- How to verify the new CA is active (broker logs, server status)
+- Comparison with per-server CA rotation (N updates vs 1)
+
+### When I have servers with unique CAs alongside a shared CA
+
+When a platform engineer has most servers behind a shared CA but some servers using unique CAs, they want to combine gateway-level and per-server CA configuration.
+
+**Cover:**
+- Setting `caCertBundleRef` on MCPGatewayExtension for the shared CA
+- Setting `caCertSecretRef` on specific MCPServerRegistrations for unique CAs
+- Additive trust pool behavior (per-server appends, never replaces)
+- YAML examples showing combined configuration
+
+## API Reference Update (`docs/reference/mcpgatewayextension.md`)
+
+### When I need to know the exact field names and types
+
+When a platform engineer is writing MCPGatewayExtension YAML, they want to know the exact API surface for `caCertBundleRef`.
+
+**Cover:**
+- `caCertBundleRef` object (optional)
+- `caCertBundleRef.name` field (required, Secret name)
+- `caCertBundleRef.key` field (optional, defaults to `ca-bundle.crt`)
+- Secret requirements: must have `mcp.kuadrant.io/secret=true` label
+- Size limit: 256 KiB max
+- Relationship to per-server `caCertSecretRef` (additive, not replacing)
+
+## AGENTS.md Update
+
+### When an AI agent needs to understand the CA trust model
+
+When an AI agent is working with this codebase, it needs to understand how the two-tier CA trust model works.
+
+**Cover:**
+- `MCPGatewayExtension.caCertBundleRef` field description
+- How it interacts with `MCPServerRegistration.caCertSecretRef`
+- Trust pool hierarchy: system roots → gateway bundle → per-server CA
+- Volume mount path and CLI flag

--- a/docs/design/gateway-ca-cert-bundle/tasks/documentation.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/documentation.md
@@ -21,7 +21,7 @@ When a platform engineer needs to rotate the CA certificate used by all upstream
 
 **Cover:**
 - Updating the CA bundle Secret
-- Propagation timing (60-120s kubelet sync + broker reload)
+- Propagation timing (~15-30s controller re-reconciliation + config watcher cycle)
 - How to verify the new CA is active (broker logs, server status)
 - Comparison with per-server CA rotation (N updates vs 1)
 
@@ -44,9 +44,10 @@ When a platform engineer is writing MCPGatewayExtension YAML, they want to know 
 **Cover:**
 - `caCertBundleRef` object (optional)
 - `caCertBundleRef.name` field (required, Secret name)
-- `caCertBundleRef.key` field (optional, defaults to `ca-bundle.crt`)
+- `caCertBundleRef.key` field (optional, defaults to `ca.crt`)
 - Secret requirements: must have `mcp.kuadrant.io/secret=true` label
 - Size limit: 256 KiB max
+- Config Secret size considerations: gateway bundle replaces N per-server copies with 1
 - Relationship to per-server `caCertSecretRef` (additive, not replacing)
 
 ## AGENTS.md Update
@@ -59,4 +60,4 @@ When an AI agent is working with this codebase, it needs to understand how the t
 - `MCPGatewayExtension.caCertBundleRef` field description
 - How it interacts with `MCPServerRegistration.caCertSecretRef`
 - Trust pool hierarchy: system roots → gateway bundle → per-server CA
-- Volume mount path and CLI flag
+- Config secret integration: `gatewayCACertPEM` field in `config.yaml`

--- a/docs/design/gateway-ca-cert-bundle/tasks/documentation.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/documentation.md
@@ -21,7 +21,7 @@ When a platform engineer needs to rotate the CA certificate used by all upstream
 
 **Cover:**
 - Updating the CA bundle Secret
-- Propagation timing (~15-30s controller re-reconciliation + config watcher cycle)
+- Propagation timing (~60-120s kubelet volume sync of config Secret)
 - How to verify the new CA is active (broker logs, server status)
 - Comparison with per-server CA rotation (N updates vs 1)
 

--- a/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
@@ -37,6 +37,6 @@ tags: Happy,CACertBundle
 
 - When the CA bundle Secret is updated with a new CA certificate (e.g. after CA rotation), the controller should detect the change, re-validate the PEM, and write the updated `gatewayCACertPEM` into the config secret. The config change flows through `mcpConfig.Notify()`, triggering the broker to rebuild its trust pool. After the update propagates (~15-30s controller re-reconciliation), servers whose certificates are signed by the new CA should connect successfully.
 
-### [CACertBundle] Gateway CA stored once in config, not per-server
+### [Happy,CACertBundle] Gateway CA bundle with existing per-server CA on same server
 
-- When an MCPGatewayExtension has `caCertBundleRef` set and multiple MCPServerRegistrations exist without `caCertSecretRef`, the config secret (`mcp-gateway-config`) should contain the CA PEM exactly once under the `gatewayCACertPEM` key, and individual server entries should NOT have inline `caCert` values. This verifies that the gateway-level CA bundle eliminates per-server CA duplication in the config.
+- When an MCPGatewayExtension has `caCertBundleRef` set with a CA that covers an upstream TLS server, and the same server's MCPServerRegistration also has `caCertSecretRef` pointing to the same CA, the broker should connect successfully. Both the gateway bundle and per-server CA contribute to the trust pool additively. This verifies no conflict when the same CA appears in both places.

--- a/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
@@ -35,8 +35,8 @@ tags: Happy,CACertBundle
 
 ### [CACertBundle] CA bundle rotation updates broker trust pool
 
-- When the CA bundle Secret is updated with a new CA certificate (e.g. after CA rotation), the broker should detect the change and rebuild its trust pool. After the update propagates, servers whose certificates are signed by the new CA should connect successfully. The propagation time depends on Kubernetes volume mount sync (60-120s).
+- When the CA bundle Secret is updated with a new CA certificate (e.g. after CA rotation), the controller should detect the change, re-validate the PEM, and write the updated `gatewayCACertPEM` into the config secret. The config change flows through `mcpConfig.Notify()`, triggering the broker to rebuild its trust pool. After the update propagates (~15-30s controller re-reconciliation), servers whose certificates are signed by the new CA should connect successfully.
 
-### [CACertBundle] Config secret does not contain duplicate CA PEM
+### [CACertBundle] Gateway CA stored once in config, not per-server
 
-- When an MCPGatewayExtension has `caCertBundleRef` set and multiple MCPServerRegistrations exist without `caCertSecretRef`, the config secret (`mcp-gateway-config`) should NOT contain inline CA PEM data for those servers. This verifies that the gateway-level CA bundle avoids config bloat — the CA is delivered via volume mount, not embedded in the config YAML.
+- When an MCPGatewayExtension has `caCertBundleRef` set and multiple MCPServerRegistrations exist without `caCertSecretRef`, the config secret (`mcp-gateway-config`) should contain the CA PEM exactly once under the `gatewayCACertPEM` key, and individual server entries should NOT have inline `caCert` values. This verifies that the gateway-level CA bundle eliminates per-server CA duplication in the config.

--- a/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
@@ -1,0 +1,42 @@
+## Gateway CA Certificate Bundle E2E Test Cases
+
+---
+test_suite: ca_bundle_test.go
+tags: Happy,CACertBundle
+---
+
+### [Happy,CACertBundle] Gateway CA bundle enables TLS connection to upstream server
+
+- When an MCPGatewayExtension is configured with `caCertBundleRef` pointing to a Secret containing the CA that signed an upstream TLS server's certificate, and an MCPServerRegistration for that server does NOT have `caCertSecretRef`, the broker should use the gateway-level CA bundle to verify the TLS connection. The upstream server's tools should be discovered and callable through the gateway.
+
+### [Happy,CACertBundle] Multiple servers sharing the same gateway CA bundle
+
+- When an MCPGatewayExtension has `caCertBundleRef` set and two MCPServerRegistrations target upstream TLS servers whose certificates are signed by the same CA (referenced by the bundle), both servers should have their tools discovered and callable without either registration needing `caCertSecretRef`. This verifies the shared trust pool works across multiple servers.
+
+### [Happy,CACertBundle] Per-server CA appends to gateway bundle
+
+- When an MCPGatewayExtension has `caCertBundleRef` set with CA-A, and an MCPServerRegistration has `caCertSecretRef` set with CA-B (a different CA), the broker should trust both CA-A and CA-B for that server. A server whose certificate is signed by CA-B should connect successfully. This verifies additive behavior.
+
+### [CACertBundle] Gateway bundle alone insufficient for server with unique CA
+
+- When an MCPGatewayExtension has `caCertBundleRef` set with CA-A, and an upstream server's certificate is signed by CA-B (not in the gateway bundle), and the MCPServerRegistration does NOT have `caCertSecretRef`, the broker should fail the TLS handshake with a certificate verification error. The MCPServerRegistration should not become Ready.
+
+### [CACertBundle] No gateway bundle — per-server CA still works
+
+- When an MCPGatewayExtension does NOT have `caCertBundleRef` set, and an MCPServerRegistration has `caCertSecretRef` pointing to the correct CA, the broker should successfully connect to the upstream TLS server. This verifies backward compatibility — the existing per-server CA flow is unaffected.
+
+### [CACertBundle] No gateway bundle, no per-server CA — public CA works
+
+- When neither `caCertBundleRef` nor `caCertSecretRef` is set, servers using publicly-trusted CAs should continue to work. Servers using private CAs should fail with certificate verification errors. This verifies no regression in default TLS behavior.
+
+### [CACertBundle] Invalid CA bundle secret — MCPGatewayExtension reports error
+
+- When `caCertBundleRef` references a Secret that does not exist, the MCPGatewayExtension should report a status condition with an error message mentioning the missing Secret. Similarly, a Secret without the required label `mcp.kuadrant.io/secret=true` should result in a validation error in the status.
+
+### [CACertBundle] CA bundle rotation updates broker trust pool
+
+- When the CA bundle Secret is updated with a new CA certificate (e.g. after CA rotation), the broker should detect the change and rebuild its trust pool. After the update propagates, servers whose certificates are signed by the new CA should connect successfully. The propagation time depends on Kubernetes volume mount sync (60-120s).
+
+### [CACertBundle] Config secret does not contain duplicate CA PEM
+
+- When an MCPGatewayExtension has `caCertBundleRef` set and multiple MCPServerRegistrations exist without `caCertSecretRef`, the config secret (`mcp-gateway-config`) should NOT contain inline CA PEM data for those servers. This verifies that the gateway-level CA bundle avoids config bloat — the CA is delivered via volume mount, not embedded in the config YAML.

--- a/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/e2e_test_cases.md
@@ -21,10 +21,6 @@ tags: Happy,CACertBundle
 
 - When an MCPGatewayExtension has `caCertBundleRef` set with CA-A, and an upstream server's certificate is signed by CA-B (not in the gateway bundle), and the MCPServerRegistration does NOT have `caCertSecretRef`, the broker should fail the TLS handshake with a certificate verification error. The MCPServerRegistration should not become Ready.
 
-### [CACertBundle] No gateway bundle — per-server CA still works
-
-- When an MCPGatewayExtension does NOT have `caCertBundleRef` set, and an MCPServerRegistration has `caCertSecretRef` pointing to the correct CA, the broker should successfully connect to the upstream TLS server. This verifies backward compatibility — the existing per-server CA flow is unaffected.
-
 ### [CACertBundle] No gateway bundle, no per-server CA — public CA works
 
 - When neither `caCertBundleRef` nor `caCertSecretRef` is set, servers using publicly-trusted CAs should continue to work. Servers using private CAs should fail with certificate verification errors. This verifies no regression in default TLS behavior.
@@ -35,7 +31,7 @@ tags: Happy,CACertBundle
 
 ### [CACertBundle] CA bundle rotation updates broker trust pool
 
-- When the CA bundle Secret is updated with a new CA certificate (e.g. after CA rotation), the controller should detect the change, re-validate the PEM, and write the updated `gatewayCACertPEM` into the config secret. The config change flows through `mcpConfig.Notify()`, triggering the broker to rebuild its trust pool. After the update propagates (~15-30s controller re-reconciliation), servers whose certificates are signed by the new CA should connect successfully.
+- When the CA bundle Secret is updated with a new CA certificate (e.g. after CA rotation), the controller should detect the change, re-validate the PEM, and write the updated `gatewayCACertPEM` into the config secret. The config change flows through `mcpConfig.Notify()`, triggering the broker to rebuild its trust pool. After the update propagates (~60-120s kubelet volume sync), servers whose certificates are signed by the new CA should connect successfully.
 
 ### [Happy,CACertBundle] Gateway CA bundle with existing per-server CA on same server
 

--- a/docs/design/gateway-ca-cert-bundle/tasks/tasks.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/tasks.md
@@ -70,6 +70,7 @@ Depends on: Task 1.
 - [ ] Secret update triggers re-reconciliation and config update
 - [ ] Config update flows through `mcpConfig.Notify()` for observer synchronization
 - [ ] No `caCertBundleRef` → no `gatewayCACertPEM` in config (backward compatible)
+- [ ] Integration test: `gatewayCACertPEM` present in config secret when bundle is set, absent when not set
 
 **Verification:** `make lint && make test-unit && make test-controller-integration`
 
@@ -102,28 +103,7 @@ Depends on: Task 2.
 
 ---
 
-### Task 4: MCPServerRegistration controller — skip embedding shared CAs in config
-
-Depends on: Task 2.
-
-**Files:**
-- `internal/controller/mcpserverregistration_controller.go` — modify config building:
-  1. If the server's `caCertSecretRef` points to the same Secret as the gateway's `caCertBundleRef`, skip embedding `CACert` in the per-server config (it's already in `gatewayCACertPEM`)
-  2. If different Secret, continue embedding as before
-- `internal/controller/mcpserverregistration_controller_integration_test.go` — integration tests
-
-**Note:** This is an optimization. Without it, the broker receives the CA both via `gatewayCACertPEM` and per-server `CACert` — functionally correct (additive) but wasteful. This task prevents the duplication that motivates the feature.
-
-**Acceptance criteria:**
-- [ ] Server CA that matches gateway bundle → `CACert` omitted from per-server config
-- [ ] Server CA that differs from gateway bundle → `CACert` embedded as before
-- [ ] No gateway bundle configured → all server CAs embedded as before
-
-**Verification:** `make test-unit && make test-controller-integration`
-
----
-
-### Task 5: Documentation and guide updates
+### Task 4: Documentation and guide updates
 
 Depends on: Tasks 1–3.
 
@@ -139,7 +119,7 @@ Depends on: Tasks 1–3.
 
 ---
 
-### Task 6: E2E tests
+### Task 5: E2E tests
 
 Depends on: Tasks 1–3.
 

--- a/docs/design/gateway-ca-cert-bundle/tasks/tasks.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/tasks.md
@@ -1,0 +1,189 @@
+# Gateway CA Certificate Bundle — Implementation Plan
+
+## Context
+
+The MCP Gateway's custom TLS support (#659, #1008) embeds per-server CA PEM data inline in the config secret. When many servers share the same CA, this causes duplication, config bloat, and operational overhead. This feature adds a `caCertBundleRef` field to `MCPGatewayExtension` for a shared trust pool.
+
+Design: `docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md`
+
+## Existing Code to Build On
+
+### Per-server CA cert flow (already implemented)
+1. **CRD field**: `MCPServerRegistrationSpec.CACertSecretRef` (`api/v1alpha1/types.go:88-93`)
+2. **Type**: `CACertSecretReference` with `Name` and `Key` (default `ca.crt`) (`api/v1alpha1/types.go:165-177`)
+3. **Controller**: reads secret via `DirectAPIReader`, validates label/key/size/PEM, writes inline to config (`mcpserverregistration_controller.go:447-479`)
+4. **Config type**: `MCPServer.CACert string` (`internal/config/types.go:97`)
+5. **Broker upstream**: `buildHTTPClient()` creates custom `*http.Client` with CA appended to system roots (`internal/broker/upstream/mcp.go:46-69`)
+6. **Broker connect**: passes custom client via `transport.WithHTTPBasicClient()` (`internal/broker/upstream/mcp.go:140-146`)
+
+### MCPGatewayExtension controller
+- `reconcileActive()` in `mcpgatewayextension_controller.go` — orchestrates Deployment, Service, HTTPRoutes, EnvoyFilter
+- `reconcileBrokerRouter()` — creates/updates the broker-router Deployment with volumes, env vars, and args
+- Existing volume mount pattern: aggregated credentials secret is already mounted as a volume
+
+## Implementation Order
+
+Tasks are ordered by dependency.
+
+### Task 1: CRD + config types
+
+**Files:**
+- `api/v1alpha1/mcpgatewayextension_types.go` — add `CACertBundleRef *CACertBundleReference` to `MCPGatewayExtensionSpec`
+- `api/v1alpha1/mcpgatewayextension_types.go` — add `CACertBundleReference` struct with `Name` and `Key` (default `ca-bundle.crt`)
+- `internal/config/types.go` — add `GatewayCACertBundle string` to `MCPServersConfig`
+- Run `make generate-all` to regenerate deepcopy, CRDs, sync Helm
+
+**Acceptance criteria:**
+- [ ] CRD accepts `caCertBundleRef` with `name` (required) and `key` (optional, default `ca-bundle.crt`)
+- [ ] `MCPServersConfig` has `GatewayCACertBundle` field
+- [ ] `make generate-all && make lint` passes
+- [ ] Existing tests pass without changes
+
+**Verification:** `make generate-all && make lint && make test-unit`
+
+---
+
+### Task 2: MCPGatewayExtension controller — validation + volume mount
+
+Depends on: Task 1.
+
+**Files:**
+- `internal/controller/mcpgatewayextension_controller.go` — add `reconcileCACertBundle()`:
+  1. If `caCertBundleRef` is nil, skip
+  2. Read the referenced Secret via `DirectAPIReader`
+  3. Validate: exists, has `mcp.kuadrant.io/secret=true` label, key exists, size ≤ 256 KiB, valid PEM
+  4. Set status condition on error
+- `internal/controller/broker_router.go` — modify `reconcileBrokerRouter()`:
+  1. If `caCertBundleRef` is set, add Secret volume + volume mount to Deployment
+  2. Add `--ca-cert-bundle-path=/etc/mcp-gateway/ca/<key>` arg to broker container
+  3. Add annotation hash of CA bundle content for rollout triggers
+- `internal/controller/mcpgatewayextension_controller.go` — add Secret watch for labeled Secrets (already exists for MCPServerRegistration, extend to MCPGatewayExtension)
+- `internal/controller/mcpgatewayextension_controller_test.go` — unit tests
+
+**Volume details:**
+- Volume name: `ca-cert-bundle`
+- Mount path: `/etc/mcp-gateway/ca/`
+- Read-only: true
+
+**Acceptance criteria:**
+- [ ] Valid CA bundle secret → volume mounted, arg added, status Ready
+- [ ] Missing secret → status condition with error message
+- [ ] Missing label → status condition with error message
+- [ ] Invalid PEM → status condition with error message
+- [ ] Size exceeds 256 KiB → status condition with error message
+- [ ] Secret update triggers Deployment rollout via annotation hash
+- [ ] No `caCertBundleRef` → no volume, no arg (backward compatible)
+
+**Verification:** `make lint && make test-unit && make test-controller-integration`
+
+---
+
+### Task 3: Broker — load gateway CA bundle + build base trust pool
+
+Depends on: Task 2.
+
+**Files:**
+- `cmd/mcp-broker-router/main.go` — add `--ca-cert-bundle-path` flag, pass to broker
+- `internal/broker/broker.go` — add `CACertBundlePath string` field, load PEM from file at startup, build base `*x509.CertPool`
+- `internal/broker/upstream/mcp.go` — modify `buildHTTPClient()`:
+  1. Accept an optional base `*x509.CertPool` parameter (the gateway CA bundle pool)
+  2. Clone the base pool (or system roots if nil)
+  3. Append per-server `CACert` if set
+  4. Return custom client with combined pool
+- `internal/broker/upstream/mcp_test.go` — unit tests for combined pool behavior
+
+**Acceptance criteria:**
+- [ ] `--ca-cert-bundle-path` flag parsed and plumbed to broker
+- [ ] Broker loads PEM from file at startup, logs cert count
+- [ ] `buildHTTPClient()` uses base pool when available
+- [ ] Per-server `CACert` appends to base pool (not replaces)
+- [ ] No `--ca-cert-bundle-path` → behavior identical to current (system roots only)
+- [ ] Invalid PEM file → broker logs error, falls back to system roots
+
+**Verification:** `make test-unit`
+
+---
+
+### Task 4: Broker — file watch for CA bundle hot reload
+
+Depends on: Task 3.
+
+**Files:**
+- `internal/broker/broker.go` — add file watcher for `CACertBundlePath`:
+  1. Watch for file changes via `fsnotify` or polling (Kubernetes volume mount propagation)
+  2. On change, rebuild base `*x509.CertPool`
+  3. Re-register all servers to pick up new trust pool
+- `internal/broker/broker_test.go` — unit tests for reload
+
+**Acceptance criteria:**
+- [ ] File change detected and pool rebuilt
+- [ ] All servers re-registered with new pool
+- [ ] Log message on reload: `reloaded gateway CA bundle certs=N`
+- [ ] No crash on temporary file absence during Secret rotation
+- [ ] No `--ca-cert-bundle-path` → no watcher started
+
+**Verification:** `make test-unit`
+
+---
+
+### Task 5: MCPServerRegistration controller — stop embedding shared CAs in config
+
+Depends on: Task 2. Independent of Tasks 3-4 (controller-side only).
+
+**Files:**
+- `internal/controller/mcpserverregistration_controller.go` — modify config building:
+  1. If the server's `caCertSecretRef` points to the same Secret as the gateway's `caCertBundleRef`, skip embedding `CACert` in the config (it's already mounted as a volume)
+  2. If different Secret, continue embedding as before
+- `internal/controller/mcpserverregistration_controller_integration_test.go` — integration tests
+
+**Note:** This is an optimization, not strictly required. Without it, the broker receives the CA both via volume mount and inline config — functionally correct but wasteful. This task prevents the duplication that motivates the feature.
+
+**Acceptance criteria:**
+- [ ] Server CA that matches gateway bundle → `CACert` omitted from config
+- [ ] Server CA that differs from gateway bundle → `CACert` embedded as before
+- [ ] No gateway bundle configured → all server CAs embedded as before
+
+**Verification:** `make test-unit && make test-controller-integration`
+
+---
+
+### Task 6: Documentation and guide updates
+
+Depends on: Tasks 1–4.
+
+**Files:**
+- `docs/guides/custom-ca-certificates.md` — add section for gateway-level CA bundle
+- `docs/reference/mcpgatewayextension.md` — add `caCertBundleRef` field documentation
+- `AGENTS.md` — update with `caCertBundleRef` information
+
+**Acceptance criteria:**
+- [ ] Guide covers: when to use gateway bundle vs per-server CA, step-by-step setup, rotation
+- [ ] API reference updated with field, type, default, constraints
+- [ ] AGENTS.md updated
+
+---
+
+### Task 7: E2E tests
+
+Depends on: Tasks 1–4.
+
+**Files:**
+- `tests/e2e/ca_bundle_test.go` (new) — E2E test cases
+
+**Acceptance criteria:**
+- [ ] All e2e test cases from `e2e_test_cases.md` pass
+- [ ] Tests clean up resources after each case
+
+**Verification:** `make test-e2e`
+
+---
+
+## Verification (full)
+
+```bash
+make generate-all       # CRD regeneration
+make lint               # Style checks
+make test-unit          # All unit tests
+make test-controller-integration  # Controller integration tests
+make test-e2e           # E2E with Kind cluster
+```

--- a/docs/design/gateway-ca-cert-bundle/tasks/tasks.md
+++ b/docs/design/gateway-ca-cert-bundle/tasks/tasks.md
@@ -16,10 +16,14 @@ Design: `docs/design/gateway-ca-cert-bundle/gateway-ca-cert-bundle-design.md`
 5. **Broker upstream**: `buildHTTPClient()` creates custom `*http.Client` with CA appended to system roots (`internal/broker/upstream/mcp.go:46-69`)
 6. **Broker connect**: passes custom client via `transport.WithHTTPBasicClient()` (`internal/broker/upstream/mcp.go:140-146`)
 
+### Config secret flow
+- `BrokerConfig` in `internal/config/types.go:169-172` — holds servers + virtual servers, serialized as `config.yaml` in `mcp-gateway-config` Secret
+- `SecretReaderWriter` in `internal/config/config_writer.go` — read-modify-write pattern with retry on conflict
+- `mcpConfig.Notify()` — observer pattern that notifies broker of config changes
+
 ### MCPGatewayExtension controller
 - `reconcileActive()` in `mcpgatewayextension_controller.go` — orchestrates Deployment, Service, HTTPRoutes, EnvoyFilter
 - `reconcileBrokerRouter()` — creates/updates the broker-router Deployment with volumes, env vars, and args
-- Existing volume mount pattern: aggregated credentials secret is already mounted as a volume
 
 ## Implementation Order
 
@@ -29,13 +33,13 @@ Tasks are ordered by dependency.
 
 **Files:**
 - `api/v1alpha1/mcpgatewayextension_types.go` — add `CACertBundleRef *CACertBundleReference` to `MCPGatewayExtensionSpec`
-- `api/v1alpha1/mcpgatewayextension_types.go` — add `CACertBundleReference` struct with `Name` and `Key` (default `ca-bundle.crt`)
-- `internal/config/types.go` — add `GatewayCACertBundle string` to `MCPServersConfig`
+- `api/v1alpha1/mcpgatewayextension_types.go` — add `CACertBundleReference` struct with `Name` and `Key` (default `ca.crt`)
+- `internal/config/types.go` — add `GatewayCACertPEM string` to `BrokerConfig`
 - Run `make generate-all` to regenerate deepcopy, CRDs, sync Helm
 
 **Acceptance criteria:**
-- [ ] CRD accepts `caCertBundleRef` with `name` (required) and `key` (optional, default `ca-bundle.crt`)
-- [ ] `MCPServersConfig` has `GatewayCACertBundle` field
+- [ ] CRD accepts `caCertBundleRef` with `name` (required) and `key` (optional, default `ca.crt`)
+- [ ] `BrokerConfig` has `GatewayCACertPEM` field serialized as `gatewayCACertPEM` in YAML
 - [ ] `make generate-all && make lint` passes
 - [ ] Existing tests pass without changes
 
@@ -43,48 +47,43 @@ Tasks are ordered by dependency.
 
 ---
 
-### Task 2: MCPGatewayExtension controller — validation + volume mount
+### Task 2: MCPGatewayExtension controller — validation + config write
 
 Depends on: Task 1.
 
 **Files:**
 - `internal/controller/mcpgatewayextension_controller.go` — add `reconcileCACertBundle()`:
-  1. If `caCertBundleRef` is nil, skip
+  1. If `caCertBundleRef` is nil, skip (clear any existing `GatewayCACertPEM` from config)
   2. Read the referenced Secret via `DirectAPIReader`
   3. Validate: exists, has `mcp.kuadrant.io/secret=true` label, key exists, size ≤ 256 KiB, valid PEM
-  4. Set status condition on error
-- `internal/controller/broker_router.go` — modify `reconcileBrokerRouter()`:
-  1. If `caCertBundleRef` is set, add Secret volume + volume mount to Deployment
-  2. Add `--ca-cert-bundle-path=/etc/mcp-gateway/ca/<key>` arg to broker container
-  3. Add annotation hash of CA bundle content for rollout triggers
+  4. Write CA PEM into `config.yaml` under `gatewayCACertPEM` key via `SecretReaderWriter`
+  5. Set status condition on error
 - `internal/controller/mcpgatewayextension_controller.go` — add Secret watch for labeled Secrets (already exists for MCPServerRegistration, extend to MCPGatewayExtension)
 - `internal/controller/mcpgatewayextension_controller_test.go` — unit tests
 
-**Volume details:**
-- Volume name: `ca-cert-bundle`
-- Mount path: `/etc/mcp-gateway/ca/`
-- Read-only: true
-
 **Acceptance criteria:**
-- [ ] Valid CA bundle secret → volume mounted, arg added, status Ready
+- [ ] Valid CA bundle secret → `gatewayCACertPEM` written to config, status Ready
 - [ ] Missing secret → status condition with error message
 - [ ] Missing label → status condition with error message
 - [ ] Invalid PEM → status condition with error message
 - [ ] Size exceeds 256 KiB → status condition with error message
-- [ ] Secret update triggers Deployment rollout via annotation hash
-- [ ] No `caCertBundleRef` → no volume, no arg (backward compatible)
+- [ ] Secret update triggers re-reconciliation and config update
+- [ ] Config update flows through `mcpConfig.Notify()` for observer synchronization
+- [ ] No `caCertBundleRef` → no `gatewayCACertPEM` in config (backward compatible)
 
 **Verification:** `make lint && make test-unit && make test-controller-integration`
 
 ---
 
-### Task 3: Broker — load gateway CA bundle + build base trust pool
+### Task 3: Broker — read gateway CA bundle from config + build base trust pool
 
 Depends on: Task 2.
 
 **Files:**
-- `cmd/mcp-broker-router/main.go` — add `--ca-cert-bundle-path` flag, pass to broker
-- `internal/broker/broker.go` — add `CACertBundlePath string` field, load PEM from file at startup, build base `*x509.CertPool`
+- `internal/broker/broker.go` — in `OnConfigChange()`:
+  1. Read `GatewayCACertPEM` from config
+  2. If non-empty, build base `*x509.CertPool` from system roots + gateway CA
+  3. Store as shared base pool for all server connections
 - `internal/broker/upstream/mcp.go` — modify `buildHTTPClient()`:
   1. Accept an optional base `*x509.CertPool` parameter (the gateway CA bundle pool)
   2. Clone the base pool (or system roots if nil)
@@ -93,53 +92,30 @@ Depends on: Task 2.
 - `internal/broker/upstream/mcp_test.go` — unit tests for combined pool behavior
 
 **Acceptance criteria:**
-- [ ] `--ca-cert-bundle-path` flag parsed and plumbed to broker
-- [ ] Broker loads PEM from file at startup, logs cert count
+- [ ] Broker reads `GatewayCACertPEM` from config on change
 - [ ] `buildHTTPClient()` uses base pool when available
 - [ ] Per-server `CACert` appends to base pool (not replaces)
-- [ ] No `--ca-cert-bundle-path` → behavior identical to current (system roots only)
-- [ ] Invalid PEM file → broker logs error, falls back to system roots
+- [ ] No `GatewayCACertPEM` in config → behavior identical to current (system roots only)
+- [ ] Invalid PEM in config → broker logs error, falls back to system roots
 
 **Verification:** `make test-unit`
 
 ---
 
-### Task 4: Broker — file watch for CA bundle hot reload
+### Task 4: MCPServerRegistration controller — skip embedding shared CAs in config
 
-Depends on: Task 3.
-
-**Files:**
-- `internal/broker/broker.go` — add file watcher for `CACertBundlePath`:
-  1. Watch for file changes via `fsnotify` or polling (Kubernetes volume mount propagation)
-  2. On change, rebuild base `*x509.CertPool`
-  3. Re-register all servers to pick up new trust pool
-- `internal/broker/broker_test.go` — unit tests for reload
-
-**Acceptance criteria:**
-- [ ] File change detected and pool rebuilt
-- [ ] All servers re-registered with new pool
-- [ ] Log message on reload: `reloaded gateway CA bundle certs=N`
-- [ ] No crash on temporary file absence during Secret rotation
-- [ ] No `--ca-cert-bundle-path` → no watcher started
-
-**Verification:** `make test-unit`
-
----
-
-### Task 5: MCPServerRegistration controller — stop embedding shared CAs in config
-
-Depends on: Task 2. Independent of Tasks 3-4 (controller-side only).
+Depends on: Task 2.
 
 **Files:**
 - `internal/controller/mcpserverregistration_controller.go` — modify config building:
-  1. If the server's `caCertSecretRef` points to the same Secret as the gateway's `caCertBundleRef`, skip embedding `CACert` in the config (it's already mounted as a volume)
+  1. If the server's `caCertSecretRef` points to the same Secret as the gateway's `caCertBundleRef`, skip embedding `CACert` in the per-server config (it's already in `gatewayCACertPEM`)
   2. If different Secret, continue embedding as before
 - `internal/controller/mcpserverregistration_controller_integration_test.go` — integration tests
 
-**Note:** This is an optimization, not strictly required. Without it, the broker receives the CA both via volume mount and inline config — functionally correct but wasteful. This task prevents the duplication that motivates the feature.
+**Note:** This is an optimization. Without it, the broker receives the CA both via `gatewayCACertPEM` and per-server `CACert` — functionally correct (additive) but wasteful. This task prevents the duplication that motivates the feature.
 
 **Acceptance criteria:**
-- [ ] Server CA that matches gateway bundle → `CACert` omitted from config
+- [ ] Server CA that matches gateway bundle → `CACert` omitted from per-server config
 - [ ] Server CA that differs from gateway bundle → `CACert` embedded as before
 - [ ] No gateway bundle configured → all server CAs embedded as before
 
@@ -147,9 +123,9 @@ Depends on: Task 2. Independent of Tasks 3-4 (controller-side only).
 
 ---
 
-### Task 6: Documentation and guide updates
+### Task 5: Documentation and guide updates
 
-Depends on: Tasks 1–4.
+Depends on: Tasks 1–3.
 
 **Files:**
 - `docs/guides/custom-ca-certificates.md` — add section for gateway-level CA bundle
@@ -163,9 +139,9 @@ Depends on: Tasks 1–4.
 
 ---
 
-### Task 7: E2E tests
+### Task 6: E2E tests
 
-Depends on: Tasks 1–4.
+Depends on: Tasks 1–3.
 
 **Files:**
 - `tests/e2e/ca_bundle_test.go` (new) — E2E test cases


### PR DESCRIPTION
## Summary

Design proposal for adding `caCertBundleRef` to `MCPGatewayExtension` — a gateway-level CA certificate bundle that acts as a shared trust pool for all upstream MCP server connections.

## Problem

With custom TLS support (#659, #1008), each `MCPServerRegistration` can reference its own CA via `caCertSecretRef`. When many upstream servers share the same CA (OpenShift service-serving CA, shared cert-manager issuer, corporate root CA), this causes:

- **Duplication** — same CA PEM repeated N times across N registrations
- **Config secret bloat** — each CA cert (up to 64 KiB) is embedded per-server in the config YAML, putting pressure on the 1 MiB Kubernetes Secret limit
- **Operational overhead** — CA rotation requires updating N Secrets instead of one

## Proposed Solution

```yaml
apiVersion: mcp.kuadrant.io/v1alpha1
kind: MCPGatewayExtension
spec:
  targetRef:
    name: mcp-gateway
    sectionName: mcp
  caCertBundleRef:
    name: shared-ca-bundle
```

The broker loads this bundle at startup as a base trust pool. Per-server `caCertSecretRef` appends additional CAs for backends with unique CAs. This mirrors how Kubernetes works — cluster-wide CA bundle plus per-resource overrides.

## Design Document Structure

```
docs/design/gateway-ca-cert-bundle/
├── gateway-ca-cert-bundle-design.md    # Main design document
└── tasks/
    ├── tasks.md                        # 7 ordered implementation tasks
    ├── e2e_test_cases.md               # 9 E2E test cases
    └── documentation.md                # Documentation plan
```

## Key Design Decisions

- **Volume mount, not config embedding** — CA bundle is mounted as a volume on the broker pod, not embedded per-server in the config YAML. Avoids config secret bloat.
- **Additive trust pools** — per-server `caCertSecretRef` appends to the gateway bundle, never replaces. System roots → gateway bundle → per-server CA.
- **File watch for hot reload** — broker watches the mounted file for changes, rebuilds cert pool without pod restart.
- **256 KiB size limit** — larger than the per-server 64 KiB limit since bundles typically contain multiple CAs.

## Verification

This is a docs-only PR. No code changes.

Relates to #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway-level shared CA certificate bundle support, enabling a gateway-wide trust pool that composes additively with per-server CAs.

* **Documentation**
  * Design, implementation plan, operational guidance for rotation/propagation, validation/labeling and size constraints, and user-guide/API documentation updates.

* **Tests**
  * E2E test scenarios for trust composition, handshake failures, validation/error reporting, rotation propagation, and no-conflict cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->