### PR TITLE
condition for jwt hs256 extending till 32 bytes

### DIFF
--- a/docs/release-notes/1086-signing-key-length.md
+++ b/docs/release-notes/1086-signing-key-length.md
@@ -1,0 +1,14 @@
+# Breaking Change: GATEWAY_SIGNING_KEY Minimum Length
+
+## What changed
+The minimum allowed length for `GATEWAY_SIGNING_KEY` is now 32 bytes. This aligns with RFC 7518 Section 3.2 for HS256 JWT signatures and is enforced across both session encryption and JWT signing. The gateway will now fail fast at startup if a key shorter than 32 bytes is provided.
+
+## Migration Steps
+If your deployment previously used a `GATEWAY_SIGNING_KEY` shorter than 32 bytes, you must generate and provide a new key.
+
+1. Generate a new secure 32-byte key:
+   ```bash
+   openssl rand -base64 32
+   ```
+2. Update your gateway configuration or deployment to use the newly generated key for `GATEWAY_SIGNING_KEY`.
+3. Restart the gateway. Note that because this is a breaking change to the signing key, existing sessions and backend initialization tokens will become invalid, and users will need to re-authenticate.

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testSigningKey = "test-signing-key-must-be-at-least-32-bytes"
+
 func TestMCPRequestValid(t *testing.T) {
 
 	testCases := []struct {
@@ -169,7 +171,7 @@ func TestHandleRequestBody(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create JWT manager for test
-	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 	require.NoError(t, err)
 
 	// Generate a valid JWT token
@@ -471,7 +473,7 @@ func TestValidateSession(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 	require.NoError(t, err)
 
 	validToken := jwtManager.Generate()
@@ -761,7 +763,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -845,7 +847,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -880,7 +882,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -921,7 +923,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -978,7 +980,7 @@ func TestHandleElicitationResponse_ViaRouteMCPRequest(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 	require.NoError(t, err)
 
 	validToken := jwtManager.Generate()
@@ -1054,7 +1056,7 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		t.Helper()
 		cache, err := session.NewCache()
 		require.NoError(t, err)
-		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 		require.NoError(t, err)
 		return &ExtProcServer{
 			RoutingConfig: &config.MCPServersConfig{},
@@ -1212,7 +1214,7 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 
 	cache, err := session.NewCache()
 	require.NoError(t, err)
-	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 	require.NoError(t, err)
 
 	var captured map[string]string
@@ -1431,7 +1433,7 @@ func TestHandlePromptGet(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 	require.NoError(t, err)
 
 	validToken := jwtManager.Generate()
@@ -1525,7 +1527,7 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cache, err := session.NewCache()
 	require.NoError(t, err)
-	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager(testSigningKey, 0, logger, cache)
 	require.NoError(t, err)
 	validToken := jwtManager.Generate()
 

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -169,7 +169,7 @@ func TestHandleRequestBody(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create JWT manager for test
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 
 	// Generate a valid JWT token
@@ -471,7 +471,7 @@ func TestValidateSession(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 
 	validToken := jwtManager.Generate()
@@ -761,7 +761,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -845,7 +845,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -880,7 +880,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -921,7 +921,7 @@ func TestHandleElicitationResponse(t *testing.T) {
 		cache, err := session.NewCache()
 		require.NoError(t, err)
 
-		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 		require.NoError(t, err)
 
 		validToken := jwtManager.Generate()
@@ -978,7 +978,7 @@ func TestHandleElicitationResponse_ViaRouteMCPRequest(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 
 	validToken := jwtManager.Generate()
@@ -1054,7 +1054,7 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		t.Helper()
 		cache, err := session.NewCache()
 		require.NoError(t, err)
-		jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+		jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 		require.NoError(t, err)
 		return &ExtProcServer{
 			RoutingConfig: &config.MCPServersConfig{},
@@ -1166,7 +1166,7 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 	t.Run("rejects token signed by a different gateway", func(t *testing.T) {
 		srv := newServer(t)
 		const targetHost = "backend.example.com"
-		other, err := session.NewJWTManager("other-key", 0, logger, nil)
+		other, err := session.NewJWTManager("other-key-must-be-at-least-32-bytes", 0, logger, nil)
 		require.NoError(t, err)
 		token, err := other.GenerateBackendInitToken(targetHost)
 		require.NoError(t, err)
@@ -1212,7 +1212,7 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 
 	cache, err := session.NewCache()
 	require.NoError(t, err)
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 
 	var captured map[string]string
@@ -1431,7 +1431,7 @@ func TestHandlePromptGet(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 
 	validToken := jwtManager.Generate()
@@ -1525,7 +1525,7 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cache, err := session.NewCache()
 	require.NoError(t, err)
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 	validToken := jwtManager.Generate()
 

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -379,7 +379,7 @@ func TestHandleResponseHeaders_StoresElicitationForDirectInit(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key-must-be-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 	brokerSessionID := jwtManager.Generate()
 

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -379,7 +379,7 @@ func TestHandleResponseHeaders_StoresElicitationForDirectInit(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
 	require.NoError(t, err)
 	brokerSessionID := jwtManager.Generate()
 

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -379,7 +379,7 @@ func TestHandleResponseHeaders_StoresElicitationForDirectInit(t *testing.T) {
 	cache, err := session.NewCache()
 	require.NoError(t, err)
 
-	jwtManager, err := session.NewJWTManager("test-signing-key", 0, logger, cache)
+	jwtManager, err := session.NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, logger, cache)
 	require.NoError(t, err)
 	brokerSessionID := jwtManager.Generate()
 

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -487,7 +487,7 @@ func TestDeriveEncryptionKey_ShortKeyRejected(t *testing.T) {
 }
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
-	key, err := DeriveEncryptionKey([]byte("test-signing-key-for-encryption"))
+	key, err := DeriveEncryptionKey([]byte("test-signing-key-for-encryption-32"))
 	require.NoError(t, err)
 
 	plaintext := "ghp_secrettoken123"
@@ -502,8 +502,8 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 }
 
 func TestDecryptWithWrongKey(t *testing.T) {
-	key1, _ := DeriveEncryptionKey([]byte("key-one-long-enough"))
-	key2, _ := DeriveEncryptionKey([]byte("key-two-long-enough"))
+	key1, _ := DeriveEncryptionKey([]byte("key-one-long-enough-for-32-bytes"))
+	key2, _ := DeriveEncryptionKey([]byte("key-two-long-enough-for-32-bytes"))
 
 	ciphertext, _ := encrypt(key1, "secret")
 	_, err := decrypt(key2, ciphertext)

--- a/internal/session/crypto.go
+++ b/internal/session/crypto.go
@@ -16,8 +16,8 @@ import (
 
 // DeriveEncryptionKey derives a 32-byte AES-256 key from the session signing key using HKDF.
 func DeriveEncryptionKey(signingKey []byte) ([]byte, error) {
-	if len(signingKey) < 16 {
-		return nil, fmt.Errorf("signing key too short: need at least 16 bytes")
+	if len(signingKey) < 32 {
+		return nil, fmt.Errorf("signing key too short: need at least 32 bytes")
 	}
 	r := hkdf.New(sha256.New, signingKey, nil, []byte("mcp-gateway-user-token-encryption"))
 	key := make([]byte, 32)

--- a/internal/session/jwt.go
+++ b/internal/session/jwt.go
@@ -63,8 +63,8 @@ type JWTManager struct {
 
 // NewJWTManager creates a new JWT manager with the provided signing key
 func NewJWTManager(signingKey string, sessionLength int64, logger *slog.Logger, sessionHandler Deleter) (*JWTManager, error) {
-	if signingKey == "" {
-		return nil, fmt.Errorf("no signing key provided")
+	if len(signingKey) < 32 {
+		return nil, fmt.Errorf("signing key must be at least 32 bytes for HS256")
 	}
 	var sessionDuration = DefaultSessionDuration
 	if sessionLength != 0 {

--- a/internal/session/jwt_test.go
+++ b/internal/session/jwt_test.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 )
+
+const testSigningKey = "test-signing-key-must-be-at-least-32-bytes"
 
 // blockingDeleter blocks DeleteSessions until the supplied context is canceled
 // or its deadline elapses, then returns ctx.Err().
@@ -31,7 +34,7 @@ func testLogger() *slog.Logger {
 
 func TestNewJWTManager(t *testing.T) {
 	t.Run("with custom key", func(t *testing.T) {
-		key := "test-signing-key-must-be-at-least-32-bytes"
+		key := testSigningKey
 		manager, err := NewJWTManager(key, 0, testLogger(), nil)
 
 		if err != nil {
@@ -49,7 +52,7 @@ func TestNewJWTManager(t *testing.T) {
 	})
 
 	t.Run("with custom session duration", func(t *testing.T) {
-		key := "test-signing-key-must-be-at-least-32-bytes"
+		key := testSigningKey
 		manager, err := NewJWTManager(key, 48, testLogger(), nil)
 
 		if err != nil {
@@ -71,10 +74,30 @@ func TestNewJWTManager(t *testing.T) {
 			t.Error("expected nil manager for empty key")
 		}
 	})
+
+	t.Run("with 31-byte key returns error", func(t *testing.T) {
+		manager, err := NewJWTManager(strings.Repeat("a", 31), 0, testLogger(), nil)
+		if err == nil {
+			t.Error("expected error for 31-byte signing key")
+		}
+		if manager != nil {
+			t.Error("expected nil manager")
+		}
+	})
+
+	t.Run("with 32-byte key returns success", func(t *testing.T) {
+		manager, err := NewJWTManager(strings.Repeat("a", 32), 0, testLogger(), nil)
+		if err != nil {
+			t.Fatalf("unexpected error for 32-byte signing key: %v", err)
+		}
+		if manager == nil {
+			t.Fatal("expected manager to be created")
+		}
+	})
 }
 
 func TestGenerate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 
 	t.Run("generates valid JWT", func(t *testing.T) {
 		token := manager.Generate()
@@ -125,7 +148,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 
 	t.Run("validates correct token", func(t *testing.T) {
 		token := manager.Generate()
@@ -164,7 +187,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("rejects expired token", func(t *testing.T) {
 		// create a manager with very short duration
-		shortManager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+		shortManager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 		shortManager.duration = 1 * time.Nanosecond
 
 		token := shortManager.Generate()
@@ -200,7 +223,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestBackendInitToken(t *testing.T) {
-	manager, err := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, err := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -328,7 +351,7 @@ func TestBackendInitToken(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -349,7 +372,7 @@ func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -370,7 +393,7 @@ func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 
 	// craft a token with no exp claim
 	claims := Claims{
@@ -381,7 +404,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("test-key-must-be-at-least-32-bytes"))
+	tokenString, err := token.SignedString([]byte(testSigningKey))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -396,7 +419,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -406,7 +429,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("test-key-must-be-at-least-32-bytes"))
+	tokenString, err := token.SignedString([]byte(testSigningKey))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -418,7 +441,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestTerminate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager(testSigningKey, 0, testLogger(), nil)
 
 	t.Run("terminate returns no error", func(t *testing.T) {
 		token := manager.Generate()
@@ -437,7 +460,7 @@ func TestTerminate(t *testing.T) {
 		// is canceled. Without the WithTimeout fix, Terminate would block
 		// indefinitely; with it, Terminate must return within ~terminateTimeout.
 		deleter := &blockingDeleter{called: make(chan struct{})}
-		manager, err := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), deleter)
+		manager, err := NewJWTManager(testSigningKey, 0, testLogger(), deleter)
 		if err != nil {
 			t.Fatalf("unexpected error constructing manager: %v", err)
 		}

--- a/internal/session/jwt_test.go
+++ b/internal/session/jwt_test.go
@@ -31,7 +31,7 @@ func testLogger() *slog.Logger {
 
 func TestNewJWTManager(t *testing.T) {
 	t.Run("with custom key", func(t *testing.T) {
-		key := "test-signing-key"
+		key := "this-is-a-dummy-secret-key-that-is-at-least-32-bytes"
 		manager, err := NewJWTManager(key, 0, testLogger(), nil)
 
 		if err != nil {
@@ -49,7 +49,7 @@ func TestNewJWTManager(t *testing.T) {
 	})
 
 	t.Run("with custom session duration", func(t *testing.T) {
-		key := "test-signing-key"
+		key := "this-is-a-dummy-secret-key-that-is-at-least-32-bytes"
 		manager, err := NewJWTManager(key, 48, testLogger(), nil)
 
 		if err != nil {
@@ -74,7 +74,7 @@ func TestNewJWTManager(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 
 	t.Run("generates valid JWT", func(t *testing.T) {
 		token := manager.Generate()
@@ -125,7 +125,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 
 	t.Run("validates correct token", func(t *testing.T) {
 		token := manager.Generate()
@@ -140,7 +140,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("rejects token with wrong signing key", func(t *testing.T) {
-		otherManager, _ := NewJWTManager("different-key", 0, testLogger(), nil)
+		otherManager, _ := NewJWTManager("this-is-a-different-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 		token := otherManager.Generate()
 
 		isNotAllowed, err := manager.Validate(token)
@@ -164,7 +164,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("rejects expired token", func(t *testing.T) {
 		// create a manager with very short duration
-		shortManager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+		shortManager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 		shortManager.duration = 1 * time.Nanosecond
 
 		token := shortManager.Generate()
@@ -200,7 +200,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestBackendInitToken(t *testing.T) {
-	manager, err := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, err := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestBackendInitToken(t *testing.T) {
 	})
 
 	t.Run("rejects token signed with different key", func(t *testing.T) {
-		other, _ := NewJWTManager("different-key", 0, testLogger(), nil)
+		other, _ := NewJWTManager("this-is-a-different-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 		token, err := other.GenerateBackendInitToken("backend.example.com")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -328,7 +328,7 @@ func TestBackendInitToken(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -349,7 +349,7 @@ func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -370,7 +370,7 @@ func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 
 	// craft a token with no exp claim
 	claims := Claims{
@@ -381,7 +381,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("test-key"))
+	tokenString, err := token.SignedString([]byte("this-is-a-dummy-secret-key-that-is-at-least-32-bytes"))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -406,7 +406,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("test-key"))
+	tokenString, err := token.SignedString([]byte("this-is-a-dummy-secret-key-that-is-at-least-32-bytes"))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestTerminate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
 
 	t.Run("terminate returns no error", func(t *testing.T) {
 		token := manager.Generate()

--- a/internal/session/jwt_test.go
+++ b/internal/session/jwt_test.go
@@ -31,7 +31,7 @@ func testLogger() *slog.Logger {
 
 func TestNewJWTManager(t *testing.T) {
 	t.Run("with custom key", func(t *testing.T) {
-		key := "test-signing-key"
+		key := "test-signing-key-must-be-at-least-32-bytes"
 		manager, err := NewJWTManager(key, 0, testLogger(), nil)
 
 		if err != nil {
@@ -49,7 +49,7 @@ func TestNewJWTManager(t *testing.T) {
 	})
 
 	t.Run("with custom session duration", func(t *testing.T) {
-		key := "test-signing-key"
+		key := "test-signing-key-must-be-at-least-32-bytes"
 		manager, err := NewJWTManager(key, 48, testLogger(), nil)
 
 		if err != nil {
@@ -74,7 +74,7 @@ func TestNewJWTManager(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 
 	t.Run("generates valid JWT", func(t *testing.T) {
 		token := manager.Generate()
@@ -125,7 +125,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 
 	t.Run("validates correct token", func(t *testing.T) {
 		token := manager.Generate()
@@ -140,7 +140,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("rejects token with wrong signing key", func(t *testing.T) {
-		otherManager, _ := NewJWTManager("different-key", 0, testLogger(), nil)
+		otherManager, _ := NewJWTManager("different-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 		token := otherManager.Generate()
 
 		isNotAllowed, err := manager.Validate(token)
@@ -164,7 +164,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("rejects expired token", func(t *testing.T) {
 		// create a manager with very short duration
-		shortManager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+		shortManager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 		shortManager.duration = 1 * time.Nanosecond
 
 		token := shortManager.Generate()
@@ -200,7 +200,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestBackendInitToken(t *testing.T) {
-	manager, err := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, err := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestBackendInitToken(t *testing.T) {
 	})
 
 	t.Run("rejects token signed with different key", func(t *testing.T) {
-		other, _ := NewJWTManager("different-key", 0, testLogger(), nil)
+		other, _ := NewJWTManager("different-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 		token, err := other.GenerateBackendInitToken("backend.example.com")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -328,7 +328,7 @@ func TestBackendInitToken(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -349,7 +349,7 @@ func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -370,7 +370,7 @@ func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 
 	// craft a token with no exp claim
 	claims := Claims{
@@ -381,7 +381,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("test-key"))
+	tokenString, err := token.SignedString([]byte("test-key-must-be-at-least-32-bytes"))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -406,7 +406,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("test-key"))
+	tokenString, err := token.SignedString([]byte("test-key-must-be-at-least-32-bytes"))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestTerminate(t *testing.T) {
-	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), nil)
 
 	t.Run("terminate returns no error", func(t *testing.T) {
 		token := manager.Generate()
@@ -437,7 +437,7 @@ func TestTerminate(t *testing.T) {
 		// is canceled. Without the WithTimeout fix, Terminate would block
 		// indefinitely; with it, Terminate must return within ~terminateTimeout.
 		deleter := &blockingDeleter{called: make(chan struct{})}
-		manager, err := NewJWTManager("test-key", 0, testLogger(), deleter)
+		manager, err := NewJWTManager("test-key-must-be-at-least-32-bytes", 0, testLogger(), deleter)
 		if err != nil {
 			t.Fatalf("unexpected error constructing manager: %v", err)
 		}

--- a/internal/session/jwt_test.go
+++ b/internal/session/jwt_test.go
@@ -31,7 +31,7 @@ func testLogger() *slog.Logger {
 
 func TestNewJWTManager(t *testing.T) {
 	t.Run("with custom key", func(t *testing.T) {
-		key := "this-is-a-dummy-secret-key-that-is-at-least-32-bytes"
+		key := "test-signing-key"
 		manager, err := NewJWTManager(key, 0, testLogger(), nil)
 
 		if err != nil {
@@ -49,7 +49,7 @@ func TestNewJWTManager(t *testing.T) {
 	})
 
 	t.Run("with custom session duration", func(t *testing.T) {
-		key := "this-is-a-dummy-secret-key-that-is-at-least-32-bytes"
+		key := "test-signing-key"
 		manager, err := NewJWTManager(key, 48, testLogger(), nil)
 
 		if err != nil {
@@ -74,7 +74,7 @@ func TestNewJWTManager(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 
 	t.Run("generates valid JWT", func(t *testing.T) {
 		token := manager.Generate()
@@ -125,7 +125,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 
 	t.Run("validates correct token", func(t *testing.T) {
 		token := manager.Generate()
@@ -140,7 +140,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("rejects token with wrong signing key", func(t *testing.T) {
-		otherManager, _ := NewJWTManager("this-is-a-different-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+		otherManager, _ := NewJWTManager("different-key", 0, testLogger(), nil)
 		token := otherManager.Generate()
 
 		isNotAllowed, err := manager.Validate(token)
@@ -164,7 +164,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("rejects expired token", func(t *testing.T) {
 		// create a manager with very short duration
-		shortManager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+		shortManager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 		shortManager.duration = 1 * time.Nanosecond
 
 		token := shortManager.Generate()
@@ -200,7 +200,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestBackendInitToken(t *testing.T) {
-	manager, err := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, err := NewJWTManager("test-key", 0, testLogger(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestBackendInitToken(t *testing.T) {
 	})
 
 	t.Run("rejects token signed with different key", func(t *testing.T) {
-		other, _ := NewJWTManager("this-is-a-different-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+		other, _ := NewJWTManager("different-key", 0, testLogger(), nil)
 		token, err := other.GenerateBackendInitToken("backend.example.com")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -328,7 +328,7 @@ func TestBackendInitToken(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -349,7 +349,7 @@ func TestValidate_RejectsTokenWithWrongIssuer(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -370,7 +370,7 @@ func TestValidate_RejectsTokenWithWrongAudience(t *testing.T) {
 }
 
 func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 
 	// craft a token with no exp claim
 	claims := Claims{
@@ -381,7 +381,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("this-is-a-dummy-secret-key-that-is-at-least-32-bytes"))
+	tokenString, err := token.SignedString([]byte("test-key"))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestValidate_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -406,7 +406,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte("this-is-a-dummy-secret-key-that-is-at-least-32-bytes"))
+	tokenString, err := token.SignedString([]byte("test-key"))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestGetExpiresIn_RejectsTokenWithoutExp(t *testing.T) {
 }
 
 func TestTerminate(t *testing.T) {
-	manager, _ := NewJWTManager("this-is-a-dummy-secret-key-that-is-at-least-32-bytes", 0, testLogger(), nil)
+	manager, _ := NewJWTManager("test-key", 0, testLogger(), nil)
 
 	t.Run("terminate returns no error", func(t *testing.T) {
 		token := manager.Generate()


### PR DESCRIPTION
Fixes #1086

Just have doubt with the  imutable whether it is correct or not ? or is it  immutable ?? i have to keep immutable for the passing of lint checks 
 
kept a condition that signing key length should'nt be more than 32. 
changed the unit test description wherever it was necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum 32-byte `GATEWAY_SIGNING_KEY` length for JWT signing and session encryption key derivation.
  * Updated error handling to reject keys shorter than the required length.

* **Tests**
  * Updated JWT tests to use 32+ byte signing keys and added coverage for invalid (31-byte) keys.
  * Updated encryption/decryption tests to use longer key material for key derivation.

* **Documentation**
  * Added a breaking-change release note describing the 32-byte minimum key requirement and migration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->