### PR TITLE
fix issue with configure-redis add user specific server to test-images

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -77,6 +77,10 @@ jobs:
             context: tests/servers/tls-server
             dockerfile: Dockerfile
             image-name: test-tls-server
+          - server: user-specific-server
+            context: .
+            dockerfile: tests/servers/user-specific-server/Dockerfile
+            image-name: test-user-specific-server
 
     steps:
       - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -246,10 +246,11 @@ deploy-redis: ## deploy redis to mcp-system namespace
 configure-redis: deploy-redis ## deploy redis and configure MCPGatewayExtension session store
 	kubectl create secret generic redis-session-store \
 		--from-literal=CACHE_CONNECTION_STRING=redis://redis.$(MCP_GATEWAY_NAMESPACE).svc.cluster.local:6379 \
-		-n $(MCP_GATEWAY_NAMESPACE) --dry-run=client -o json | \
-		jq '.metadata.labels = {"mcp.kuadrant.io/secret": "true"}' | kubectl apply -f -
+		-n $(MCP_GATEWAY_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	kubectl label secret redis-session-store mcp.kuadrant.io/secret=true -n $(MCP_GATEWAY_NAMESPACE) --overwrite
 	kubectl patch mcpgatewayextension mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --type=merge \
 		-p '{"spec":{"sessionStore":{"secretName":"redis-session-store"}}}'
+	kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --timeout=$(WAIT_TIME)
 
 # Deploy only the controller
 deploy-controller: install-crd ## Deploy only the controller

--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,13 @@ deploy-redis: ## deploy redis to mcp-system namespace
 	kubectl rollout status deployment/redis -n $(MCP_GATEWAY_NAMESPACE) --timeout=60s
 
 .PHONY: configure-redis
-configure-redis: deploy-redis ## deploy redis and patch deployment with redis connection
-	kubectl patch deployment $(BROKER_ROUTER_NAME) -n $(MCP_GATEWAY_NAMESPACE) --patch-file config/mcp-gateway/overlays/mcp-system/deployment-controller-redis-patch.yaml
+configure-redis: deploy-redis ## deploy redis and configure MCPGatewayExtension session store
+	kubectl create secret generic redis-session-store \
+		--from-literal=CACHE_CONNECTION_STRING=redis://redis.$(MCP_GATEWAY_NAMESPACE).svc.cluster.local:6379 \
+		-n $(MCP_GATEWAY_NAMESPACE) --dry-run=client -o json | \
+		jq '.metadata.labels = {"mcp.kuadrant.io/secret": "true"}' | kubectl apply -f -
+	kubectl patch mcpgatewayextension mcp-gateway-extension -n $(MCP_GATEWAY_NAMESPACE) --type=merge \
+		-p '{"spec":{"sessionStore":{"secretName":"redis-session-store"}}}'
 
 # Deploy only the controller
 deploy-controller: install-crd ## Deploy only the controller


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD: added an additional test image build for a user-specific test server to the pipeline.
  * Deployment config: changed Redis session handling to create and label a session-store secret and point the gateway extension to use it, removing the previous static patch approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->