### PR TITLE
fix: add rich HTML performance report to CI benchmark

### DIFF
--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -73,6 +73,14 @@ jobs:
             git switch -
           fi
 
+      - name: Upload performance report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: performance-report
+          path: out/perf/mcp-report.html
+          retention-days: 30
+
       - name: Store and compare benchmark results
         uses: benchmark-action/github-action-benchmark@5bbce78ef18edf5b96cb2d23e8d240b485f9dc4a  # v1.16.2
         with:
@@ -87,6 +95,21 @@ jobs:
           comment-on-alert: true
           # Post a summary comment on every PR (not just regressions)
           summary-always: true
+
+      - name: Publish HTML report to gh-pages
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+          mkdir -p /tmp/gh-pages/perf
+          cp out/perf/mcp-report.html /tmp/gh-pages/perf/index.html
+          cd /tmp/gh-pages
+          git add perf/index.html
+          git diff --cached --quiet && exit 0
+          git commit -m "update performance report"
+          git push origin gh-pages
+          cd -
+          git worktree remove /tmp/gh-pages
 
       # Collect debug information on failure for easier diagnosis
       - name: Collect logs on failure

--- a/build/perf.mk
+++ b/build/perf.mk
@@ -180,16 +180,28 @@ perf-ci-run: ## Run the in-cluster benchmark Job and extract results
 	@echo "Applying benchmark Job..."
 	kubectl delete -f tests/perf/manifests/k6-benchmark-job.yaml --ignore-not-found
 	kubectl create -f tests/perf/manifests/k6-benchmark-job.yaml
-	@echo "Waiting for Job to complete (timeout 180 s)..."
-	kubectl wait --for=condition=complete job/mcp-gateway-benchmark -n mcp-test --timeout=180s
+	@echo "Waiting for Job to finish (timeout 180 s)..."
+	@for i in $$(seq 1 180); do \
+		STATUS=$$(kubectl get job/mcp-gateway-benchmark -n mcp-test -o jsonpath='{.status.conditions[0].type}' 2>/dev/null); \
+		if [ "$$STATUS" = "Complete" ] || [ "$$STATUS" = "Failed" ]; then break; fi; \
+		sleep 1; \
+	done
 	@POD=$$(kubectl get pod -n mcp-test -l app=mcp-gateway-benchmark \
 		-o jsonpath='{.items[0].metadata.name}'); \
-	echo "Extracting results from pod logs: $$POD"; \
-	kubectl logs "$$POD" -n mcp-test | sed -n '/___K6_JSON_SUMMARY___/,/___K6_JSON_SUMMARY_END___/p' | grep -v '___K6_JSON_SUMMARY' > out/perf/k6-ci-summary.json
+	echo "Extracting results from pod $$POD"; \
+	kubectl logs "$$POD" -n mcp-test > out/perf/k6-ci-full.log; \
+	sed -n '/___K6_JSON_SUMMARY___/,/___K6_JSON_SUMMARY_END___/p' out/perf/k6-ci-full.log | grep -v '___K6_JSON_SUMMARY' > out/perf/k6-ci-summary.json; \
+	echo "Extracting CSV from pod $$POD"; \
+	sed -n '/___K6_CSV_DATA___/,/___K6_CSV_DATA_END___/p' out/perf/k6-ci-full.log | grep -v '___K6_CSV_DATA' > out/perf/k6-ci.csv
 	@chmod +x tests/perf/scripts/convert-k6-to-benchmark.sh
 	@tests/perf/scripts/convert-k6-to-benchmark.sh out/perf/k6-ci-summary.json \
 		> out/perf/benchmark-results.json
-	@echo "Results written to out/perf/benchmark-results.json"
+	@echo "Generating HTML performance report..."
+	@go run ./tests/perf/cmd/report \
+		-csv out/perf/k6-ci.csv \
+		-title "MCP Gateway CI Benchmark" \
+		-out out/perf/mcp-report.html
+	@echo "Results written to out/perf/"
 	@cat out/perf/benchmark-results.json
 
 .PHONY: perf-ci-clean

--- a/tests/perf/k6/ci-benchmark.js
+++ b/tests/perf/k6/ci-benchmark.js
@@ -25,7 +25,7 @@ import { Counter, Trend, Rate } from 'k6/metrics';
 // Default URL targets the Istio gateway service via in-cluster DNS.
 // Override with TARGET_URL env var when running locally.
 const TARGET_URL = __ENV.TARGET_URL
-    || 'http://mcp-gateway-istio.gateway-system.svc.cluster.local/mcp';
+    || 'http://mcp-gateway-istio.gateway-system.svc.cluster.local:8080/mcp';
 const PREFIX     = __ENV.PREFIX   || 'mock_';
 const VUS        = parseInt(__ENV.VUS      || '10');
 const DURATION   = __ENV.DURATION || '30s';

--- a/tests/perf/manifests/k6-benchmark-job.yaml
+++ b/tests/perf/manifests/k6-benchmark-job.yaml
@@ -49,11 +49,18 @@ spec:
             - sh
             - -c
             - |
-              k6 run /scenarios/ci-benchmark.js --summary-export /results/summary.json && \
-              echo "___K6_JSON_SUMMARY___" && \
-              cat /results/summary.json && \
-              echo "" && \
-              echo "___K6_JSON_SUMMARY_END___"
+              k6 run /scenarios/ci-benchmark.js \
+                --summary-export /results/summary.json \
+                --out csv=/results/k6.csv; \
+              K6_EXIT=$?; \
+              echo "___K6_JSON_SUMMARY___"; \
+              cat /results/summary.json; \
+              echo ""; \
+              echo "___K6_JSON_SUMMARY_END___"; \
+              echo "___K6_CSV_DATA___"; \
+              cat /results/k6.csv; \
+              echo "___K6_CSV_DATA_END___"; \
+              exit $K6_EXIT
           env:
             # In-cluster DNS for the Istio gateway service.
             # Override when running in a different topology.

--- a/tests/perf/scripts/convert-k6-to-benchmark.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark.sh
@@ -10,10 +10,10 @@
 # Input format (k6 --summary-export):
 #   {
 #     "metrics": {
-#       "http_req_duration": { "values": { "avg": 20.1, "p(95)": 45.2, "p(99)": 98.3 } },
-#       "mcp_tool_call_duration": { "values": { "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0 } },
-#       "mcp_tool_call_fail_rate": { "values": { "rate": 0.001 } },
-#       "mcp_session_open_fail":   { "values": { "rate": 0.000 } },
+#       "http_req_duration": { "avg": 20.1, "p(95)": 45.2, "p(99)": 98.3 },
+#       "mcp_tool_call_duration": { "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0 },
+#       "mcp_tool_call_fail_rate": { "rate": 0.001 },
+#       "mcp_session_open_fail":   { "rate": 0.000 },
 #       ...
 #     }
 #   }
@@ -52,31 +52,31 @@ jq '
   {
     name:  "p95_tool_call_ms",
     unit:  "ms",
-    value: (.metrics.mcp_tool_call_duration.values["p(95)"] // 0)
+    value: (.metrics.mcp_tool_call_duration["p(95)"] // 0)
   },
   # MCP tool call p99 latency
   {
     name:  "p99_tool_call_ms",
     unit:  "ms",
-    value: (.metrics.mcp_tool_call_duration.values["p(99)"] // 0)
+    value: (.metrics.mcp_tool_call_duration["p(99)"] // 0)
   },
   # MCP tool call average latency
   {
     name:  "avg_tool_call_ms",
     unit:  "ms",
-    value: (.metrics.mcp_tool_call_duration.values.avg // 0)
+    value: (.metrics.mcp_tool_call_duration.avg // 0)
   },
   # MCP tool call error rate (as a percentage)
   {
     name:  "tool_error_rate",
     unit:  "percent",
-    value: ((.metrics.mcp_tool_call_fail_rate.values.rate // 0) * 100)
+    value: ((.metrics.mcp_tool_call_fail_rate.rate // 0) * 100)
   },
   # MCP session open failure rate (as a percentage)
   {
     name:  "session_fail_rate",
     unit:  "percent",
-    value: ((.metrics.mcp_session_open_fail.values.rate // 0) * 100)
+    value: ((.metrics.mcp_session_open_fail.rate // 0) * 100)
   }
 ]
 ' "$SUMMARY_FILE"

--- a/tests/perf/scripts/convert-k6-to-benchmark_test.sh
+++ b/tests/perf/scripts/convert-k6-to-benchmark_test.sh
@@ -37,17 +37,17 @@ cat > "$TMPDIR_TEST/summary.json" <<'EOF'
     "mcp_tool_call_duration": {
       "type": "trend",
       "contains": "time",
-      "values": { "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0 }
+      "avg": 18.4, "p(95)": 42.1, "p(99)": 95.0
     },
     "mcp_tool_call_fail_rate": {
       "type": "rate",
       "contains": "default",
-      "values": { "rate": 0.001, "passes": 999, "fails": 1 }
+      "rate": 0.001, "passes": 999, "fails": 1
     },
     "mcp_session_open_fail": {
       "type": "rate",
       "contains": "default",
-      "values": { "rate": 0.0, "passes": 100, "fails": 0 }
+      "rate": 0.0, "passes": 100, "fails": 0
     }
   }
 }
@@ -105,17 +105,17 @@ cat > "$TMPDIR_TEST/zeros.json" <<'EOF'
     "mcp_tool_call_duration": {
       "type": "trend",
       "contains": "time",
-      "values": { "avg": 0, "p(95)": 0, "p(99)": 0 }
+      "avg": 0, "p(95)": 0, "p(99)": 0
     },
     "mcp_tool_call_fail_rate": {
       "type": "rate",
       "contains": "default",
-      "values": { "rate": 0 }
+      "rate": 0
     },
     "mcp_session_open_fail": {
       "type": "rate",
       "contains": "default",
-      "values": { "rate": 0 }
+      "rate": 0
     }
   }
 }


### PR DESCRIPTION
## Summary

- CI benchmark now produces the same rich HTML report as `make perf-run-ramp` (using `tests/perf/cmd/report`)
- k6 Job outputs CSV alongside summary JSON (`--out csv=/results/k6.csv`)
- Report uploaded as Actions artifact (30-day retention) and published to gh-pages
- Fixed default TARGET_URL in ci-benchmark.js to include `:8080`

Addresses the gap where the CI benchmark used benchmark-action's generic page instead of the existing custom report tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Performance HTML report generation and publishing to gh-pages.
  * Benchmark results are uploaded as retained CI artifacts.
  * Performance metrics exported in CSV and JSON for easier analysis.
* **Tests / Tools**
  * CI benchmark output and conversion updated to match new k6 summary format and default target endpoint port.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->