### PR TITLE
ci: add test-tls-server to test server image build workflow

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -73,6 +73,10 @@ jobs:
             context: tests/servers/conformance-server
             dockerfile: Dockerfile
             image-name: test-conformance-server
+          - server: tls-server
+            context: tests/servers/tls-server
+            dockerfile: Dockerfile
+            image-name: test-tls-server
 
     steps:
       - name: Check out code


### PR DESCRIPTION
### Summary
Adds `test-tls-server` to the GitHub Actions workflow matrix that builds test server container images. This ensures the TLS test server image is built and published alongside other test servers.

### Changes
  - Added `test-tls-server` entry to the `test-images.yaml` workflow matrix
  - References `tests/servers/tls-server` context with standard Dockerfile
  - Follows existing naming convention: `test-tls-server` image name

### Verification Steps
Not sure here, probably just check whether the image was built by that workflow now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to include an additional TLS test server configuration, expanding test coverage for secure-connection scenarios and improving build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->