### PR TITLE
ensured that inmemorymap stores the encrypted token and it must be de…

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -206,26 +206,26 @@ func (a *app) setupSessionInfra(ctx context.Context) {
 		}
 	}
 
-	var sessionCacheOpts []func(*session.Cache)
-	sessionCacheOpts = append(sessionCacheOpts, session.WithRedisClient(a.redisClient))
-	if a.redisClient != nil {
-		encKey, err := session.DeriveEncryptionKey([]byte(a.brokerCfg.gatewaySigningKey))
-		if err != nil {
-			panic("failed to derive encryption key: " + err.Error())
-		}
-		sessionCacheOpts = append(sessionCacheOpts, session.WithEncryptionKey(encKey))
-	}
-	var err error
-	a.sessionCache, err = session.NewCache(sessionCacheOpts...)
-	if err != nil {
-		panic("failed to setup session cache: " + err.Error())
-	}
-
 	if a.brokerCfg.gatewaySigningKey == "" {
 		panic("GATEWAY_SIGNING_KEY (or JWT_SESSION_SIGNING_KEY) is required but not set. " +
 			"When running via the controller, this is managed automatically. " +
 			"For standalone use, set the GATEWAY_SIGNING_KEY environment variable.")
 	}
+
+	var sessionCacheOpts []func(*session.Cache)
+	sessionCacheOpts = append(sessionCacheOpts, session.WithRedisClient(a.redisClient))
+	
+	encKey, err := session.DeriveEncryptionKey([]byte(a.brokerCfg.gatewaySigningKey))
+	if err != nil {
+		panic("failed to derive encryption key: " + err.Error())
+	}
+	sessionCacheOpts = append(sessionCacheOpts, session.WithEncryptionKey(encKey))
+
+	a.sessionCache, err = session.NewCache(sessionCacheOpts...)
+	if err != nil {
+		panic("failed to setup session cache: " + err.Error())
+	}
+
 	a.jwtMgr, err = session.NewJWTManager(a.brokerCfg.gatewaySigningKey, a.brokerCfg.sessionDurationMins, a.logger, a.sessionCache)
 	if err != nil {
 		panic("failed to setup jwt manager " + err.Error())

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -148,6 +148,15 @@ func (c *Cache) GetClientElicitation(ctx context.Context, gatewaySessionID strin
 // SetUserToken stores a per-user upstream token in the session hash.
 func (c *Cache) SetUserToken(ctx context.Context, sessionID, serverName, token string) error {
 	field := userTokenFieldPrefix + serverName
+	value := token
+	if c.encryptionKey != nil {
+		encrypted, err := encrypt(c.encryptionKey, token)
+		if err != nil {
+			return fmt.Errorf("encrypting user token: %w", err)
+		}
+		value = encrypted
+	}
+
 	if c.inmemory != nil {
 		c.innerMu.Lock()
 		defer c.innerMu.Unlock()
@@ -159,17 +168,9 @@ func (c *Cache) SetUserToken(ctx context.Context, sessionID, serverName, token s
 		if next == nil {
 			next = map[string]string{}
 		}
-		next[field] = token
+		next[field] = value
 		c.inmemory.Store(sessionID, next)
 		return nil
-	}
-	value := token
-	if c.encryptionKey != nil {
-		encrypted, err := encrypt(c.encryptionKey, token)
-		if err != nil {
-			return fmt.Errorf("encrypting user token: %w", err)
-		}
-		value = encrypted
 	}
 	return c.extClient.HSet(ctx, sessionID, field, value).Err()
 }
@@ -189,6 +190,13 @@ func (c *Cache) GetUserToken(ctx context.Context, sessionID, serverName string) 
 		token, ok := m[field]
 		if !ok {
 			return "", false, nil
+		}
+		if c.encryptionKey != nil {
+			decrypted, err := decrypt(c.encryptionKey, token)
+			if err != nil {
+				return "", false, fmt.Errorf("decrypting user token: %w", err)
+			}
+			token = decrypted
 		}
 		if checkUpstreamJWTExpiry(token) {
 			next := maps.Clone(m)


### PR DESCRIPTION
fixes #1087
 - just moved the encryption block to the top of setusertoken section 
 - and added decryption block to the getusertoken section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured tokens are encrypted consistently across all storage backends for enhanced security
  * Improved session configuration validation to catch configuration errors earlier during initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->