### PR TITLE
broker: federate MCP resources alongside tools and prompts

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -35,6 +35,9 @@ type MCPBroker interface {
 	// Returns server info for a given prompt name
 	GetServerInfoByPrompt(prompt string) (*config.MCPServer, error)
 
+	// Returns server info for a given resource URI
+	GetServerInfoByResource(uri string) (*config.MCPServer, error)
+
 	// MCPServer gets an MCP server that federates the upstreams known to this MCPBroker
 	MCPServer() *server.MCPServer
 
@@ -253,10 +256,15 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		mcpBkr.FilterPrompts(ctx, id, message, result)
 	})
 
+	hooks.AddAfterListResources(func(ctx context.Context, id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult) {
+		mcpBkr.FilterResources(ctx, id, message, result)
+	})
+
 	serverOpts := []server.ServerOption{
 		server.WithHooks(hooks),
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),
+		server.WithResourceCapabilities(false, true),
 	}
 	if mcpBkr.discovery.enabled {
 		serverOpts = append(serverOpts, server.WithInstructions(gatewayInstructions))
@@ -315,7 +323,7 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		// check if we need to setup a new manager
 		if _, ok := m.mcpServers[mcpServer.ID()]; !ok {
 			m.logger.InfoContext(ctx, "starting new manager", "server id", mcpServer.ID())
-			manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
+			manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer), m.listeningMCPServer, m.listeningMCPServer, m.listeningMCPServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
 			if err != nil {
 				m.logger.ErrorContext(ctx, "failed to create manager", "server id", mcpServer.ID(), "error", err)
 				continue
@@ -441,6 +449,26 @@ func (m *mcpBrokerImpl) GetServerInfoByPrompt(prompt string) (*config.MCPServer,
 	}
 
 	return nil, fmt.Errorf("prompt name %q doesn't match any configured server", prompt)
+}
+
+// GetServerInfoByResource implements MCPBroker by providing a lookup of the server that implements a resource URI.
+func (m *mcpBrokerImpl) GetServerInfoByResource(uri string) (*config.MCPServer, error) {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+
+	for _, upstream := range m.mcpServers {
+		r := upstream.GetServedManagedResource(uri)
+		if r != nil {
+			cfg := upstream.Config()
+			m.logger.Debug("found matching server for resource",
+				"uri", uri,
+				"serverName", upstream.MCPName())
+			retval := cfg
+			return &retval, nil
+		}
+	}
+
+	return nil, fmt.Errorf("resource URI %q doesn't match any configured server", uri)
 }
 
 // IsBrokerToolName returns true if the given tool name belongs to a broker-internal

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -402,7 +402,8 @@ func createResourceTestManager(t *testing.T, serverName, prefix string, resource
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
 	manager.SetResourcesForTesting(resources)
 	return manager
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -34,16 +34,19 @@ const (
 
 var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-// mockGateway is a no-op ToolsAdderDeleter/PromptsAdderDeleter for tests that don't need real gateway behaviour.
+// mockGateway is a no-op ToolsAdderDeleter/PromptsAdderDeleter/ResourcesAdderDeleter for tests that don't need real gateway behaviour.
 type mockGateway struct{}
 
-func newMockGateway() *mockGateway                                  { return &mockGateway{} }
-func (m *mockGateway) AddTools(_ ...server.ServerTool)              {}
-func (m *mockGateway) DeleteTools(_ ...string)                      {}
-func (m *mockGateway) ListTools() map[string]*server.ServerTool     { return nil }
-func (m *mockGateway) AddPrompts(_ ...server.ServerPrompt)          {}
-func (m *mockGateway) DeletePrompts(_ ...string)                    {}
-func (m *mockGateway) ListPrompts() map[string]*server.ServerPrompt { return nil }
+func newMockGateway() *mockGateway                                      { return &mockGateway{} }
+func (m *mockGateway) AddTools(_ ...server.ServerTool)                  {}
+func (m *mockGateway) DeleteTools(_ ...string)                          {}
+func (m *mockGateway) ListTools() map[string]*server.ServerTool         { return nil }
+func (m *mockGateway) AddPrompts(_ ...server.ServerPrompt)              {}
+func (m *mockGateway) DeletePrompts(_ ...string)                        {}
+func (m *mockGateway) ListPrompts() map[string]*server.ServerPrompt     { return nil }
+func (m *mockGateway) AddResources(_ ...server.ServerResource)          {}
+func (m *mockGateway) DeleteResources(_ ...string)                      {}
+func (m *mockGateway) ListResources() map[string]*server.ServerResource { return nil }
 
 // TestMain starts an MCP server that we will run actual tests against
 func TestMain(m *testing.M) {
@@ -261,7 +264,7 @@ func TestGetServerInfo_UserSpecificLongestPrefix(t *testing.T) {
 func createTestManagerUserSpecific(t *testing.T, cfg config.MCPServer) *upstream.MCPManager {
 	t.Helper()
 	mcpServer := upstream.NewUpstreamMCP(&cfg)
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	return manager
 }
@@ -390,4 +393,48 @@ func TestIsReady(t *testing.T) {
 			require.Equal(t, tt.expected, b.IsReady())
 		})
 	}
+}
+
+func createResourceTestManager(t *testing.T, serverName, prefix string, resources []mcp.Resource) *upstream.MCPManager {
+	t.Helper()
+	mcpServer := upstream.NewUpstreamMCP(&config.MCPServer{
+		Name:   serverName,
+		Prefix: prefix,
+		URL:    "http://test.local/mcp",
+	})
+	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager.SetResourcesForTesting(resources)
+	return manager
+}
+
+func TestGetServerInfoByResource(t *testing.T) {
+	b := NewBroker(logger)
+	bImpl := b.(*mcpBrokerImpl)
+
+	bImpl.mcpServers["srv1"] = upstream.NewActiveForTesting(createResourceTestManager(t, "srv1", "", []mcp.Resource{
+		{URI: "test://docs/overview", Name: "Overview"},
+	}))
+	bImpl.mcpServers["srv2"] = upstream.NewActiveForTesting(createResourceTestManager(t, "srv2", "", []mcp.Resource{
+		{URI: "test://docs/api", Name: "API Reference"},
+	}))
+
+	t.Run("returns correct server for known URI", func(t *testing.T) {
+		svr, err := b.GetServerInfoByResource("test://docs/overview")
+		require.NoError(t, err)
+		require.NotNil(t, svr)
+		require.Equal(t, "srv1", svr.Name)
+	})
+
+	t.Run("returns correct server for second URI", func(t *testing.T) {
+		svr, err := b.GetServerInfoByResource("test://docs/api")
+		require.NoError(t, err)
+		require.NotNil(t, svr)
+		require.Equal(t, "srv2", svr.Name)
+	})
+
+	t.Run("returns error for unknown URI", func(t *testing.T) {
+		svr, err := b.GetServerInfoByResource("test://unknown")
+		require.Error(t, err)
+		require.Nil(t, svr)
+	})
 }

--- a/internal/broker/discovery_test.go
+++ b/internal/broker/discovery_test.go
@@ -25,7 +25,7 @@ func createTestManagerWithMeta(t *testing.T, serverName, prefix string, tools []
 		Category: category,
 		Hint:     hint,
 	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)
 	return upstream.NewActiveForTesting(manager)

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -13,11 +13,7 @@ import (
 
 // FilterPrompts reduces the prompt set based on authorization headers.
 func (broker *mcpBrokerImpl) FilterPrompts(ctx context.Context, _ any, mcpReq *mcp.ListPromptsRequest, mcpRes *mcp.ListPromptsResult) {
-	attrs := []attribute.KeyValue{brokerComponentAttr}
-	if sid := sessionIDFromContext(ctx); sid != "" {
-		attrs = append(attrs, attribute.String("mcp.session.id", sid))
-	}
-	ctx, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(attrs...))
+	ctx, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(broker.filterSpanAttrs(ctx)...))
 	defer span.End()
 
 	broker.logger.DebugContext(ctx, "FilterPrompts called", "input_prompts_count", len(mcpRes.Prompts))

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -39,7 +39,7 @@ func (broker *mcpBrokerImpl) FilterPrompts(ctx context.Context, _ any, mcpReq *m
 func (broker *mcpBrokerImpl) removeGatewayMetaFromPrompts(prompts []mcp.Prompt) []mcp.Prompt {
 	for i := range prompts {
 		if prompts[i].Meta != nil {
-			delete(prompts[i].Meta.AdditionalFields, "kuadrant/id")
+			delete(prompts[i].Meta.AdditionalFields, gatewayServerIDKey)
 			if len(prompts[i].Meta.AdditionalFields) == 0 {
 				prompts[i].Meta = nil
 			}

--- a/internal/broker/filtered_prompts_handler_test.go
+++ b/internal/broker/filtered_prompts_handler_test.go
@@ -19,7 +19,7 @@ func createPromptTestManager(t *testing.T, serverName, prefix string, prompts []
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	manager.SetPromptsForTesting(prompts)
 	return manager
 }

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -38,6 +38,7 @@ func (broker *mcpBrokerImpl) removeGatewayMetaFromResources(resources []mcp.Reso
 	for i := range resources {
 		if resources[i].Meta != nil {
 			delete(resources[i].Meta.AdditionalFields, gatewayServerIDKey)
+			delete(resources[i].Meta.AdditionalFields, gatewaySourceURLKey)
 			if len(resources[i].Meta.AdditionalFields) == 0 {
 				resources[i].Meta = nil
 			}

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -11,11 +11,7 @@ import (
 
 // FilterResources reduces the resource set based on authorization headers.
 func (broker *mcpBrokerImpl) FilterResources(ctx context.Context, _ any, mcpReq *mcp.ListResourcesRequest, mcpRes *mcp.ListResourcesResult) {
-	attrs := []attribute.KeyValue{brokerComponentAttr}
-	if sid := sessionIDFromContext(ctx); sid != "" {
-		attrs = append(attrs, attribute.String("mcp.session.id", sid))
-	}
-	ctx, span := brokerTracer().Start(ctx, "mcp-broker.resources-list", trace.WithAttributes(attrs...))
+	ctx, span := brokerTracer().Start(ctx, "mcp-broker.resources-list", trace.WithAttributes(broker.filterSpanAttrs(ctx)...))
 	defer span.End()
 
 	broker.logger.DebugContext(ctx, "FilterResources called", "input_resources_count", len(mcpRes.Resources))

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -37,7 +37,7 @@ func (broker *mcpBrokerImpl) FilterResources(ctx context.Context, _ any, mcpReq 
 func (broker *mcpBrokerImpl) removeGatewayMetaFromResources(resources []mcp.Resource) []mcp.Resource {
 	for i := range resources {
 		if resources[i].Meta != nil {
-			delete(resources[i].Meta.AdditionalFields, "kuadrant/id")
+			delete(resources[i].Meta.AdditionalFields, gatewayServerIDKey)
 			if len(resources[i].Meta.AdditionalFields) == 0 {
 				resources[i].Meta = nil
 			}

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -116,7 +116,7 @@ func (broker *mcpBrokerImpl) applyVirtualServerFilterForResources(headers http.H
 	vs, err := broker.GetVirtualSeverByHeader(virtualServerID)
 	if err != nil {
 		broker.logger.Error("failed to get virtual server for resource filtering", "error", err)
-		return resources
+		return []mcp.Resource{}
 	}
 
 	if len(vs.Resources) == 0 {

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -3,7 +3,6 @@ package broker
 import (
 	"context"
 	"net/http"
-	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.opentelemetry.io/otel/attribute"
@@ -92,8 +91,13 @@ func (broker *mcpBrokerImpl) filterResourcesByServerMap(allowedResources map[str
 			continue
 		}
 
+		allowedSet := make(map[string]struct{}, len(uris))
+		for _, uri := range uris {
+			allowedSet[uri] = struct{}{}
+		}
+
 		for _, resource := range resources {
-			if slices.Contains(uris, resource.URI) {
+			if _, ok := allowedSet[resource.URI]; ok {
 				filtered = append(filtered, resource)
 			}
 		}

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -1,0 +1,135 @@
+package broker
+
+import (
+	"context"
+	"net/http"
+	"slices"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// FilterResources reduces the resource set based on authorization headers.
+func (broker *mcpBrokerImpl) FilterResources(ctx context.Context, _ any, mcpReq *mcp.ListResourcesRequest, mcpRes *mcp.ListResourcesResult) {
+	attrs := []attribute.KeyValue{brokerComponentAttr}
+	if sid := sessionIDFromContext(ctx); sid != "" {
+		attrs = append(attrs, attribute.String("mcp.session.id", sid))
+	}
+	ctx, span := brokerTracer().Start(ctx, "mcp-broker.resources-list", trace.WithAttributes(attrs...))
+	defer span.End()
+
+	broker.logger.DebugContext(ctx, "FilterResources called", "input_resources_count", len(mcpRes.Resources))
+	resources := mcpRes.Resources
+	emptyResources := []mcp.Resource{}
+	if len(mcpRes.Resources) == 0 {
+		mcpRes.Resources = emptyResources
+		return
+	}
+
+	resources = broker.applyAuthorizedCapabilitiesFilterForResources(mcpReq.Header, resources)
+	resources = broker.applyVirtualServerFilterForResources(mcpReq.Header, resources)
+	resources = broker.removeGatewayMetaFromResources(resources)
+
+	span.SetAttributes(attribute.Int("mcp.resources.count", len(resources)))
+
+	if resources == nil {
+		resources = emptyResources
+	}
+	mcpRes.Resources = resources
+}
+
+func (broker *mcpBrokerImpl) removeGatewayMetaFromResources(resources []mcp.Resource) []mcp.Resource {
+	for i := range resources {
+		if resources[i].Meta != nil {
+			delete(resources[i].Meta.AdditionalFields, "kuadrant/id")
+			if len(resources[i].Meta.AdditionalFields) == 0 {
+				resources[i].Meta = nil
+			}
+		}
+	}
+	return resources
+}
+
+func (broker *mcpBrokerImpl) applyAuthorizedCapabilitiesFilterForResources(headers http.Header, resources []mcp.Resource) []mcp.Resource {
+	headerValues, present := headers[authorizedCapabilitiesHeader]
+
+	if !present {
+		if broker.enforceCapabilityFilter {
+			return []mcp.Resource{}
+		}
+		return resources
+	}
+
+	capabilities, err := broker.parseAuthorizedCapabilitiesJWT(headerValues)
+	if err != nil {
+		broker.logger.Error("failed to parse x-mcp-authorized header for resources", "error", err)
+		return []mcp.Resource{}
+	}
+
+	allowedResources, hasResources := capabilities["resources"]
+	if !hasResources {
+		if broker.enforceCapabilityFilter {
+			return []mcp.Resource{}
+		}
+		return resources
+	}
+
+	return broker.filterResourcesByServerMap(allowedResources)
+}
+
+func (broker *mcpBrokerImpl) filterResourcesByServerMap(allowedResources map[string][]string) []mcp.Resource {
+	var filtered []mcp.Resource
+
+	for serverName, uris := range allowedResources {
+		upstream := broker.findServerByName(serverName)
+		if upstream == nil {
+			broker.logger.Error("upstream not found for resource filtering", "server", serverName)
+			continue
+		}
+		resources := upstream.GetManagedResources()
+		if resources == nil {
+			continue
+		}
+
+		for _, resource := range resources {
+			if slices.Contains(uris, resource.URI) {
+				filtered = append(filtered, resource)
+			}
+		}
+	}
+
+	return filtered
+}
+
+func (broker *mcpBrokerImpl) applyVirtualServerFilterForResources(headers http.Header, resources []mcp.Resource) []mcp.Resource {
+	headerValues, ok := headers[virtualMCPHeader]
+	if !ok || len(headerValues) != 1 {
+		return resources
+	}
+
+	virtualServerID := headerValues[0]
+	vs, err := broker.GetVirtualSeverByHeader(virtualServerID)
+	if err != nil {
+		broker.logger.Error("failed to get virtual server for resource filtering", "error", err)
+		return resources
+	}
+
+	if len(vs.Resources) == 0 {
+		return resources
+	}
+
+	filteredSet := make(map[string]struct{}, len(vs.Resources))
+	for _, uri := range vs.Resources {
+		filteredSet[uri] = struct{}{}
+	}
+
+	var filtered []mcp.Resource
+	for _, resource := range resources {
+		if _, inFilter := filteredSet[resource.URI]; inFilter {
+			filtered = append(filtered, resource)
+		}
+	}
+
+	return filtered
+}

--- a/internal/broker/filtered_resources_handler_test.go
+++ b/internal/broker/filtered_resources_handler_test.go
@@ -5,25 +5,10 @@ import (
 	"net/http"
 	"testing"
 
-	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/stretchr/testify/require"
 )
-
-func createResourceFilterTestManager(t *testing.T, serverName, prefix string, resources []mcp.Resource) *upstream.MCPManager {
-	t.Helper()
-	mcpServer := upstream.NewUpstreamMCP(&config.MCPServer{
-		Name:   serverName,
-		Prefix: prefix,
-		URL:    "http://test.local/mcp",
-	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
-	require.NoError(t, err)
-	manager.SetResourcesForTesting(resources)
-	return manager
-}
 
 func TestFilterResources(t *testing.T) {
 	testCases := []struct {
@@ -88,7 +73,7 @@ func TestFilterResources_JWTFiltering(t *testing.T) {
 		trustedHeadersPublicKey: testPublicKey,
 		logger:                  slog.Default(),
 		mcpServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
-			"mcp-test/test-server1:test_:http://test.local/mcp": upstream.NewActiveForTesting(createResourceFilterTestManager(t,
+			"mcp-test/test-server1:test_:http://test.local/mcp": upstream.NewActiveForTesting(createResourceTestManager(t,
 				"mcp-test/test-server1",
 				"test_",
 				[]mcp.Resource{{URI: "test://r1", Name: "r1"}, {URI: "test://r2", Name: "r2"}},

--- a/internal/broker/filtered_resources_handler_test.go
+++ b/internal/broker/filtered_resources_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
 )
 
 func createResourceFilterTestManager(t *testing.T, serverName, prefix string, resources []mcp.Resource) *upstream.MCPManager {
@@ -18,7 +19,8 @@ func createResourceFilterTestManager(t *testing.T, serverName, prefix string, re
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
 	manager.SetResourcesForTesting(resources)
 	return manager
 }

--- a/internal/broker/filtered_resources_handler_test.go
+++ b/internal/broker/filtered_resources_handler_test.go
@@ -1,0 +1,197 @@
+package broker
+
+import (
+	"log/slog"
+	"net/http"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func createResourceFilterTestManager(t *testing.T, serverName, prefix string, resources []mcp.Resource) *upstream.MCPManager {
+	t.Helper()
+	mcpServer := upstream.NewUpstreamMCP(&config.MCPServer{
+		Name:   serverName,
+		Prefix: prefix,
+		URL:    "http://test.local/mcp",
+	})
+	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager.SetResourcesForTesting(resources)
+	return manager
+}
+
+func TestFilterResources(t *testing.T) {
+	testCases := []struct {
+		Name                 string
+		FullResourceList     *mcp.ListResourcesResult
+		RegisteredMCPServers map[config.UpstreamMCPID]upstream.ActiveMCPServer
+		enforceFilterList    bool
+		ExpectedCount        int
+	}{
+		{
+			Name: "returns all resources when no headers and enforce is false",
+			FullResourceList: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test://r1", Name: "r1"},
+				{URI: "test://r2", Name: "r2"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
+			enforceFilterList:    false,
+			ExpectedCount:        2,
+		},
+		{
+			Name: "returns empty resources when no headers and enforce is true",
+			FullResourceList: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test://r1", Name: "r1"},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
+			enforceFilterList:    true,
+			ExpectedCount:        0,
+		},
+		{
+			Name:                 "returns empty slice for nil resources input",
+			FullResourceList:     &mcp.ListResourcesResult{Resources: nil},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{},
+			enforceFilterList:    false,
+			ExpectedCount:        0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mcpBroker := &mcpBrokerImpl{
+				enforceCapabilityFilter: tc.enforceFilterList,
+				trustedHeadersPublicKey: testPublicKey,
+				logger:                  slog.Default(),
+				mcpServers:              tc.RegisteredMCPServers,
+			}
+			request := &mcp.ListResourcesRequest{Header: http.Header{}}
+			mcpBroker.FilterResources(t.Context(), 1, request, tc.FullResourceList)
+			if len(tc.FullResourceList.Resources) != tc.ExpectedCount {
+				t.Fatalf("expected %d resources but got %d", tc.ExpectedCount, len(tc.FullResourceList.Resources))
+			}
+		})
+	}
+}
+
+func TestFilterResources_JWTFiltering(t *testing.T) {
+	jwt := createTestJWTWithCapabilities(t, map[string]map[string][]string{
+		"resources": {"mcp-test/test-server1": {"test://r1"}},
+	})
+
+	mcpBroker := &mcpBrokerImpl{
+		enforceCapabilityFilter: true,
+		trustedHeadersPublicKey: testPublicKey,
+		logger:                  slog.Default(),
+		mcpServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			"mcp-test/test-server1:test_:http://test.local/mcp": upstream.NewActiveForTesting(createResourceFilterTestManager(t,
+				"mcp-test/test-server1",
+				"test_",
+				[]mcp.Resource{{URI: "test://r1", Name: "r1"}, {URI: "test://r2", Name: "r2"}},
+			)),
+		},
+	}
+
+	result := &mcp.ListResourcesResult{Resources: []mcp.Resource{
+		{URI: "test://r1", Name: "r1"},
+		{URI: "test://r2", Name: "r2"},
+	}}
+	request := &mcp.ListResourcesRequest{
+		Header: http.Header{
+			authorizedCapabilitiesHeader: {jwt},
+		},
+	}
+
+	mcpBroker.FilterResources(t.Context(), 1, request, result)
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+	if result.Resources[0].URI != "test://r1" {
+		t.Fatalf("expected test://r1 but got %s", result.Resources[0].URI)
+	}
+}
+
+func TestVirtualServerResourceFiltering(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		InputResources  *mcp.ListResourcesResult
+		VirtualServers  map[string]*config.VirtualServer
+		VirtualServerID string
+		ExpectedURIs    []string
+	}{
+		{
+			Name: "filters resources to virtual server subset",
+			InputResources: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test://r1", Name: "r1"},
+				{URI: "test://r2", Name: "r2"},
+				{URI: "test://r3", Name: "r3"},
+			}},
+			VirtualServers: map[string]*config.VirtualServer{
+				"mcp-test/my-vs": {
+					Name:      "mcp-test/my-vs",
+					Resources: []string{"test://r1", "test://r3"},
+				},
+			},
+			VirtualServerID: "mcp-test/my-vs",
+			ExpectedURIs:    []string{"test://r1", "test://r3"},
+		},
+		{
+			Name: "returns all resources when virtual server has empty resources list",
+			InputResources: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test://r1", Name: "r1"},
+				{URI: "test://r2", Name: "r2"},
+			}},
+			VirtualServers: map[string]*config.VirtualServer{
+				"mcp-test/my-vs": {
+					Name:      "mcp-test/my-vs",
+					Resources: []string{},
+				},
+			},
+			VirtualServerID: "mcp-test/my-vs",
+			ExpectedURIs:    []string{"test://r1", "test://r2"},
+		},
+		{
+			Name: "returns all resources when no virtual server header",
+			InputResources: &mcp.ListResourcesResult{Resources: []mcp.Resource{
+				{URI: "test://r1", Name: "r1"},
+			}},
+			VirtualServers:  map[string]*config.VirtualServer{},
+			VirtualServerID: "",
+			ExpectedURIs:    []string{"test://r1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mcpBroker := &mcpBrokerImpl{
+				enforceCapabilityFilter: false,
+				virtualServers:          tc.VirtualServers,
+				logger:                  slog.Default(),
+			}
+
+			request := &mcp.ListResourcesRequest{Header: http.Header{}}
+			if tc.VirtualServerID != "" {
+				request.Header[virtualMCPHeader] = []string{tc.VirtualServerID}
+			}
+
+			mcpBroker.FilterResources(t.Context(), 1, request, tc.InputResources)
+
+			if len(tc.InputResources.Resources) != len(tc.ExpectedURIs) {
+				t.Fatalf("expected %d resources but got %d: %v", len(tc.ExpectedURIs), len(tc.InputResources.Resources), tc.InputResources.Resources)
+			}
+
+			resultURIs := make(map[string]bool, len(tc.InputResources.Resources))
+			for _, r := range tc.InputResources.Resources {
+				resultURIs[r.URI] = true
+			}
+			for _, expectedURI := range tc.ExpectedURIs {
+				if !resultURIs[expectedURI] {
+					t.Fatalf("expected resource URI %s not found in result set", expectedURI)
+				}
+			}
+		})
+	}
+}

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -22,6 +22,15 @@ var virtualMCPHeader = http.CanonicalHeaderKey("x-mcp-virtualserver")
 
 const allowedCapabilitiesClaimKey = "allowed-capabilities"
 
+// filterSpanAttrs returns the base OTel attributes for a list-filter span, appending the session ID if present.
+func (broker *mcpBrokerImpl) filterSpanAttrs(ctx context.Context) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{brokerComponentAttr}
+	if sid := sessionIDFromContext(ctx); sid != "" {
+		attrs = append(attrs, attribute.String("mcp.session.id", sid))
+	}
+	return attrs
+}
+
 // FilterTools reduces the tool set based on authorization headers.
 // Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
 func (broker *mcpBrokerImpl) FilterTools(ctx context.Context, _ any, mcpReq *mcp.ListToolsRequest, mcpRes *mcp.ListToolsResult) {

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -20,7 +20,11 @@ import (
 var authorizedCapabilitiesHeader = http.CanonicalHeaderKey("x-mcp-authorized")
 var virtualMCPHeader = http.CanonicalHeaderKey("x-mcp-virtualserver")
 
-const allowedCapabilitiesClaimKey = "allowed-capabilities"
+const (
+	allowedCapabilitiesClaimKey = "allowed-capabilities"
+	// gatewayServerIDKey matches the upstream.gatewayServerID constant used to tag registered items.
+	gatewayServerIDKey = "kuadrant/id"
+)
 
 // filterSpanAttrs returns the base OTel attributes for a list-filter span, appending the session ID if present.
 func (broker *mcpBrokerImpl) filterSpanAttrs(ctx context.Context) []attribute.KeyValue {

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -24,6 +24,8 @@ const (
 	allowedCapabilitiesClaimKey = "allowed-capabilities"
 	// gatewayServerIDKey matches the upstream.gatewayServerID constant used to tag registered items.
 	gatewayServerIDKey = "kuadrant/id"
+	// gatewaySourceURLKey matches the upstream.gatewaySourceURLKey used to tag the backend URL of registered resources.
+	gatewaySourceURLKey = "kuadrant/source-url"
 )
 
 // filterSpanAttrs returns the base OTel attributes for a list-filter span, appending the session ID if present.

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -59,7 +59,7 @@ func createTestManager(t *testing.T, serverName, prefix string, tools []mcp.Tool
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	// populate tools directly for testing (this requires accessing internal state)
 	manager.SetToolsForTesting(tools)

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -34,7 +34,7 @@ func createTestManagerForStatus(t *testing.T, serverName string, tools []mcp.Too
 		Prefix: "test_",
 		URL:    "http://test.local/mcp",
 	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)
 	manager.SetStatusForTesting(upstream.ServerValidationStatus{

--- a/internal/broker/tags_handler_test.go
+++ b/internal/broker/tags_handler_test.go
@@ -154,7 +154,7 @@ func createTestManagerWithTags(t *testing.T, serverName, prefix string, tools []
 		URL:    "http://test.local/mcp",
 		Tags:   tags,
 	})
-	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)
 	return upstream.NewActiveForTesting(manager)

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -76,6 +76,7 @@ type ServerValidationStatus struct {
 	Ready             bool                `json:"ready"`
 	TotalTools        int                 `json:"totalTools"`
 	TotalPrompts      int                 `json:"totalPrompts"`
+	TotalResources    int                 `json:"totalResources"`
 	InvalidTools      int                 `json:"invalidTools"`
 	InvalidToolList   []InvalidToolInfo   `json:"invalidToolList,omitempty"`
 	InvalidPrompts    int                 `json:"invalidPrompts"`
@@ -349,12 +350,13 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.removeAllTools()
 		man.removeAllPrompts()
 		_ = man.mcp.Disconnect()
-		man.setStatus(fmt.Errorf("server is disabled"), 0, 0, nil, nil)
+		man.setStatus(fmt.Errorf("server is disabled"), 0, 0, 0, nil, nil)
 		return
 	}
 
 	numberOfTools := len(man.tools)
 	numberOfPrompts := len(man.prompts)
+	numberOfResources := len(man.resources)
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
 	man.logger.DebugContext(ctx, "attempting to connect", "upstream mcp server", man.mcp.ID())
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
@@ -366,7 +368,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.removeAllPrompts()
 		// we call disconnect here as we may have connected but failed to initialize
 		_ = man.mcp.Disconnect()
-		man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+		man.setStatus(err, numberOfTools, numberOfPrompts, numberOfResources, nil, nil)
 		return
 	}
 	// there may be an active client so we also ping
@@ -379,7 +381,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.removeAllTools()
 		man.removeAllPrompts()
 		_ = man.mcp.Disconnect()
-		man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+		man.setStatus(err, numberOfTools, numberOfPrompts, numberOfResources, nil, nil)
 		return
 	}
 
@@ -527,6 +529,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 			} else {
 				man.toolsLock.Lock()
 				man.resources = fetchedResources
+				numberOfResources = len(fetchedResources)
 				man.resourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
 				man.servedResourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
 				for i := range fetchedResources {
@@ -551,7 +554,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	}
 
 	jointErr := errors.Join(toolErr, promptErr, resourceErr)
-	man.setStatus(jointErr, numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
+	man.setStatus(jointErr, numberOfTools, numberOfPrompts, numberOfResources, invalidTools, invalidPrompts)
 	if jointErr != nil {
 		man.applyBackoff()
 	} else {
@@ -596,7 +599,7 @@ func (man *MCPManager) GetStatus() ServerValidationStatus {
 	return man.status
 }
 
-func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo) {
+func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, resourceCount int, invalidTools []InvalidToolInfo, invalidPrompts []InvalidPromptInfo) {
 	man.status.ID = string(man.mcp.ID())
 	man.status.LastValidated = time.Now()
 	man.status.Name = man.MCPName()
@@ -611,8 +614,9 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	}
 	man.status.TotalTools = toolCount
 	man.status.TotalPrompts = promptCount
+	man.status.TotalResources = resourceCount
 	man.status.Ready = true
-	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
+	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d. Total resources added %d", toolCount, promptCount, resourceCount)
 }
 
 func (man *MCPManager) resetBackoff() {
@@ -968,7 +972,7 @@ func (man *MCPManager) resourceToServerResource(newResource mcp.Resource) server
 	return server.ServerResource{
 		Resource: newResource,
 		Handler: func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-			return []mcp.ResourceContents{}, nil
+			return nil, fmt.Errorf("resources/read must be routed via ext_proc, not called directly")
 		},
 	}
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -56,6 +56,7 @@ const (
 	notificationPromptsListChanged   = "notifications/prompts/list_changed"
 	notificationResourcesListChanged = "notifications/resources/list_changed"
 	gatewayServerID                  = "kuadrant/id"
+	gatewaySourceURLKey              = "kuadrant/source-url"
 )
 
 type eventType int
@@ -927,15 +928,36 @@ func (man *MCPManager) findResourceConflicts(mcpResources []server.ServerResourc
 	if man.resourcesServer == nil {
 		return nil
 	}
-	metas := make(map[string]*mcp.Meta)
+	// build URI → source URL map for currently registered resources.
+	// resource URIs are globally unique per MCP spec but that uniqueness is per origin
+	// server — two registrations pointing to the same backend URL legitimately serve
+	// the same URIs (tools avoid this problem because prefixes make names unique).
+	// A conflict only exists when two different backend URLs claim the same URI.
+	existingURLByURI := make(map[string]string)
 	for uri, info := range man.resourcesServer.ListResources() {
-		metas[uri] = info.Resource.Meta
+		meta := info.Resource.Meta
+		if meta == nil || meta.AdditionalFields == nil {
+			continue
+		}
+		rawURL, ok := meta.AdditionalFields[gatewaySourceURLKey]
+		if !ok {
+			continue
+		}
+		if sourceURL, is := rawURL.(string); is {
+			existingURLByURI[uri] = sourceURL
+		}
 	}
-	newKeys := make([]string, 0, len(mcpResources))
+	currentURL := man.mcp.GetConfig().URL
+	var conflicting []string
 	for _, r := range mcpResources {
-		newKeys = append(newKeys, r.Resource.URI)
+		if existingURL, ok := existingURLByURI[r.Resource.URI]; ok && existingURL != currentURL {
+			conflicting = append(conflicting, r.Resource.URI)
+		}
 	}
-	return man.checkConflicts(newKeys, man.extractRegisteredServerIDs(metas, "resource"), "resource")
+	if len(conflicting) > 0 {
+		return fmt.Errorf("conflicting resources discovered. conflicting URIs %v", conflicting)
+	}
+	return nil
 }
 
 // GetManagedPrompts returns a copy of all prompts discovered from the upstream server.
@@ -967,7 +989,8 @@ func (man *MCPManager) SetPromptsForTesting(prompts []mcp.Prompt) {
 
 func (man *MCPManager) resourceToServerResource(newResource mcp.Resource) server.ServerResource {
 	newResource.Meta = mcp.NewMetaFromMap(map[string]any{
-		gatewayServerID: string(man.mcp.ID()),
+		gatewayServerID:     string(man.mcp.ID()),
+		gatewaySourceURLKey: man.mcp.GetConfig().URL,
 	})
 	return server.ServerResource{
 		Resource: newResource,

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -865,72 +865,73 @@ func (man *MCPManager) getPrompts(ctx context.Context) ([]mcp.Prompt, []mcp.Prom
 	return prompts, res.Prompts, nil
 }
 
+// checkConflicts returns an error if any of newKeys already exist in the gateway registered
+// by a different upstream server. existing maps each registered key to the server ID that owns it.
+func (man *MCPManager) checkConflicts(newKeys []string, existing map[string]string, itemType string) error {
+	var conflicting []string
+	for _, key := range newKeys {
+		if ownerID, ok := existing[key]; ok && ownerID != string(man.mcp.ID()) {
+			conflicting = append(conflicting, key)
+		}
+	}
+	if len(conflicting) > 0 {
+		return fmt.Errorf("conflicting %ss discovered. conflicting %s names %v", itemType, itemType, conflicting)
+	}
+	return nil
+}
+
+// extractRegisteredServerIDs builds a key→serverID map from a set of registered item metas.
+// Items with missing or invalid meta are logged (keyed by logLabel) and skipped.
+func (man *MCPManager) extractRegisteredServerIDs(metaByKey map[string]*mcp.Meta, logLabel string) map[string]string {
+	result := make(map[string]string, len(metaByKey))
+	for key, meta := range metaByKey {
+		if meta == nil || meta.AdditionalFields == nil {
+			man.logger.Error("unable to check conflict, meta is nil", "upstream mcp server", man.mcp.ID(), logLabel, key)
+			continue
+		}
+		rawID, ok := meta.AdditionalFields[gatewayServerID]
+		if !ok {
+			man.logger.Error("unable to check conflict, id is missing", "upstream mcp server", man.mcp.ID(), logLabel, key)
+			continue
+		}
+		id, is := rawID.(string)
+		if !is {
+			man.logger.Error("unable to check conflict, id is not a string", "upstream mcp server", man.mcp.ID(), logLabel, key, "type", reflect.TypeOf(rawID))
+			continue
+		}
+		result[key] = id
+	}
+	return result
+}
+
 func (man *MCPManager) findPromptConflicts(mcpPrompts []server.ServerPrompt) error {
 	if man.promptsServer == nil {
 		return nil
 	}
-	gatewayServerPrompts := man.promptsServer.ListPrompts()
-	var conflictingPromptNames []string
-	for _, prompt := range mcpPrompts {
-		for existingPromptName, existingPromptInfo := range gatewayServerPrompts {
-			existingPrompt := existingPromptInfo.Prompt
-			if existingPrompt.Meta == nil || existingPrompt.Meta.AdditionalFields == nil {
-				man.logger.Error("unable to check conflict, prompt meta is nil", "upstream mcp server", man.mcp.ID(), "prompt", existingPromptName)
-				continue
-			}
-			existingPromptID, ok := existingPrompt.Meta.AdditionalFields[gatewayServerID]
-			if !ok {
-				man.logger.Error("unable to check conflict, prompt id is missing", "upstream mcp server", man.mcp.ID())
-				continue
-			}
-			promptID, is := existingPromptID.(string)
-			if !is {
-				man.logger.Error("unable to check conflict, prompt id is not a string", "upstream mcp server", man.mcp.ID(), "type", reflect.TypeOf(existingPromptID))
-				continue
-			}
-			if existingPromptName == prompt.Prompt.Name && promptID != string(man.mcp.ID()) {
-				conflictingPromptNames = append(conflictingPromptNames, prompt.Prompt.Name)
-			}
-		}
+	metas := make(map[string]*mcp.Meta, len(mcpPrompts))
+	for name, info := range man.promptsServer.ListPrompts() {
+		metas[name] = info.Prompt.Meta
 	}
-	if len(conflictingPromptNames) > 0 {
-		return fmt.Errorf("conflicting prompts discovered. conflicting prompt names %v", conflictingPromptNames)
+	newKeys := make([]string, 0, len(mcpPrompts))
+	for _, p := range mcpPrompts {
+		newKeys = append(newKeys, p.Prompt.Name)
 	}
-	return nil
+	return man.checkConflicts(newKeys, man.extractRegisteredServerIDs(metas, "prompt"), "prompt")
 }
 
 func (man *MCPManager) findResourceConflicts(mcpResources []server.ServerResource) error {
 	if man.resourcesServer == nil {
 		return nil
 	}
-	gatewayServerResources := man.resourcesServer.ListResources()
-	var conflictingURIs []string
-	for _, resource := range mcpResources {
-		for existingURI, existingResourceInfo := range gatewayServerResources {
-			existingResource := existingResourceInfo.Resource
-			if existingResource.Meta == nil || existingResource.Meta.AdditionalFields == nil {
-				man.logger.Error("unable to check conflict, resource meta is nil", "upstream mcp server", man.mcp.ID(), "uri", existingURI)
-				continue
-			}
-			existingResourceID, ok := existingResource.Meta.AdditionalFields[gatewayServerID]
-			if !ok {
-				man.logger.Error("unable to check conflict, resource id is missing", "upstream mcp server", man.mcp.ID())
-				continue
-			}
-			resourceID, is := existingResourceID.(string)
-			if !is {
-				man.logger.Error("unable to check conflict, resource id is not a string", "upstream mcp server", man.mcp.ID(), "type", reflect.TypeOf(existingResourceID))
-				continue
-			}
-			if existingURI == resource.Resource.URI && resourceID != string(man.mcp.ID()) {
-				conflictingURIs = append(conflictingURIs, resource.Resource.URI)
-			}
-		}
+	metas := make(map[string]*mcp.Meta)
+	for uri, info := range man.resourcesServer.ListResources() {
+		metas[uri] = info.Resource.Meta
 	}
-	if len(conflictingURIs) > 0 {
-		return fmt.Errorf("conflicting resources discovered. conflicting URIs %v", conflictingURIs)
+	newKeys := make([]string, 0, len(mcpResources))
+	for _, r := range mcpResources {
+		newKeys = append(newKeys, r.Resource.URI)
 	}
-	return nil
+	return man.checkConflicts(newKeys, man.extractRegisteredServerIDs(metas, "resource"), "resource")
 }
 
 // GetManagedPrompts returns a copy of all prompts discovered from the upstream server.

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -520,26 +520,32 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 			man.logger.ErrorContext(ctx, "failed to list resources", "upstream mcp server", man.mcp.ID(), "error", resourceErr)
 		} else {
 			toAddResources, toRemoveResources := man.diffResources(currentResources, fetchedResources)
-			man.toolsLock.Lock()
-			man.resources = fetchedResources
-			man.resourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
-			man.servedResourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
-			for i := range fetchedResources {
-				man.resourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
-				man.servedResourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
-			}
-			man.serverResources = slices.DeleteFunc(man.serverResources, func(r server.ServerResource) bool {
-				return slices.Contains(toRemoveResources, r.Resource.URI)
-			})
-			man.serverResources = append(man.serverResources, toAddResources...)
-			man.toolsLock.Unlock()
+			if conflictErr := man.findResourceConflicts(toAddResources); conflictErr != nil {
+				resourceErr = fmt.Errorf("upstream mcp failed to add resources to gateway %s : %w", man.mcp.ID(), conflictErr)
+				man.recordBackendError(span, resourceErr)
+				man.logger.ErrorContext(ctx, "resource conflict detected", "upstream mcp server", man.mcp.ID(), "error", resourceErr)
+			} else {
+				man.toolsLock.Lock()
+				man.resources = fetchedResources
+				man.resourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
+				man.servedResourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
+				for i := range fetchedResources {
+					man.resourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
+					man.servedResourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
+				}
+				man.serverResources = slices.DeleteFunc(man.serverResources, func(r server.ServerResource) bool {
+					return slices.Contains(toRemoveResources, r.Resource.URI)
+				})
+				man.serverResources = append(man.serverResources, toAddResources...)
+				man.toolsLock.Unlock()
 
-			man.logger.DebugContext(ctx, "updating gateway resources", "upstream mcp server", man.mcp.ID(), "adding", len(toAddResources), "removing", len(toRemoveResources))
-			if len(toRemoveResources) > 0 {
-				man.resourcesServer.DeleteResources(toRemoveResources...)
-			}
-			if len(toAddResources) > 0 {
-				man.resourcesServer.AddResources(toAddResources...)
+				man.logger.DebugContext(ctx, "updating gateway resources", "upstream mcp server", man.mcp.ID(), "adding", len(toAddResources), "removing", len(toRemoveResources))
+				if len(toRemoveResources) > 0 {
+					man.resourcesServer.DeleteResources(toRemoveResources...)
+				}
+				if len(toAddResources) > 0 {
+					man.resourcesServer.AddResources(toAddResources...)
+				}
 			}
 		}
 	}
@@ -889,6 +895,40 @@ func (man *MCPManager) findPromptConflicts(mcpPrompts []server.ServerPrompt) err
 	}
 	if len(conflictingPromptNames) > 0 {
 		return fmt.Errorf("conflicting prompts discovered. conflicting prompt names %v", conflictingPromptNames)
+	}
+	return nil
+}
+
+func (man *MCPManager) findResourceConflicts(mcpResources []server.ServerResource) error {
+	if man.resourcesServer == nil {
+		return nil
+	}
+	gatewayServerResources := man.resourcesServer.ListResources()
+	var conflictingURIs []string
+	for _, resource := range mcpResources {
+		for existingURI, existingResourceInfo := range gatewayServerResources {
+			existingResource := existingResourceInfo.Resource
+			if existingResource.Meta == nil || existingResource.Meta.AdditionalFields == nil {
+				man.logger.Error("unable to check conflict, resource meta is nil", "upstream mcp server", man.mcp.ID(), "uri", existingURI)
+				continue
+			}
+			existingResourceID, ok := existingResource.Meta.AdditionalFields[gatewayServerID]
+			if !ok {
+				man.logger.Error("unable to check conflict, resource id is missing", "upstream mcp server", man.mcp.ID())
+				continue
+			}
+			resourceID, is := existingResourceID.(string)
+			if !is {
+				man.logger.Error("unable to check conflict, resource id is not a string", "upstream mcp server", man.mcp.ID(), "type", reflect.TypeOf(existingResourceID))
+				continue
+			}
+			if existingURI == resource.Resource.URI && resourceID != string(man.mcp.ID()) {
+				conflictingURIs = append(conflictingURIs, resource.Resource.URI)
+			}
+		}
+	}
+	if len(conflictingURIs) > 0 {
+		return fmt.Errorf("conflicting resources discovered. conflicting URIs %v", conflictingURIs)
 	}
 	return nil
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -1054,6 +1054,6 @@ func (man *MCPManager) SetResourcesForTesting(resources []mcp.Resource) {
 	for i := range resources {
 		man.resourcesMap[resources[i].URI] = &resources[i]
 		man.servedResourcesMap[resources[i].URI] = &resources[i]
-		man.serverResources = append(man.serverResources, server.ServerResource{Resource: resources[i]})
+		man.serverResources = append(man.serverResources, man.resourceToServerResource(resources[i]))
 	}
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -44,10 +44,18 @@ type PromptsAdderDeleter interface {
 	ListPrompts() map[string]*server.ServerPrompt
 }
 
+// ResourcesAdderDeleter defines the interface for managing resources on the gateway server
+type ResourcesAdderDeleter interface {
+	AddResources(resources ...server.ServerResource)
+	DeleteResources(uris ...string)
+	ListResources() map[string]*server.ServerResource
+}
+
 const (
-	notificationToolsListChanged   = "notifications/tools/list_changed"
-	notificationPromptsListChanged = "notifications/prompts/list_changed"
-	gatewayServerID                = "kuadrant/id"
+	notificationToolsListChanged     = "notifications/tools/list_changed"
+	notificationPromptsListChanged   = "notifications/prompts/list_changed"
+	notificationResourcesListChanged = "notifications/resources/list_changed"
+	gatewayServerID                  = "kuadrant/id"
 )
 
 type eventType int
@@ -56,6 +64,7 @@ const (
 	eventTypeTimer eventType = iota
 	eventTypeToolNotification
 	eventTypePromptNotification
+	eventTypeResourceNotification
 )
 
 // ServerValidationStatus contains the validation results for an upstream MCP server
@@ -86,6 +95,9 @@ type MCP interface {
 	ListPrompts(context.Context, mcp.ListPromptsRequest) (*mcp.ListPromptsResult, error)
 	SupportsPrompts() bool
 	SupportsPromptsListChanged() bool
+	ListResources(context.Context, mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error)
+	SupportsResources() bool
+	SupportsResourcesListChanged() bool
 	OnNotification(func(notification mcp.JSONRPCNotification))
 	OnConnectionLost(func(err error))
 	Ping(context.Context) error
@@ -103,6 +115,8 @@ type ActiveMCPServer interface {
 	GetServedManagedTool(toolName string) *mcp.Tool
 	GetManagedPrompts() []mcp.Prompt
 	GetServedManagedPrompt(promptName string) *mcp.Prompt
+	GetManagedResources() []mcp.Resource
+	GetServedManagedResource(uri string) *mcp.Resource
 	Config() config.MCPServer
 }
 
@@ -133,7 +147,15 @@ type MCPManager struct {
 	promptsMap       map[string]*mcp.Prompt
 	servedPromptsMap map[string]*mcp.Prompt
 
-	// toolsLock protects tools, serverTools, prompts, serverPrompts
+	resourcesServer ResourcesAdderDeleter
+	// serverResources is an internal copy of resources registered with the gateway
+	serverResources []server.ServerResource
+	// resources is the original set from MCP server
+	resources          []mcp.Resource
+	resourcesMap       map[string]*mcp.Resource
+	servedResourcesMap map[string]*mcp.Resource
+
+	// toolsLock protects tools, serverTools, prompts, serverPrompts, resources
 	toolsLock sync.RWMutex
 
 	logger *slog.Logger
@@ -141,14 +163,15 @@ type MCPManager struct {
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy mcpv1alpha1.InvalidToolPolicy
 
-	// toolEvents and promptEvents funnel notifications into the Start() loop.
+	// toolEvents, promptEvents, and resourceEvents funnel notifications into the Start() loop.
 	// Separate channels with buffer of 1 each ensure a tool notification cannot
-	// block a prompt notification (or vice versa) while still coalescing rapid
+	// block a prompt or resource notification while still coalescing rapid
 	// same-type notifications.
-	toolEvents   chan struct{}
-	promptEvents chan struct{}
-	done         chan struct{} // closed when the event loop exits
-	status       ServerValidationStatus
+	toolEvents     chan struct{}
+	promptEvents   chan struct{}
+	resourceEvents chan struct{}
+	done           chan struct{} // closed when the event loop exits
+	status         ServerValidationStatus
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
@@ -157,7 +180,7 @@ const DefaultTickerInterval = time.Minute * 1
 // NewUpstreamMCPManager creates a new MCPManager for managing a single upstream MCP server.
 // The addTools and removeTools callbacks are used to update the gateway's tool registry.
 // The tickerInterval controls how often the manager checks backend health (use 0 for default).
-func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, promptsServer PromptsAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) (*MCPManager, error) {
+func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, promptsServer PromptsAdderDeleter, resourcesServer ResourcesAdderDeleter, logger *slog.Logger, tickerInterval time.Duration, policy mcpv1alpha1.InvalidToolPolicy) (*MCPManager, error) {
 	if gatewayServer == nil {
 		return nil, fmt.Errorf("gateway server is required for upstream MCP manager")
 	}
@@ -174,24 +197,29 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 	}
 
 	return &MCPManager{
-		mcp:               upstream,
-		gatewayServer:     gatewayServer,
-		promptsServer:     promptsServer,
-		tickerInterval:    tickerInterval,
-		ticker:            time.NewTicker(tickerInterval),
-		backoff:           bo,
-		baseBackoff:       bo,
-		logger:            logger,
-		invalidToolPolicy: policy,
-		toolEvents:        make(chan struct{}, 1),
-		promptEvents:      make(chan struct{}, 1),
-		done:              make(chan struct{}),
-		toolsMap:          map[string]*mcp.Tool{},
-		servedToolsMap:    map[string]*mcp.Tool{},
-		serverTools:       []server.ServerTool{},
-		promptsMap:        map[string]*mcp.Prompt{},
-		servedPromptsMap:  map[string]*mcp.Prompt{},
-		serverPrompts:     []server.ServerPrompt{},
+		mcp:                upstream,
+		gatewayServer:      gatewayServer,
+		promptsServer:      promptsServer,
+		resourcesServer:    resourcesServer,
+		tickerInterval:     tickerInterval,
+		ticker:             time.NewTicker(tickerInterval),
+		backoff:            bo,
+		baseBackoff:        bo,
+		logger:             logger,
+		invalidToolPolicy:  policy,
+		toolEvents:         make(chan struct{}, 1),
+		promptEvents:       make(chan struct{}, 1),
+		resourceEvents:     make(chan struct{}, 1),
+		done:               make(chan struct{}),
+		toolsMap:           map[string]*mcp.Tool{},
+		servedToolsMap:     map[string]*mcp.Tool{},
+		serverTools:        []server.ServerTool{},
+		promptsMap:         map[string]*mcp.Prompt{},
+		servedPromptsMap:   map[string]*mcp.Prompt{},
+		serverPrompts:      []server.ServerPrompt{},
+		resourcesMap:       map[string]*mcp.Resource{},
+		servedResourcesMap: map[string]*mcp.Resource{},
+		serverResources:    []server.ServerResource{},
 	}, nil
 }
 
@@ -216,6 +244,7 @@ func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 				if err := man.mcp.Disconnect(); err != nil {
 					man.logger.Error("failed to disconnect during stop", "upstream mcp server", man.mcp.ID(), "error", err)
 				}
+				man.removeAllResources()
 				man.removeAllPrompts()
 				man.removeAllTools()
 
@@ -231,6 +260,9 @@ func (man *MCPManager) Start(ctx context.Context) ActiveMCPServer {
 			case <-man.promptEvents:
 				man.logger.DebugContext(ctx, "received prompt notification", "upstream mcp server", man.mcp.ID())
 				man.manage(ctx, eventTypePromptNotification)
+			case <-man.resourceEvents:
+				man.logger.DebugContext(ctx, "received resource notification", "upstream mcp server", man.mcp.ID())
+				man.manage(ctx, eventTypeResourceNotification)
 			}
 		}
 	}()
@@ -257,6 +289,10 @@ func (a *activeMCP) GetManagedPrompts() []mcp.Prompt { return a.manager.GetManag
 func (a *activeMCP) GetServedManagedPrompt(p string) *mcp.Prompt {
 	return a.manager.GetServedManagedPrompt(p)
 }
+func (a *activeMCP) GetManagedResources() []mcp.Resource { return a.manager.GetManagedResources() }
+func (a *activeMCP) GetServedManagedResource(uri string) *mcp.Resource {
+	return a.manager.GetServedManagedResource(uri)
+}
 func (a *activeMCP) Config() config.MCPServer { return a.manager.mcp.GetConfig() }
 
 func (man *MCPManager) registerCallbacks() func() {
@@ -274,6 +310,12 @@ func (man *MCPManager) registerCallbacks() func() {
 				man.logger.Debug("received notification", "upstream mcp server", man.mcp.ID(), "notification", notification.Method)
 				select {
 				case man.promptEvents <- struct{}{}:
+				default:
+				}
+			case notificationResourcesListChanged:
+				man.logger.Debug("received notification", "upstream mcp server", man.mcp.ID(), "notification", notification.Method)
+				select {
+				case man.resourceEvents <- struct{}{}:
 				default:
 				}
 			}
@@ -302,7 +344,8 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	// If disabled, remove all tools and prompts, set status to not ready, and return.
 	// The manager stays alive and will check again on the next ticker tick.
 	if !man.mcp.IsEnabled() {
-		man.logger.Debug("server is not enabled, removing tools and prompts", "upstream mcp server", man.mcp.ID())
+		man.logger.Debug("server is not enabled, removing tools, prompts, and resources", "upstream mcp server", man.mcp.ID())
+		man.removeAllResources()
 		man.removeAllTools()
 		man.removeAllPrompts()
 		_ = man.mcp.Disconnect()
@@ -318,6 +361,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.mcp.ID(), err)
 		man.recordBackendError(span, err)
 		man.logger.ErrorContext(ctx, "connection failed", "upstream mcp server", man.mcp.ID(), "error", err)
+		man.removeAllResources()
 		man.removeAllTools()
 		man.removeAllPrompts()
 		// we call disconnect here as we may have connected but failed to initialize
@@ -331,6 +375,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		err = fmt.Errorf("upstream mcp failed to ping server %s removing tools : %w", man.mcp.ID(), err)
 		man.recordBackendError(span, err)
 		man.logger.ErrorContext(ctx, "ping failed", "upstream mcp server", man.mcp.ID(), "error", err)
+		man.removeAllResources()
 		man.removeAllTools()
 		man.removeAllPrompts()
 		_ = man.mcp.Disconnect()
@@ -466,7 +511,40 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 			}
 		}
 	}
-	jointErr := errors.Join(toolErr, promptErr)
+	var resourceErr error
+	if man.resourcesServer != nil && man.mcp.SupportsResources() && man.shouldFetchResources(event) {
+		currentResources, fetchedResources, listErr := man.getResources(ctx)
+		if listErr != nil {
+			resourceErr = fmt.Errorf("upstream mcp failed to list resources server %s : %w", man.mcp.ID(), listErr)
+			man.recordBackendError(span, resourceErr)
+			man.logger.ErrorContext(ctx, "failed to list resources", "upstream mcp server", man.mcp.ID(), "error", resourceErr)
+		} else {
+			toAddResources, toRemoveResources := man.diffResources(currentResources, fetchedResources)
+			man.toolsLock.Lock()
+			man.resources = fetchedResources
+			man.resourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
+			man.servedResourcesMap = make(map[string]*mcp.Resource, len(fetchedResources))
+			for i := range fetchedResources {
+				man.resourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
+				man.servedResourcesMap[fetchedResources[i].URI] = &fetchedResources[i]
+			}
+			man.serverResources = slices.DeleteFunc(man.serverResources, func(r server.ServerResource) bool {
+				return slices.Contains(toRemoveResources, r.Resource.URI)
+			})
+			man.serverResources = append(man.serverResources, toAddResources...)
+			man.toolsLock.Unlock()
+
+			man.logger.DebugContext(ctx, "updating gateway resources", "upstream mcp server", man.mcp.ID(), "adding", len(toAddResources), "removing", len(toRemoveResources))
+			if len(toRemoveResources) > 0 {
+				man.resourcesServer.DeleteResources(toRemoveResources...)
+			}
+			if len(toAddResources) > 0 {
+				man.resourcesServer.AddResources(toAddResources...)
+			}
+		}
+	}
+
+	jointErr := errors.Join(toolErr, promptErr, resourceErr)
 	man.setStatus(jointErr, numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
 	if jointErr != nil {
 		man.applyBackoff()
@@ -494,6 +572,16 @@ func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
 		return true
 	}
 	return event == eventTypeTimer && len(man.serverPrompts) == 0
+}
+
+func (man *MCPManager) shouldFetchResources(event eventType) bool {
+	if !man.mcp.SupportsResourcesListChanged() {
+		return true
+	}
+	if event == eventTypeResourceNotification {
+		return true
+	}
+	return event == eventTypeTimer && len(man.serverResources) == 0
 }
 
 // GetStatus returns the current status of the MCP Server
@@ -829,5 +917,102 @@ func (man *MCPManager) SetPromptsForTesting(prompts []mcp.Prompt) {
 	for i := range prompts {
 		man.promptsMap[prompts[i].Name] = &prompts[i]
 		man.servedPromptsMap[prefixedName(man.mcp.GetPrefix(), prompts[i].Name)] = &prompts[i]
+	}
+}
+
+func (man *MCPManager) resourceToServerResource(newResource mcp.Resource) server.ServerResource {
+	newResource.Meta = mcp.NewMetaFromMap(map[string]any{
+		gatewayServerID: string(man.mcp.ID()),
+	})
+	return server.ServerResource{
+		Resource: newResource,
+		Handler: func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			return []mcp.ResourceContents{}, nil
+		},
+	}
+}
+
+func (man *MCPManager) diffResources(oldResources, newResources []mcp.Resource) ([]server.ServerResource, []string) {
+	oldMap := make(map[string]mcp.Resource)
+	for _, r := range oldResources {
+		oldMap[r.URI] = r
+	}
+
+	newMap := make(map[string]mcp.Resource)
+	for _, r := range newResources {
+		newMap[r.URI] = r
+	}
+
+	added := make([]server.ServerResource, 0)
+	for _, r := range newMap {
+		if _, ok := oldMap[r.URI]; !ok {
+			added = append(added, man.resourceToServerResource(r))
+		}
+	}
+
+	removed := make([]string, 0)
+	for _, r := range oldMap {
+		if _, ok := newMap[r.URI]; !ok {
+			removed = append(removed, r.URI)
+		}
+	}
+
+	return added, removed
+}
+
+// getResources returns the existing and new resources. Must only be called from the Start() event loop.
+func (man *MCPManager) getResources(ctx context.Context) ([]mcp.Resource, []mcp.Resource, error) {
+	resources := make([]mcp.Resource, len(man.resources))
+	copy(resources, man.resources)
+	res, err := man.mcp.ListResources(ctx, mcp.ListResourcesRequest{})
+	if err != nil {
+		return resources, resources, fmt.Errorf("failed to get resources: %w", err)
+	}
+	return resources, res.Resources, nil
+}
+
+func (man *MCPManager) removeAllResources() {
+	if man.resourcesServer == nil {
+		return
+	}
+	man.toolsLock.Lock()
+	toRemove := make([]string, 0, len(man.serverResources))
+	for _, r := range man.serverResources {
+		toRemove = append(toRemove, r.Resource.URI)
+	}
+	man.serverResources = []server.ServerResource{}
+	man.resources = []mcp.Resource{}
+	man.resourcesMap = map[string]*mcp.Resource{}
+	man.servedResourcesMap = map[string]*mcp.Resource{}
+	man.toolsLock.Unlock()
+	man.resourcesServer.DeleteResources(toRemove...)
+}
+
+// GetManagedResources returns a copy of all resources discovered from the upstream server.
+func (man *MCPManager) GetManagedResources() []mcp.Resource {
+	man.toolsLock.RLock()
+	result := make([]mcp.Resource, len(man.resources))
+	copy(result, man.resources)
+	man.toolsLock.RUnlock()
+	return result
+}
+
+// GetServedManagedResource returns the resource if present that is being served by the gateway.
+func (man *MCPManager) GetServedManagedResource(uri string) *mcp.Resource {
+	man.toolsLock.RLock()
+	defer man.toolsLock.RUnlock()
+	return man.servedResourcesMap[uri]
+}
+
+// SetResourcesForTesting sets resources directly for testing purposes.
+func (man *MCPManager) SetResourcesForTesting(resources []mcp.Resource) {
+	man.toolsLock.Lock()
+	defer man.toolsLock.Unlock()
+	man.resources = resources
+	man.serverResources = make([]server.ServerResource, 0, len(resources))
+	for i := range resources {
+		man.resourcesMap[resources[i].URI] = &resources[i]
+		man.servedResourcesMap[resources[i].URI] = &resources[i]
+		man.serverResources = append(man.serverResources, server.ServerResource{Resource: resources[i]})
 	}
 }

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -399,7 +399,7 @@ func TestMCPManager_setStatus(t *testing.T) {
 			require.NoError(t, err)
 			manager.serverTools = make([]server.ServerTool, tc.numServerTools)
 
-			manager.setStatus(tc.err, tc.totalTools, 0, nil, nil)
+			manager.setStatus(tc.err, tc.totalTools, 0, 0, nil, nil)
 
 			assert.Equal(t, string(mock.id), manager.status.ID)
 			assert.Equal(t, "test-server", manager.status.Name)

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -112,7 +112,7 @@ func (m *MockMCP) SupportsResources() bool {
 }
 
 func (m *MockMCP) SupportsResourcesListChanged() bool {
-	return m.hasResourcesListChangedCap
+	return m.hasResourcesCap && m.hasResourcesListChangedCap
 }
 
 func (m *MockMCP) ListResources(_ context.Context, _ mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
@@ -1682,6 +1682,7 @@ func TestMCPManager_shouldFetchResources(t *testing.T) {
 
 	t.Run("returns true on resource notification event", func(t *testing.T) {
 		mock := newMockMCP("test", "")
+		mock.hasResourcesCap = true
 		mock.hasResourcesListChangedCap = true
 		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 		require.NoError(t, err)
@@ -1690,6 +1691,7 @@ func TestMCPManager_shouldFetchResources(t *testing.T) {
 
 	t.Run("returns true on timer when no resources cached", func(t *testing.T) {
 		mock := newMockMCP("test", "")
+		mock.hasResourcesCap = true
 		mock.hasResourcesListChangedCap = true
 		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 		require.NoError(t, err)
@@ -1698,6 +1700,7 @@ func TestMCPManager_shouldFetchResources(t *testing.T) {
 
 	t.Run("returns false on timer when resources already cached", func(t *testing.T) {
 		mock := newMockMCP("test", "")
+		mock.hasResourcesCap = true
 		mock.hasResourcesListChangedCap = true
 		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 		require.NoError(t, err)

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1509,6 +1509,165 @@ func TestMCPManager_Backoff(t *testing.T) {
 	assert.True(t, manager.GetStatus().Ready)
 }
 
+func TestDiffResources(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mock := newMockMCP("test-server", "")
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		oldResources    []mcp.Resource
+		newResources    []mcp.Resource
+		expectedAdded   int
+		expectedRemoved int
+		addedURIs       []string
+		removedURIs     []string
+	}{
+		{
+			name:            "no changes",
+			oldResources:    []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			newResources:    []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			expectedAdded:   0,
+			expectedRemoved: 0,
+		},
+		{
+			name:          "add new resource",
+			oldResources:  []mcp.Resource{{URI: "test://r1"}},
+			newResources:  []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			expectedAdded: 1,
+			addedURIs:     []string{"test://r2"},
+		},
+		{
+			name:            "remove resource",
+			oldResources:    []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			newResources:    []mcp.Resource{{URI: "test://r1"}},
+			expectedRemoved: 1,
+			removedURIs:     []string{"test://r2"},
+		},
+		{
+			name:            "add and remove",
+			oldResources:    []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			newResources:    []mcp.Resource{{URI: "test://r1"}, {URI: "test://r3"}},
+			expectedAdded:   1,
+			expectedRemoved: 1,
+			addedURIs:       []string{"test://r3"},
+			removedURIs:     []string{"test://r2"},
+		},
+		{
+			name:          "empty old",
+			oldResources:  []mcp.Resource{},
+			newResources:  []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			expectedAdded: 2,
+		},
+		{
+			name:            "empty new",
+			oldResources:    []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}},
+			newResources:    []mcp.Resource{},
+			expectedRemoved: 2,
+		},
+		{
+			name:         "both empty",
+			oldResources: []mcp.Resource{},
+			newResources: []mcp.Resource{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			added, removed := manager.diffResources(tt.oldResources, tt.newResources)
+			assert.Len(t, added, tt.expectedAdded, "unexpected number of added resources")
+			assert.Len(t, removed, tt.expectedRemoved, "unexpected number of removed resources")
+			for _, uri := range tt.addedURIs {
+				uris := make([]string, len(added))
+				for i, r := range added {
+					uris[i] = r.Resource.URI
+				}
+				assert.Contains(t, uris, uri)
+			}
+			for _, uri := range tt.removedURIs {
+				assert.Contains(t, removed, uri)
+			}
+		})
+	}
+}
+
+func TestMCPManager_removeAllResources(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("DeleteResources called on connect failure", func(t *testing.T) {
+		mock := newMockMCP("test-server", "")
+		mock.hasResourcesCap = true
+		mock.hasResourcesListChangedCap = false
+		mock.resources = []mcp.Resource{{URI: "test://r1"}}
+		gateway := newMockToolsAdderDeleter()
+		resourcesGateway := newMockResourcesAdderDeleter()
+		manager, err := NewUpstreamMCPManager(mock, gateway, nil, resourcesGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+
+		// establish resources
+		manager.manage(t.Context(), eventTypeTimer)
+		assert.Len(t, resourcesGateway.resources, 1)
+
+		// simulate connection failure on next tick
+		mock.connectErr = fmt.Errorf("connection refused")
+		manager.manage(t.Context(), eventTypeTimer)
+
+		assert.Len(t, resourcesGateway.resources, 0, "resources should be removed on connect failure")
+		assert.Equal(t, 1, resourcesGateway.delCalls)
+	})
+
+	t.Run("DeleteResources called on ping failure", func(t *testing.T) {
+		mock := newMockMCP("test-server", "")
+		mock.hasResourcesCap = true
+		mock.hasResourcesListChangedCap = false
+		mock.resources = []mcp.Resource{{URI: "test://r1"}, {URI: "test://r2"}}
+		gateway := newMockToolsAdderDeleter()
+		resourcesGateway := newMockResourcesAdderDeleter()
+		manager, err := NewUpstreamMCPManager(mock, gateway, nil, resourcesGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+
+		manager.manage(t.Context(), eventTypeTimer)
+		assert.Len(t, resourcesGateway.resources, 2)
+
+		mock.pingErr = fmt.Errorf("ping timeout")
+		manager.manage(t.Context(), eventTypeTimer)
+
+		assert.Len(t, resourcesGateway.resources, 0, "resources should be removed on ping failure")
+		assert.Equal(t, 1, resourcesGateway.delCalls)
+	})
+
+	t.Run("DeleteResources called when server disabled", func(t *testing.T) {
+		mock := newMockMCP("test-server", "")
+		mock.hasResourcesCap = true
+		mock.hasResourcesListChangedCap = false
+		mock.resources = []mcp.Resource{{URI: "test://r1"}}
+		gateway := newMockToolsAdderDeleter()
+		resourcesGateway := newMockResourcesAdderDeleter()
+		manager, err := NewUpstreamMCPManager(mock, gateway, nil, resourcesGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+
+		manager.manage(t.Context(), eventTypeTimer)
+		assert.Len(t, resourcesGateway.resources, 1)
+
+		mock.cfg.State = string(mcpv1alpha1.ServerStateDisabled)
+		manager.manage(t.Context(), eventTypeTimer)
+
+		assert.Len(t, resourcesGateway.resources, 0, "resources should be removed when server is disabled")
+		assert.Equal(t, 1, resourcesGateway.delCalls)
+	})
+
+	t.Run("no-op when resourcesServer is nil", func(t *testing.T) {
+		mock := newMockMCP("test-server", "")
+		mock.connectErr = fmt.Errorf("fail")
+		gateway := newMockToolsAdderDeleter()
+		manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		// should not panic
+		manager.manage(t.Context(), eventTypeTimer)
+	})
+}
+
 func TestMCPManager_shouldFetchResources(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -20,22 +20,26 @@ import (
 
 // MockMCP implements the MCP interface for testing
 type MockMCP struct {
-	name                string
-	prefix              string
-	id                  config.UpstreamMCPID
-	cfg                 *config.MCPServer
-	connectErr          error
-	pingErr             error
-	tools               []mcp.Tool
-	listToolsErr        error
-	listToolsDelay      time.Duration
-	prompts             []mcp.Prompt
-	listPromptsErr      error
-	protocolVersion     string
-	hasToolsCap         bool
-	hasPromptsCap       bool
-	connected           atomic.Bool
-	notificationHandler func(mcp.JSONRPCNotification)
+	name                       string
+	prefix                     string
+	id                         config.UpstreamMCPID
+	cfg                        *config.MCPServer
+	connectErr                 error
+	pingErr                    error
+	tools                      []mcp.Tool
+	listToolsErr               error
+	listToolsDelay             time.Duration
+	prompts                    []mcp.Prompt
+	listPromptsErr             error
+	resources                  []mcp.Resource
+	listResourcesErr           error
+	protocolVersion            string
+	hasToolsCap                bool
+	hasPromptsCap              bool
+	hasResourcesCap            bool
+	hasResourcesListChangedCap bool
+	connected                  atomic.Bool
+	notificationHandler        func(mcp.JSONRPCNotification)
 }
 
 func (m *MockMCP) GetName() string {
@@ -101,6 +105,21 @@ func (m *MockMCP) ListPrompts(_ context.Context, _ mcp.ListPromptsRequest) (*mcp
 		return nil, m.listPromptsErr
 	}
 	return &mcp.ListPromptsResult{Prompts: m.prompts}, nil
+}
+
+func (m *MockMCP) SupportsResources() bool {
+	return m.hasResourcesCap
+}
+
+func (m *MockMCP) SupportsResourcesListChanged() bool {
+	return m.hasResourcesListChangedCap
+}
+
+func (m *MockMCP) ListResources(_ context.Context, _ mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	if m.listResourcesErr != nil {
+		return nil, m.listResourcesErr
+	}
+	return &mcp.ListResourcesResult{Resources: m.resources}, nil
 }
 
 func (m *MockMCP) OnNotification(handler func(notification mcp.JSONRPCNotification)) {
@@ -211,7 +230,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP(tc.name, "")
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, tc.interval, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedInterval, manager.tickerInterval)
 		})
@@ -221,7 +240,7 @@ func TestNewUpstreamMCPManager(t *testing.T) {
 func TestMCPManager_MCPName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("my-test-server", "prefix_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-test-server", manager.MCPName())
@@ -230,7 +249,7 @@ func TestMCPManager_MCPName(t *testing.T) {
 func TestMCPManager_GetStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	expectedStatus := ServerValidationStatus{
@@ -254,7 +273,7 @@ func TestMCPManager_GetManagedTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tools := []mcp.Tool{
@@ -274,7 +293,7 @@ func TestMCPManager_GetManagedTools_ReturnsCopy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tools := []mcp.Tool{validTool("tool1")}
@@ -329,7 +348,7 @@ func TestMCPManager_GetServedManagedTool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tc.prefix)
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 			manager.SetToolsForTesting(tc.tools)
 
@@ -376,7 +395,7 @@ func TestMCPManager_setStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
-			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 			manager.serverTools = make([]server.ServerTool, tc.numServerTools)
 
@@ -431,7 +450,7 @@ func TestPrefixedName(t *testing.T) {
 func TestMCPManager_toolToServerTool(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tool := mcp.Tool{
@@ -460,7 +479,7 @@ func TestMCPManager_Stop_Idempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test", "")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	active := manager.Start(context.Background())
@@ -479,10 +498,10 @@ func TestMCPManager_manage_ConnectError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.connectErr = fmt.Errorf("connection refused")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.False(t, status.Ready)
@@ -494,10 +513,10 @@ func TestMCPManager_manage_PingError(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.pingErr = fmt.Errorf("ping timeout")
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.False(t, status.Ready)
@@ -510,10 +529,10 @@ func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	mock.listToolsErr = fmt.Errorf("list tools failed")
 	mock.hasToolsCap = false // ensure we try to list tools
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.False(t, status.Ready)
@@ -526,10 +545,10 @@ func TestMCPManager_manage_Success(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false // ensure we list tools every time
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready)
@@ -548,10 +567,10 @@ func TestMCPManager_manage_UserSpecificList_SkipsToolCaching(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready, "server should be healthy")
@@ -568,7 +587,7 @@ func TestMCPManager_manage_UserSpecificList_SkipsToolCaching(t *testing.T) {
 func TestDiffTools(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -750,7 +769,7 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = tt.supportsToolsListChange
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			if tt.hasExistingTools {
@@ -770,11 +789,11 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true // supports tools list change notifications
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	// First call with notification - should fetch and add tools
-	manager.manage(context.Background(), eventTypeToolNotification)
+	manager.manage(t.Context(), eventTypeToolNotification)
 	assert.Equal(t, 1, gateway.addCalls, "should add tools on notification")
 	assert.Len(t, gateway.tools, 1)
 
@@ -782,12 +801,12 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 
 	// Timer event - should skip fetching since we support notifications and have tools
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 	assert.Equal(t, 1, gateway.addCalls, "should not fetch tools on timer when notifications supported")
 	assert.Len(t, gateway.tools, 1, "tools should remain unchanged")
 
 	// Notification event - should fetch and update tools
-	manager.manage(context.Background(), eventTypeToolNotification)
+	manager.manage(t.Context(), eventTypeToolNotification)
 	assert.Equal(t, 2, gateway.addCalls, "should fetch tools on notification")
 	assert.Len(t, gateway.tools, 2, "tools should be updated")
 }
@@ -852,7 +871,7 @@ func TestMCPManager_manage_OnlyCallsAddDeleteWhenNeeded(t *testing.T) {
 			mock := newMockMCP("test-server", "test_")
 			mock.hasToolsCap = false // ensure we fetch tools on every manage call
 			gateway := newMockToolsAdderDeleter()
-			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			// first manage call - establish initial tools
@@ -946,7 +965,7 @@ func TestServerToolsManagement(t *testing.T) {
 			mockMCP := newMockMCP("test-server", tt.prefix)
 			mockMCP.hasToolsCap = false // ensure we fetch tools on every manage call
 			mockGateway := NewMockGatewayServer()
-			manager, err := NewUpstreamMCPManager(mockMCP, mockGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mockMCP, mockGateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			// First manage call - establish initial tools
@@ -997,10 +1016,10 @@ func TestMCPManager_manage_FilterOutPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready)
@@ -1021,10 +1040,10 @@ func TestMCPManager_manage_FilterOutPolicy_AllInvalid(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready)
@@ -1042,10 +1061,10 @@ func TestMCPManager_manage_RejectServerPolicy(t *testing.T) {
 	}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyRejectServer)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.False(t, status.Ready)
@@ -1060,10 +1079,10 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready)
@@ -1076,7 +1095,7 @@ func TestMCPManager_manage_AllValidTools(t *testing.T) {
 func TestMCPManager_NewUpstreamMCPManager_nilGateway(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	_, err := NewUpstreamMCPManager(mock, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	_, err := NewUpstreamMCPManager(mock, nil, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gateway server is required")
 }
@@ -1087,7 +1106,7 @@ func TestMCPManager_EventChannel_NotificationRoutesThrough(t *testing.T) {
 	mock.tools = []mcp.Tool{validTool("tool1")}
 	mock.hasToolsCap = true
 	gateway := NewMockGatewayServer()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1121,7 +1140,7 @@ func TestMCPManager_ConcurrentReadsDuringManage(t *testing.T) {
 	mock := newMockMCP("test-server", "test_")
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -1167,7 +1186,7 @@ func TestMCPManager_StopDuringManage(t *testing.T) {
 	// slow down ListTools so manage() is mid-flight when Stop() fires
 	mock.listToolsDelay = 100 * time.Millisecond
 	gateway := NewMockGatewayServer()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	active := manager.Start(context.Background())
@@ -1229,6 +1248,48 @@ func (m *MockPromptsAdderDeleter) ListPrompts() map[string]*server.ServerPrompt 
 	return result
 }
 
+// MockResourcesAdderDeleter implements ResourcesAdderDeleter for testing
+type MockResourcesAdderDeleter struct {
+	resources map[string]*server.ServerResource
+	addCalls  int
+	delCalls  int
+	mu        sync.Mutex
+}
+
+func newMockResourcesAdderDeleter() *MockResourcesAdderDeleter {
+	return &MockResourcesAdderDeleter{
+		resources: make(map[string]*server.ServerResource),
+	}
+}
+
+func (m *MockResourcesAdderDeleter) AddResources(resources ...server.ServerResource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.addCalls++
+	for i := range resources {
+		m.resources[resources[i].Resource.URI] = &resources[i]
+	}
+}
+
+func (m *MockResourcesAdderDeleter) DeleteResources(uris ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.delCalls++
+	for _, uri := range uris {
+		delete(m.resources, uri)
+	}
+}
+
+func (m *MockResourcesAdderDeleter) ListResources() map[string]*server.ServerResource {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]*server.ServerResource, len(m.resources))
+	for k, v := range m.resources {
+		result[k] = v
+	}
+	return result
+}
+
 func TestMCPManager_promptToServerPrompt(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
@@ -1246,7 +1307,7 @@ func TestMCPManager_promptToServerPrompt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := newMockMCP("test-server", tt.prefix)
-			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 			require.NoError(t, err)
 
 			serverPrompt := manager.promptToServerPrompt(mcp.Prompt{Name: tt.promptName, Description: tt.promptDesc})
@@ -1269,7 +1330,7 @@ func TestMCPManager_promptToServerPrompt(t *testing.T) {
 func TestMCPManager_diffPrompts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1321,7 +1382,7 @@ func TestMCPManager_diffPrompts(t *testing.T) {
 func TestMCPManager_GetManagedPrompts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "test_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	prompts := []mcp.Prompt{
@@ -1339,7 +1400,7 @@ func TestMCPManager_GetManagedPrompts(t *testing.T) {
 func TestMCPManager_GetServedManagedPrompt(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mock := newMockMCP("test-server", "prefix_")
-	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetPromptsForTesting([]mcp.Prompt{{Name: "myprompt", Description: "My Prompt"}})
 
@@ -1360,10 +1421,10 @@ func TestMCPManager_manage_PromptsSuccess(t *testing.T) {
 	mock.hasPromptsCap = true
 	gateway := newMockToolsAdderDeleter()
 	promptsGateway := newMockPromptsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, promptsGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, promptsGateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready)
@@ -1383,10 +1444,10 @@ func TestMCPManager_manage_PromptsNilServer(t *testing.T) {
 	mock.prompts = []mcp.Prompt{{Name: "prompt1"}}
 	mock.hasToolsCap = false
 	gateway := newMockToolsAdderDeleter()
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	manager.manage(context.Background(), eventTypeTimer)
+	manager.manage(t.Context(), eventTypeTimer)
 
 	status := manager.GetStatus()
 	assert.True(t, status.Ready)
@@ -1402,7 +1463,7 @@ func TestMCPManager_Backoff(t *testing.T) {
 
 	// Set a long ticker interval
 	tickerInterval := time.Minute
-	manager, err := NewUpstreamMCPManager(mock, gateway, nil, slog.Default(), tickerInterval, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, slog.Default(), tickerInterval, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
 	// 1. Simulate failure (Connect)
@@ -1446,4 +1507,112 @@ func TestMCPManager_Backoff(t *testing.T) {
 	mock.listToolsErr = nil
 	manager.manage(ctx, eventTypeTimer)
 	assert.True(t, manager.GetStatus().Ready)
+}
+
+func TestMCPManager_shouldFetchResources(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("returns true when server has no list_changed support", func(t *testing.T) {
+		mock := newMockMCP("test", "")
+		mock.hasResourcesListChangedCap = false
+		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		// no list_changed support → always fetch
+		assert.True(t, manager.shouldFetchResources(eventTypeTimer))
+	})
+
+	t.Run("returns true on resource notification event", func(t *testing.T) {
+		mock := newMockMCP("test", "")
+		mock.hasResourcesListChangedCap = true
+		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		assert.True(t, manager.shouldFetchResources(eventTypeResourceNotification))
+	})
+
+	t.Run("returns true on timer when no resources cached", func(t *testing.T) {
+		mock := newMockMCP("test", "")
+		mock.hasResourcesListChangedCap = true
+		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		assert.True(t, manager.shouldFetchResources(eventTypeTimer))
+	})
+
+	t.Run("returns false on timer when resources already cached", func(t *testing.T) {
+		mock := newMockMCP("test", "")
+		mock.hasResourcesListChangedCap = true
+		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		manager.SetResourcesForTesting([]mcp.Resource{{URI: "test://r1", Name: "r1"}})
+		assert.False(t, manager.shouldFetchResources(eventTypeTimer))
+	})
+}
+
+func TestMCPManager_manage_ResourcesSuccess(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "")
+	mock.hasToolsCap = false
+	mock.hasResourcesCap = true
+	mock.hasResourcesListChangedCap = false
+	mock.resources = []mcp.Resource{
+		{URI: "test://res1", Name: "Resource 1"},
+		{URI: "test://res2", Name: "Resource 2"},
+	}
+	gateway := newMockToolsAdderDeleter()
+	resourcesGateway := newMockResourcesAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, resourcesGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	manager.manage(t.Context(), eventTypeTimer)
+
+	assert.Len(t, resourcesGateway.resources, 2)
+	_, ok1 := resourcesGateway.resources["test://res1"]
+	_, ok2 := resourcesGateway.resources["test://res2"]
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+}
+
+func TestMCPManager_manage_ResourcesDiff(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "")
+	mock.hasToolsCap = false
+	mock.hasResourcesCap = true
+	mock.hasResourcesListChangedCap = false // no list_changed support → always fetch on timer
+	mock.resources = []mcp.Resource{{URI: "test://res1", Name: "r1"}, {URI: "test://res2", Name: "r2"}}
+
+	gateway := newMockToolsAdderDeleter()
+	resourcesGateway := newMockResourcesAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, resourcesGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	manager.manage(t.Context(), eventTypeTimer)
+	assert.Len(t, resourcesGateway.resources, 2)
+
+	// remove res1, add res3
+	mock.resources = []mcp.Resource{{URI: "test://res2", Name: "r2"}, {URI: "test://res3", Name: "r3"}}
+	manager.manage(t.Context(), eventTypeTimer)
+
+	assert.Len(t, resourcesGateway.resources, 2)
+	_, hasRes1 := resourcesGateway.resources["test://res1"]
+	_, hasRes2 := resourcesGateway.resources["test://res2"]
+	_, hasRes3 := resourcesGateway.resources["test://res3"]
+	assert.False(t, hasRes1, "res1 should be removed")
+	assert.True(t, hasRes2)
+	assert.True(t, hasRes3)
+}
+
+func TestMCPManager_manage_ResourcesNilServer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "")
+	mock.hasToolsCap = false
+	mock.hasResourcesCap = true
+	mock.hasResourcesListChangedCap = false
+	mock.resources = []mcp.Resource{{URI: "test://res1", Name: "r1"}}
+	gateway := newMockToolsAdderDeleter()
+	// resourcesServer = nil: no resources fetched
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	manager.manage(t.Context(), eventTypeTimer)
+
+	assert.Len(t, manager.GetManagedResources(), 0)
 }

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -282,3 +282,33 @@ func (up *MCPServer) ListTools(ctx context.Context, req mcp.ListToolsRequest) (*
 	}
 	return up.client.ListTools(ctx, req)
 }
+
+// SupportsResources checks if the upstream server declared resource capabilities
+func (up *MCPServer) SupportsResources() bool {
+	if up.init == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources != nil
+}
+
+// SupportsResourcesListChanged validates the mcp server supports resources/list_changed notifications
+func (up *MCPServer) SupportsResourcesListChanged() bool {
+	if up.init == nil {
+		return false
+	}
+	if up.init.Capabilities.Resources == nil {
+		return false
+	}
+	return up.init.Capabilities.Resources.ListChanged
+}
+
+// ListResources retrieves the list of available resources from the upstream MCP server
+func (up *MCPServer) ListResources(ctx context.Context, req mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+
+	if up.client == nil {
+		return nil, fmt.Errorf("client not connected")
+	}
+	return up.client.ListResources(ctx, req)
+}

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -17,8 +17,73 @@ import (
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMCPServer_SupportsResources(t *testing.T) {
+	up := NewUpstreamMCP(&config.MCPServer{Name: "test"})
+
+	t.Run("returns false when init is nil", func(t *testing.T) {
+		up.init = nil
+		require.False(t, up.SupportsResources())
+	})
+
+	t.Run("returns false when Resources capability is nil", func(t *testing.T) {
+		up.init = &mcp.InitializeResult{Capabilities: mcp.ServerCapabilities{}}
+		require.False(t, up.SupportsResources())
+	})
+
+	t.Run("returns true when Resources capability is set", func(t *testing.T) {
+		up.init = &mcp.InitializeResult{
+			Capabilities: mcp.ServerCapabilities{
+				Resources: &struct {
+					Subscribe   bool `json:"subscribe,omitempty"`
+					ListChanged bool `json:"listChanged,omitempty"`
+				}{},
+			},
+		}
+		require.True(t, up.SupportsResources())
+	})
+}
+
+func TestMCPServer_SupportsResourcesListChanged(t *testing.T) {
+	up := NewUpstreamMCP(&config.MCPServer{Name: "test"})
+
+	t.Run("returns false when init is nil", func(t *testing.T) {
+		up.init = nil
+		require.False(t, up.SupportsResourcesListChanged())
+	})
+
+	t.Run("returns false when Resources capability is nil", func(t *testing.T) {
+		up.init = &mcp.InitializeResult{Capabilities: mcp.ServerCapabilities{}}
+		require.False(t, up.SupportsResourcesListChanged())
+	})
+
+	t.Run("returns false when ListChanged is false", func(t *testing.T) {
+		up.init = &mcp.InitializeResult{
+			Capabilities: mcp.ServerCapabilities{
+				Resources: &struct {
+					Subscribe   bool `json:"subscribe,omitempty"`
+					ListChanged bool `json:"listChanged,omitempty"`
+				}{ListChanged: false},
+			},
+		}
+		require.False(t, up.SupportsResourcesListChanged())
+	})
+
+	t.Run("returns true when ListChanged is true", func(t *testing.T) {
+		up.init = &mcp.InitializeResult{
+			Capabilities: mcp.ServerCapabilities{
+				Resources: &struct {
+					Subscribe   bool `json:"subscribe,omitempty"`
+					ListChanged bool `json:"listChanged,omitempty"`
+				}{ListChanged: true},
+			},
+		}
+		require.True(t, up.SupportsResourcesListChanged())
+	})
+}
 
 func TestNewUpstreamMCP(t *testing.T) {
 	testServer := config.MCPServer{

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -181,9 +181,10 @@ func (mcpServer *MCPServer) Path() (string, error) {
 
 // VirtualServer represents a virtual server configuration
 type VirtualServer struct {
-	Name    string
-	Tools   []string
-	Prompts []string
+	Name      string
+	Tools     []string
+	Prompts   []string
+	Resources []string
 }
 
 // Observer provides an interface to implement in order to register as an Observer of config changes
@@ -207,7 +208,8 @@ type AuthConfig struct {
 
 // VirtualServerConfig represents virtual server config
 type VirtualServerConfig struct {
-	Name    string   `json:"name"    yaml:"name"`
-	Tools   []string `json:"tools"   yaml:"tools"`
-	Prompts []string `json:"prompts,omitempty" yaml:"prompts,omitempty"`
+	Name      string   `json:"name"               yaml:"name"`
+	Tools     []string `json:"tools"              yaml:"tools"`
+	Prompts   []string `json:"prompts,omitempty"  yaml:"prompts,omitempty"`
+	Resources []string `json:"resources,omitempty" yaml:"resources,omitempty"`
 }

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -64,9 +64,10 @@ func NewRouterErrorf(code int32, format string, args ...any) *RouterError {
 }
 
 const (
-	methodToolCall   = "tools/call"
-	methodPromptGet  = "prompts/get"
-	methodInitialize = "initialize"
+	methodToolCall     = "tools/call"
+	methodPromptGet    = "prompts/get"
+	methodResourceRead = "resources/read"
+	methodInitialize   = "initialize"
 
 	elicitationResultAction  = "action"
 	elicitationActionAccept  = "accept"
@@ -219,6 +220,27 @@ func (mr *MCPRequest) ReWritePromptName(actualPrompt string) {
 	mr.Params["name"] = actualPrompt
 }
 
+// isResourceRead will check if the request is a resources/read request
+func (mr *MCPRequest) isResourceRead() bool {
+	return mr.Method == methodResourceRead
+}
+
+// ResourceURI returns the resource URI in a resources/read request
+func (mr *MCPRequest) ResourceURI() string {
+	if !mr.isResourceRead() {
+		return ""
+	}
+	uri, ok := mr.Params["uri"]
+	if !ok {
+		return ""
+	}
+	u, ok := uri.(string)
+	if !ok {
+		return ""
+	}
+	return u
+}
+
 // ToBytes marshals the data ready to send on
 func (mr *MCPRequest) ToBytes() ([]byte, error) {
 	return json.Marshal(mr)
@@ -254,6 +276,9 @@ func (s *ExtProcServer) RouteMCPRequest(ctx context.Context, mcpReq *MCPRequest)
 	case mcpReq.Method == methodPromptGet:
 		span.SetAttributes(attribute.String("mcp.route", "prompt-get"))
 		return s.HandlePromptGet(ctx, mcpReq)
+	case mcpReq.Method == methodResourceRead:
+		span.SetAttributes(attribute.String("mcp.route", "resource-read"))
+		return s.HandleResourceRead(ctx, mcpReq)
 	default:
 		span.SetAttributes(attribute.String("mcp.route", "broker"))
 		return s.HandleNoneToolCall(ctx, mcpReq)
@@ -493,6 +518,84 @@ data: {"error":{"code":-32602,"message":"Prompt not found"},"jsonrpc":"2.0"}`)
 	upstreamPromptName, _ := strings.CutPrefix(promptName, serverInfo.Prefix)
 	headers.WithMCPPromptName(upstreamPromptName)
 	mcpReq.ReWritePromptName(upstreamPromptName)
+	headers.WithMCPServerName(serverInfo.Name)
+
+	return s.routeToUpstream(ctx, span, mcpReq, serverInfo, headers, calculatedResponse)
+}
+
+// HandleResourceRead handles an MCP resources/read request by routing to the correct upstream server
+func (s *ExtProcServer) HandleResourceRead(ctx context.Context, mcpReq *MCPRequest) []*eppb.ProcessingResponse {
+	uri := mcpReq.ResourceURI()
+
+	ctx, span := tracer().Start(ctx, "mcp-router.resource-read",
+		trace.WithAttributes(
+			componentAttr,
+			attribute.String("mcp.resource.uri", uri),
+			attribute.String("mcp.session.id", mcpReq.GetSessionID()),
+		),
+	)
+	defer span.End()
+
+	calculatedResponse := NewResponse()
+	if uri == "" {
+		s.Logger.ErrorContext(ctx, "[EXT-PROC] HandleResourceRead no URI set in resources/read")
+		span.SetStatus(codes.Error, "no URI set")
+		span.SetAttributes(attribute.String("error.type", "missing_resource_uri"))
+		calculatedResponse.WithImmediateResponse(400, "no URI set")
+		return calculatedResponse.Build()
+	}
+	if sessionErr := s.validateSession(mcpReq.GetSessionID()); sessionErr != nil {
+		s.Logger.ErrorContext(ctx, "session validation failed", "session", mcpReq.GetSessionID(), "error", sessionErr)
+		mcpotel.SpanError(span, sessionErr, sessionErr.Error())
+		span.SetAttributes(attribute.String("error.type", "invalid_session"))
+		calculatedResponse.WithImmediateResponse(sessionErr.Code(), sessionErr.Error())
+		return calculatedResponse.Build()
+	}
+
+	headers := NewHeaders()
+	var serverInfo *config.MCPServer
+	var err error
+	{
+		_, infoSpan := tracer().Start(ctx, "mcp-router.broker.get-server-info-by-resource",
+			trace.WithAttributes(
+				componentAttr,
+				attribute.String("mcp.resource.uri", uri),
+			),
+		)
+		var infoErr error
+		serverInfo, infoErr = s.Broker.GetServerInfoByResource(uri)
+		if infoErr != nil {
+			mcpotel.SpanError(infoSpan, infoErr, "resource not found")
+		}
+		infoSpan.End()
+		err = infoErr
+	}
+	if err != nil {
+		s.Logger.DebugContext(ctx, "no server for resource", "uri", uri)
+		mcpotel.SpanError(span, err, "resource not found")
+		span.SetAttributes(attribute.String("error.type", "resource_not_found"))
+		calculatedResponse.WithImmediateJSONRPCResponse(200,
+			[]*corev3.HeaderValueOption{
+				{
+					Header: &corev3.HeaderValue{
+						Key:   "mcp-session-id",
+						Value: mcpReq.GetSessionID(),
+					},
+				},
+			},
+			`
+event: message
+data: {"error":{"code":-32602,"message":"Resource not found"},"jsonrpc":"2.0"}`)
+		return calculatedResponse.Build()
+	}
+
+	span.SetAttributes(
+		attribute.String("mcp.server", serverInfo.Name),
+		attribute.String("mcp.server.hostname", serverInfo.Hostname),
+	)
+
+	headers.WithMCPMethod(mcpReq.Method)
+	mcpReq.serverName = serverInfo.Name
 	headers.WithMCPServerName(serverInfo.Name)
 
 	return s.routeToUpstream(ctx, span, mcpReq, serverInfo, headers, calculatedResponse)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1505,6 +1505,107 @@ func TestHandlePromptGet(t *testing.T) {
 	require.NotContains(t, string(body), `"name":"s_myprompt"`)
 }
 
+func TestHandleResourceRead(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	serverConfigs := []*config.MCPServer{
+		{
+			Name:     "upstream",
+			URL:      "http://localhost:8080/mcp",
+			Prefix:   "",
+			State:    "Enabled",
+			Hostname: "localhost",
+		},
+	}
+
+	setupSrv := func(t *testing.T, resource2svr map[string]string) (*ExtProcServer, string) {
+		t.Helper()
+		cache, err := session.NewCache()
+		require.NoError(t, err)
+		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+		require.NoError(t, err)
+		validToken := jwtManager.Generate()
+		added, err := cache.AddSession(t.Context(), validToken, "upstream", "mock-upstream-session-id", 0)
+		require.NoError(t, err)
+		require.True(t, added)
+
+		testBroker := newMockBroker(serverConfigs, map[string]string{})
+		testBroker.(*mockBrokerImpl).resource2svr = resource2svr
+
+		srv := &ExtProcServer{
+			RoutingConfig: &config.MCPServersConfig{Servers: serverConfigs},
+			JWTManager:    jwtManager,
+			Logger:        logger,
+			SessionCache:  cache,
+			InitForClient: func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool) (*client.Client, error) {
+				return nil, fmt.Errorf("InitForClient should not be called when session exists")
+			},
+			Broker: testBroker,
+		}
+		return srv, validToken
+	}
+
+	makeReq := func(uri, sessionToken string) *MCPRequest {
+		req := &MCPRequest{
+			ID:      ptr.To(1),
+			JSONRPC: "2.0",
+			Method:  "resources/read",
+			Params:  map[string]any{},
+			Headers: &corev3.HeaderMap{
+				Headers: []*corev3.HeaderValue{
+					{Key: "mcp-session-id", RawValue: []byte(sessionToken)},
+				},
+			},
+		}
+		if uri != "" {
+			req.Params["uri"] = uri
+		}
+		return req
+	}
+
+	t.Run("happy path routes to upstream", func(t *testing.T) {
+		srv, token := setupSrv(t, map[string]string{"test://docs/api": "upstream"})
+		resp := srv.RouteMCPRequest(t.Context(), makeReq("test://docs/api", token))
+		require.Len(t, resp, 1)
+		require.IsType(t, &eppb.ProcessingResponse_RequestBody{}, resp[0].Response)
+		rb := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+		headers := rb.RequestBody.Response.HeaderMutation.SetHeaders
+		require.Equal(t, "x-mcp-method", headers[0].Header.Key)
+		require.Equal(t, []uint8("resources/read"), headers[0].Header.RawValue)
+		require.Equal(t, "x-mcp-servername", headers[1].Header.Key)
+		require.Equal(t, []uint8("upstream"), headers[1].Header.RawValue)
+	})
+
+	t.Run("empty URI returns 400", func(t *testing.T) {
+		srv, token := setupSrv(t, map[string]string{})
+		resp := srv.RouteMCPRequest(t.Context(), makeReq("", token))
+		require.Len(t, resp, 1)
+		require.IsType(t, &eppb.ProcessingResponse_ImmediateResponse{}, resp[0].Response)
+		ir := resp[0].Response.(*eppb.ProcessingResponse_ImmediateResponse)
+		require.Equal(t, int32(400), int32(ir.ImmediateResponse.Status.Code))
+	})
+
+	t.Run("unknown URI returns JSON-RPC error", func(t *testing.T) {
+		srv, token := setupSrv(t, map[string]string{})
+		resp := srv.RouteMCPRequest(t.Context(), makeReq("test://unknown", token))
+		require.Len(t, resp, 1)
+		require.IsType(t, &eppb.ProcessingResponse_ImmediateResponse{}, resp[0].Response)
+		ir := resp[0].Response.(*eppb.ProcessingResponse_ImmediateResponse)
+		body := string(ir.ImmediateResponse.Body)
+		require.Contains(t, body, "-32602")
+		require.Contains(t, body, "Resource not found")
+	})
+
+	t.Run("invalid session returns error", func(t *testing.T) {
+		srv, _ := setupSrv(t, map[string]string{"test://docs/api": "upstream"})
+		resp := srv.RouteMCPRequest(t.Context(), makeReq("test://docs/api", "bad-token"))
+		require.Len(t, resp, 1)
+		require.IsType(t, &eppb.ProcessingResponse_ImmediateResponse{}, resp[0].Response)
+		ir := resp[0].Response.(*eppb.ProcessingResponse_ImmediateResponse)
+		require.NotNil(t, ir.ImmediateResponse)
+	})
+}
+
 func testBearerJWT(sub string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":"%s"}`, sub)))

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -716,6 +716,10 @@ func (m *mockBrokerImpl) GetServerInfoByPrompt(prompt string) (*config.MCPServer
 	return nil, fmt.Errorf("failed to get server %q for prompt %q", svrName, prompt)
 }
 
+func (m *mockBrokerImpl) GetServerInfoByResource(uri string) (*config.MCPServer, error) {
+	return nil, fmt.Errorf("resource URI %q not found", uri)
+}
+
 // GetServerInfo implements broker.MCPBroker.
 func (m *mockBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 	svrName, ok := m.tool2svr[tool]

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -20,9 +20,10 @@ import (
 )
 
 type mockBrokerImpl struct {
-	svrConfigs []*config.MCPServer
-	tool2svr   map[string]string
-	prompt2svr map[string]string
+	svrConfigs   []*config.MCPServer
+	tool2svr     map[string]string
+	prompt2svr   map[string]string
+	resource2svr map[string]string
 }
 
 func TestHandleResponseHeaders_ReturnsGatewaySessionID(t *testing.T) {
@@ -697,9 +698,10 @@ func TestHandleResponseHeaders_SuccessStatusDoesNotDeleteUserToken(t *testing.T)
 
 func newMockBroker(svrConfigs []*config.MCPServer, tool2svr map[string]string) broker.MCPBroker {
 	return &mockBrokerImpl{
-		svrConfigs: svrConfigs,
-		tool2svr:   tool2svr,
-		prompt2svr: map[string]string{},
+		svrConfigs:   svrConfigs,
+		tool2svr:     tool2svr,
+		prompt2svr:   map[string]string{},
+		resource2svr: map[string]string{},
 	}
 }
 
@@ -717,7 +719,16 @@ func (m *mockBrokerImpl) GetServerInfoByPrompt(prompt string) (*config.MCPServer
 }
 
 func (m *mockBrokerImpl) GetServerInfoByResource(uri string) (*config.MCPServer, error) {
-	return nil, fmt.Errorf("resource URI %q not found", uri)
+	svrName, ok := m.resource2svr[uri]
+	if !ok {
+		return nil, fmt.Errorf("resource URI %q not found", uri)
+	}
+	for _, svrInfo := range m.svrConfigs {
+		if svrName == svrInfo.Name {
+			return svrInfo, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to get server %q for resource URI %q", svrName, uri)
 }
 
 // GetServerInfo implements broker.MCPBroker.

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -1362,6 +1362,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(status).To(Equal(http.StatusOK))
 		Expect(body).NotTo(BeEmpty())
 		Expect(body).NotTo(ContainSubstring(`"code":`), "resources/read should not return a JSON-RPC error")
+		Expect(body).To(ContainSubstring(`"contents"`), "resources/read should return actual resource content")
 
 		By("Unregistering the MCPServerRegistration")
 		Expect(k8sClient.Delete(ctx, registeredServer)).To(Succeed())

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -1329,4 +1329,48 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
+
+	It("[Happy] should list resources, read one, and remove them on unregistration", func() {
+		By("Registering the everything-server which serves resources")
+		registration := NewMCPServerResources("resource-happy", "resource-happy.mcp.local", "everything-server", 9090, k8sClient).
+			WithPrefix("").Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Ensuring the gateway has registered the server")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Verifying resources/list returns at least one resource")
+		var knownURI string
+		Eventually(func(g Gomega) {
+			resourcesList, err := mcpGatewayClient.ListResources(ctx, mcp.ListResourcesRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(resourcesList).NotTo(BeNil())
+			g.Expect(len(resourcesList.Resources)).To(BeNumerically(">", 0), "expected at least one resource")
+			knownURI = resourcesList.Resources[0].URI
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Reading the resource via resources/read using the raw HTTP helper")
+		sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
+
+		status, body, err := mcpReadResource(ctx, gatewayURL, sessionID, knownURI, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(http.StatusOK))
+		Expect(body).NotTo(BeEmpty())
+		Expect(body).NotTo(ContainSubstring(`"code":`), "resources/read should not return a JSON-RPC error")
+
+		By("Unregistering the MCPServerRegistration")
+		Expect(k8sClient.Delete(ctx, registeredServer)).To(Succeed())
+
+		By("Verifying resources are removed after unregistration")
+		Eventually(func(g Gomega) {
+			resourcesList, err := mcpGatewayClient.ListResources(ctx, mcp.ListResourcesRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ResourcesListHasURI(resourcesList, knownURI)).To(BeFalseBecause("resource %q should be removed after unregistration", knownURI))
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+	})
 })

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -210,6 +210,29 @@ func mcpGetPrompt(ctx context.Context, url, sessionID, promptName string, args m
 	return resp.StatusCode, string(respBody), nil
 }
 
+func mcpReadResource(ctx context.Context, url, sessionID, uri string, headers map[string]string) (int, string, error) {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "resources/read",
+		"params":  map[string]any{"uri": uri},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to marshal resources/read: %w", err)
+	}
+	resp, err := mcpPost(ctx, url, sessionID, body, headers)
+	if err != nil {
+		return 0, "", fmt.Errorf("resources/read failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", fmt.Errorf("reading resources/read response: %w", err)
+	}
+	return resp.StatusCode, string(respBody), nil
+}
+
 func mcpRawPost(ctx context.Context, url, sessionID string, body []byte, headers map[string]string) (int, string, http.Header, error) {
 	resp, err := mcpPost(ctx, url, sessionID, body, headers)
 	if err != nil {

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -387,3 +387,26 @@ When an MCPVirtualServer is configured that includes a specific user-specific to
 ## Common pitfalls
 
 - MCPServerRegistrations with empty prefix: `strings.HasPrefix(name, "")` matches all tools, including broker meta-tools (discover_tools, select_tools). Always use a non-empty prefix in tests.
+
+## Resources federation
+
+### [Happy] resources/list and resources/read
+
+Precondition: Everything Server is running (it serves resources)
+
+1. Connect MCP client to gateway
+2. Call `resources/list` — verify resources from Everything Server appear in the aggregated list
+3. Call `resources/read` with a known URI from the list — verify content is returned correctly
+4. Stop Everything Server, call `resources/list` — verify its resources are removed from the list
+
+### [Auth] JWT-filtered resources/list
+
+- When a client authenticates via Keycloak and sends a `resources/list` request, only resources the user has `resources:*` roles for should be returned.
+
+### [Auth] VirtualServer-filtered resources/list
+
+- When a client sends a `resources/list` request with an `X-Mcp-Virtualserver` header and the VirtualServer's `resources` field is set, only the listed URIs should be returned.
+
+### [Happy] resources/read for nonexistent URI returns error
+
+- When a client sends a `resources/read` request with a URI that does not match any registered server, the gateway should return a JSON-RPC error with code -32602.

--- a/tests/e2e/verifiers.go
+++ b/tests/e2e/verifiers.go
@@ -298,19 +298,6 @@ func ResourcesListHasURI(resourcesList *mcp.ListResourcesResult, uri string) boo
 	return false
 }
 
-// ResourcesListHasPrefix checks if any resource in the list has a URI with the given prefix
-func ResourcesListHasPrefix(resourcesList *mcp.ListResourcesResult, prefix string) bool {
-	if resourcesList == nil {
-		return false
-	}
-	for _, r := range resourcesList.Resources {
-		if strings.HasPrefix(r.URI, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
 // PromptsListHasPrefix checks if any prompt in the list has the given prefix
 func PromptsListHasPrefix(promptsList *mcp.ListPromptsResult, prefix string) bool {
 	return promptsListMatches(promptsList, func(name string) bool {

--- a/tests/e2e/verifiers.go
+++ b/tests/e2e/verifiers.go
@@ -285,6 +285,32 @@ func VerifyHTTPRouteNoProgrammedCondition(ctx context.Context, k8sClient client.
 
 //revive:enable:exported
 
+// ResourcesListHasURI checks if the resources list contains a resource with the exact URI
+func ResourcesListHasURI(resourcesList *mcp.ListResourcesResult, uri string) bool {
+	if resourcesList == nil {
+		return false
+	}
+	for _, r := range resourcesList.Resources {
+		if r.URI == uri {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourcesListHasPrefix checks if any resource in the list has a URI with the given prefix
+func ResourcesListHasPrefix(resourcesList *mcp.ListResourcesResult, prefix string) bool {
+	if resourcesList == nil {
+		return false
+	}
+	for _, r := range resourcesList.Resources {
+		if strings.HasPrefix(r.URI, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // PromptsListHasPrefix checks if any prompt in the list has the given prefix
 func PromptsListHasPrefix(promptsList *mcp.ListPromptsResult, prefix string) bool {
 	return promptsListMatches(promptsList, func(name string) bool {

--- a/tests/servers/custom-response-server/main.go
+++ b/tests/servers/custom-response-server/main.go
@@ -56,10 +56,6 @@ func main() {
 			"protocolVersion": "2025-06-18",
 			"capabilities": {
 			"logging": {},
-			"resources": {
-				"subscribe": true,
-				"listChanged": true
-			},
 			"tools": {
 				"listChanged": true
 			}


### PR DESCRIPTION
Resources are the third MCP primitive and we were federating two of the three ; this fills the gap.

I used prompts as the template throughout. The pattern is identical: `SupportsResources` / `SupportsResourcesListChanged` on `MCPServer`, a `ResourcesAdderDeleter` interface, resource fields on `MCPManager` with the same diff-on-tick logic, a `FilterResources` hook wired into `AddAfterListResources`, and `Resources []string` on `VirtualServer` for scoping. The one real difference from prompts is that URIs are globally unique so there's no prefix rewriting anywhere ; `GetServerInfoByResource` is a straight map lookup, no `strings.CutPrefix`.

For `resources/read` routing I followed the same `ext_proc` path as `prompts/get` ; added `HandleResourceRead` in `request_handlers.go` so traffic still flows through Envoy rather than short-circuiting through the broker directly. Felt important to keep that consistent with the "all MCP traffic flows through Envoy" principle in the design doc.

The constructor signature for `NewUpstreamMCPManager` gains one parameter (`resourcesServer ResourcesAdderDeleter`), which touched a lot of call sites ; all mechanical `nil` additions in tests. Everything else is additive.

Tests follow the existing patterns exactly: capability cases in `mcp_test.go`, diff/notification/nil-server cases in `manager_test.go`, JWT and virtual-server filtering in `filtered_resources_handler_test.go`, and lookup cases in `broker_test.go`. All green, builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway now aggregates upstream resources, supports resources/list and resources/read, routes reads to the correct backend, and lets VirtualServer configs declare resources; resources can be JWT-filtered by capability claims and scoped by VirtualServer allowlists.

* **Tests**
  * Added unit and e2e coverage for listing, JWT filtering, VirtualServer filtering, routing, read error handling, and resource sync behavior.

* **Documentation**
  * Added e2e test cases for resources federation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->