### PR TITLE
test: add protocol version coverage (#363)

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -118,4 +118,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: cache export is an optimisation; transient GHA cache
+          # errors (error writing layer blob: not_found) should not fail the build
+          cache-to: type=gha,mode=max,ignore-error=true

--- a/docs/design/protocol-versions.md
+++ b/docs/design/protocol-versions.md
@@ -1,0 +1,64 @@
+## MCP Protocol Version Negotiation
+
+### Problem
+
+The MCP protocol is versioned (e.g. `2024-11-05`, `2025-03-26`, `2025-06-18`,
+`2025-11-25`) and new versions are released over time. The gateway connects to
+arbitrary upstream MCP servers, which may speak different versions. The gateway must:
+
+1. Negotiate a protocol version with each upstream that both sides support
+2. Reject upstreams that only speak versions the gateway does not understand
+3. Keep working when the MCP ecosystem moves to a new version, without code changes
+   for every release
+
+The set of versions the gateway understands is owned by the
+`github.com/mark3labs/mcp-go` library, not by this repo.
+
+### Solution
+
+The broker delegates negotiation to the mark3labs client. During `MCPServer.Connect`
+(`internal/broker/upstream/mcp.go`) the broker sends an `initialize` request proposing
+`mcp.LATEST_PROTOCOL_VERSION` — the newest version the linked library knows. The
+upstream replies with the version it chose:
+
+- If the reply is in `mcp.ValidProtocolVersions`, the client accepts it and the
+  negotiated version is stored on the upstream (`MCPServer.ProtocolInfo()`).
+- Otherwise the client returns an `UnsupportedProtocolVersionError` and `Connect`
+  fails; the broker marks the server not ready and the MCPServerRegistration status
+  reports `unsupported protocol version`.
+
+A stock mark3labs server echoes the client's proposed version when it is valid, so a
+normal upstream negotiates the latest. An upstream can still pin an older-but-valid
+version (e.g. behind a proxy or an older SDK); the broker accepts it.
+
+The negotiated version is surfaced on the broker `/status` endpoint per server as
+`protocolValidation.supportedVersion` (populated in `MCPManager.setStatus`), with
+`expectedVersion` set to the version the broker proposed.
+
+> **Note:** the gateway does not pin a version itself. The floor and ceiling of
+> supported versions are whatever `mcp.ValidProtocolVersions` contains in the linked
+> `mark3labs/mcp-go` release.
+
+### Testing strategy
+
+Two layers, all automated:
+
+- **Unit — version matrix** (`internal/broker/upstream/protocol_version_test.go`):
+  iterates `mcp.ValidProtocolVersions` against a fake upstream pinned to each version,
+  asserting the broker accepts it and records the negotiated version. The matrix is
+  driven by the library's own list, so it expands automatically when the library
+  learns a new version. A negative case asserts an out-of-range version
+  (`2021-11-05`) is rejected.
+- **Unit — status** (`internal/broker/upstream/manager_test.go`): asserts
+  `setStatus` populates `protocolValidation` from the negotiated version.
+
+### Reacting to a new protocol version
+
+When the MCP spec ships a new version:
+
+1. Bump `github.com/mark3labs/mcp-go` in `go.mod`. `LATEST_PROTOCOL_VERSION` and
+   `ValidProtocolVersions` come from the library.
+2. Run `make test-unit`. The version-matrix unit test automatically picks up the new
+   entry in `ValidProtocolVersions` and exercises it — no test edits required.
+3. If the new version adds or removes capabilities the broker depends on, update the
+   broker handling and add coverage. See `docs/design/backend-mcp-management.md`.

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -60,17 +60,27 @@ const (
 
 // ServerValidationStatus contains the validation results for an upstream MCP server
 type ServerValidationStatus struct {
-	ID                string              `json:"id"`
-	Name              string              `json:"name"`
-	LastValidated     time.Time           `json:"lastValidated"`
-	Message           string              `json:"message"`
-	Ready             bool                `json:"ready"`
-	TotalTools        int                 `json:"totalTools"`
-	TotalPrompts      int                 `json:"totalPrompts"`
-	InvalidTools      int                 `json:"invalidTools"`
-	InvalidToolList   []InvalidToolInfo   `json:"invalidToolList,omitempty"`
-	InvalidPrompts    int                 `json:"invalidPrompts"`
-	InvalidPromptList []InvalidPromptInfo `json:"invalidPromptList,omitempty"`
+	ID                 string              `json:"id"`
+	Name               string              `json:"name"`
+	LastValidated      time.Time           `json:"lastValidated"`
+	Message            string              `json:"message"`
+	Ready              bool                `json:"ready"`
+	TotalTools         int                 `json:"totalTools"`
+	TotalPrompts       int                 `json:"totalPrompts"`
+	InvalidTools       int                 `json:"invalidTools"`
+	InvalidToolList    []InvalidToolInfo   `json:"invalidToolList,omitempty"`
+	InvalidPrompts     int                 `json:"invalidPrompts"`
+	InvalidPromptList  []InvalidPromptInfo `json:"invalidPromptList,omitempty"`
+	ProtocolValidation ProtocolValidation  `json:"protocolValidation"`
+}
+
+// ProtocolValidation reports the MCP protocol version negotiated with the upstream.
+// supportedVersion is the version the upstream replied with during initialize;
+// expectedVersion is the version the broker proposed (always the latest the broker knows).
+type ProtocolValidation struct {
+	IsValid          bool   `json:"isValid"`
+	SupportedVersion string `json:"supportedVersion"`
+	ExpectedVersion  string `json:"expectedVersion"`
 }
 
 // MCP defines the interface for the manager to interact with an MCP server
@@ -91,6 +101,8 @@ type MCP interface {
 	Ping(context.Context) error
 	// IsEnabled returns true if the server should be connected to and have its tools registered.
 	IsEnabled() bool
+	// ProtocolInfo returns the initialize result (including the negotiated protocol version), or nil if not yet connected.
+	ProtocolInfo() *mcp.InitializeResult
 }
 
 // ActiveMCPServer is the handle returned by Start. It exposes read-only
@@ -519,6 +531,12 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	man.status.TotalPrompts = promptCount
 	man.status.Ready = true
 	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
+	// always report the version we expect; fill in the negotiated version once it is known
+	man.status.ProtocolValidation = ProtocolValidation{ExpectedVersion: mcp.LATEST_PROTOCOL_VERSION}
+	if info := man.mcp.ProtocolInfo(); info != nil {
+		man.status.ProtocolValidation.IsValid = true
+		man.status.ProtocolValidation.SupportedVersion = info.ProtocolVersion
+	}
 }
 
 func (man *MCPManager) resetBackoff() {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -388,7 +388,34 @@ func TestMCPManager_setStatus(t *testing.T) {
 			assert.Contains(t, manager.status.Message, tc.messageContain)
 			if tc.expectReady {
 				assert.Equal(t, tc.totalTools, manager.status.TotalTools)
+				// protocol validation is populated from the negotiated version on success
+				assert.True(t, manager.status.ProtocolValidation.IsValid)
+				assert.Equal(t, mock.protocolVersion, manager.status.ProtocolValidation.SupportedVersion)
+				assert.Equal(t, mcp.LATEST_PROTOCOL_VERSION, manager.status.ProtocolValidation.ExpectedVersion)
 			}
+		})
+	}
+}
+
+// TestMCPManager_setStatus_ProtocolVersions verifies the negotiated protocol version
+// reported by an upstream is surfaced on the status across the full valid-version
+// matrix. The matrix is driven by mcp.ValidProtocolVersions so it expands
+// automatically when the MCP library learns a new version.
+func TestMCPManager_setStatus_ProtocolVersions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	for _, version := range mcp.ValidProtocolVersions {
+		t.Run(version, func(t *testing.T) {
+			mock := newMockMCP("test-server", "test_")
+			mock.protocolVersion = version
+			manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			require.NoError(t, err)
+
+			manager.setStatus(nil, 1, 0, nil, nil)
+
+			assert.True(t, manager.status.ProtocolValidation.IsValid)
+			assert.Equal(t, version, manager.status.ProtocolValidation.SupportedVersion)
+			assert.Equal(t, mcp.LATEST_PROTOCOL_VERSION, manager.status.ProtocolValidation.ExpectedVersion)
 		})
 	}
 }

--- a/internal/broker/upstream/protocol_version_test.go
+++ b/internal/broker/upstream/protocol_version_test.go
@@ -1,0 +1,95 @@
+package upstream
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// pinnedVersionServer returns an httptest server that speaks just enough raw
+// JSON-RPC to complete an MCP initialize handshake, always replying with the
+// given protocol version regardless of what the client proposed.
+func pinnedVersionServer(t *testing.T, version string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("mcp-session-id", "test-session")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%d,"result":{"protocolVersion":%q,"capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"pinned","version":"1.0.0"}}}`, req.ID, version)
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%d,"result":{}}`, req.ID)
+		}
+	}))
+}
+
+func connectTo(t *testing.T, url string) (*MCPServer, error) {
+	t.Helper()
+	up := NewUpstreamMCP(&config.MCPServer{
+		Name:     "pinned",
+		URL:      url,
+		State:    string(mcpv1alpha1.ServerStateEnabled),
+		Hostname: "pinned",
+	})
+	return up, up.Connect(t.Context(), func() {})
+}
+
+// TestConnect_NegotiatesValidProtocolVersions asserts the broker accepts an
+// upstream pinned to any version in mcp.ValidProtocolVersions and records the
+// negotiated version. The matrix is driven by the library's own list, so it
+// stays current as new MCP versions are added upstream.
+func TestConnect_NegotiatesValidProtocolVersions(t *testing.T) {
+	for _, version := range mcp.ValidProtocolVersions {
+		t.Run(version, func(t *testing.T) {
+			srv := pinnedVersionServer(t, version)
+			t.Cleanup(srv.Close)
+
+			up, err := connectTo(t, srv.URL+"/mcp")
+			require.NoError(t, err, "broker should accept valid protocol version %s", version)
+			// disconnect before the server closes (cleanups run LIFO) to avoid noisy logs
+			t.Cleanup(func() { _ = up.Disconnect() })
+
+			info := up.ProtocolInfo()
+			require.NotNil(t, info)
+			require.Equal(t, version, info.ProtocolVersion)
+		})
+	}
+}
+
+// TestConnect_RejectsUnsupportedProtocolVersion asserts an upstream replying
+// with a version outside mcp.ValidProtocolVersions is rejected at connect time,
+// mirroring the broken-server e2e negative case at the unit level.
+func TestConnect_RejectsUnsupportedProtocolVersion(t *testing.T) {
+	srv := pinnedVersionServer(t, "2021-11-05")
+	t.Cleanup(srv.Close)
+
+	up, err := connectTo(t, srv.URL+"/mcp")
+	if up != nil {
+		t.Cleanup(func() { _ = up.Disconnect() })
+	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported protocol version")
+}


### PR DESCRIPTION
Fixes #363

## Summary

Adds **unit** coverage for MCP protocol-version negotiation.

The broker proposes the latest protocol version on connect and accepts whatever valid version the upstream replies with. A stock mark3labs server echoes the version we propose, so it always negotiates the latest — meaning the older-but-valid versions (`2024-11-05`, `2025-03-26`, `2025-06-18`) were never exercised by any test. This adds a unit-level matrix over all valid versions, plus a rejection case for an out-of-range version, driven directly by the library's own `mcp.ValidProtocolVersions` list so it expands automatically as new versions ship.

> Reworked from the original revision per review (@jasonmadigan): the e2e test server, its image, manifests, Makefile/CI matrix wiring and the rollout-loop e2e spec have been dropped. The `Connect()` path is proven at the unit level without new infra, keeping the e2e suite lighter.

## Changes

- **Unit matrix** (`internal/broker/upstream/protocol_version_test.go`): runs the full `mcp.ValidProtocolVersions` matrix against an in-process `httptest` upstream pinned to each version (raw JSON-RPC, since a normal mark3labs server cannot return a non-latest version), asserting the broker accepts each and records the negotiated version. A negative case asserts a version outside the valid set (`2021-11-05`) is rejected with `unsupported protocol version`.
- **Status coverage** (`internal/broker/upstream/manager.go`, `manager_test.go`): populate `protocolValidation` on the broker `/status` endpoint from the negotiated version (`supportedVersion`) and the proposed version (`expectedVersion`), with a unit matrix asserting it across all valid versions.
- **Design doc** (`docs/design/protocol-versions.md`): describes negotiation, validation, and the steps to react to a new protocol version.

## Verification

- `go build ./...`, `go test ./internal/broker/upstream/...` pass.
- Pinned `golangci-lint` (v2.4.0) reports 0 issues.

## Summary by CodeRabbit

* **New Features**
  * Gateway reports MCP protocol negotiation/validation in server status
* **Documentation**
  * New design doc on MCP protocol negotiation, validation, testing, and release guidance
* **Tests**
  * Unit coverage for protocol negotiation across supported versions, plus a rejection case for an unsupported version
