### PR TITLE
fix(broker): use router-injected verified sub for elicitation identity binding

### DIFF
--- a/internal/broker/tokens.go
+++ b/internal/broker/tokens.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
-	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
+	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
 )
 
 //go:embed templates/*.html
@@ -209,24 +209,12 @@ func renderTemplate(name string, data any) string {
 	return buf.String()
 }
 
-// extractRequestSub extracts the sub claim from the request identity.
-// Checks Authorization header first, then falls back to the "jwt" cookie.
+// extractRequestSub returns the verified JWT sub injected by the router after
+// AuthPolicy validation. Returns "" if the header is absent, which causes the
+// caller to reject the request — ensuring identity binding is never based on a
+// raw, unverified JWT decoded inside the broker.
 func extractRequestSub(r *http.Request) string {
-	sub, _ := internaljwt.ExtractSubClaim(r.Header.Get("Authorization"))
-	if sub != "" {
-		return sub
-	}
-	c, err := r.Cookie("jwt")
-	if err != nil {
-		return ""
-	}
-	var claims struct {
-		Sub string `json:"sub"`
-	}
-	if internaljwt.DecodePayload(c.Value, &claims) {
-		return claims.Sub
-	}
-	return ""
+	return r.Header.Get(sharedheaders.VerifiedSubHeader)
 }
 
 func generateCSRFToken() (string, error) {

--- a/internal/broker/tokens_test.go
+++ b/internal/broker/tokens_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
+	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
 )
 
 type stubTokenCache struct {
@@ -261,7 +262,7 @@ func TestTokenHandler_POST_SubMatch(t *testing.T) {
 	csrf := getCSRFToken(t, handler, id)
 
 	req := postTokenForm(id, "ghp_secret", csrf)
-	req.Header.Set("Authorization", buildBearerJWT("user123"))
+	req.Header.Set(sharedheaders.VerifiedSubHeader, "user123")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
@@ -281,7 +282,7 @@ func TestTokenHandler_POST_SubMismatch(t *testing.T) {
 	csrf := getCSRFToken(t, handler, id)
 
 	req := postTokenForm(id, "ghp_secret", csrf)
-	req.Header.Set("Authorization", buildBearerJWT("attacker"))
+	req.Header.Set(sharedheaders.VerifiedSubHeader, "attacker")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
@@ -324,56 +325,32 @@ func TestTokenHandler_POST_SubRequiredButNoIdentity(t *testing.T) {
 	}
 }
 
-func TestTokenHandler_POST_SubMatchViaCookie(t *testing.T) {
-	handler, eMap, cache := setupHandler(t)
-	ctx := context.Background()
-	id, _ := eMap.Store(ctx, "sess1", "github", "user123")
-	csrf := getCSRFToken(t, handler, id)
+// TestTokenHandler_POST_RawJWTNoLongerGrantsIdentity verifies that sending a
+// raw Bearer JWT or jwt cookie does NOT satisfy the identity check — only the
+// router-injected x-mcp-verified-sub header is trusted. This is the attack
+// surface fixed by issue #1083.
+func TestTokenHandler_POST_RawJWTNoLongerGrantsIdentity(t *testing.T) {
+	for _, name := range []string{"bearer_only", "cookie_only"} {
+		t.Run(name, func(t *testing.T) {
+			handler, eMap, _ := setupHandler(t)
+			id, _ := eMap.Store(context.Background(), "sess1", "github", "user123")
+			csrf := getCSRFToken(t, handler, id)
 
-	req := postTokenForm(id, "ghp_secret", csrf)
-	req.AddCookie(&http.Cookie{Name: "jwt", Value: buildRawJWT("user123")})
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
+			req := postTokenForm(id, "ghp_secret", csrf)
+			switch name {
+			case "bearer_only":
+				req.Header.Set("Authorization", buildBearerJWT("user123"))
+			case "cookie_only":
+				req.AddCookie(&http.Cookie{Name: "jwt", Value: buildRawJWT("user123")})
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-
-	token, ok := cache.GetUserToken(ctx, "sess1", "github")
-	if !ok || token != "ghp_secret" {
-		t.Fatal("expected token stored after cookie sub match")
-	}
-}
-
-func TestTokenHandler_POST_SubMismatchViaCookie(t *testing.T) {
-	handler, eMap, _ := setupHandler(t)
-	id, _ := eMap.Store(context.Background(), "sess1", "github", "user123")
-	csrf := getCSRFToken(t, handler, id)
-
-	req := postTokenForm(id, "ghp_secret", csrf)
-	req.AddCookie(&http.Cookie{Name: "jwt", Value: buildRawJWT("attacker")})
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
-
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", w.Code)
-	}
-}
-
-func TestTokenHandler_POST_IgnoresNonJWTCookies(t *testing.T) {
-	handler, eMap, _ := setupHandler(t)
-	id, _ := eMap.Store(context.Background(), "sess1", "github", "user123")
-	csrf := getCSRFToken(t, handler, id)
-
-	req := postTokenForm(id, "ghp_secret", csrf)
-	// non-JWT cookie with a sub-like value should be ignored
-	req.AddCookie(&http.Cookie{Name: "other", Value: "not-a-jwt"})
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
-
-	// no valid identity found → 403
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+			// without x-mcp-verified-sub the broker has no verified identity → 403
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("expected 403, got %d — raw JWT must not grant identity", w.Code)
+			}
+		})
 	}
 }
 

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -5,4 +5,10 @@ package headers
 const (
 	ElicitationRequestID = "x-mcp-request-id"
 	ElicitationID        = "x-mcp-elicitation-id"
+
+	// VerifiedSubHeader carries the JWT sub claim after the router has validated
+	// the Authorization token via AuthPolicy. The broker reads this header to
+	// bind token submissions to a verified identity without re-parsing the JWT.
+	// Stripped from any client-supplied value by the router.
+	VerifiedSubHeader = "x-mcp-verified-sub"
 )

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
 )
 
 const (
@@ -22,11 +23,16 @@ const (
 	// broker-only filtering headers that must not reach upstream servers
 	mcpAuthorizedHeader    = "x-mcp-authorized"
 	mcpVirtualServerHeader = "x-mcp-virtualserver"
+
+	// mcpVerifiedSubHeader carries the JWT sub the router verified via AuthPolicy.
+	// Injected by the router; stripped from any client-supplied value so the
+	// broker can trust it without re-parsing the raw JWT.
+	mcpVerifiedSubHeader = sharedheaders.VerifiedSubHeader
 )
 
 // internalOnlyHeaders are headers used internally by the gateway for filtering
 // and routing that must be stripped before forwarding to upstream MCP servers.
-var internalOnlyHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader}
+var internalOnlyHeaders = []string{mcpAuthorizedHeader, mcpVirtualServerHeader, mcpVerifiedSubHeader}
 
 func getSingleValueHeader(headers *basepb.HeaderMap, name string) string {
 	if headers == nil {
@@ -173,6 +179,19 @@ func (hb *HeadersBuilder) WithPath(path string) *HeadersBuilder {
 		Header: &basepb.HeaderValue{
 			Key:      ":path",
 			RawValue: []byte(path),
+		},
+	})
+	return hb
+}
+
+// WithVerifiedSub sets the x-mcp-verified-sub header to the JWT sub claim
+// extracted by the router after AuthPolicy verification. The broker reads this
+// instead of decoding the raw JWT, so identity binding is always verified.
+func (hb *HeadersBuilder) WithVerifiedSub(sub string) *HeadersBuilder {
+	hb.headers = append(hb.headers, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{
+			Key:      mcpVerifiedSubHeader,
+			RawValue: []byte(sub),
 		},
 	})
 	return hb

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -3,8 +3,8 @@ package mcprouter
 import (
 	"fmt"
 
-	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
+	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
 const (

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -225,11 +225,20 @@ func (mr *MCPRequest) ToBytes() ([]byte, error) {
 }
 
 // HandleRequestHeaders handles request headers minimally.
-func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, _ *eppb.HttpHeaders) ([]*eppb.ProcessingResponse, error) {
+func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, headers *eppb.HttpHeaders) ([]*eppb.ProcessingResponse, error) {
 	s.Logger.DebugContext(ctx, "Request Handler: HandleRequestHeaders called")
 	requestHeaders := NewHeaders()
 	response := NewResponse()
 	requestHeaders.WithAuthority(s.RoutingConfig.MCPGatewayExternalHostname)
+	// AuthPolicy has already verified the Authorization JWT before the request
+	// reaches ext_proc, so extracting sub here is safe. Injecting it as
+	// x-mcp-verified-sub lets the broker bind token submissions to a verified
+	// identity without re-parsing the raw token. The header is also in
+	// internalOnlyHeaders so any client-supplied value is stripped first.
+	authHeader := getSingleValueHeader(headers.GetHeaders(), authorizationHeader)
+	if sub, _ := internaljwt.ExtractSubClaim(authHeader); sub != "" {
+		requestHeaders.WithVerifiedSub(sub)
+	}
 	return response.WithRequestHeadersResponse(requestHeaders.Build(), internalOnlyHeaders...).Build(), nil
 }
 

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -230,11 +230,13 @@ func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, headers *eppb.
 	requestHeaders := NewHeaders()
 	response := NewResponse()
 	requestHeaders.WithAuthority(s.RoutingConfig.MCPGatewayExternalHostname)
-	// AuthPolicy has already verified the Authorization JWT before the request
-	// reaches ext_proc, so extracting sub here is safe. Injecting it as
-	// x-mcp-verified-sub lets the broker bind token submissions to a verified
-	// identity without re-parsing the raw token. The header is also in
-	// internalOnlyHeaders so any client-supplied value is stripped first.
+	// Trust model: ExtractSubClaim only decodes the JWT payload, it does NOT
+	// verify the signature. That is safe here because AuthPolicy validates the
+	// Authorization JWT before the request reaches ext_proc, so by this point
+	// the token is already trusted. We surface the verified sub as the internal
+	// x-mcp-verified-sub header so the broker can bind token submissions to an
+	// identity without re-parsing the raw token. The header is in
+	// internalOnlyHeaders, so any client-supplied value is stripped first.
 	authHeader := getSingleValueHeader(headers.GetHeaders(), authorizationHeader)
 	if sub, _ := internaljwt.ExtractSubClaim(authHeader); sub != "" {
 		requestHeaders.WithVerifiedSub(sub)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1292,17 +1292,42 @@ func TestInitializeMCPSeverSession_PassThroughHeaders(t *testing.T) {
 func TestHandleRequestHeaders(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
+	// helper: build a minimal unsigned JWT payload with the given sub
+	makeBearer := func(sub string) string {
+		hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"` + sub + `"}`))
+		return "Bearer " + hdr + "." + payload + ".sig"
+	}
+
 	testCases := []struct {
-		Name            string
-		GatewayHostname string
+		Name              string
+		GatewayHostname   string
+		AuthHeader        string
+		wantVerifiedSub   string // "" means header must NOT appear in SetHeaders
+		wantSetHeadersLen int
 	}{
 		{
-			Name:            "sets authority header to gateway hostname",
-			GatewayHostname: "mcp.example.com",
+			Name:              "sets authority — no Authorization header",
+			GatewayHostname:   "mcp.example.com",
+			wantSetHeadersLen: 1, // only :authority
 		},
 		{
-			Name:            "handles wildcard gateway hostname",
-			GatewayHostname: "*.mcp.local",
+			Name:              "handles wildcard gateway hostname",
+			GatewayHostname:   "*.mcp.local",
+			wantSetHeadersLen: 1,
+		},
+		{
+			Name:              "injects x-mcp-verified-sub when Authorization has JWT with sub",
+			GatewayHostname:   "mcp.example.com",
+			AuthHeader:        makeBearer("alice"),
+			wantVerifiedSub:   "alice",
+			wantSetHeadersLen: 2, // :authority + x-mcp-verified-sub
+		},
+		{
+			Name:              "does not inject x-mcp-verified-sub when JWT has no sub",
+			GatewayHostname:   "mcp.example.com",
+			AuthHeader:        "Bearer " + base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`)) + "." + base64.RawURLEncoding.EncodeToString([]byte(`{}`)) + ".sig",
+			wantSetHeadersLen: 1,
 		},
 	}
 
@@ -1316,33 +1341,56 @@ func TestHandleRequestHeaders(t *testing.T) {
 				Broker: newMockBroker(nil, map[string]string{}),
 			}
 
+			incomingHeaders := []*corev3.HeaderValue{
+				{Key: ":authority", RawValue: []byte("original.host.com")},
+			}
+			if tc.AuthHeader != "" {
+				incomingHeaders = append(incomingHeaders, &corev3.HeaderValue{
+					Key:      "authorization",
+					RawValue: []byte(tc.AuthHeader),
+				})
+			}
+			// simulate a client trying to forge x-mcp-verified-sub
+			incomingHeaders = append(incomingHeaders, &corev3.HeaderValue{
+				Key:      "x-mcp-verified-sub",
+				RawValue: []byte("forged"),
+			})
+
 			headers := &eppb.HttpHeaders{
-				Headers: &corev3.HeaderMap{
-					Headers: []*corev3.HeaderValue{
-						{
-							Key:      ":authority",
-							RawValue: []byte("original.host.com"),
-						},
-					},
-				},
+				Headers: &corev3.HeaderMap{Headers: incomingHeaders},
 			}
 
 			responses, err := server.HandleRequestHeaders(context.Background(), headers)
 
 			require.NoError(t, err)
 			require.Len(t, responses, 1)
-
-			// should be a request headers response
 			require.IsType(t, &eppb.ProcessingResponse_RequestHeaders{}, responses[0].Response)
 			rh := responses[0].Response.(*eppb.ProcessingResponse_RequestHeaders)
-			require.NotNil(t, rh.RequestHeaders)
-
-			// verify authority header was set
 			headerMutation := rh.RequestHeaders.Response.HeaderMutation
 			require.NotNil(t, headerMutation)
-			require.Len(t, headerMutation.SetHeaders, 1)
-			require.Equal(t, ":authority", headerMutation.SetHeaders[0].Header.Key)
-			require.Equal(t, tc.GatewayHostname, string(headerMutation.SetHeaders[0].Header.RawValue))
+
+			require.Len(t, headerMutation.SetHeaders, tc.wantSetHeadersLen)
+			var authorityVal string
+			for _, h := range headerMutation.SetHeaders {
+				if h.Header.Key == ":authority" {
+					authorityVal = string(h.Header.RawValue)
+				}
+			}
+			require.Equal(t, tc.GatewayHostname, authorityVal, ":authority header not found or wrong value")
+
+			if tc.wantVerifiedSub != "" {
+				found := ""
+				for _, h := range headerMutation.SetHeaders {
+					if h.Header.Key == "x-mcp-verified-sub" {
+						found = string(h.Header.RawValue)
+					}
+				}
+				require.Equal(t, tc.wantVerifiedSub, found, "x-mcp-verified-sub mismatch")
+			}
+
+			// x-mcp-verified-sub must always be in RemoveHeaders (strips client forgery)
+			require.Contains(t, headerMutation.RemoveHeaders, "x-mcp-verified-sub",
+				"x-mcp-verified-sub must be stripped from client requests")
 		})
 	}
 }

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -253,7 +253,7 @@ func TestProcess_EndOfStream(t *testing.T) {
 									SetHeaders: []*corev3.HeaderValueOption{
 										{Header: &corev3.HeaderValue{Key: ":authority"}},
 									},
-									RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver"},
+									RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver", "x-mcp-verified-sub"},
 								},
 							},
 						},
@@ -569,7 +569,7 @@ func requestHeadersStep() mockProcessServerMessageAndErr {
 								SetHeaders: []*corev3.HeaderValueOption{
 									{Header: &corev3.HeaderValue{Key: ":authority"}},
 								},
-								RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver"},
+								RemoveHeaders: []string{"x-mcp-authorized", "x-mcp-virtualserver", "x-mcp-verified-sub"},
 							},
 						},
 					},


### PR DESCRIPTION
## Problem

`extractRequestSub` in `tokens.go` decoded the `sub` claim from the raw `Authorization` header or `jwt` cookie using `DecodePayload` — no signature verification. An attacker who can reach `/tokens` without AuthPolicy enforcement can craft a JWT with any `sub` they want and submit a token on behalf of another user's session.

```
// before: trusts the raw, unverified JWT inside the broker
sub, _ := internaljwt.ExtractSubClaim(r.Header.Get("Authorization"))
```

## Fix

The router already holds a **verified** sub: AuthPolicy validates the JWT before the request hits ext_proc, so when the router calls `ExtractSubClaim` it can trust what it reads. The fix has the router inject that sub as `x-mcp-verified-sub` — an internal-only header the broker can trust unconditionally.

```
// after: broker reads only the router-injected, verified header
func extractRequestSub(r *http.Request) string {
    return r.Header.Get(sharedheaders.VerifiedSubHeader)
}
```

Two safeguards prevent forgery:

1. `x-mcp-verified-sub` is added to `internalOnlyHeaders` — the router strips any client-supplied value before setting its own.
2. Without Envoy in front, the header is absent → identity check returns 403 safely.

## Changes

| File | What changed |
|---|---|
| `internal/headers/headers.go` | Add `VerifiedSubHeader = "x-mcp-verified-sub"` shared constant |
| `internal/mcp-router/headers.go` | Add `mcpVerifiedSubHeader`, `WithVerifiedSub` builder, add to `internalOnlyHeaders` |
| `internal/mcp-router/request_handlers.go` | `HandleRequestHeaders` reads Authorization and injects `x-mcp-verified-sub` when sub is present |
| `internal/broker/tokens.go` | `extractRequestSub` reads `x-mcp-verified-sub` only; raw JWT decode and `jwt` cookie fallback removed |

## Tests

- **Router** — `TestHandleRequestHeaders` extended: injects header when JWT has sub, skips when no sub, strips client-forged value in `RemoveHeaders`.
- **Broker** — `TestTokenHandler_POST_SubMatch/SubMismatch` updated to use the new header. `TestTokenHandler_POST_RawJWTNoLongerGrantsIdentity` explicitly verifies that a raw Bearer token or `jwt` cookie no longer satisfies the identity check — this is the attack from the issue.

## On the `jwt` cookie fallback

The original cookie path was dead code in practice: `entry.Sub` is only non-empty when the router extracted a sub from a Bearer token at elicitation time, so cookie-only requests would have had `entry.Sub == ""` and skipped the identity check entirely. Removing it tightens the surface.

Fixes #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved JWT identity verification: Identity binding now requires pre-validated authentication from the gateway, preventing unauthorized access through unverified Bearer tokens or cookies.

* **Authorization Changes**
  * Requests attempting identity binding without validated credentials from the gateway are now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->