### PR TITLE
fixes : #1089 (L3)

### DIFF
--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -267,7 +267,7 @@ func (s *ExtProcServer) validateSession(sessionID string) *RouterError {
 	}
 	isInvalid, err := s.JWTManager.Validate(sessionID)
 	if err != nil || isInvalid {
-		return NewRouterError(404, fmt.Errorf("session no longer valid"))
+		return NewRouterError(401, fmt.Errorf("session no longer valid"))
 	}
 	return nil
 }
@@ -777,7 +777,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 			// this err would be caused by an invalid token so force a re-initialize
 			s.Logger.ErrorContext(ctx, "failed to get expires in value. Forcing session reset", "err", err)
 			sessionCloser()
-			return "", NewRouterError(404, fmt.Errorf("invalid session"))
+			return "", NewRouterError(401, fmt.Errorf("invalid session"))
 		}
 		// compute once: reuse for both the Redis TTL and the cleanup timer so they
 		// are always in sync, and guard against a near-zero/negative value which
@@ -786,7 +786,7 @@ func (s *ExtProcServer) initializeMCPSeverSession(ctx context.Context, mcpReq *M
 		if ttl <= 0 {
 			s.Logger.ErrorContext(ctx, "session already expired, forcing reset", "session", mcpReq.GetSessionID())
 			sessionCloser()
-			return "", NewRouterError(404, fmt.Errorf("invalid session"))
+			return "", NewRouterError(401, fmt.Errorf("invalid session"))
 		}
 		remoteSessionID := clientHandle.GetSessionId()
 		s.Logger.DebugContext(ctx, "got remote session id ", "mcp server", mcpServerConfig.Name, "session", remoteSessionID)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -493,7 +493,7 @@ func TestValidateSession(t *testing.T) {
 	t.Run("invalid JWT", func(t *testing.T) {
 		routerErr := server.validateSession("invalid-jwt-token")
 		require.NotNil(t, routerErr)
-		require.Equal(t, int32(404), routerErr.Code())
+		require.Equal(t, int32(401), routerErr.Code())
 	})
 }
 


### PR DESCRIPTION
Changes:
- `validateSession` — invalid JWT now returns 401
- `initializeMCPSeverSession` — invalid token and expired TTL now return 401
- Updated test assertion accordingly
Fixes #1089 (L3)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP session validation error responses to return HTTP 401 Unauthorized for invalid or expired sessions, replacing incorrect 404 Not Found responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->