### PR TITLE
test: refactor trusted headers setup into reusable helper

### DIFF
--- a/tests/e2e/builders.go
+++ b/tests/e2e/builders.go
@@ -23,6 +23,75 @@ import (
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 )
 
+// SetupTrustedHeadersAuth configures trusted headers for JWT validation on the MCPGateway.
+// creates the required secret and patches MCPGatewayExtension, then registers cleanup
+// to restore the original state.
+func SetupTrustedHeadersAuth(ctx context.Context, k8sClient client.Client) {
+	// create the secret if it doesn't exist
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "trusted-headers-public-key",
+			Namespace: SystemNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"key": []byte(GetTestHeaderPublicKey()),
+		},
+	}
+	Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, secret))).To(Succeed())
+
+	DeferCleanup(func() {
+		Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+	})
+
+	// get current deployment generation before patching
+	gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
+	Expect(err).NotTo(HaveOccurred())
+
+	ext := &mcpv1alpha1.MCPGatewayExtension{}
+	Expect(k8sClient.Get(ctx, client.ObjectKey{
+		Name: MCPExtensionName, Namespace: SystemNamespace,
+	}, ext)).To(Succeed())
+
+	patch := client.MergeFrom(ext.DeepCopy())
+	ext.Spec.TrustedHeadersKey = &mcpv1alpha1.TrustedHeadersKey{
+		SecretName: "trusted-headers-public-key",
+	}
+	Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
+
+	DeferCleanup(func() {
+		// get current deployment generation before cleanup
+		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
+		Expect(err).NotTo(HaveOccurred())
+
+		ext := &mcpv1alpha1.MCPGatewayExtension{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name: MCPExtensionName, Namespace: SystemNamespace,
+		}, ext)
+		if err == nil {
+			patch := client.MergeFrom(ext.DeepCopy())
+			ext.Spec.TrustedHeadersKey = nil
+			Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
+
+			// wait for deployment spec to be updated
+			Eventually(func(g Gomega) {
+				g.Expect(IsTrustedHeadersEnabled(ctx)).To(BeFalse())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+			// wait for deployment to roll out
+			Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
+		}
+	})
+
+	// wait for deployment to be updated with the env var
+	Eventually(func(g Gomega) {
+		g.Expect(IsTrustedHeadersEnabled(ctx)).To(BeTrue())
+	}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+	// wait for deployment to roll out with new pods
+	Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
+}
+
 // TestResourcesBuilder is a unified builder for creating test resources
 type TestResourcesBuilder struct {
 	k8sClient           client.Client

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -737,74 +737,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 	})
 
 	It("[Happy] should filter tools based on x-mcp-authorized JWT header", func() {
-		By("Ensuring trusted headers key is configured")
-
-		// create the secret if it doesn't exist
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trusted-headers-public-key",
-				Namespace: SystemNamespace,
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				"key": []byte(GetTestHeaderPublicKey()),
-			},
-		}
-		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, secret))).To(Succeed())
-
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
-		})
-
-		// Patch MCPGatewayExtension
-		// Get current deployment generation before patching
-		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
-		Expect(err).NotTo(HaveOccurred())
-
-		ext := &mcpv1alpha1.MCPGatewayExtension{}
-		Expect(k8sClient.Get(ctx, client.ObjectKey{
-			Name: MCPExtensionName, Namespace: SystemNamespace,
-		}, ext)).To(Succeed())
-
-		patch := client.MergeFrom(ext.DeepCopy())
-		ext.Spec.TrustedHeadersKey = &mcpv1alpha1.TrustedHeadersKey{
-			SecretName: "trusted-headers-public-key",
-		}
-		Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
-
-		DeferCleanup(func() {
-			By("Cleaning up: removing trustedHeadersKey from MCPGatewayExtension")
-
-			// Get current deployment generation before cleanup
-			gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
-			Expect(err).NotTo(HaveOccurred())
-
-			ext := &mcpv1alpha1.MCPGatewayExtension{}
-			err = k8sClient.Get(ctx, client.ObjectKey{
-				Name: MCPExtensionName, Namespace: SystemNamespace,
-			}, ext)
-			if err == nil {
-				patch := client.MergeFrom(ext.DeepCopy())
-				ext.Spec.TrustedHeadersKey = nil
-				Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
-
-				// Wait for deployment spec to be updated
-				Eventually(func(g Gomega) {
-					g.Expect(IsTrustedHeadersEnabled(ctx)).To(BeFalse())
-				}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-
-				// Wait for deployment to roll out
-				Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
-			}
-		})
-
-		// Wait for deployment to be updated with the env var
-		Eventually(func(g Gomega) {
-			g.Expect(IsTrustedHeadersEnabled(ctx)).To(BeTrue())
-		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-
-		// Wait for deployment to roll out with new pods
-		Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
+		SetupTrustedHeadersAuth(ctx, k8sClient)
 
 		By("Creating an MCPServerRegistration with tools")
 		registration := NewMCPServerResourcesWithDefaults("authorized-capabilities-test", k8sClient).Build()

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -227,9 +227,7 @@ var _ = Describe("Tool Discovery", func() {
 		})
 
 		It("respects auth filtering in discover_tools", func() {
-			if !IsTrustedHeadersEnabled(ctx) {
-				Skip("trusted headers not configured")
-			}
+			SetupTrustedHeadersAuth(ctx, k8sClient)
 
 			By("registering a server")
 			reg := NewMCPServerResourcesWithDefaults("disc-auth", k8sClient).
@@ -242,8 +240,6 @@ var _ = Describe("Tool Discovery", func() {
 				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
 			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "discauth_")
-
 			By("creating a JWT that allows only one tool")
 			allowedTools := map[string][]string{
 				fmt.Sprintf("%s/%s", server.Namespace, server.Name): {"hello_world"},
@@ -252,9 +248,13 @@ var _ = Describe("Tool Discovery", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("calling discover_tools with auth header")
-			sessionID, err := mcpInitialize(ctx, gatewayURL, map[string]string{"X-Mcp-Authorized": jwtToken})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, map[string]string{"X-Mcp-Authorized": jwtToken})).To(Succeed())
+			var sessionID string
+			Eventually(func(g Gomega) {
+				var initErr error
+				sessionID, initErr = mcpInitialize(ctx, gatewayURL, map[string]string{"X-Mcp-Authorized": jwtToken})
+				g.Expect(initErr).NotTo(HaveOccurred())
+				g.Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, map[string]string{"X-Mcp-Authorized": jwtToken})).To(Succeed())
+			}, TestTimeoutMedium, TestRetryFast).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, nil, map[string]string{"X-Mcp-Authorized": jwtToken})


### PR DESCRIPTION
### Summary
Refactors duplicated trusted headers authentication setup code into a reusable helper function `SetupTrustedHeadersAuth()`. This reduces test code duplication. It also prevents the `respects auth filtering in discover_tools` test being skipped by ensuring auth configuration is actively set up.

This is basically a follow up on https://github.com/Kuadrant/mcp-gateway/pull/1021 but given there are two tests now that  requires the same config the helper function was introduced (DRY principle).

### Changes
  - Add SetupTrustedHeadersAuth() including proper cleanup and rollout waits
  - Replace inline setup code in JWT header filtering test
  - Update tool discovery auth test to use helper instead of skip
  - Add Eventually retry logic for session initialization

### Verification Steps
Eye review. Also look at E2E PR check that both affected tests were executed (not skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable E2E helper to enable trusted-headers JWT authentication for tests.
  * Refactored tests to use the new helper, reducing duplication and improving maintainability.
  * Updated a discovery test to always configure trusted-headers auth and to handle asynchronous session initialization more reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->