### PR TITLE
fix: add explicit runAsUser to k6 benchmark job

### DIFF
--- a/Dockerfile.k6
+++ b/Dockerfile.k6
@@ -27,7 +27,7 @@ RUN xk6 build \
 FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
-RUN addgroup -S k6 && adduser -S -G k6 k6
+RUN addgroup -S -g 101 k6 && adduser -S -u 100 -G k6 k6
 
 COPY --from=builder /k6 /usr/local/bin/k6
 

--- a/tests/perf/manifests/k6-benchmark-job.yaml
+++ b/tests/perf/manifests/k6-benchmark-job.yaml
@@ -31,6 +31,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Never


### PR DESCRIPTION
## Summary

- k6 benchmark Job fails with `CreateContainerConfigError` because `runAsNonRoot: true` requires a numeric UID but the image only sets `USER k6` (a name)
- Adds `runAsUser: 100` and `runAsGroup: 101` to match the k6 user created in `Dockerfile.k6`

Fixes the benchmark workflow failure seen in https://github.com/Kuadrant/mcp-gateway/actions/runs/26581432548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security configuration for performance test workloads to enforce non-root execution with explicit user and group identifiers.
  * Aligned the runtime image to include a dedicated user/group matching the job configuration for consistent permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->