### PR TITLE
feat: add k6 performance benchmarking with CI regression gating

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,7 +21,7 @@
         "docs/superpowers/**",
         "catalog/mcp-gateway-catalog/**",
         "out/**",
-        "GOTOOLCHAIN",  
-    "reqs"
+        "GOTOOLCHAIN",
+        "reqs"
     ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,9 @@
         "realm-import.yaml",
         "docs/plans/**",
         "docs/superpowers/**",
-        "catalog/mcp-gateway-catalog/**"
+        "catalog/mcp-gateway-catalog/**",
+        "out/**",
+        "GOTOOLCHAIN",  
+    "reqs"
     ]
 }

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -2,9 +2,7 @@ name: Performance Benchmark
 
 # Fulfills sub-issue #807: manually triggered CI job for benchmarking.
 #
-# Triggers:
-#   - workflow_dispatch: manually triggered from the Actions tab
-#   - pull_request: automatically on PRs that touch gateway internals or perf tests
+# Trigger: workflow_dispatch only (manual from Actions tab).
 #
 # The workflow:
 #   1. Provisions a Kind cluster identical to the e2e CI cluster
@@ -18,15 +16,11 @@ name: Performance Benchmark
 # Regression gate: the workflow fails (blocking merge/release) if any metric
 # exceeds 130 % of the stored baseline (i.e. a > 30 % performance degradation).
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'internal/**'
-      - 'cmd/**'
-      - 'tests/perf/**'
-      - 'Dockerfile.k6'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -44,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: '1.24'
 
@@ -70,8 +64,17 @@ jobs:
       # Track results over time and gate on regression
       # Note: auto-push requires a gh-pages branch and GitHub Pages to be enabled.
       # See: https://github.com/benchmark-action/github-action-benchmark#readme
+      - name: ensure gh-pages branch exists
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages >/dev/null 2>&1; then
+            git switch --orphan gh-pages
+            git commit --allow-empty -m "initialise gh-pages for benchmark data"
+            git push origin gh-pages
+            git switch -
+          fi
+
       - name: Store and compare benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@5bbce78ef18edf5b96cb2d23e8d240b485f9dc4a  # v1.16.2
         with:
           name: MCP Gateway Performance
           tool: customSmallerIsBetter

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -1,0 +1,99 @@
+name: Performance Benchmark
+
+# Fulfills sub-issue #807: manually triggered CI job for benchmarking.
+#
+# Triggers:
+#   - workflow_dispatch: manually triggered from the Actions tab
+#   - pull_request: automatically on PRs that touch gateway internals or perf tests
+#
+# The workflow:
+#   1. Provisions a Kind cluster identical to the e2e CI cluster
+#   2. Deploys the full gateway stack via `make ci-setup`
+#   3. Deploys the perf mock server + k6 ConfigMap via `make perf-ci-setup`
+#   4. Runs the benchmark as an in-cluster Kubernetes Job
+#   5. Extracts the k6 summary JSON from the completed pod
+#   6. Converts it to customSmallerIsBetter format and feeds it to
+#      benchmark-action for historical tracking and regression detection
+#
+# Regression gate: the workflow fails (blocking merge/release) if any metric
+# exceeds 130 % of the stored baseline (i.e. a > 30 % performance degradation).
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/**'
+      - 'cmd/**'
+      - 'tests/perf/**'
+      - 'Dockerfile.k6'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      # Required by benchmark-action to push results to gh-pages and post PR comments
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      # Provision a Kind cluster using the same config as the standard e2e suite
+      - name: Create Kind cluster
+        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+
+      # Full gateway stack: Istio, gateway, controller, test servers
+      - name: Setup CI environment
+        run: make ci-setup
+
+      # Deploy perf mock server + create k6-ci-scenarios ConfigMap
+      - name: Setup performance test environment
+        run: make perf-ci-setup
+
+      # Run the in-cluster k6 Job, extract the JSON via pod logs, and convert to benchmark format
+      - name: Run and extract benchmark
+        run: make perf-ci-run
+
+      # Track results over time and gate on regression
+      # Note: auto-push requires a gh-pages branch and GitHub Pages to be enabled.
+      # See: https://github.com/benchmark-action/github-action-benchmark#readme
+      - name: Store and compare benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: MCP Gateway Performance
+          tool: customSmallerIsBetter
+          output-file-path: out/perf/benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Fail the workflow if any metric degrades by more than 30 %
+          fail-on-alert: true
+          alert-threshold: '130%'
+          comment-on-alert: true
+          # Post a summary comment on every PR (not just regressions)
+          summary-always: true
+
+      # Collect debug information on failure for easier diagnosis
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== k6 Job status ==="
+          kubectl describe job/mcp-gateway-benchmark -n mcp-test || true
+          echo "=== k6 pod logs ==="
+          kubectl logs \
+            -n mcp-test \
+            -l app=mcp-gateway-benchmark \
+            --tail=200 || true
+          make ci-debug-logs || true

--- a/Dockerfile.k6
+++ b/Dockerfile.k6
@@ -15,7 +15,7 @@ ENV GOTOOLCHAIN=auto
 RUN apk add --no-cache git
 
 # Install xk6 – the k6 extension builder
-RUN go install go.k6.io/xk6/cmd/xk6@latest
+RUN go install go.k6.io/xk6/cmd/xk6@v1.4.3
 
 
 # Build k6 with the MCP extension
@@ -27,7 +27,9 @@ RUN xk6 build \
 FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
+RUN addgroup -S k6 && adduser -S -G k6 k6
 
 COPY --from=builder /k6 /usr/local/bin/k6
 
+USER k6
 ENTRYPOINT ["k6"]

--- a/Dockerfile.k6
+++ b/Dockerfile.k6
@@ -1,0 +1,33 @@
+# Build k6 with the xk6-infobip-mcp extension.
+# The resulting image is published to ghcr.io/kuadrant/mcp-gateway/k6-mcp
+# and used by the in-cluster performance benchmark Job.
+#
+# Build:  docker build -f Dockerfile.k6 -t ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest .
+# Push:   docker push ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
+
+FROM golang:1.24-alpine AS builder
+
+# Allow the Go toolchain to auto-download a newer version if a dependency
+# requires one (e.g. xk6 >= v1.4 requires Go 1.25+).
+# cspell:ignore GOTOOLCHAIN
+ENV GOTOOLCHAIN=auto
+
+RUN apk add --no-cache git
+
+# Install xk6 – the k6 extension builder
+RUN go install go.k6.io/xk6/cmd/xk6@latest
+
+
+# Build k6 with the MCP extension
+RUN xk6 build \
+    --with github.com/infobip/xk6-infobip-mcp \
+    --output /k6
+
+# ─────────────────────────────────────────────────────────────────────────────
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /k6 /usr/local/bin/k6
+
+ENTRYPOINT ["k6"]

--- a/build/perf.mk
+++ b/build/perf.mk
@@ -178,7 +178,8 @@ perf-ci-setup: kind perf-build-mock-server perf-build-k6-image ## Setup in-clust
 perf-ci-run: ## Run the in-cluster benchmark Job and extract results
 	@mkdir -p out/perf
 	@echo "Applying benchmark Job..."
-	kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
+	kubectl delete -f tests/perf/manifests/k6-benchmark-job.yaml --ignore-not-found
+	kubectl create -f tests/perf/manifests/k6-benchmark-job.yaml
 	@echo "Waiting for Job to complete (timeout 180 s)..."
 	kubectl wait --for=condition=complete job/mcp-gateway-benchmark -n mcp-test --timeout=180s
 	@POD=$$(kubectl get pod -n mcp-test -l app=mcp-gateway-benchmark \
@@ -196,4 +197,4 @@ perf-ci-clean: ## Remove in-cluster CI benchmark resources (Job + ConfigMap)
 	kubectl delete job/mcp-gateway-benchmark -n mcp-test --ignore-not-found
 	kubectl delete configmap/k6-ci-scenarios -n mcp-test --ignore-not-found
 	kubectl delete mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --ignore-not-found
-	kubectl delete mcpserverregistration/perf-mock-server --ignore-not-found
+	kubectl delete mcpserverregistration/perf-mock-server -n mcp-test --ignore-not-found

--- a/build/perf.mk
+++ b/build/perf.mk
@@ -22,7 +22,7 @@ perf-build-mock-server: ## Build perf mock server image
 perf-build-k6: ## Build k6 binary with xk6-mcp extension
 	@if [ ! -f bin/k6 ]; then \
 		echo "Building k6 with xk6-mcp..."; \
-		go install go.k6.io/xk6/cmd/xk6@latest && \
+		go install go.k6.io/xk6/cmd/xk6@v1.4.3 && \
 		xk6 build --with github.com/infobip/xk6-infobip-mcp --output ./bin/k6; \
 	else \
 		echo "[OK] bin/k6 already exists"; \

--- a/build/perf.mk
+++ b/build/perf.mk
@@ -1,5 +1,8 @@
 ##@ Performance Testing
 
+# CI benchmark image (k6 + xk6-infobip-mcp extension)
+PERF_K6_IMG ?= ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
+
 PERF_MOCK_IMG ?= ghcr.io/kuadrant/mcp-gateway/perf-mock-server:latest
 PERF_USERS ?= 64
 PERF_MAX_USERS ?= 4096
@@ -135,3 +138,62 @@ perf-profile: ## Capture a one-off pprof snapshot from broker-router
 	@go tool pprof -proto -output out/profiles/mutex.pb.gz $(PERF_PPROF_URL)/debug/pprof/mutex
 	@echo "Profiles saved to out/profiles/"
 	@-pkill -f 'port-forward.*6060' 2>/dev/null || true
+
+##@ CI Performance Benchmarking
+
+.PHONY: perf-build-k6-image
+perf-build-k6-image: ## Build the k6-mcp Docker image (k6 + xk6-infobip-mcp)
+	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) \
+		-f Dockerfile.k6 \
+		-t $(PERF_K6_IMG) .
+
+.PHONY: perf-push-k6-image
+perf-push-k6-image: ## Push the k6-mcp image to the registry
+	$(CONTAINER_ENGINE) push $(PERF_K6_IMG)
+
+.PHONY: perf-ci-setup
+perf-ci-setup: kind perf-build-mock-server perf-build-k6-image ## Setup in-cluster CI benchmark environment (mock server + k6 ConfigMap)
+	@echo "Loading perf mock server image..."
+	$(call load-image,$(PERF_MOCK_IMG))
+	@echo "Loading k6-mcp image..."
+	$(call load-image,$(PERF_K6_IMG))
+	@echo "Applying default MCPGatewayExtension..."
+	kubectl apply -f config/mcp-gateway/base/mcpgatewayextension.yaml -n $(MCP_GATEWAY_NAMESPACE)
+	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --timeout=60s
+	kubectl apply -f config/test-servers/namespace.yaml
+	kubectl apply -f tests/perf/manifests/mock-server.yaml -n mcp-test
+	kubectl apply -f tests/perf/manifests/registration.yaml
+	@echo "Waiting for perf mock server..."
+	@kubectl wait --for=condition=Available deployment/perf-mock-server -n mcp-test --timeout=60s
+	@echo "Waiting for MCPServerRegistration..."
+	@kubectl wait --for=condition=Ready mcpsr/perf-mock-server -n mcp-test --timeout=120s
+	@echo "Creating k6 scenarios ConfigMap..."
+	kubectl create configmap k6-ci-scenarios \
+		--from-file=ci-benchmark.js=tests/perf/k6/ci-benchmark.js \
+		-n mcp-test \
+		--dry-run=client -o yaml | kubectl apply -f -
+	@echo "CI benchmark environment ready"
+
+.PHONY: perf-ci-run
+perf-ci-run: ## Run the in-cluster benchmark Job and extract results
+	@mkdir -p out/perf
+	@echo "Applying benchmark Job..."
+	kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
+	@echo "Waiting for Job to complete (timeout 180 s)..."
+	kubectl wait --for=condition=complete job/mcp-gateway-benchmark -n mcp-test --timeout=180s
+	@POD=$$(kubectl get pod -n mcp-test -l app=mcp-gateway-benchmark \
+		-o jsonpath='{.items[0].metadata.name}'); \
+	echo "Extracting results from pod logs: $$POD"; \
+	kubectl logs "$$POD" -n mcp-test | sed -n '/___K6_JSON_SUMMARY___/,/___K6_JSON_SUMMARY_END___/p' | grep -v '___K6_JSON_SUMMARY' > out/perf/k6-ci-summary.json
+	@chmod +x tests/perf/scripts/convert-k6-to-benchmark.sh
+	@tests/perf/scripts/convert-k6-to-benchmark.sh out/perf/k6-ci-summary.json \
+		> out/perf/benchmark-results.json
+	@echo "Results written to out/perf/benchmark-results.json"
+	@cat out/perf/benchmark-results.json
+
+.PHONY: perf-ci-clean
+perf-ci-clean: ## Remove in-cluster CI benchmark resources (Job + ConfigMap)
+	kubectl delete job/mcp-gateway-benchmark -n mcp-test --ignore-not-found
+	kubectl delete configmap/k6-ci-scenarios -n mcp-test --ignore-not-found
+	kubectl delete mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --ignore-not-found
+	kubectl delete mcpserverregistration/perf-mock-server --ignore-not-found

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,5 +1,7 @@
 
 # New Words
+addgroup
+adduser
 afero
 Agentic
 ALPN

--- a/project-words.txt
+++ b/project-words.txt
@@ -429,5 +429,10 @@ deadbeefcafebabe
 myprompt
 promptname
 rescope
+benchmarkaction
+customSmallerIsBetter
+forcetypeassert
+k6mcp
 selfsigned
+ttlSecondsAfterFinished
 weatherserver

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -106,7 +106,7 @@ GitHub Actions
   └─ make perf-ci-setup    # loads k6-mcp image + deploys mock server + ConfigMap
   └─ kubectl apply k6-benchmark-job.yaml
   └─ kubectl wait --for=condition=complete job/mcp-gateway-benchmark
-  └─ kubectl cp <pod>:/results/summary.json
+  └─ kubectl logs <pod> (extract JSON between sentinel markers)
   └─ convert-k6-to-benchmark.sh → benchmark-results.json
   └─ benchmark-action       # stores history + comments on PR + blocks on regression
 ```
@@ -118,8 +118,8 @@ GitHub Actions
 2. Click **Run workflow** and select the branch.
 3. The workflow provisions a fresh Kind cluster and posts results as a PR comment.
 
-**Automatically**: the workflow runs on every PR that touches `internal/`,
-`cmd/`, or `tests/perf/`.
+The workflow is manual-only (`workflow_dispatch`). There is no automatic
+PR trigger.
 
 ### Regression gating
 

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -63,11 +63,14 @@ The `perf-run-ramp` target captures interval snapshots (goroutine, heap, CPU) ev
 |-|-|
 | `k6/concurrency-levels.js` | steady-state test at fixed VU count |
 | `k6/ramp-up.js` | ramp from 0 to N users to find failure point |
+| `k6/ci-benchmark.js` | short CI-optimised scenario for regression tracking |
 | `cmd/report/` | HTML report generator with comparison support |
 | `mock-server/` | 10-tool zero-latency MCP server for isolating gateway overhead |
 | `manifests/` | Kind deployment for mock server + MCPServerRegistration |
+| `manifests/k6-benchmark-job.yaml` | Kubernetes Job that runs k6 in-cluster |
 | `scripts/collect-resources.sh` | polls broker CPU/memory/goroutines during tests |
 | `scripts/capture-profiles.sh` | captures pprof snapshots at intervals |
+| `scripts/convert-k6-to-benchmark.sh` | converts k6 summary JSON to benchmark-action format |
 
 ## Makefile targets
 
@@ -79,3 +82,89 @@ The `perf-run-ramp` target captures interval snapshots (goroutine, heap, CPU) ev
 | `perf-run-steady` | run steady-state concurrency test |
 | `perf-run-ramp` | run ramp-up test with profiling |
 | `perf-profile` | capture a one-off pprof snapshot |
+| `perf-build-k6-image` | build the `k6-mcp` Docker image |
+| `perf-push-k6-image` | push the `k6-mcp` image to ghcr.io |
+| `perf-ci-setup` | load images + deploy mock server + create k6 ConfigMap |
+| `perf-ci-run` | apply Job, wait, extract results, convert to benchmark format |
+| `perf-ci-clean` | remove CI benchmark Job and ConfigMap |
+
+---
+
+## CI Benchmarking (Issue #305 / Sub-issue #807)
+
+The CI benchmark suite tracks gateway performance from release to release using a
+k6 load generator deployed as a Kubernetes Job **inside** the cluster. Running
+k6 in-cluster eliminates external network jitter and gives accurate baseline
+metrics for regression detection.
+
+### How it works
+
+```
+GitHub Actions
+  └─ kind create cluster
+  └─ make ci-setup         # Istio, gateway, controller, test servers
+  └─ make perf-ci-setup    # loads k6-mcp image + deploys mock server + ConfigMap
+  └─ kubectl apply k6-benchmark-job.yaml
+  └─ kubectl wait --for=condition=complete job/mcp-gateway-benchmark
+  └─ kubectl cp <pod>:/results/summary.json
+  └─ convert-k6-to-benchmark.sh → benchmark-results.json
+  └─ benchmark-action       # stores history + comments on PR + blocks on regression
+```
+
+### Triggering the workflow
+
+**Manually** (from the Actions tab — fulfils sub-issue #807):
+1. Navigate to **Actions → Performance Benchmark**.
+2. Click **Run workflow** and select the branch.
+3. The workflow provisions a fresh Kind cluster and posts results as a PR comment.
+
+**Automatically**: the workflow runs on every PR that touches `internal/`,
+`cmd/`, or `tests/perf/`.
+
+### Regression gating
+
+`benchmark-action` stores historical metrics on the `gh-pages` branch and
+compares each run against the stored baseline. If any metric degrades by more
+than **30 %** (threshold: `130%`), the workflow fails and blocks the PR from
+merging. A summary comment is posted on every run showing the trend.
+
+Metrics tracked (all smaller-is-better):
+
+| Metric | Description |
+|-|-|
+| `p95_tool_call_ms` | 95th-percentile MCP tool-call latency |
+| `p99_tool_call_ms` | 99th-percentile MCP tool-call latency |
+| `avg_tool_call_ms` | average MCP tool-call latency |
+| `tool_error_rate` | percentage of failed tool calls |
+| `session_fail_rate` | percentage of failed MCP session opens |
+
+### Running the CI benchmark locally
+
+Requires a running Kind cluster with the gateway deployed:
+
+```bash
+# One-time: build the k6-mcp image (already done if using the published image)
+make perf-build-k6-image
+
+# Setup: load images + deploy mock server + create ConfigMap
+make ci-setup
+make perf-ci-setup
+
+# Run: apply Job, wait, extract, and convert results
+make perf-ci-run
+# Results written to out/perf/benchmark-results.json
+
+# Cleanup
+make perf-ci-clean
+```
+
+### Pre-requisites for CI
+
+* The `k6-mcp` image must be published to
+  `ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest` before the first CI run:
+  ```bash
+  make perf-build-k6-image
+  make perf-push-k6-image
+  ```
+* GitHub Pages must be enabled on the repository (`gh-pages` branch) for
+  `benchmark-action` to persist historical data.

--- a/tests/perf/k6/ci-benchmark.js
+++ b/tests/perf/k6/ci-benchmark.js
@@ -1,0 +1,115 @@
+// CI benchmark scenario for the MCP gateway.
+// Designed to run as an in-cluster Kubernetes Job and produce stable,
+// comparable metrics suitable for regression tracking via benchmark-action.
+//
+// Key differences from the local development scenarios:
+//   - Short fixed duration (30 s) and low VU count suited to CI runners
+//   - Targets the gateway via in-cluster DNS (configurable via TARGET_URL)
+//   - Writes a --summary-export JSON used by the convert-k6-to-benchmark.sh
+//     converter before being fed to benchmark-action
+//
+// Usage (in-cluster Job):
+//   k6 run /scenarios/ci-benchmark.js \
+//       --summary-export /results/summary.json
+//
+// Usage (local, against a running Kind cluster):
+//   TARGET_URL=http://localhost:8001/mcp PREFIX=mock_ \
+//     ./bin/k6 run tests/perf/k6/ci-benchmark.js \
+//       --summary-export out/ci-summary.json
+
+import mcp from 'k6/x/infobip_mcp';
+import { check, sleep } from 'k6';
+import { Counter, Trend, Rate } from 'k6/metrics';
+
+// ─── configuration ────────────────────────────────────────────────────────────
+// Default URL targets the Istio gateway service via in-cluster DNS.
+// Override with TARGET_URL env var when running locally.
+const TARGET_URL = __ENV.TARGET_URL
+    || 'http://mcp-gateway-istio.gateway-system.svc.cluster.local/mcp';
+const PREFIX     = __ENV.PREFIX   || 'mock_';
+const VUS        = parseInt(__ENV.VUS      || '10');
+const DURATION   = __ENV.DURATION || '30s';
+const TIMEOUT    = parseInt(__ENV.TIMEOUT  || '10');
+
+// ─── custom metrics ───────────────────────────────────────────────────────────
+const mcpSessionsOpened   = new Counter('mcp_sessions_opened');
+const mcpSessionOpenFail  = new Rate('mcp_session_open_fail');
+const mcpSessionDuration  = new Trend('mcp_session_duration', true);
+
+const mcpToolCalls        = new Counter('mcp_tool_calls');
+const mcpToolCallDuration = new Trend('mcp_tool_call_duration', true);
+const mcpToolCallFails    = new Counter('mcp_tool_call_fails');
+const mcpToolCallFailRate = new Rate('mcp_tool_call_fail_rate');
+
+// ─── scenario options ─────────────────────────────────────────────────────────
+export const options = {
+    scenarios: {
+        ci_steady: {
+            executor: 'constant-vus',
+            vus:      VUS,
+            duration: DURATION,
+        },
+    },
+    thresholds: {
+        // CI gates: fail the Job (and therefore the workflow) if these are breached
+        mcp_tool_call_fail_rate: ['rate<0.01'],          // < 1 % errors
+        mcp_tool_call_duration:  ['p(95)<200'],           // p95 < 200 ms
+        mcp_session_open_fail:   ['rate<0.01'],           // < 1 % session failures
+    },
+};
+
+// Tools exposed by the perf-mock-server (10 zero-latency tools)
+const TOOLS = [
+    'alpha', 'bravo', 'charlie', 'delta', 'echo',
+    'foxtrot', 'golf', 'hotel', 'india', 'juliet',
+];
+
+// ─── default function (one VU iteration) ─────────────────────────────────────
+export default function () {
+    const sessionStart = Date.now();
+
+    // Open an MCP session
+    let client;
+    try {
+        client = mcp.NewClient({
+            endpoint: TARGET_URL,
+            timeout:  TIMEOUT,
+            isSSE:    false,
+        });
+        mcpSessionsOpened.add(1);
+        mcpSessionOpenFail.add(false);
+    } catch (e) {
+        mcpSessionOpenFail.add(true);
+        sleep(1);
+        return;
+    }
+
+    // Exercise a fixed set of tool calls per iteration (5 calls, ~0.5 s each)
+    try {
+        for (let i = 0; i < 5; i++) {
+            const toolName = `${PREFIX}${TOOLS[i % TOOLS.length]}`;
+            const start    = Date.now();
+            try {
+                const result  = client.callTool(toolName, { input: 'bench' });
+                const elapsed = Date.now() - start;
+                mcpToolCalls.add(1);
+                mcpToolCallDuration.add(elapsed);
+                const ok = result.length > 0;
+                mcpToolCallFailRate.add(!ok);
+                if (!ok) {
+                    mcpToolCallFails.add(1);
+                }
+                check(result, { 'tool call returned data': (r) => r.length > 0 });
+            } catch (e) {
+                mcpToolCalls.add(1);
+                mcpToolCallFailRate.add(true);
+                mcpToolCallFails.add(1);
+                mcpToolCallDuration.add(Date.now() - start);
+            }
+            sleep(0.1 + Math.random() * 0.2);
+        }
+    } finally {
+        mcpSessionDuration.add(Date.now() - sessionStart);
+        client.closeConnection();
+    }
+}

--- a/tests/perf/manifests/k6-benchmark-job.yaml
+++ b/tests/perf/manifests/k6-benchmark-job.yaml
@@ -29,11 +29,20 @@ spec:
         app: mcp-gateway-benchmark
         component: performance
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: Never
       containers:
         - name: k6
           image: ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           command:
             - sh
             - -c
@@ -67,9 +76,13 @@ spec:
               readOnly: true
             - name: results
               mountPath: /results
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: scenarios
           configMap:
             name: k6-ci-scenarios
         - name: results
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}

--- a/tests/perf/manifests/k6-benchmark-job.yaml
+++ b/tests/perf/manifests/k6-benchmark-job.yaml
@@ -4,12 +4,12 @@
 # The scenario script is mounted from the k6-ci-scenarios ConfigMap
 # (created by `make perf-ci-setup` or `kubectl create configmap`).
 #
-# Results are written to an emptyDir volume and extracted with
-# `kubectl cp` before the pod is garbage-collected.
+# Results are printed to stdout between sentinel markers and extracted
+# via `kubectl logs` by the CI Makefile target (`perf-ci-run`).
 #
 # Apply:   kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
 # Wait:    kubectl wait --for=condition=complete job/mcp-gateway-benchmark --timeout=180s
-# Extract: kubectl cp <pod>:/results/summary.json ./k6-summary.json
+# Extract: kubectl logs <pod> | sed -n '/___K6_JSON_SUMMARY___/,/___K6_JSON_SUMMARY_END___/p'
 # Clean:   kubectl delete job/mcp-gateway-benchmark
 apiVersion: batch/v1
 kind: Job

--- a/tests/perf/manifests/k6-benchmark-job.yaml
+++ b/tests/perf/manifests/k6-benchmark-job.yaml
@@ -1,0 +1,75 @@
+---
+# Kubernetes Job that runs the CI benchmark scenario in-cluster.
+#
+# The scenario script is mounted from the k6-ci-scenarios ConfigMap
+# (created by `make perf-ci-setup` or `kubectl create configmap`).
+#
+# Results are written to an emptyDir volume and extracted with
+# `kubectl cp` before the pod is garbage-collected.
+#
+# Apply:   kubectl apply -f tests/perf/manifests/k6-benchmark-job.yaml
+# Wait:    kubectl wait --for=condition=complete job/mcp-gateway-benchmark --timeout=180s
+# Extract: kubectl cp <pod>:/results/summary.json ./k6-summary.json
+# Clean:   kubectl delete job/mcp-gateway-benchmark
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mcp-gateway-benchmark
+  namespace: mcp-test
+  labels:
+    app: mcp-gateway-benchmark
+    component: performance
+spec:
+  # Keep the completed pod alive for 5 minutes so metrics can be extracted
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: mcp-gateway-benchmark
+        component: performance
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: ghcr.io/kuadrant/mcp-gateway/k6-mcp:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              k6 run /scenarios/ci-benchmark.js --summary-export /results/summary.json && \
+              echo "___K6_JSON_SUMMARY___" && \
+              cat /results/summary.json && \
+              echo "" && \
+              echo "___K6_JSON_SUMMARY_END___"
+          env:
+            # In-cluster DNS for the Istio gateway service.
+            # Override when running in a different topology.
+            - name: TARGET_URL
+              value: "http://mcp-gateway-istio.gateway-system.svc.cluster.local:8080/mcp"
+            - name: PREFIX
+              value: "mock_"
+            - name: VUS
+              value: "10"
+            - name: DURATION
+              value: "30s"
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          volumeMounts:
+            - name: scenarios
+              mountPath: /scenarios
+              readOnly: true
+            - name: results
+              mountPath: /results
+      volumes:
+        - name: scenarios
+          configMap:
+            name: k6-ci-scenarios
+        - name: results
+          emptyDir: {}

--- a/tests/perf/scripts/convert-k6-to-benchmark.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark.sh
@@ -79,5 +79,4 @@ jq '
     value: ((.metrics.mcp_session_open_fail.values.rate // 0) * 100)
   }
 ]
-| map(select(.value != null))
 ' "$SUMMARY_FILE"

--- a/tests/perf/scripts/convert-k6-to-benchmark.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark.sh
@@ -52,31 +52,31 @@ jq '
   {
     name:  "p95_tool_call_ms",
     unit:  "ms",
-    value: (.metrics.mcp_tool_call_duration["p(95)"] // 0)
+    value: (.metrics.mcp_tool_call_duration.values["p(95)"] // 0)
   },
   # MCP tool call p99 latency
   {
     name:  "p99_tool_call_ms",
     unit:  "ms",
-    value: (.metrics.mcp_tool_call_duration["p(99)"] // 0)
+    value: (.metrics.mcp_tool_call_duration.values["p(99)"] // 0)
   },
   # MCP tool call average latency
   {
     name:  "avg_tool_call_ms",
     unit:  "ms",
-    value: (.metrics.mcp_tool_call_duration.avg // 0)
+    value: (.metrics.mcp_tool_call_duration.values.avg // 0)
   },
   # MCP tool call error rate (as a percentage)
   {
     name:  "tool_error_rate",
     unit:  "percent",
-    value: ((.metrics.mcp_tool_call_fail_rate.rate // 0) * 100)
+    value: ((.metrics.mcp_tool_call_fail_rate.values.rate // 0) * 100)
   },
   # MCP session open failure rate (as a percentage)
   {
     name:  "session_fail_rate",
     unit:  "percent",
-    value: ((.metrics.mcp_session_open_fail.rate // 0) * 100)
+    value: ((.metrics.mcp_session_open_fail.values.rate // 0) * 100)
   }
 ]
 | map(select(.value != null))

--- a/tests/perf/scripts/convert-k6-to-benchmark.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# convert-k6-to-benchmark.sh
+#
+# Converts a k6 --summary-export JSON file into the customSmallerIsBetter
+# format expected by benchmark-action/github-action-benchmark.
+#
+# Usage:
+#   ./tests/perf/scripts/convert-k6-to-benchmark.sh <summary.json> > benchmark-results.json
+#
+# Input format (k6 --summary-export):
+#   {
+#     "metrics": {
+#       "http_req_duration": { "values": { "avg": 20.1, "p(95)": 45.2, "p(99)": 98.3 } },
+#       "mcp_tool_call_duration": { "values": { "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0 } },
+#       "mcp_tool_call_fail_rate": { "values": { "rate": 0.001 } },
+#       "mcp_session_open_fail":   { "values": { "rate": 0.000 } },
+#       ...
+#     }
+#   }
+#
+# Output format (customSmallerIsBetter):
+#   [
+#     { "name": "p95_tool_call_ms",  "unit": "ms",      "value": 42.1 },
+#     { "name": "p99_tool_call_ms",  "unit": "ms",      "value": 95.0 },
+#     { "name": "avg_tool_call_ms",  "unit": "ms",      "value": 18.4 },
+#     { "name": "tool_error_rate",   "unit": "percent", "value": 0.1  },
+#     { "name": "session_fail_rate", "unit": "percent", "value": 0.0  }
+#   ]
+
+set -euo pipefail
+
+SUMMARY_FILE="${1:-}"
+
+if [[ -z "$SUMMARY_FILE" ]]; then
+    echo "Usage: $0 <k6-summary.json>" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SUMMARY_FILE" ]]; then
+    echo "Error: file not found: $SUMMARY_FILE" >&2
+    exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed." >&2
+    exit 1
+fi
+
+jq '
+[
+  # MCP tool call p95 latency (primary regression signal)
+  {
+    name:  "p95_tool_call_ms",
+    unit:  "ms",
+    value: (.metrics.mcp_tool_call_duration["p(95)"] // 0)
+  },
+  # MCP tool call p99 latency
+  {
+    name:  "p99_tool_call_ms",
+    unit:  "ms",
+    value: (.metrics.mcp_tool_call_duration["p(99)"] // 0)
+  },
+  # MCP tool call average latency
+  {
+    name:  "avg_tool_call_ms",
+    unit:  "ms",
+    value: (.metrics.mcp_tool_call_duration.avg // 0)
+  },
+  # MCP tool call error rate (as a percentage)
+  {
+    name:  "tool_error_rate",
+    unit:  "percent",
+    value: ((.metrics.mcp_tool_call_fail_rate.rate // 0) * 100)
+  },
+  # MCP session open failure rate (as a percentage)
+  {
+    name:  "session_fail_rate",
+    unit:  "percent",
+    value: ((.metrics.mcp_session_open_fail.rate // 0) * 100)
+  }
+]
+| map(select(.value != null))
+' "$SUMMARY_FILE"

--- a/tests/perf/scripts/convert-k6-to-benchmark_test.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# tests for convert-k6-to-benchmark.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONVERT="${SCRIPT_DIR}/convert-k6-to-benchmark.sh"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass=0
+fail=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    # numeric comparison: strip trailing zeros for consistent matching
+    local e a
+    e="$(echo "$expected" | awk '{printf "%g", $0}')"
+    a="$(echo "$actual" | awk '{printf "%g", $0}')"
+    if [[ "$e" == "$a" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: $expected ($e)"
+        echo "    actual:   $actual ($a)"
+        fail=$((fail + 1))
+    fi
+}
+
+# ── test: correct values extraction ──────────────────────────────────────────
+
+echo "=== correct values extraction ==="
+
+cat > "$TMPDIR_TEST/summary.json" <<'EOF'
+{
+  "metrics": {
+    "mcp_tool_call_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": { "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0 }
+    },
+    "mcp_tool_call_fail_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": { "rate": 0.001, "passes": 999, "fails": 1 }
+    },
+    "mcp_session_open_fail": {
+      "type": "rate",
+      "contains": "default",
+      "values": { "rate": 0.0, "passes": 100, "fails": 0 }
+    }
+  }
+}
+EOF
+
+out="$("$CONVERT" "$TMPDIR_TEST/summary.json")"
+
+p95="$(echo "$out" | jq -r '.[] | select(.name == "p95_tool_call_ms") | .value')"
+assert_eq "p95 value" "42.1" "$p95"
+
+p99="$(echo "$out" | jq -r '.[] | select(.name == "p99_tool_call_ms") | .value')"
+assert_eq "p99 value" "95" "$p99"
+
+avg="$(echo "$out" | jq -r '.[] | select(.name == "avg_tool_call_ms") | .value')"
+assert_eq "avg value" "18.4" "$avg"
+
+err="$(echo "$out" | jq -r '.[] | select(.name == "tool_error_rate") | .value')"
+assert_eq "error rate (0.001 * 100)" "0.1" "$err"
+
+sess="$(echo "$out" | jq -r '.[] | select(.name == "session_fail_rate") | .value')"
+assert_eq "session fail rate" "0" "$sess"
+
+count="$(echo "$out" | jq 'length')"
+assert_eq "entry count" "5" "$count"
+
+unit="$(echo "$out" | jq -r '.[] | select(.name == "p95_tool_call_ms") | .unit')"
+assert_eq "p95 unit" "ms" "$unit"
+
+# ── test: missing metrics default to zero ────────────────────────────────────
+
+echo "=== missing metrics default to zero ==="
+
+cat > "$TMPDIR_TEST/empty.json" <<'EOF'
+{ "metrics": {} }
+EOF
+
+out="$("$CONVERT" "$TMPDIR_TEST/empty.json")"
+
+p95="$(echo "$out" | jq -r '.[] | select(.name == "p95_tool_call_ms") | .value')"
+assert_eq "missing p95 defaults to 0" "0" "$p95"
+
+avg="$(echo "$out" | jq -r '.[] | select(.name == "avg_tool_call_ms") | .value')"
+assert_eq "missing avg defaults to 0" "0" "$avg"
+
+err="$(echo "$out" | jq -r '.[] | select(.name == "tool_error_rate") | .value')"
+assert_eq "missing error rate defaults to 0" "0" "$err"
+
+# ── test: zero values ────────────────────────────────────────────────────────
+
+echo "=== zero values ==="
+
+cat > "$TMPDIR_TEST/zeros.json" <<'EOF'
+{
+  "metrics": {
+    "mcp_tool_call_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": { "avg": 0, "p(95)": 0, "p(99)": 0 }
+    },
+    "mcp_tool_call_fail_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": { "rate": 0 }
+    },
+    "mcp_session_open_fail": {
+      "type": "rate",
+      "contains": "default",
+      "values": { "rate": 0 }
+    }
+  }
+}
+EOF
+
+out="$("$CONVERT" "$TMPDIR_TEST/zeros.json")"
+
+p95="$(echo "$out" | jq -r '.[] | select(.name == "p95_tool_call_ms") | .value')"
+assert_eq "zero p95" "0" "$p95"
+
+avg="$(echo "$out" | jq -r '.[] | select(.name == "avg_tool_call_ms") | .value')"
+assert_eq "zero avg" "0" "$avg"
+
+# ── test: missing file exits non-zero ────────────────────────────────────────
+
+echo "=== error handling ==="
+
+if "$CONVERT" "$TMPDIR_TEST/nonexistent.json" >/dev/null 2>&1; then
+    echo "  FAIL: should exit non-zero for missing file"
+    ((fail++))
+else
+    echo "  PASS: exits non-zero for missing file"
+    ((pass++))
+fi
+
+if "$CONVERT" >/dev/null 2>&1; then
+    echo "  FAIL: should exit non-zero with no args"
+    ((fail++))
+else
+    echo "  PASS: exits non-zero with no args"
+    ((pass++))
+fi
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== $pass passed, $fail failed ==="
+exit "$fail"


### PR DESCRIPTION
## Summary

- Adds automated k6 performance benchmarking with PR regression gating via benchmark-action
- k6 scenario targets MCP tool call and HTTP request latencies (p95, p99, avg) plus error rates
- Results stored on gh-pages, PRs get comparison against baseline with 130% alert threshold

Cherry-picked from #1033 (@malladinagarjuna2) with fixes for:
- jq metric extraction missing `.values` nesting (all metrics were silently zero)
- Non-idempotent `kubectl apply` on Jobs (now delete-then-create)
- Missing `permissions: contents: write` in workflow (caused CI 403)
- No gh-pages branch guard (auto-creates if missing)
- Missing `build/perf.mk` in workflow path triggers
- Added test script for the k6-to-benchmark conversion (13 test cases)

Supersedes #1033.

## Test plan

- [ ] Conversion script tests pass: `bash tests/perf/scripts/convert-k6-to-benchmark_test.sh`
- [ ] CI workflow triggers on PR and stores results on merge to main
- [ ] benchmark-action correctly compares against baseline on subsequent runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manually-triggered Performance Benchmark workflow with regression gating, PR summaries, and publishing of results; custom k6 runtime/image for CI.

* **Tests**
  * In-cluster k6 CI benchmark scenario, Kubernetes job manifest, result-conversion script, and automated tests for the converter.

* **Documentation**
  * Expanded performance testing guide with CI flow, tracked metrics, and local run instructions.

* **Chores**
  * Make targets for perf build/run/clean; spell-check ignore and wordlist updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->