### PR TITLE
fix(broker): add transport timeouts to upstream HTTP client

### DIFF
--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -7,12 +7,23 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Transport-level timeouts for upstream HTTP clients. We bound connection
+// establishment and response-header reads instead of setting http.Client.Timeout,
+// because the streamable HTTP client reuses the same client for the long-lived
+// SSE listen stream, which must not be capped.
+var (
+	defaultTLSHandshakeTimeout   = 10 * time.Second
+	defaultResponseHeaderTimeout = 30 * time.Second
+	defaultExpectContinueTimeout = 1 * time.Second
 )
 
 // MCPServer represents a connection to an upstream MCP server. It wraps the
@@ -43,26 +54,29 @@ func NewUpstreamMCP(config *config.MCPServer) *MCPServer {
 	return up
 }
 
-// buildHTTPClient creates a custom HTTP client with the configured CA certificate
-// appended to the system root pool. Returns nil if no CACert is configured.
+// buildHTTPClient constructs the HTTP client used to talk to this upstream MCP
+// server. The transport always has handshake and response-header timeouts so a
+// hung or unresponsive upstream cannot block the broker indefinitely. When a
+// CACert is configured, that CA is appended to the system root pool and used
+// for TLS verification.
 func (up *MCPServer) buildHTTPClient() (*http.Client, error) {
-	if up.CACert == "" {
-		return nil, nil //nolint:nilnil // nil client signals caller to use default transport
-	}
-
-	rootCAs, err := x509.SystemCertPool()
-	if err != nil {
-		rootCAs = x509.NewCertPool()
-	}
-
-	if !rootCAs.AppendCertsFromPEM([]byte(up.CACert)) {
-		return nil, fmt.Errorf("failed to parse CA certificate PEM for upstream %s", up.Name)
-	}
-
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    rootCAs,
+	transport.TLSHandshakeTimeout = defaultTLSHandshakeTimeout
+	transport.ResponseHeaderTimeout = defaultResponseHeaderTimeout
+	transport.ExpectContinueTimeout = defaultExpectContinueTimeout
+
+	if up.CACert != "" {
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			rootCAs = x509.NewCertPool()
+		}
+		if !rootCAs.AppendCertsFromPEM([]byte(up.CACert)) {
+			return nil, fmt.Errorf("failed to parse CA certificate PEM for upstream %s", up.Name)
+		}
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    rootCAs,
+		}
 	}
 
 	return &http.Client{Transport: transport}, nil
@@ -137,13 +151,11 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 		transport.WithHTTPHeaders(up.headers),
 	}
 
-	customClient, err := up.buildHTTPClient()
+	httpC, err := up.buildHTTPClient()
 	if err != nil {
 		return fmt.Errorf("failed to build HTTP client: %w", err)
 	}
-	if customClient != nil {
-		options = append(options, transport.WithHTTPBasicClient(customClient))
-	}
+	options = append(options, transport.WithHTTPBasicClient(httpC))
 
 	httpClient, err := client.NewStreamableHttpClient(up.URL, options...)
 	if err != nil {

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -147,7 +147,12 @@ func TestBuildHTTPClient_NoCACert(t *testing.T) {
 	})
 	client, err := up.buildHTTPClient()
 	require.NoError(t, err)
-	require.Nil(t, client, "should return nil when no CACert configured")
+	require.NotNil(t, client, "should always return a client with timeouts set")
+
+	tr, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "transport should be *http.Transport")
+	require.Equal(t, defaultTLSHandshakeTimeout, tr.TLSHandshakeTimeout)
+	require.Equal(t, defaultResponseHeaderTimeout, tr.ResponseHeaderTimeout)
 }
 
 func TestBuildHTTPClient_WithValidCACert(t *testing.T) {
@@ -217,14 +222,14 @@ func TestBuildHTTPClient_TLSConnectionFailsWithoutCA(t *testing.T) {
 		Name: "no-ca-test",
 		URL:  srv.URL + "/mcp",
 	})
-	client, err := up.buildHTTPClient()
+	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
-	require.Nil(t, client, "no CACert means nil client")
+	require.NotNil(t, httpClient, "client is always returned, only TLS pool varies")
 
 	req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, reqErr)
-	_, err = http.DefaultClient.Do(req) //nolint:bodyclose // expected to fail, no body to close
-	require.Error(t, err, "default client should not trust self-signed cert")
+	_, err = httpClient.Do(req) //nolint:bodyclose // expected to fail, no body to close
+	require.Error(t, err, "upstream client without CACert should not trust self-signed cert")
 }
 
 func TestBuildHTTPClient_WrongCACertFailsTLS(t *testing.T) {
@@ -284,4 +289,37 @@ func TestBuildHTTPClient_MultiCertBundle(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestBuildHTTPClient_ResponseHeaderTimeout verifies the upstream client does
+// not block indefinitely when an upstream server accepts the connection but
+// never sends response headers. Without ResponseHeaderTimeout the broker would
+// hang on this request forever.
+func TestBuildHTTPClient_ResponseHeaderTimeout(t *testing.T) {
+	prev := defaultResponseHeaderTimeout
+	defaultResponseHeaderTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { defaultResponseHeaderTimeout = prev })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "hang", URL: srv.URL + "/mcp"})
+	httpClient, err := up.buildHTTPClient()
+	require.NoError(t, err)
+	require.NotNil(t, httpClient)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	resp, err := httpClient.Do(req)
+	elapsed := time.Since(start)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err, "expected timeout error from hanging server")
+	require.Less(t, elapsed, 2*time.Second, "client should give up well before 2s")
+	require.Contains(t, err.Error(), "timeout")
 }


### PR DESCRIPTION
## Description

Broker's upstream HTTP client had no timeouts, a hung upstream (TLS handshake stall, noesponse headers) blocked the broker forever. Pre-existing, made more visible by custom TLS support in
* #1008.

`buildHTTPClient` now always returns a client with `TLSHandshakeTimeout` (10s), `ResponseHeaderTimeout` (30s), and `ExpectContinueTimeout` (1s) on the transport. CA-cert branch layers TLS config on top. Timeouts live on the transport (not `http.Client.Timeout`) because the streamable HTTP client reuses the same client for the long-lived SSE listen stream.

##  Fixes 
* #1038

## Changes

  - `internal/broker/upstream/mcp.go` always return a client with transport-level timeouts; drop nil-guard in `Connect`.
  - `internal/broker/upstream/mcp_test.go` update two existing tests that asserted nil; added
  `TestBuildHTTPClient_ResponseHeaderTimeout` using a hanging `httptest.Server`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upstream server connections now enforce default timeout limits on TLS handshakes and response headers to prevent indefinite hangs
  * Enhanced error handling when establishing connections to upstream servers
  * More reliable server-to-server communications with consistent HTTP client configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->