### PR TITLE
fix: remove stale virtual servers on config change

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -339,8 +339,9 @@ func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServ
 		}
 	}
 
-	// register virtual servers
+	// rebuild virtual servers so deleted ones stop scoping tools
 	m.vsLock.Lock()
+	m.virtualServers = make(map[string]*config.VirtualServer, len(virtualServers))
 	for _, vs := range virtualServers {
 		m.virtualServers[vs.Name] = vs
 	}

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -113,12 +113,17 @@ func TestOnConfigChange(t *testing.T) {
 	}
 
 	conf.Servers = []*config.MCPServer{}
+	conf.VirtualServers = []*config.VirtualServer{}
 	b.OnConfigChange(context.TODO(), conf)
 	servers = b.RegisteredMCPServers()
 	require.Equal(t, 0, len(servers))
 	if _, ok := servers[server1.ID()]; ok {
 		t.Fatalf("expected server 1 not to be registered")
 	}
+
+	// deleting the virtual server must stop it from scoping tools
+	_, err = b.GetVirtualSeverByHeader("test/test")
+	require.Error(t, err, "expected deleted virtual server to no longer be found")
 
 	_ = b.Shutdown(context.Background())
 }


### PR DESCRIPTION
## What

`OnConfigChange` only ever added virtual servers to the map — it never removed them. So when an `MCPVirtualServer` CRD is deleted, its entry stays in the broker and keeps scoping tools indefinitely.

MCP servers already handle this correctly (they get deregistered when they drop out of the config). Virtual servers were the odd one out.

## Fix

Rebuild the map on each config change, the same way the server deregistration path keeps the broker in sync:

```go
m.virtualServers = make(map[string]*config.VirtualServer, len(virtualServers))
for _, vs := range virtualServers {
    m.virtualServers[vs.Name] = vs
}
```

Deleted virtual servers now fall out of the map, so their tool scoping stops.

## Test

Extended `TestOnConfigChange` to delete the virtual server and assert the lookup fails. Confirmed it fails on `main` and passes with the fix.

```
ok  github.com/Kuadrant/mcp-gateway/internal/broker
```

Closes #1084
Related #984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual servers removed from configuration are now properly cleaned up, so they no longer affect tool availability or scoping behavior.

* **Tests**
  * Added/updated tests to verify that removed virtual servers are deregistered and no longer retrievable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->