### PR TITLE
fix(broker): allowlist X-Forwarded-Proto scheme in elicitation URL

### DIFF
--- a/internal/broker/elicitation_handler.go
+++ b/internal/broker/elicitation_handler.go
@@ -85,8 +85,13 @@ func (h *ElicitationHandler) buildElicitationURL(serverName, elicitationID strin
 	if err == nil && serverConfig.TokenURLElicitation != nil && serverConfig.TokenURLElicitation.URL != "" {
 		return serverConfig.TokenURLElicitation.URL + "?elicitation_id=" + escapedID
 	}
-	scheme := r.Header.Get("X-Forwarded-Proto")
-	if scheme == "" {
+	// only "http" is honored; everything else (including invalid/injected
+	// schemes like javascript: or data:) falls back to "https".
+	// normalize: lowercase + take the first comma-separated value so
+	// proxies that produce "http,https" or "HTTP" don't force https.
+	raw := r.Header.Get("X-Forwarded-Proto")
+	scheme := strings.ToLower(strings.TrimSpace(strings.SplitN(raw, ",", 2)[0]))
+	if scheme != "http" {
 		scheme = "https"
 	}
 	return scheme + "://" + h.Config.GetExternalHostname() + "/tokens?elicitation_id=" + escapedID

--- a/internal/broker/elicitation_handler_test.go
+++ b/internal/broker/elicitation_handler_test.go
@@ -181,6 +181,72 @@ func TestElicitationHandler_XForwardedProto(t *testing.T) {
 	assertSSEContains(t, body, "http://gateway.example.com/tokens?elicitation_id="+eid)
 }
 
+func TestElicitationHandler_XForwardedProtoInjection(t *testing.T) {
+	eid := "eid-inj"
+	// any scheme other than http must fall back to https, so a spoofed header
+	// can't inject a javascript:/data: URL or downgrade to cleartext.
+	for _, proto := range []string{"javascript", "data", "ftp", "HTTPS"} {
+		t.Run(proto, func(t *testing.T) {
+			handler := setupElicitationHandler(
+				elicitation.Entry{SessionID: "sess1", ServerName: "github"},
+				eid,
+				&config.MCPServer{Name: "github"},
+				"gateway.example.com",
+			)
+
+			req := httptest.NewRequest(http.MethodPost, "http://gateway.example.com/mcp/elicitation", nil)
+			req.Header.Set(sharedheaders.ElicitationRequestID, "7")
+			req.Header.Set(sharedheaders.ElicitationID, eid)
+			req.Header.Set("X-Forwarded-Proto", proto)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			assertSSEContains(t, w.Body.String(), "https://gateway.example.com/tokens?elicitation_id="+eid)
+		})
+	}
+}
+
+func TestElicitationHandler_XForwardedProtoNormalization(t *testing.T) {
+	// proxies may produce uppercase or comma-separated values; normalization
+	// must still resolve to the correct scheme.
+	eid := "eid-norm"
+	for _, tc := range []struct {
+		header   string
+		wantScheme string
+	}{
+		{"HTTP", "http"},
+		{"http,https", "http"},
+		{"HTTP, https", "http"},
+		{"HTTPS", "https"},
+		{" https ", "https"},
+	} {
+		t.Run(tc.header, func(t *testing.T) {
+			handler := setupElicitationHandler(
+				elicitation.Entry{SessionID: "sess1", ServerName: "github"},
+				eid,
+				&config.MCPServer{Name: "github"},
+				"gateway.example.com",
+			)
+
+			req := httptest.NewRequest(http.MethodPost, "http://gateway.example.com/mcp/elicitation", nil)
+			req.Header.Set(sharedheaders.ElicitationRequestID, "7")
+			req.Header.Set(sharedheaders.ElicitationID, eid)
+			req.Header.Set("X-Forwarded-Proto", tc.header)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			want := tc.wantScheme + "://gateway.example.com/tokens?elicitation_id=" + eid
+			assertSSEContains(t, w.Body.String(), want)
+		})
+	}
+}
+
 func TestElicitationHandler_FallbackHostname(t *testing.T) {
 	eid := "eid-ghi"
 	handler := setupElicitationHandler(


### PR DESCRIPTION
## What

`buildElicitationURL` used the `X-Forwarded-Proto` header verbatim as the elicitation URL scheme, defaulting to `https` only when the header was empty — any other value was trusted.

If the broker is reached without Envoy in front (dev, misconfiguration), a spoofed header could inject a `javascript:`/`data:` scheme or downgrade to `http`, exposing elicitation IDs in cleartext.

## Fix

Allowlist the scheme — anything other than `http` falls back to `https`:

```go
scheme := r.Header.Get("X-Forwarded-Proto")
if scheme != "http" {
    scheme = "https"
}
```

## On `tokens.go:88` (called out in the issue)

Left unchanged. It compares the header with an exact `== "https"`, so a spoofed value just yields a non-Secure cookie (the conservative default) — it's already injection-safe. Its default is also deliberately opposite to the URL's (cookie: Secure only when positively https; URL: https unless positively http), so folding them into one helper would be the wrong abstraction.

## Tests

Added `TestElicitationHandler_XForwardedProtoInjection` — `javascript`, `data`, `ftp`, `HTTPS` all fall back to `https`. The existing `http` passthrough test still passes.

Fixes #1085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened token URL generation: protocol values from forwarded headers are normalized and restricted, and any non-exact "http" value now defaults to HTTPS to prevent scheme-based injection or downgrade risks.

* **Tests**
  * Added tests validating normalization and resistance to spoofed forwarded-protocol values, ensuring generated token URLs use the correct scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->