### PR TITLE
fix: use atomic.Pointer for RoutingConfig to eliminate data race

### DIFF
--- a/cmd/mcp-broker-router/router.go
+++ b/cmd/mcp-broker-router/router.go
@@ -11,7 +11,6 @@ func (a *app) createRouter() {
 	cfg := &a.routerCfg
 	a.grpcServer = grpc.NewServer()
 	a.router = &mcpRouter.ExtProcServer{
-		RoutingConfig:       a.mcpConfig,
 		Logger:              a.logger.With("component", "router"),
 		JWTManager:          a.jwtMgr,
 		InitForClient:       clients.Initialize,
@@ -22,6 +21,7 @@ func (a *app) createRouter() {
 		MaxRequestBodySize:  cfg.maxRequestBodySize,
 		ElicitationEnabled:  cfg.enableURLElicitation,
 	}
+	a.router.RoutingConfig.Store(a.mcpConfig)
 
 	extProcV3.RegisterExternalProcessorServer(a.grpcServer, a.router)
 }

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -229,7 +229,7 @@ func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, _ *eppb.HttpHe
 	s.Logger.DebugContext(ctx, "Request Handler: HandleRequestHeaders called")
 	requestHeaders := NewHeaders()
 	response := NewResponse()
-	requestHeaders.WithAuthority(s.RoutingConfig.MCPGatewayExternalHostname)
+	requestHeaders.WithAuthority(s.RoutingConfig.Load().MCPGatewayExternalHostname)
 	return response.WithRequestHeadersResponse(requestHeaders.Build(), internalOnlyHeaders...).Build(), nil
 }
 
@@ -621,7 +621,7 @@ func (s *ExtProcServer) HandleElicitationResponse(
 	// restore the id for the request
 	mcpReq.ID = entry.BackendID
 
-	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(entry.ServerName)
+	mcpServerConfig, err := s.RoutingConfig.Load().GetServerConfigByName(entry.ServerName)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, "server not found for elicitation response", "server", entry.ServerName)
 		mcpotel.SpanError(span, err, "server not found")
@@ -672,7 +672,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 	)
 	defer initSpan.End()
 
-	mcpServerConfig, err := s.RoutingConfig.GetServerConfigByName(mcpReq.serverName)
+	mcpServerConfig, err := s.RoutingConfig.Load().GetServerConfigByName(mcpReq.serverName)
 	if err != nil {
 		return "", NewRouterErrorf(500, "failed check for server: %w", err)
 	}
@@ -753,7 +753,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			mcpotel.SpanError(initSpan, err, "failed to generate backend-init token")
 			return "", NewRouterErrorf(500, "failed to generate backend-init token: %w", err)
 		}
-		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation)
+		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.Load().MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation)
 		if err != nil {
 			s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
 			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -197,9 +197,6 @@ func TestHandleRequestBody(t *testing.T) {
 	}
 
 	server := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: serverConfigs,
-		},
 		JWTManager:    jwtManager,
 		Logger:        logger,
 		SessionCache:  cache,
@@ -208,6 +205,9 @@ func TestHandleRequestBody(t *testing.T) {
 			"s_mytool": "dummy",
 		}),
 	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers: serverConfigs,
+	})
 
 	data := &MCPRequest{
 		ID:      ptr.To(0),
@@ -779,15 +779,15 @@ func TestHandleElicitationResponse(t *testing.T) {
 		gatewayID := mustStoreIDMap(t, elicitationMap, float64(42), "weather-server", "backend-session-abc", validToken)
 
 		server := &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{
-				Servers: serverConfigs,
-			},
 			JWTManager:     jwtManager,
 			Logger:         logger,
 			SessionCache:   cache,
 			ElicitationMap: elicitationMap,
 			Broker:         newMockBroker(serverConfigs, map[string]string{}),
 		}
+		server.RoutingConfig.Store(&config.MCPServersConfig{
+			Servers: serverConfigs,
+		})
 
 		data := &MCPRequest{
 			ID:      gatewayID,
@@ -888,15 +888,15 @@ func TestHandleElicitationResponse(t *testing.T) {
 		gatewayID := mustStoreIDMap(t, elicitationMap, float64(1), "nonexistent-server", "session-123", validToken)
 
 		server := &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{
-				Servers: []*config.MCPServer{}, // no servers configured
-			},
 			JWTManager:     jwtManager,
 			Logger:         logger,
 			SessionCache:   cache,
 			ElicitationMap: elicitationMap,
 			Broker:         newMockBroker(nil, map[string]string{}),
 		}
+		server.RoutingConfig.Store(&config.MCPServersConfig{
+			Servers: []*config.MCPServer{},
+		})
 
 		data := &MCPRequest{
 			ID:      gatewayID,
@@ -937,15 +937,15 @@ func TestHandleElicitationResponse(t *testing.T) {
 		gatewayID := mustStoreIDMap(t, elicitationMap, "original-string-id", "test-server", "backend-session-xyz", validToken)
 
 		server := &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{
-				Servers: serverConfigs,
-			},
 			JWTManager:     jwtManager,
 			Logger:         logger,
 			SessionCache:   cache,
 			ElicitationMap: elicitationMap,
 			Broker:         newMockBroker(serverConfigs, map[string]string{}),
 		}
+		server.RoutingConfig.Store(&config.MCPServersConfig{
+			Servers: serverConfigs,
+		})
 
 		data := &MCPRequest{
 			ID:      gatewayID,
@@ -994,15 +994,15 @@ func TestHandleElicitationResponse_ViaRouteMCPRequest(t *testing.T) {
 	gatewayID := mustStoreIDMap(t, elicitationMap, float64(99), "test-server", "backend-session-456", validToken)
 
 	server := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: serverConfigs,
-		},
 		JWTManager:     jwtManager,
 		Logger:         logger,
 		SessionCache:   cache,
 		ElicitationMap: elicitationMap,
 		Broker:         newMockBroker(serverConfigs, map[string]string{}),
 	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers: serverConfigs,
+	})
 
 	// elicitation response routed via RouteMCPRequest (the main switch)
 	data := &MCPRequest{
@@ -1055,13 +1055,14 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		require.NoError(t, err)
 		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
 		require.NoError(t, err)
-		return &ExtProcServer{
-			RoutingConfig: &config.MCPServersConfig{},
-			JWTManager:    jwtManager,
-			Logger:        logger,
-			SessionCache:  cache,
-			Broker:        newMockBroker(nil, map[string]string{}),
+		s := &ExtProcServer{
+			JWTManager:   jwtManager,
+			Logger:       logger,
+			SessionCache: cache,
+			Broker:       newMockBroker(nil, map[string]string{}),
 		}
+		s.RoutingConfig.Store(&config.MCPServersConfig{})
+		return s
 	}
 
 	mustImmediate := func(t *testing.T, resp []*eppb.ProcessingResponse, expectedCode int32) {
@@ -1235,16 +1236,16 @@ func TestInitializeMCPSeverSession_PassThroughHeaders(t *testing.T) {
 		},
 	}
 	srv := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers:                    serverConfigs,
-			MCPGatewayInternalHostname: "mcp-gateway.local",
-		},
 		JWTManager:    jwtManager,
 		Logger:        logger,
 		SessionCache:  cache,
 		InitForClient: mockInitForClient,
 		Broker:        newMockBroker(serverConfigs, map[string]string{}),
 	}
+	srv.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers:                    serverConfigs,
+		MCPGatewayInternalHostname: "mcp-gateway.local",
+	})
 
 	req := &MCPRequest{
 		ID:         ptr.To(0),
@@ -1309,12 +1310,12 @@ func TestHandleRequestHeaders(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			server := &ExtProcServer{
-				RoutingConfig: &config.MCPServersConfig{
-					MCPGatewayExternalHostname: tc.GatewayHostname,
-				},
 				Logger: logger,
 				Broker: newMockBroker(nil, map[string]string{}),
 			}
+			server.RoutingConfig.Store(&config.MCPServersConfig{
+				MCPGatewayExternalHostname: tc.GatewayHostname,
+			})
 
 			headers := &eppb.HttpHeaders{
 				Headers: &corev3.HeaderMap{
@@ -1459,15 +1460,15 @@ func TestHandlePromptGet(t *testing.T) {
 	}
 
 	srv := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: serverConfigs,
-		},
 		JWTManager:    jwtManager,
 		Logger:        logger,
 		SessionCache:  cache,
 		InitForClient: mockInitForClient,
 		Broker:        testBroker,
 	}
+	srv.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers: serverConfigs,
+	})
 
 	data := &MCPRequest{
 		ID:      ptr.To(0),
@@ -1535,10 +1536,6 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 	}
 
 	server := &ExtProcServer{
-		RoutingConfig: &config.MCPServersConfig{
-			Servers:                    serverConfigs,
-			MCPGatewayExternalHostname: "gateway.example.com",
-		},
 		JWTManager:   jwtManager,
 		Logger:       logger,
 		SessionCache: cache,
@@ -1550,6 +1547,10 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 		TokenElicitationMap: tokenElicitationMap,
 		ElicitationEnabled:  true,
 	}
+	server.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers:                    serverConfigs,
+		MCPGatewayExternalHostname: "gateway.example.com",
+	})
 	return server, validToken
 }
 

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -59,7 +59,7 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 	// intercept 401 from backend: if the server uses URL token elicitation,
 	// delete the cached user token so the next tool call triggers re-elicitation
 	if status == "401" && req != nil && s.ElicitationEnabled {
-		serverInfo, cfgErr := s.RoutingConfig.GetServerConfigByName(req.serverName)
+		serverInfo, cfgErr := s.RoutingConfig.Load().GetServerConfigByName(req.serverName)
 		if cfgErr == nil && serverInfo.TokenURLElicitation != nil {
 			span := trace.SpanFromContext(ctx)
 			span.SetAttributes(

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -492,9 +492,9 @@ func TestHandleResponseHeaders_401DeletesUserToken(t *testing.T) {
 		Logger:             logger,
 		SessionCache:       cache,
 		Broker:             newMockBroker(nil, map[string]string{}),
-		RoutingConfig:      routingConfig,
 		ElicitationEnabled: true,
 	}
+	srv.RoutingConfig.Store(routingConfig)
 
 	// store a user token in the cache
 	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "expired-token"))
@@ -571,9 +571,9 @@ func TestHandleResponseHeaders_401SkipsTokenDeleteWhenNotApplicable(t *testing.T
 				Logger:             logger,
 				SessionCache:       cache,
 				Broker:             newMockBroker(nil, map[string]string{}),
-				RoutingConfig:      routingConfig,
 				ElicitationEnabled: tt.elicitationEnabled,
 			}
+			srv.RoutingConfig.Store(routingConfig)
 
 			require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, tt.serverName, "my-token"))
 
@@ -660,9 +660,9 @@ func TestHandleResponseHeaders_SuccessStatusDoesNotDeleteUserToken(t *testing.T)
 		Logger:             logger,
 		SessionCache:       cache,
 		Broker:             newMockBroker(nil, map[string]string{}),
-		RoutingConfig:      routingConfig,
 		ElicitationEnabled: true,
 	}
+	srv.RoutingConfig.Store(routingConfig)
 
 	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "valid-token"))
 

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
@@ -44,7 +45,7 @@ type InitForClient func(ctx context.Context, gatewayHost, initToken string, conf
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {
-	RoutingConfig       *config.MCPServersConfig
+	RoutingConfig       atomic.Pointer[config.MCPServersConfig]
 	JWTManager          *session.JWTManager
 	Logger              *slog.Logger
 	InitForClient       InitForClient
@@ -62,7 +63,7 @@ type ExtProcServer struct {
 
 // OnConfigChange is used to register the router for config changes
 func (s *ExtProcServer) OnConfigChange(_ context.Context, newConfig *config.MCPServersConfig) {
-	s.RoutingConfig = newConfig
+	s.RoutingConfig.Store(newConfig)
 }
 
 // Process function

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -528,22 +528,23 @@ func newTestServer(t *testing.T) *ExtProcServer {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cache, err := session.NewCache()
 	require.NoError(t, err)
-	return &ExtProcServer{
+	s := &ExtProcServer{
 		Logger:       logger,
 		SessionCache: cache,
 		Broker:       newMockBroker(nil, map[string]string{}),
-		RoutingConfig: &config.MCPServersConfig{
-			Servers: []*config.MCPServer{
-				{
-					Name:     "dummy",
-					URL:      "http://localhost:9090",
-					Prefix:   "",
-					State:    "Enabled",
-					Hostname: "dummy",
-				},
+	}
+	s.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers: []*config.MCPServer{
+			{
+				Name:     "dummy",
+				URL:      "http://localhost:9090",
+				Prefix:   "",
+				State:    "Enabled",
+				Hostname: "dummy",
 			},
 		},
-	}
+	})
+	return s
 }
 
 // requestHeadersStep returns a standard request headers step


### PR DESCRIPTION
## Summary

- Fix data race on `ExtProcServer.RoutingConfig` where `OnConfigChange` performed a bare pointer write while concurrent `Process` goroutines read it
- Change field type from `*config.MCPServersConfig` to `atomic.Pointer[config.MCPServersConfig]`
- All writes use `.Store()`, all reads use `.Load()`

Closes #1081

## Review Guidance

- `internal/mcp-router/server.go` -- field type change and `OnConfigChange` write
- `internal/mcp-router/request_handlers.go` -- 4 read sites updated to `.Load()`
- `internal/mcp-router/response_handlers.go` -- 1 read site updated
- `cmd/mcp-broker-router/router.go` -- initialisation changed from struct literal to `.Store()` call
- Test files -- mechanical: move config out of struct literal, call `.Store()` after

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/mcp-router/...` passes with no race warnings
- [x] `make test-unit` passes
- [x] `make lint` passes (pre-existing 29 issues unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal routing configuration management to use consistent storage and retrieval patterns across request handlers, response handlers, and server initialization. These changes improve the reliability of configuration access throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->