### PR TITLE
removed the mcp lock from validateservertools

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -48,14 +48,14 @@ type commonConfig struct {
 }
 
 type routerConfig struct {
-	// commonConfig is to be considered imutable
+	// commonConfig is to be considered immutable
 	commonConfig
 	addr               string
 	maxRequestBodySize int
 }
 
 type brokerConfig struct {
-	// commonConfig is to be considered imutable
+	// commonConfig is to be considered immutable
 	commonConfig
 	addr                       string
 	writeTimeoutSecs           int64

--- a/internal/broker/discovery.go
+++ b/internal/broker/discovery.go
@@ -230,11 +230,17 @@ func (m *mcpBrokerImpl) handleSelectTools(ctx context.Context, req mcp.CallToolR
 		return m.marshalToolResult(m.selectResponse("scope reset to all tools", nil, warning)), nil
 	}
 
-	if err := m.validateToolSelection(toolNames, req.Header, sessionID); err != nil {
+	m.mcpLock.RLock()
+	valErr := m.validateToolSelectionLocked(toolNames, req.Header, sessionID)
+	if valErr == nil {
+		m.scopeStore.setScope(sessionID, toolNames)
+	}
+	m.mcpLock.RUnlock()
+
+	if valErr != nil {
 		return mcp.NewToolResultError("tool not available"), nil
 	}
 
-	m.scopeStore.setScope(sessionID, toolNames)
 	warning := m.sendToolsListChanged(sessionID)
 
 	if span.IsRecording() {
@@ -245,11 +251,10 @@ func (m *mcpBrokerImpl) handleSelectTools(ctx context.Context, req mcp.CallToolR
 	return m.marshalToolResult(m.selectResponse(status, toolNames, warning)), nil
 }
 
-// validateToolSelection checks that every requested tool is visible and not a broker meta-tool.
-func (m *mcpBrokerImpl) validateToolSelection(toolNames []string, headers map[string][]string, sessionID string) error {
-	m.mcpLock.RLock()
+// validateToolSelectionLocked checks that every requested tool is visible and not a broker meta-tool.
+// caller must hold mcpLock.
+func (m *mcpBrokerImpl) validateToolSelectionLocked(toolNames []string, headers map[string][]string, sessionID string) error {
 	visible := m.getVisibleToolNames(headers)
-	m.mcpLock.RUnlock()
 
 	for _, name := range toolNames {
 		if isBrokerToolName(name) {


### PR DESCRIPTION
closes #1088

 fixes a race condition where OnConfigChange could modify upstream servers between tool validation and scope application during a select_tools request.

- Held mcpLock.RLock() across the entire handleSelectTools transaction.
- Refactored validateToolSelection to validateToolSelectionLocked.
- Fixed a minor spelling typo (imutable -> immutable).
- Tested with go test -race to guarantee thread safety.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed documentation typo in configuration comments.

* **Refactor**
  * Optimized internal tool validation performance by reducing lock acquisition overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->