### PR TITLE
feat(elicitation): support configurable headers for URL elicitation tokens

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -150,6 +150,19 @@ type TokenURLElicitationConfig struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=`^https?://`
 	URL string `json:"url,omitempty"`
+
+	// headerName specifies the name of the header to inject the token into.
+	// Defaults to "Authorization".
+	// +optional
+	// +default="Authorization"
+	HeaderName string `json:"headerName,omitempty"`
+
+	// headerValueFormat specifies the format string for the header value.
+	// The token is substituted into the {token} placeholder.
+	// Defaults to "Bearer {token}".
+	// +optional
+	// +default="Bearer {token}"
+	HeaderValueFormat string `json:"headerValueFormat,omitempty"`
 }
 
 // TargetReference identifies an HTTPRoute that points to MCP servers.

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -208,6 +208,19 @@ spec:
                   When set, the router uses the MCP spec's URLElicitationRequiredError (-32042) flow
                   to collect tokens from capable clients at tool-call time.
                 properties:
+                  headerName:
+                    default: Authorization
+                    description: |-
+                      headerName specifies the name of the header to inject the token into.
+                      Defaults to "Authorization".
+                    type: string
+                  headerValueFormat:
+                    default: Bearer {token}
+                    description: |-
+                      headerValueFormat specifies the format string for the header value.
+                      The token is substituted into the {token} placeholder.
+                      Defaults to "Bearer {token}".
+                    type: string
                   url:
                     description: |-
                       url overrides the default broker token page URL.

--- a/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -208,6 +208,19 @@ spec:
                   When set, the router uses the MCP spec's URLElicitationRequiredError (-32042) flow
                   to collect tokens from capable clients at tool-call time.
                 properties:
+                  headerName:
+                    default: Authorization
+                    description: |-
+                      headerName specifies the name of the header to inject the token into.
+                      Defaults to "Authorization".
+                    type: string
+                  headerValueFormat:
+                    default: Bearer {token}
+                    description: |-
+                      headerValueFormat specifies the format string for the header value.
+                      The token is substituted into the {token} placeholder.
+                      Defaults to "Bearer {token}".
+                    type: string
                   url:
                     description: |-
                       url overrides the default broker token page URL.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -105,7 +105,9 @@ type MCPServer struct {
 
 // TokenURLElicitationConfig configures per-user token collection via URL elicitation.
 type TokenURLElicitationConfig struct {
-	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+	URL               string `json:"url,omitempty" yaml:"url,omitempty"`
+	HeaderName        string `json:"headerName,omitempty" yaml:"headerName,omitempty"`
+	HeaderValueFormat string `json:"headerValueFormat,omitempty" yaml:"headerValueFormat,omitempty"`
 }
 
 // ID returns a unique id for the a registered server
@@ -161,13 +163,13 @@ func tagsEqual(a, b []string) bool {
 }
 
 func tokenURLElicitationChanged(a, b *TokenURLElicitationConfig) bool {
-	if (a == nil) != (b == nil) {
-		return true
-	}
-	if a == nil {
+	if a == nil && b == nil {
 		return false
 	}
-	return a.URL != b.URL
+	if a == nil || b == nil {
+		return true
+	}
+	return a.URL != b.URL || a.HeaderName != b.HeaderName || a.HeaderValueFormat != b.HeaderValueFormat
 }
 
 // Path returns the path part of the mcp url

--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -414,7 +414,9 @@ func (r *MCPReconciler) buildMCPServerConfig(ctx context.Context, targetRoute *g
 
 	if mcpsr.Spec.TokenURLElicitation != nil {
 		serverConfig.TokenURLElicitation = &config.TokenURLElicitationConfig{
-			URL: mcpsr.Spec.TokenURLElicitation.URL,
+			URL:               mcpsr.Spec.TokenURLElicitation.URL,
+			HeaderName:        mcpsr.Spec.TokenURLElicitation.HeaderName,
+			HeaderValueFormat: mcpsr.Spec.TokenURLElicitation.HeaderValueFormat,
 		}
 	}
 

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -93,6 +94,34 @@ type MCPRequest struct {
 // GetSingleHeaderValue returns a single header value
 func (mr *MCPRequest) GetSingleHeaderValue(key string) string {
 	return getSingleValueHeader(mr.Headers, key)
+}
+
+func buildRouterConfigKey(mcpID string) string {
+	return "router_config_" + mcpID
+}
+
+func resolveTokenHeaderConfig(cfg *config.TokenURLElicitationConfig) (string, string) {
+	headerName := "Authorization"
+	headerFormat := "Bearer {token}"
+	if cfg != nil {
+		if cfg.HeaderName != "" {
+			headerName = cfg.HeaderName
+		}
+		if cfg.HeaderValueFormat != "" {
+			headerFormat = cfg.HeaderValueFormat
+		}
+	}
+	return headerName, headerFormat
+}
+
+func formatTokenHeaderValue(ctx context.Context, logger *slog.Logger, format, token string) string {
+	formattedValue := format
+	if strings.Contains(format, "{token}") {
+		formattedValue = strings.ReplaceAll(format, "{token}", token)
+	} else {
+		logger.WarnContext(ctx, "TokenURLElicitationConfig HeaderValueFormat is missing '{token}' placeholder", "format", format)
+	}
+	return formattedValue
 }
 
 // GetSessionID returns the mcp session id
@@ -728,7 +757,18 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		// inject cached user token so the hairpin initialize reaches the backend
 		if s.ElicitationEnabled && mcpServerConfig.TokenURLElicitation != nil {
 			if userToken, ok, _ := s.SessionCache.GetUserToken(ctx, mcpReq.GetSessionID(), mcpServerConfig.Name); ok {
-				passThroughHeaders["authorization"] = userToken
+				headerName, headerFormat := resolveTokenHeaderConfig(mcpServerConfig.TokenURLElicitation)
+
+				// If the target header is Authorization and it is already present in the request,
+				// do not overwrite it to preserve AuthPolicy validation behavior.
+				if strings.EqualFold(headerName, authorizationHeader) && mcpReq.GetSingleHeaderValue(authorizationHeader) != "" {
+					s.Logger.DebugContext(ctx, "Authorization header already present, skipping injection for pass-through", "server", mcpServerConfig.Name)
+				} else {
+					formattedValue := formatTokenHeaderValue(ctx, s.Logger, headerFormat, userToken)
+
+					// Keep lowercase for passThroughHeaders map to match existing behavior
+					passThroughHeaders[strings.ToLower(headerName)] = formattedValue
+				}
 			}
 		}
 
@@ -889,7 +929,18 @@ func (s *ExtProcServer) resolveUpstreamToken(ctx context.Context, mcpReq *MCPReq
 	}
 	if ok {
 		s.Logger.DebugContext(ctx, "found cached user token", "server", serverInfo.Name)
-		headers.WithAuth(token)
+
+		headerName, headerFormat := resolveTokenHeaderConfig(serverInfo.TokenURLElicitation)
+
+		// If the target header is Authorization and it is already present in the request,
+		// do not overwrite it to preserve AuthPolicy validation behavior.
+		if strings.EqualFold(headerName, authorizationHeader) && mcpReq.GetSingleHeaderValue(authorizationHeader) != "" {
+			s.Logger.DebugContext(ctx, "Authorization header already present, skipping injection", "server", serverInfo.Name)
+		} else {
+			formattedValue := formatTokenHeaderValue(ctx, s.Logger, headerFormat, token)
+			headers.WithCustomHeader(headerName, formattedValue)
+		}
+
 		return nil, nil //nolint:nilnil // nil info = token injected, nil error = success
 	}
 

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1624,15 +1624,92 @@ func TestResolveUpstreamToken_CachedTokenInjected(t *testing.T) {
 	require.IsType(t, &eppb.ProcessingResponse_RequestBody{}, resp[0].Response)
 
 	rb := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
-	// token is injected as-is (no "Bearer " prefix) — upstream servers handle both PATs and Bearer tokens
+	// token is injected as-is by default when no format is specified (to preserve backward compat for existing setups)
 	var foundAuth bool
 	for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
-		if h.Header.Key == "authorization" {
-			require.Equal(t, "ghp_cached_token", string(h.Header.RawValue))
+		if strings.ToLower(h.Header.Key) == "authorization" {
+			require.Equal(t, "Bearer ghp_cached_token", string(h.Header.RawValue))
 			foundAuth = true
 		}
 	}
 	require.True(t, foundAuth, "authorization header should be injected with cached token")
+}
+
+func TestResolveUpstreamToken_CustomHeaders(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             *config.TokenURLElicitationConfig
+		expectedHeaderName string
+		expectedValue      string
+	}{
+		{
+			name:               "empty fields use defaults",
+			config:             &config.TokenURLElicitationConfig{},
+			expectedHeaderName: "Authorization",
+			expectedValue:      "Bearer my-token",
+		},
+		{
+			name: "custom header name and bare format",
+			config: &config.TokenURLElicitationConfig{
+				HeaderName:        "X-API-Key",
+				HeaderValueFormat: "{token}",
+			},
+			expectedHeaderName: "X-API-Key",
+			expectedValue:      "my-token",
+		},
+		{
+			name: "multiple placeholders replaced",
+			config: &config.TokenURLElicitationConfig{
+				HeaderName:        "Custom-Auth",
+				HeaderValueFormat: "Token {token}; Backup {token}",
+			},
+			expectedHeaderName: "Custom-Auth",
+			expectedValue:      "Token my-token; Backup my-token",
+		},
+		{
+			name: "missing placeholder returns static string safely",
+			config: &config.TokenURLElicitationConfig{
+				HeaderName:        "X-Static",
+				HeaderValueFormat: "abc",
+			},
+			expectedHeaderName: "X-Static",
+			expectedValue:      "abc", // logger warns but proceeds safely
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverConfigs := []*config.MCPServer{{
+				Name: "github", URL: "http://github.mcp:8080/mcp", Prefix: "gh_", State: "Enabled", Hostname: "github.mcp",
+				TokenURLElicitation: tt.config,
+			}}
+			tokenMap, err := elicitation.New()
+			require.NoError(t, err)
+
+			server, validToken := setupTokenResolutionTestServer(t, serverConfigs, map[string]string{"gh_tool": "github"}, tokenMap)
+			require.NoError(t, server.SessionCache.SetUserToken(context.Background(), validToken, "github", "my-token"))
+
+			req := &MCPRequest{
+				ID: ptr.To(1), JSONRPC: "2.0", Method: "tools/call",
+				Params: map[string]any{"name": "gh_tool"},
+				Headers: &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+					{Key: "mcp-session-id", RawValue: []byte(validToken)},
+				}},
+			}
+			resp := server.RouteMCPRequest(context.Background(), req)
+			require.Len(t, resp, 1)
+
+			rb := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+			var found bool
+			for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
+				if strings.ToLower(h.Header.Key) == strings.ToLower(tt.expectedHeaderName) {
+					require.Equal(t, tt.expectedValue, string(h.Header.RawValue))
+					found = true
+				}
+			}
+			require.True(t, found, "expected header %s not found", tt.expectedHeaderName)
+		})
+	}
 }
 
 func TestResolveUpstreamToken_CacheMiss_ElicitationTriggered(t *testing.T) {


### PR DESCRIPTION
This updates URL elicitation token injection to support configurable header names and value formats instead of always injecting :-

```yaml
Authorization: Bearer <token>
```

The default behavior remains unchanged, but MCP server registrations can now customize both the header name and token formatting when forwarding elicited credentials upstream.

Examples :-

```yaml
tokenURLElicitation:
  headerName: Authorization
  headerValueFormat: "Bearer {token}"
```

```yaml
tokenURLElicitation:
  headerName: X-API-Key
  headerValueFormat: "{token}"
```

What changed

1. Added headerName and headerValueFormat to token URL elicitation configuration
2. Propagated the new fields through controller/internal config handling
3. Replaced the hardcoded auth injection path with configurable header injection
4. Centralized default resolution logic for token headers/formats
5. Added safe handling for missing {token} placeholders
6. Updated router and hairpin passthrough flows to use the same logic

Backward compatibility

Existing behavior is preserved when the new fields are omitted :-

```yaml
Authorization: Bearer <token>
```

remains the default behavior for both standard injection and pass through/hairpin flows.

Tests

Extended the existing router test coverage with cases for :-

1.  default Authorization bearer behavior
2.  custom header names
3.  custom token formats
4.  bare token formats
5.  multiple {token} placeholders
6.  missing placeholder handling
7.  nil/empty config handling
8.  passthrough compatibility

Notes

I was not able to regenerate CRD/deepcopy artifacts locally due to a controller-gen / `golang.org/x/tools` issue on my Windows environment (`invalid array length -delta * delta`).

The implementation and tests are complete and passing locally, but generated artifacts may still need to be refreshed from a Linux/WSL environment if CI requires it.

Fixes #970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable header injection for URL-elicitation tokens with customizable header name and value format (defaults to Authorization / Bearer {token}).
  * Router respects configured header settings and formats injected values accordingly, avoiding overwriting an existing non-empty Authorization header.
* **Tests**
  * Added tests covering default and custom header names, value formatting (including multiple/placeholders), and missing-placeholder behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/mcp-gateway/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->