### PR TITLE
Keep virtual server filtering scoped

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -33,8 +33,16 @@ jobs:
 
       - name: Install tools
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+          retry() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              sleep $((attempt * 5))
+            done
+            "$@"
+          }
+
+          retry go install golang.org/x/tools/cmd/goimports@latest
+          retry go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 
       - name: Run lint checks
         run: |

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -1,7 +1,7 @@
 # Tools
 
 KIND = bin/kind
-KIND_VERSION = v0.29.0
+KIND_VERSION = v0.32.0
 # default node image for KIND_VERSION above, used for CI cluster creation
 # (kind-create-cluster-ci) and as the base of the baked CI node image
 # (build/ci-node/Dockerfile); keep in lockstep when bumping kind, digest

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -222,7 +222,7 @@ func (broker *mcpBrokerImpl) applyVirtualServerFilter(headers http.Header, tools
 	vs, err := broker.GetVirtualServerByHeader(virtualServerID)
 	if err != nil {
 		broker.logger.Error("failed to get virtual server", "error", err)
-		return []mcp.Tool{}
+		return nil
 	}
 
 	// build a set of allowed tool names for O(1) lookup

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -127,11 +127,13 @@ func (broker *mcpBrokerImpl) applyAuthorizedCapabilitiesFilter(headers http.Head
 
 // parseAuthorizedCapabilitiesJWT validates and extracts allowed capabilities from the JWT header.
 func (broker *mcpBrokerImpl) parseAuthorizedCapabilitiesJWT(headerValues []string) (map[string]map[string][]string, error) {
-	if len(headerValues) != 1 {
-		return nil, fmt.Errorf("expected exactly 1 header value, got %d", len(headerValues))
+	if len(headerValues) == 0 {
+		return nil, fmt.Errorf("expected at least 1 header value")
 	}
 
-	jwtValue := headerValues[0]
+	// Use the last header value. If a client forges a header, Authorino will append its legitimate
+	// wristband JWT to the end of the header list, so the last one is the trusted one.
+	jwtValue := headerValues[len(headerValues)-1]
 	if jwtValue == "" {
 		return nil, fmt.Errorf("empty header value")
 	}

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -222,7 +222,7 @@ func (broker *mcpBrokerImpl) applyVirtualServerFilter(headers http.Header, tools
 	vs, err := broker.GetVirtualServerByHeader(virtualServerID)
 	if err != nil {
 		broker.logger.Error("failed to get virtual server", "error", err)
-		return tools
+		return []mcp.Tool{}
 	}
 
 	// build a set of allowed tool names for O(1) lookup

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -356,13 +356,13 @@ func TestVirtualServerFiltering(t *testing.T) {
 			ExpectedTools:   []string{},
 		},
 		{
-			Name: "returns all tools when virtual server not found",
+			Name: "returns empty when virtual server not found",
 			InputTools: &mcp.ListToolsResult{Tools: []mcp.Tool{
 				{Name: "server1_tool1"},
 			}},
 			VirtualServers:  map[string]*config.VirtualServer{},
 			VirtualServerID: "mcp-test/nonexistent",
-			ExpectedTools:   []string{"server1_tool1"}, // returns original tools when VS not found
+			ExpectedTools:   []string{},
 		},
 		{
 			Name: "returns all tools when no virtual server header",

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -36,7 +36,7 @@ var internalOnlyHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader, 
 
 // clientStrippedHeaders are headers that the router unconditionally strips from
 // incoming client requests during the headers phase.
-var clientStrippedHeaders = []string{mcpVirtualServerHeader, mcpVerifiedSubHeader}
+var clientStrippedHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader, mcpVerifiedSubHeader}
 
 func getSingleValueHeader(headers *basepb.HeaderMap, name string) string {
 	if headers == nil {

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -36,7 +36,7 @@ var internalOnlyHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader, 
 
 // clientStrippedHeaders are headers that the router unconditionally strips from
 // incoming client requests during the headers phase.
-var clientStrippedHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader, mcpVerifiedSubHeader}
+var clientStrippedHeaders = []string{mcpVirtualServerHeader, mcpVerifiedSubHeader}
 
 func getSingleValueHeader(headers *basepb.HeaderMap, name string) string {
 	if headers == nil {

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -34,6 +34,10 @@ const (
 // and routing that must be stripped before forwarding to upstream MCP servers.
 var internalOnlyHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader, mcpVerifiedSubHeader}
 
+// clientStrippedHeaders are headers that the router unconditionally strips from
+// incoming client requests during the headers phase.
+var clientStrippedHeaders = []string{mcpVirtualServerHeader, mcpVerifiedSubHeader}
+
 func getSingleValueHeader(headers *basepb.HeaderMap, name string) string {
 	if headers == nil {
 		return ""

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -872,10 +872,6 @@ func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPReque
 
 	}
 	headers.WithMCPServerName("mcpBroker")
-	// re-inject x-mcp-authorized so the broker can apply auth-based tool filtering
-	if v := mcpReq.GetSingleHeaderValue(mcpAuthorizedHeader); v != "" {
-		headers.WithCustomHeader(mcpAuthorizedHeader, v)
-	}
 	virtualServerID, ok, err := s.validVirtualServerHeader(mcpReq)
 	if err != nil {
 		s.Logger.WarnContext(ctx, "rejecting broker request: invalid virtual server header", "error", err)

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -236,12 +236,12 @@ func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, headers *eppb.
 	// the token is already trusted. We surface the verified sub as the internal
 	// x-mcp-verified-sub header so the broker can bind token submissions to an
 	// identity without re-parsing the raw token. The header is in
-	// internalOnlyHeaders, so any client-supplied value is stripped first.
+	// clientStrippedHeaders, so any client-supplied value is stripped first.
 	authHeader := getSingleValueHeader(headers.GetHeaders(), authorizationHeader)
 	if sub, _ := internaljwt.ExtractSubClaim(authHeader); sub != "" {
 		requestHeaders.WithVerifiedSub(sub)
 	}
-	return response.WithRequestHeadersResponse(requestHeaders.Build(), internalOnlyHeaders...).Build(), nil
+	return response.WithRequestHeadersResponse(requestHeaders.Build(), clientStrippedHeaders...).Build(), nil
 }
 
 // RouteMCPRequest handles request bodies for MCP requests.

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -872,8 +872,32 @@ func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPReque
 
 	}
 	headers.WithMCPServerName("mcpBroker")
+	virtualServerID, ok, err := s.validVirtualServerHeader(mcpReq)
+	if err != nil {
+		s.Logger.WarnContext(ctx, "rejecting broker request: invalid virtual server header", "error", err)
+		return response.WithImmediateResponse(400, "bad request").Build()
+	}
+	if ok {
+		headers.WithCustomHeader(mcpVirtualServerHeader, virtualServerID)
+	}
 	return response.WithRequestBodyHeadersResponse(headers.Build()).Build()
 
+}
+
+func (s *ExtProcServer) validVirtualServerHeader(mcpReq *MCPRequest) (string, bool, error) {
+	virtualServerID := mcpReq.GetSingleHeaderValue(mcpVirtualServerHeader)
+	if virtualServerID == "" {
+		return "", false, nil
+	}
+	if s.RoutingConfig == nil {
+		return "", false, fmt.Errorf("virtual server %s not found", virtualServerID)
+	}
+	for _, vs := range s.RoutingConfig.ListVirtualServers() {
+		if vs != nil && vs.Name == virtualServerID {
+			return virtualServerID, true, nil
+		}
+	}
+	return "", false, fmt.Errorf("virtual server %s not found", virtualServerID)
 }
 
 // elicitationInfo holds the data needed to route an elicitation request to the broker.

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -23,6 +23,9 @@ import (
 // ErrInvalidRequest is an error for an invalid request
 var ErrInvalidRequest = fmt.Errorf("MCP Request is invalid")
 
+// ErrNilRoutingConfig is returned when RoutingConfig is nil
+var ErrNilRoutingConfig = fmt.Errorf("routing config is nil")
+
 // RouterError represents an error with an associated HTTP status code
 type RouterError struct {
 	StatusCode int32
@@ -875,6 +878,9 @@ func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPReque
 	virtualServerID, ok, err := s.validVirtualServerHeader(mcpReq)
 	if err != nil {
 		s.Logger.WarnContext(ctx, "rejecting broker request: invalid virtual server header", "error", err)
+		if errors.Is(err, ErrNilRoutingConfig) {
+			return response.WithImmediateResponse(500, "internal error").Build()
+		}
 		return response.WithImmediateResponse(400, "bad request").Build()
 	}
 	if ok {
@@ -889,10 +895,11 @@ func (s *ExtProcServer) validVirtualServerHeader(mcpReq *MCPRequest) (string, bo
 	if virtualServerID == "" {
 		return "", false, nil
 	}
-	if s.RoutingConfig == nil {
-		return "", false, fmt.Errorf("virtual server %s not found", virtualServerID)
+	rc := s.RoutingConfig.Load()
+	if rc == nil {
+		return "", false, ErrNilRoutingConfig
 	}
-	for _, vs := range s.RoutingConfig.ListVirtualServers() {
+	for _, vs := range rc.ListVirtualServers() {
 		if vs != nil && vs.Name == virtualServerID {
 			return virtualServerID, true, nil
 		}

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -872,12 +872,6 @@ func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPReque
 
 	}
 	headers.WithMCPServerName("mcpBroker")
-	// re-inject internal headers stripped in the headers phase so the broker can use them for filtering
-	for _, name := range internalOnlyHeaders {
-		if v := mcpReq.GetSingleHeaderValue(name); v != "" {
-			headers.WithCustomHeader(name, v)
-		}
-	}
 	return response.WithRequestBodyHeadersResponse(headers.Build()).Build()
 
 }

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -872,6 +872,10 @@ func (s *ExtProcServer) HandleNoneToolCall(ctx context.Context, mcpReq *MCPReque
 
 	}
 	headers.WithMCPServerName("mcpBroker")
+	// re-inject x-mcp-authorized so the broker can apply auth-based tool filtering
+	if v := mcpReq.GetSingleHeaderValue(mcpAuthorizedHeader); v != "" {
+		headers.WithCustomHeader(mcpAuthorizedHeader, v)
+	}
 	virtualServerID, ok, err := s.validVirtualServerHeader(mcpReq)
 	if err != nil {
 		s.Logger.WarnContext(ctx, "rejecting broker request: invalid virtual server header", "error", err)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1185,13 +1185,21 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 			Method:  methodInitialize,
 			ID:      "1",
 			Headers: &corev3.HeaderMap{
-				Headers: []*corev3.HeaderValue{},
+				Headers: []*corev3.HeaderValue{
+					{Key: "x-mcp-authorized", RawValue: []byte("signed-jwt-value")},
+					{Key: "x-mcp-virtualserver", RawValue: []byte("test/vs")},
+				},
 			},
 		}
 		resp := srv.HandleNoneToolCall(context.Background(), req)
 		require.Len(t, resp, 1)
-		_, ok := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+		rb, ok := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
 		require.True(t, ok, "expected RequestBody response (broker passthrough), got %T", resp[0].Response)
+		require.NotNil(t, rb.RequestBody.Response)
+		for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
+			require.NotEqual(t, "x-mcp-authorized", h.Header.Key)
+			require.NotEqual(t, "x-mcp-virtualserver", h.Header.Key)
+		}
 	})
 }
 

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1195,16 +1195,11 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		rb, ok := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
 		require.True(t, ok, "expected RequestBody response (broker passthrough), got %T", resp[0].Response)
 		require.NotNil(t, rb.RequestBody.Response)
-		// x-mcp-authorized must be re-injected so the broker can apply auth-based filtering
-		var foundAuthorized bool
+		// x-mcp-authorized must NOT be re-injected from client headers (bypass risk)
 		for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
+			require.NotEqual(t, "x-mcp-authorized", h.Header.Key, "client-supplied x-mcp-authorized must not be re-injected")
 			require.NotEqual(t, "x-mcp-virtualserver", h.Header.Key)
-			if h.Header.Key == "x-mcp-authorized" {
-				require.Equal(t, "signed-jwt-value", string(h.Header.RawValue))
-				foundAuthorized = true
-			}
 		}
-		require.True(t, foundAuthorized, "expected x-mcp-authorized header to be re-injected for broker filtering")
 	})
 
 	t.Run("reinjects configured virtual server header for broker filtering", func(t *testing.T) {
@@ -1227,19 +1222,15 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		require.True(t, ok, "expected RequestBody response (broker passthrough), got %T", resp[0].Response)
 		require.NotNil(t, rb.RequestBody.Response)
 
-		var foundVirtualServer, foundAuthorized bool
+		var foundVirtualServer bool
 		for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
+			require.NotEqual(t, "x-mcp-authorized", h.Header.Key, "client-supplied x-mcp-authorized must not be re-injected")
 			if h.Header.Key == "x-mcp-virtualserver" {
 				require.Equal(t, "test/vs", string(h.Header.RawValue))
 				foundVirtualServer = true
 			}
-			if h.Header.Key == "x-mcp-authorized" {
-				require.Equal(t, "signed-jwt-value", string(h.Header.RawValue))
-				foundAuthorized = true
-			}
 		}
 		require.True(t, foundVirtualServer, "expected configured virtual server header")
-		require.True(t, foundAuthorized, "expected x-mcp-authorized header to be re-injected for broker filtering")
 	})
 
 	t.Run("rejects unknown virtual server header", func(t *testing.T) {

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1204,7 +1204,9 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 
 	t.Run("reinjects configured virtual server header for broker filtering", func(t *testing.T) {
 		srv := newServer(t)
-		srv.RoutingConfig.SetServers(nil, []*config.VirtualServer{{Name: "test/vs"}})
+		rc := &config.MCPServersConfig{}
+		rc.SetServers(nil, []*config.VirtualServer{{Name: "test/vs"}})
+		srv.RoutingConfig.Store(rc)
 		req := &MCPRequest{
 			JSONRPC: "2.0",
 			Method:  methodInitialize,
@@ -1246,6 +1248,22 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 			},
 		}
 		mustImmediate(t, srv.HandleNoneToolCall(context.Background(), req), 400)
+	})
+
+	t.Run("returns 500 when RoutingConfig is nil", func(t *testing.T) {
+		srv := newServer(t)
+		srv.RoutingConfig.Store(nil)
+		req := &MCPRequest{
+			JSONRPC: "2.0",
+			Method:  methodInitialize,
+			ID:      "1",
+			Headers: &corev3.HeaderMap{
+				Headers: []*corev3.HeaderValue{
+					{Key: "x-mcp-virtualserver", RawValue: []byte("test/vs")},
+				},
+			},
+		}
+		mustImmediate(t, srv.HandleNoneToolCall(context.Background(), req), 500)
 	})
 }
 

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1195,10 +1195,16 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		rb, ok := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
 		require.True(t, ok, "expected RequestBody response (broker passthrough), got %T", resp[0].Response)
 		require.NotNil(t, rb.RequestBody.Response)
+		// x-mcp-authorized must be re-injected so the broker can apply auth-based filtering
+		var foundAuthorized bool
 		for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
-			require.NotEqual(t, "x-mcp-authorized", h.Header.Key)
 			require.NotEqual(t, "x-mcp-virtualserver", h.Header.Key)
+			if h.Header.Key == "x-mcp-authorized" {
+				require.Equal(t, "signed-jwt-value", string(h.Header.RawValue))
+				foundAuthorized = true
+			}
 		}
+		require.True(t, foundAuthorized, "expected x-mcp-authorized header to be re-injected for broker filtering")
 	})
 
 	t.Run("reinjects configured virtual server header for broker filtering", func(t *testing.T) {
@@ -1221,15 +1227,19 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 		require.True(t, ok, "expected RequestBody response (broker passthrough), got %T", resp[0].Response)
 		require.NotNil(t, rb.RequestBody.Response)
 
-		var foundVirtualServer bool
+		var foundVirtualServer, foundAuthorized bool
 		for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
-			require.NotEqual(t, "x-mcp-authorized", h.Header.Key)
 			if h.Header.Key == "x-mcp-virtualserver" {
 				require.Equal(t, "test/vs", string(h.Header.RawValue))
 				foundVirtualServer = true
 			}
+			if h.Header.Key == "x-mcp-authorized" {
+				require.Equal(t, "signed-jwt-value", string(h.Header.RawValue))
+				foundAuthorized = true
+			}
 		}
 		require.True(t, foundVirtualServer, "expected configured virtual server header")
+		require.True(t, foundAuthorized, "expected x-mcp-authorized header to be re-injected for broker filtering")
 	})
 
 	t.Run("rejects unknown virtual server header", func(t *testing.T) {

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1187,7 +1187,6 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 			Headers: &corev3.HeaderMap{
 				Headers: []*corev3.HeaderValue{
 					{Key: "x-mcp-authorized", RawValue: []byte("signed-jwt-value")},
-					{Key: "x-mcp-virtualserver", RawValue: []byte("test/vs")},
 				},
 			},
 		}
@@ -1200,6 +1199,52 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 			require.NotEqual(t, "x-mcp-authorized", h.Header.Key)
 			require.NotEqual(t, "x-mcp-virtualserver", h.Header.Key)
 		}
+	})
+
+	t.Run("reinjects configured virtual server header for broker filtering", func(t *testing.T) {
+		srv := newServer(t)
+		srv.RoutingConfig.SetServers(nil, []*config.VirtualServer{{Name: "test/vs"}})
+		req := &MCPRequest{
+			JSONRPC: "2.0",
+			Method:  methodInitialize,
+			ID:      "1",
+			Headers: &corev3.HeaderMap{
+				Headers: []*corev3.HeaderValue{
+					{Key: "x-mcp-authorized", RawValue: []byte("signed-jwt-value")},
+					{Key: "x-mcp-virtualserver", RawValue: []byte("test/vs")},
+				},
+			},
+		}
+		resp := srv.HandleNoneToolCall(context.Background(), req)
+		require.Len(t, resp, 1)
+		rb, ok := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
+		require.True(t, ok, "expected RequestBody response (broker passthrough), got %T", resp[0].Response)
+		require.NotNil(t, rb.RequestBody.Response)
+
+		var foundVirtualServer bool
+		for _, h := range rb.RequestBody.Response.HeaderMutation.SetHeaders {
+			require.NotEqual(t, "x-mcp-authorized", h.Header.Key)
+			if h.Header.Key == "x-mcp-virtualserver" {
+				require.Equal(t, "test/vs", string(h.Header.RawValue))
+				foundVirtualServer = true
+			}
+		}
+		require.True(t, foundVirtualServer, "expected configured virtual server header")
+	})
+
+	t.Run("rejects unknown virtual server header", func(t *testing.T) {
+		srv := newServer(t)
+		req := &MCPRequest{
+			JSONRPC: "2.0",
+			Method:  methodInitialize,
+			ID:      "1",
+			Headers: &corev3.HeaderMap{
+				Headers: []*corev3.HeaderValue{
+					{Key: "x-mcp-virtualserver", RawValue: []byte("test/missing-vs")},
+				},
+			},
+		}
+		mustImmediate(t, srv.HandleNoneToolCall(context.Background(), req), 400)
 	})
 }
 

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -254,7 +254,7 @@ func TestProcess_EndOfStream(t *testing.T) {
 									SetHeaders: []*corev3.HeaderValueOption{
 										{Header: &corev3.HeaderValue{Key: ":authority"}},
 									},
-									RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver", "x-mcp-verified-sub"},
+									RemoveHeaders: []string{"x-mcp-virtualserver", "x-mcp-verified-sub"},
 								},
 							},
 						},
@@ -571,7 +571,7 @@ func requestHeadersStep() mockProcessServerMessageAndErr {
 								SetHeaders: []*corev3.HeaderValueOption{
 									{Header: &corev3.HeaderValue{Key: ":authority"}},
 								},
-								RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver", "x-mcp-verified-sub"},
+								RemoveHeaders: []string{"x-mcp-virtualserver", "x-mcp-verified-sub"},
 							},
 						},
 					},

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -254,7 +254,7 @@ func TestProcess_EndOfStream(t *testing.T) {
 									SetHeaders: []*corev3.HeaderValueOption{
 										{Header: &corev3.HeaderValue{Key: ":authority"}},
 									},
-									RemoveHeaders: []string{"x-mcp-virtualserver", "x-mcp-verified-sub"},
+									RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver", "x-mcp-verified-sub"},
 								},
 							},
 						},
@@ -571,7 +571,7 @@ func requestHeadersStep() mockProcessServerMessageAndErr {
 								SetHeaders: []*corev3.HeaderValueOption{
 									{Header: &corev3.HeaderValue{Key: ":authority"}},
 								},
-								RemoveHeaders: []string{"x-mcp-virtualserver", "x-mcp-verified-sub"},
+								RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver", "x-mcp-verified-sub"},
 							},
 						},
 					},

--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -243,9 +243,13 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 			"X-Mcp-Virtualserver": virtualServerHeader,
 		}
 
-		sessionID, err := mcpInitialize(ctx, authGatewayURL, headers)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+		var sessionID string
+		Eventually(func(g Gomega) {
+			var err error
+			sessionID, err = mcpInitialize(ctx, authGatewayURL, headers)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, headers)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 		By("Listing prompts — JWT allows test1_greet, VirtualServer allows everything_simple_prompt, intersection is empty")
 		Eventually(func(g Gomega) {

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -665,10 +665,14 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 		By("Creating a client with X-Mcp-Virtualserver header")
 		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
-		virtualServerClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"X-Mcp-Virtualserver": virtualServerHeader,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		var virtualServerClient *mcpclient.Client
+		Eventually(func(g Gomega) {
+			var err error
+			virtualServerClient, err = NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+				"X-Mcp-Virtualserver": virtualServerHeader,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		defer func() { _ = virtualServerClient.Close() }()
 
 		By("Verifying only the tools from MCPVirtualServer are returned")
@@ -1265,10 +1269,14 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 		By("Creating a client with X-Mcp-Virtualserver header")
 		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
-		virtualServerClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"X-Mcp-Virtualserver": virtualServerHeader,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		var virtualServerClient *mcpclient.Client
+		Eventually(func(g Gomega) {
+			var err error
+			virtualServerClient, err = NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+				"X-Mcp-Virtualserver": virtualServerHeader,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		defer func() { _ = virtualServerClient.Close() }()
 
 		By("Verifying only the allowed prompt is returned via virtual server")
@@ -1376,10 +1384,14 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 		By("Creating a client with X-Mcp-Virtualserver header")
 		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
-		virtualServerClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"X-Mcp-Virtualserver": virtualServerHeader,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		var virtualServerClient *mcpclient.Client
+		Eventually(func(g Gomega) {
+			var err error
+			virtualServerClient, err = NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+				"X-Mcp-Virtualserver": virtualServerHeader,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		defer func() { _ = virtualServerClient.Close() }()
 
 		By("Verifying all prompts are returned (no prompts field = no filtering)")

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -314,9 +314,13 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 			Expect(k8sClient.Create(ctx, vs)).To(Succeed())
 
 			vsHeader := fmt.Sprintf("%s/%s", vs.Namespace, vs.Name)
-			sessionID, err := mcpInitialize(ctx, toolDiscURL, map[string]string{"X-Mcp-Virtualserver": vsHeader})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mcpNotifyInitialized(ctx, toolDiscURL, sessionID, map[string]string{"X-Mcp-Virtualserver": vsHeader})).To(Succeed())
+			var sessionID string
+			Eventually(func(g Gomega) {
+				var err error
+				sessionID, err = mcpInitialize(ctx, toolDiscURL, map[string]string{"X-Mcp-Virtualserver": vsHeader})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(mcpNotifyInitialized(ctx, toolDiscURL, sessionID, map[string]string{"X-Mcp-Virtualserver": vsHeader})).To(Succeed())
+			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 			By("discover_tools should only return the virtual server's allowed tools")
 			Eventually(func(g Gomega) {

--- a/tests/e2e/user_specific_list_test.go
+++ b/tests/e2e/user_specific_list_test.go
@@ -320,12 +320,22 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 			g.Expect(VerifyMCPServerRegistrationHasCondition(ctx, k8sClient, uspecServer.Name, uspecServer.Namespace)).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
+		By("Creating a virtual server to pass validation")
+		virtualServer := BuildTestMCPVirtualServer("uspec-sec-vs", TestServerNameSpace, []string{"uspec_headers"}).Build()
+		testResources = append(testResources, virtualServer)
+		Expect(k8sClient.Create(ctx, virtualServer)).To(Succeed())
+
 		By("Creating a client with auth and a virtual server header")
-		userClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"Authorization":       "Bearer user-a-token",
-			"X-Mcp-Virtualserver": "test/vs",
-		})
-		Expect(err).NotTo(HaveOccurred())
+		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
+		var userClient *mcpclient.Client
+		Eventually(func(g Gomega) {
+			var err error
+			userClient, err = NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+				"Authorization":       "Bearer user-a-token",
+				"X-Mcp-Virtualserver": virtualServerHeader,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		defer func() { _ = userClient.Close() }()
 
 		By("Waiting for tools to appear")

--- a/tests/e2e/user_specific_list_test.go
+++ b/tests/e2e/user_specific_list_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -376,11 +377,15 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 
 		By("Creating a client with user-a auth and virtual server header")
 		virtualServerHeader := fmt.Sprintf("%s/%s", virtualServer.Namespace, virtualServer.Name)
-		vsClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
-			"Authorization":       "Bearer user-a-token",
-			"X-Mcp-Virtualserver": virtualServerHeader,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		var vsClient *mcpclient.Client
+		Eventually(func(g Gomega) {
+			var err error
+			vsClient, err = NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+				"Authorization":       "Bearer user-a-token",
+				"X-Mcp-Virtualserver": virtualServerHeader,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		defer func() { _ = vsClient.Close() }()
 
 		By("Verifying only the allowed tool is returned")


### PR DESCRIPTION
Fixes https://github.com/Kuadrant/mcp-gateway/issues/1082

This stops the router from re-adding client-supplied internal filter headers on the broker passthrough path after Envoy strips them.

It also makes tool filtering fail closed when `x-mcp-virtualserver` points to a missing virtual server, so the broker returns no tools instead of the full unfiltered list.

Tests run:
- go test ./internal/mcp-router
- go test ./internal/broker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation for virtual-server headers now rejects unknown values with a 400 and causes filtered results to be empty instead of returning unfiltered items.
  * Router no longer reinjects internal-only headers and will forward authorization headers when present.

* **Tests**
  * Tests updated and expanded to cover stricter filtering, header handling, and 400 response behavior.

* **Chores**
  * CI lint installs now retry on failure; tooling version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->