### PR TITLE
test(e2e): cover prompts/list filtering via x-mcp-authorized JWT

### DIFF
--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -1046,6 +1046,64 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(PromptsListHasPrompt(promptsAll, expectedPrompt)).To(BeTrue())
 	})
 
+	It("[Happy] should filter prompts based on x-mcp-authorized JWT header", func() {
+		SetupTrustedHeadersAuth(ctx, k8sClient)
+
+		// server1 exposes a single prompt (greet), so register it twice with
+		// different prefixes; allowing only one registration's prompt in the
+		// JWT proves the other is filtered out rather than the filter being a no-op
+		By("Creating two MCPServerRegistrations for server1 with different prefixes")
+		registrationA := NewMCPServerResourcesWithDefaults("authz-prompt-a", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("pauthza_").Build()
+		testResources = append(testResources, registrationA.GetObjects()...)
+		registeredServerA := registrationA.Register(ctx)
+
+		registrationB := NewMCPServerResourcesWithDefaults("authz-prompt-b", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("pauthzb_").Build()
+		testResources = append(testResources, registrationB.GetObjects()...)
+		registeredServerB := registrationB.Register(ctx)
+
+		By("Ensuring the gateway has registered both servers")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServerA.Name, registeredServerA.Namespace)).To(BeNil())
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServerB.Name, registeredServerB.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Verifying both prompts are present without filtering")
+		WaitForPromptsWithPrefix(ctx, mcpGatewayClient, registeredServerA.Spec.Prefix)
+		WaitForPromptsWithPrefix(ctx, mcpGatewayClient, registeredServerB.Spec.Prefix)
+
+		By("Creating a JWT allowing only the greet prompt from the first server")
+		allowedPrompts := map[string][]string{
+			fmt.Sprintf("%s/%s", registeredServerA.Namespace, registeredServerA.Name): {"greet"},
+		}
+		jwtToken, err := CreateAuthorizedPromptsJWT(allowedPrompts)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a client with x-mcp-authorized header")
+		authorizedClient, err := NewMCPGatewayClientWithHeaders(ctx, gatewayURL, map[string]string{
+			"X-Mcp-Authorized": jwtToken,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = authorizedClient.Close() }()
+
+		By("Verifying only the allowed prompt is returned")
+		expectedPrompt := fmt.Sprintf("%s%s", registeredServerA.Spec.Prefix, "greet")
+		Eventually(func(g Gomega) {
+			filteredPrompts, err := authorizedClient.ListPrompts(ctx, mcp.ListPromptsRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(filteredPrompts).NotTo(BeNil())
+			g.Expect(len(filteredPrompts.Prompts)).To(Equal(1), "expected exactly 1 prompt from authorized capabilities header")
+			g.Expect(filteredPrompts.Prompts[0].Name).To(Equal(expectedPrompt))
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Verifying a client without the header still sees both prompts")
+		promptsAll, err := mcpGatewayClient.ListPrompts(ctx, mcp.ListPromptsRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(PromptsListHasPrompt(promptsAll, expectedPrompt)).To(BeTrue())
+		Expect(PromptsListHasPrompt(promptsAll, fmt.Sprintf("%s%s", registeredServerB.Spec.Prefix, "greet"))).To(BeTrue())
+	})
+
 	It("[Happy] should expose all prompts when MCPVirtualServer omits prompts field", func() {
 		By("Creating MCPServerRegistration for server1 with prompts")
 		registration := NewMCPServerResourcesWithDefaults("prompt-vs-nofilter", k8sClient).

--- a/tests/e2e/jwt_helpers.go
+++ b/tests/e2e/jwt_helpers.go
@@ -37,10 +37,18 @@ func GetTestHeaderPublicKey() string {
 // CreateAuthorizedCapabilitiesJWT creates a signed JWT for the x-mcp-authorized header
 // allowedTools is a map of server namespace/name to list of tool names
 func CreateAuthorizedCapabilitiesJWT(allowedTools map[string][]string) (string, error) {
+	return createCapabilitiesJWT(map[string]map[string][]string{"tools": allowedTools})
+}
+
+// CreateAuthorizedPromptsJWT creates a signed JWT for the x-mcp-authorized header
+// allowedPrompts is a map of server namespace/name to list of unprefixed prompt
+// names; the broker re-applies the server prefix when filtering prompts/list
+func CreateAuthorizedPromptsJWT(allowedPrompts map[string][]string) (string, error) {
+	return createCapabilitiesJWT(map[string]map[string][]string{"prompts": allowedPrompts})
+}
+
+func createCapabilitiesJWT(capabilities map[string]map[string][]string) (string, error) {
 	keyBytes := []byte(testHeaderSigningKey)
-	capabilities := map[string]map[string][]string{
-		"tools": allowedTools,
-	}
 	claimPayload, err := json.Marshal(capabilities)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal allowed capabilities: %w", err)

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -167,6 +167,10 @@
 
 - When an MCPVirtualServer resource omits the `prompts` field, all federated prompts should be returned in a prompts/list response. Tools should still be filtered by the `tools` field. This matches the behavior where omitting a field means "no filtering" rather than "deny all".
 
+### [Happy] Test prompts are filtered down based on x-mcp-authorized header
+
+- When the value of the `x-mcp-authorized` header is set as a JWT signed by a trusted key with a `prompts` capabilities payload, the MCP Gateway should respond to prompts/list with only the prompts in that list. Prompts from servers not named in the JWT should be excluded, and a client without the header should still see all prompts.
+
 ### [Happy] prompts/get for nonexistent prompt returns error
 
 - When a client sends a prompts/get request with a prompt name that does not match any registered server, the gateway should return a JSON-RPC error with code -32602 (Invalid params).


### PR DESCRIPTION
## What

Adds the missing e2e coverage for `prompts/list` filtering through the `X-Mcp-Authorized` trusted header. The broker already implements this in `filtered_prompts_handler.go` (`capabilities["prompts"]` keyed by `namespace/name` with unprefixed prompt names), so this is test-only — no implementation work was needed, answering the open question in the issue.

## Why two registrations

server1 exposes a single prompt (`greet`). A one-registration test asserting "1 prompt returned" would pass even if the filter were a no-op. So the test registers server1 twice with different prefixes (`pauthza_` / `pauthzb_`), allows only the first registration's prompt in the JWT, and asserts the second one is excluded — that proves the filter actually ran. Same shape as the existing multi-server prompt aggregation test.

## Changes

- `tests/e2e/jwt_helpers.go` — `CreateAuthorizedCapabilitiesJWT` only emitted a `tools` key; the signing body moved to a shared `createCapabilitiesJWT`, and `CreateAuthorizedPromptsJWT` added for the `prompts` key. Existing callers unchanged.
- `tests/e2e/happy_path_test.go` — new `[Happy]` spec next to the other prompt-filtering specs; mirrors the tools-filter test at line 739 (`SetupTrustedHeadersAuth`, JWT, client with header, assert filtered list). Also asserts a header-less client still sees both prompts.
- `tests/e2e/test_cases.md` — entry added alongside the other prompt cases.

## Verification

`go vet -tags=e2e` and golangci-lint pass. Tagged `[Happy]` per the acceptance criteria, so the PR gate executes the spec in CI.

Fixes #1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating prompt filtering behavior when JWT authorization headers are provided to the gateway.
  * Refactored JWT test helper functions to support more flexible capability validation scenarios.

* **Documentation**
  * Added test case documentation describing prompt filtering behavior with JWT authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->