### PR TITLE
fix: serialize manager event handling to avoid concurrent manage races

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -148,7 +148,9 @@ type MCPManager struct {
 	toolEvents   chan struct{}
 	promptEvents chan struct{}
 	done         chan struct{} // closed when the event loop exits
-	status       ServerValidationStatus
+
+	statusLock sync.RWMutex
+	status     ServerValidationStatus
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
@@ -486,12 +488,17 @@ func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
 }
 
 // GetStatus returns the current status of the MCP Server
-// no locking is done here as it is expected to be called multiple times
+// This is called concurrently by external controllers and tests, so it uses RLock.
 func (man *MCPManager) GetStatus() ServerValidationStatus {
+	man.statusLock.RLock()
+	defer man.statusLock.RUnlock()
 	return man.status
 }
 
 func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo) {
+	man.statusLock.Lock()
+	defer man.statusLock.Unlock()
+
 	man.status.ID = string(man.mcp.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()

--- a/internal/broker/upstream/manager_race_test.go
+++ b/internal/broker/upstream/manager_race_test.go
@@ -1,0 +1,95 @@
+package upstream
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPManager_ManageConcurrencyRace validates the fix for issue #916
+// It concurrently fires tool and prompt list changed notifications while the
+// manager's internal ticker is also firing. The event loop architecture
+// should serialize these events safely without data races or panics.
+func TestMCPManager_ManageConcurrencyRace(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mockMCP := newMockMCP("race-test", "rt_")
+	mockTools := newMockToolsAdderDeleter()
+
+	// Create manager with a very fast ticker (1ms) to maximize collision probability
+	manager, err := NewUpstreamMCPManager(mockMCP, mockTools, nil, logger, time.Millisecond, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the manager event loop
+	activeServer := manager.Start(ctx)
+	defer activeServer.Stop()
+
+	// Wait for the manager to connect and register callbacks
+	require.Eventually(t, func() bool {
+		return mockMCP.GetNotificationHandler() != nil
+	}, 2*time.Second, 10*time.Millisecond, "notification handler should be registered")
+
+	handler := mockMCP.GetNotificationHandler()
+	require.NotNil(t, handler)
+
+	var wg sync.WaitGroup
+
+	// Fire 100 concurrent tool list changed notifications
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler(mcp.JSONRPCNotification{
+				Notification: mcp.Notification{
+					Method: "notifications/tools/list_changed",
+				},
+			})
+		}()
+	}
+
+	// Fire 100 concurrent prompt list changed notifications
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler(mcp.JSONRPCNotification{
+				Notification: mcp.Notification{
+					Method: "notifications/prompts/list_changed",
+				},
+			})
+		}()
+	}
+
+	// Wait for all concurrent notifications to be sent
+	wg.Wait()
+
+	// Wait for the event loop to process the buffered notifications and converge
+	require.Eventually(t, func() bool {
+		status := activeServer.GetStatus()
+		tools := activeServer.GetManagedTools()
+		return status.Ready && status.TotalTools == 1 && len(tools) == 1 && tools[0].Name == "mock_tool"
+	}, 2*time.Second, 10*time.Millisecond, "manager should process notifications and converge to correct state")
+
+	// Verify that the manager is still healthy and no panic/race occurred
+	require.True(t, activeServer.GetStatus().Ready)
+	require.Equal(t, 1, activeServer.GetStatus().TotalTools)
+	require.Empty(t, activeServer.GetStatus().InvalidToolList)
+
+	// Ensure tools can be fetched safely concurrently
+	tools := activeServer.GetManagedTools()
+	require.NotNil(t, tools)
+
+	// Validate state consistency: no duplicate managed tools or stale entries
+	// The mock MCP server is initialized with exactly 1 tool ("mock_tool")
+	require.Len(t, tools, 1, "There should be exactly 1 tool without duplicates")
+	require.Equal(t, "mock_tool", tools[0].Name, "Tool name should match the raw tool name from upstream")
+}

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -35,6 +35,7 @@ type MockMCP struct {
 	hasToolsCap         bool
 	hasPromptsCap       bool
 	connected           atomic.Bool
+	mu                  sync.RWMutex
 	notificationHandler func(mcp.JSONRPCNotification)
 }
 
@@ -104,7 +105,15 @@ func (m *MockMCP) ListPrompts(_ context.Context, _ mcp.ListPromptsRequest) (*mcp
 }
 
 func (m *MockMCP) OnNotification(handler func(notification mcp.JSONRPCNotification)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.notificationHandler = handler
+}
+
+func (m *MockMCP) GetNotificationHandler() func(mcp.JSONRPCNotification) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.notificationHandler
 }
 
 func (m *MockMCP) OnConnectionLost(_ func(err error)) {}


### PR DESCRIPTION
This fixes the race condition reported in #916 where manage() could run concurrently from both the ticker loop and notification callbacks leading to unsynchronised access to serverTools.

Instead of protecting the entire manager with a broad mutex, this change routes notification triggered reconciliations through the existing event loop so all manage() executions happen sequentially in a single goroutine.

What changed

1. Added serialized event handling for tool and prompt notifications
2. Updated notification callbacks to enqueue events instead of calling manage() directly
3. Added buffered non-blocking event channels to avoid callback stalls
4. Kept targeted locking around shared state reads/writes
5. Added a regression test covering concurrent notification delivery

Notes

1.  Notifications are intentionally coalesced when an event is already pending
2.  Channels are not closed during shutdown, avoiding callback panics after stop
3.  Existing reconciliation behaviour is preserved

Fixes #916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a concurrency/race test that stress-tests handling of many simultaneous notifications, verifies the system converges to a single managed tool with no duplicates, and confirms invalid tool lists remain empty—improving reliability and preventing race-condition regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->