### PR TITLE
ci: cut PR-gate e2e wall time via setup image caching and rollout-churn fixes

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -29,8 +29,10 @@ jobs:
         id: test-server-images
         run: |
           source=pull
-          git fetch --quiet --depth=1 origin main
-          if ! git diff --quiet FETCH_HEAD HEAD -- tests/servers internal/tests; then
+          if ! git fetch --quiet --depth=1 origin main; then
+            echo "could not fetch origin main, building test servers locally"
+            source=build
+          elif ! git diff --quiet FETCH_HEAD HEAD -- tests/servers internal/tests; then
             source=build
           fi
           echo "source=$source" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -23,11 +23,52 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # the published test-server images are built from main, so only pull
+      # them when the checked-out ref has identical test-server sources
+      - name: Determine test-server image source
+        id: test-server-images
+        run: |
+          source=pull
+          git fetch --quiet --depth=1 origin main
+          if ! git diff --quiet FETCH_HEAD HEAD -- tests/servers internal/tests; then
+            source=build
+          fi
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+          echo "test-server image source: $source"
+
+      - name: Compute image build LDFLAGS
+        id: ldflags
+        run: echo "ldflags=$(make -s print-ldflags)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build gateway image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/kuadrant/mcp-gateway:latest
+          build-args: |
+            LDFLAGS=${{ steps.ldflags.outputs.ldflags }}
+          cache-from: type=gha,scope=gateway-image
+          cache-to: type=gha,mode=max,scope=gateway-image
+
+      - name: Build controller image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.controller
+          load: true
+          tags: ghcr.io/kuadrant/mcp-controller:latest
+          cache-from: type=gha,scope=controller-image
+          cache-to: type=gha,mode=max,scope=controller-image
+
       - name: Create Kind cluster
         run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
 
       - name: Setup CI environment
-        run: make ci-setup
+        run: make ci-setup GATEWAY_IMAGE_SOURCE=prebuilt TEST_SERVER_IMAGE_SOURCE=${{ steps.test-server-images.outputs.source }}
 
       - name: Run full E2E suite
         run: make test-e2e-ci-full

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,8 @@ jobs:
           source=pull
           case "${{ github.event_name }}" in
             pull_request)
-              if ! files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename'); then
+              # previous_filename covers renames out of the watched paths
+              if ! files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[] | .filename, (.previous_filename // empty)'); then
                 echo "could not list PR files, building test servers locally"
                 source=build
               elif echo "$files" | grep -qE '^(tests/servers/|internal/tests/)'; then
@@ -66,8 +67,10 @@ jobs:
               fi
               ;;
             *)
-              git fetch --quiet --depth=1 origin main
-              if ! git diff --quiet FETCH_HEAD HEAD -- tests/servers internal/tests; then
+              if ! git fetch --quiet --depth=1 origin main; then
+                echo "could not fetch origin main, building test servers locally"
+                source=build
+              elif ! git diff --quiet FETCH_HEAD HEAD -- tests/servers internal/tests; then
                 source=build
               fi
               ;;

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,11 +39,75 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # test-images.yaml publishes test-server images to ghcr.io on merges to
+      # main but not from PRs, so runs with modified test-server sources must
+      # build the images locally instead of pulling stale ones
+      - name: Determine test-server image source
+        id: test-server-images
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source=pull
+          case "${{ github.event_name }}" in
+            pull_request)
+              if ! files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename'); then
+                echo "could not list PR files, building test servers locally"
+                source=build
+              elif echo "$files" | grep -qE '^(tests/servers/|internal/tests/)'; then
+                source=build
+              fi
+              ;;
+            push)
+              if ! git fetch --quiet --depth=1 origin "${{ github.event.before }}"; then
+                echo "could not fetch pre-push commit, building test servers locally"
+                source=build
+              elif ! git diff --quiet "${{ github.event.before }}" HEAD -- tests/servers internal/tests; then
+                source=build
+              fi
+              ;;
+            *)
+              git fetch --quiet --depth=1 origin main
+              if ! git diff --quiet FETCH_HEAD HEAD -- tests/servers internal/tests; then
+                source=build
+              fi
+              ;;
+          esac
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+          echo "test-server image source: $source"
+
+      - name: Compute image build LDFLAGS
+        id: ldflags
+        run: echo "ldflags=$(make -s print-ldflags)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build gateway image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/kuadrant/mcp-gateway:latest
+          build-args: |
+            LDFLAGS=${{ steps.ldflags.outputs.ldflags }}
+          cache-from: type=gha,scope=gateway-image
+          cache-to: type=gha,mode=max,scope=gateway-image
+
+      - name: Build controller image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.controller
+          load: true
+          tags: ghcr.io/kuadrant/mcp-controller:latest
+          cache-from: type=gha,scope=controller-image
+          cache-to: type=gha,mode=max,scope=controller-image
+
       - name: Create Kind cluster
         run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
 
       - name: Setup CI environment
-        run: make ci-setup
+        run: make ci-setup GATEWAY_IMAGE_SOURCE=prebuilt TEST_SERVER_IMAGE_SOURCE=${{ steps.test-server-images.outputs.source }}
 
       - name: Run E2E tests
         run: make test-e2e-ci

--- a/Makefile
+++ b/Makefile
@@ -366,14 +366,18 @@ TEST_SERVER_IMAGES = test-server1 test-server2 test-server3 test-api-key-server 
 	test-everything-server test-custom-response-server test-user-specific-server
 
 # pull pre-built images straight into containerd on the kind node, in parallel,
-# avoiding both the local rebuild and the docker save + kind load tax
+# avoiding both the local rebuild and the docker save + kind load tax.
+# each image gets one retry to ride out transient registry hiccups.
 define pull-images-into-kind
 	@set -e; pids=""; \
 	for img in $(1); do \
 		ref="$(TEST_SERVER_IMAGE_REPO)/$$img:$(TEST_SERVER_IMAGE_TAG)"; \
 		echo "Pulling $$ref into Kind node..."; \
-		$(CONTAINER_ENGINE) exec $(KIND_CLUSTER_NAME)-control-plane \
-			ctr -n k8s.io images pull "$$ref" >/dev/null & \
+		( $(CONTAINER_ENGINE) exec $(KIND_CLUSTER_NAME)-control-plane \
+			ctr -n k8s.io images pull "$$ref" >/dev/null \
+			|| { echo "Retrying pull of $$ref..."; sleep 2; \
+				$(CONTAINER_ENGINE) exec $(KIND_CLUSTER_NAME)-control-plane \
+					ctr -n k8s.io images pull "$$ref" >/dev/null; } ) & \
 		pids="$$pids $$!"; \
 	done; \
 	rc=0; \

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ build-conformance-server: ## Build conformance server Docker image locally
 	cd tests/servers/conformance-server && $(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t ghcr.io/kuadrant/mcp-gateway/test-conformance-server:latest .
 
 # Load test server images into Kind cluster
-kind-load-test-servers: kind build-test-servers ## Load test server images into Kind cluster
+kind-load-test-servers: kind build-test-servers ## Build test server images locally and load them into Kind
 	@echo "Loading test server images into Kind cluster..."
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-server1:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-server2:latest)
@@ -353,6 +353,38 @@ kind-load-test-servers: kind build-test-servers ## Load test server images into 
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-user-specific-server:latest)
+
+# Pre-built test server images published to ghcr.io by .github/workflows/test-images.yaml
+TEST_SERVER_IMAGE_REPO ?= ghcr.io/kuadrant/mcp-gateway
+TEST_SERVER_IMAGE_TAG ?= latest
+TEST_SERVER_IMAGES = test-server1 test-server2 test-server3 test-api-key-server \
+	test-broken-server test-custom-path-server test-oidc-server \
+	test-everything-server test-custom-response-server test-user-specific-server
+
+# pull pre-built images straight into containerd on the kind node, in parallel,
+# avoiding both the local rebuild and the docker save + kind load tax
+define pull-images-into-kind
+	@set -e; pids=""; \
+	for img in $(1); do \
+		ref="$(TEST_SERVER_IMAGE_REPO)/$$img:$(TEST_SERVER_IMAGE_TAG)"; \
+		echo "Pulling $$ref into Kind node..."; \
+		$(CONTAINER_ENGINE) exec $(KIND_CLUSTER_NAME)-control-plane \
+			ctr -n k8s.io images pull "$$ref" >/dev/null & \
+		pids="$$pids $$!"; \
+	done; \
+	rc=0; \
+	for pid in $$pids; do wait "$$pid" || rc=1; done; \
+	if [ "$$rc" -ne 0 ]; then echo "ERROR: failed to pull one or more test server images"; exit 1; fi
+endef
+
+.PHONY: kind-pull-test-servers
+kind-pull-test-servers: ## Pull pre-built test server images from ghcr.io into Kind
+	$(call pull-images-into-kind,$(TEST_SERVER_IMAGES))
+	@echo "Test server images pulled"
+
+.PHONY: kind-pull-tls-server
+kind-pull-tls-server: ## Pull pre-built TLS test server image from ghcr.io into Kind
+	$(call pull-images-into-kind,test-tls-server)
 
 # Load everything server image into Kind cluster
 kind-load-everything-server: kind build-everything-server ## Load everything server image into Kind cluster
@@ -373,13 +405,30 @@ build-tls-server: ## Build TLS test server Docker image locally
 
 # Load TLS test server image into Kind cluster
 .PHONY: kind-load-tls-server
-kind-load-tls-server: kind build-tls-server ## Load TLS test server image into Kind cluster
+kind-load-tls-server: kind build-tls-server ## Build TLS test server image locally and load it into Kind
 	@echo "Loading TLS test server image into Kind cluster..."
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-tls-server:latest)
 
+# How test server images reach the Kind cluster: "build" (default) builds them
+# locally and loads via kind load, "pull" fetches the pre-built images published
+# to ghcr.io on merges to main. CI uses pull unless the change touches
+# tests/servers/** or internal/tests/**, which are not published from PRs.
+TEST_SERVER_IMAGE_SOURCE ?= build
+
+.PHONY: load-test-servers load-tls-server
+ifeq ($(TEST_SERVER_IMAGE_SOURCE),pull)
+load-test-servers: kind-pull-test-servers
+load-tls-server: kind-pull-tls-server
+else ifeq ($(TEST_SERVER_IMAGE_SOURCE),build)
+load-test-servers: kind-load-test-servers
+load-tls-server: kind-load-tls-server
+else
+$(error TEST_SERVER_IMAGE_SOURCE must be "build" or "pull", got "$(TEST_SERVER_IMAGE_SOURCE)")
+endif
+
 # Deploy TLS test server with cert-manager CA chain
 .PHONY: deploy-tls-test-server
-deploy-tls-test-server: kind-load-tls-server cert-manager-install ## Deploy TLS test server with cert-manager certificates
+deploy-tls-test-server: load-tls-server cert-manager-install ## Deploy TLS test server with cert-manager certificates
 	@echo "Setting up cert-manager CA and issuing TLS certificate..."
 	$(KUBECTL) apply -f config/test-servers/namespace.yaml
 	$(KUBECTL) apply -f config/test-servers/tls-server-cert-manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY := $(shell git diff --quiet 2>/dev/null && echo "" || echo "-dirty")
 LDFLAGS := -X main.version=$(VERSION) -X main.gitSHA=$(GIT_SHA) -X main.dirty=$(GIT_DIRTY)
 
+.PHONY: print-ldflags
+print-ldflags: # print Go LDFLAGS so CI image build steps use the same values as build-image
+	@echo $(LDFLAGS)
+
 # Image tag and bundle version derivation (matches kuadrant-operator pattern)
 DEFAULT_IMAGE_TAG = latest
 is_semantic_version = $(shell echo "$(1)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$' && echo "true")

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -20,9 +20,9 @@ ci-setup: setup-cluster-base ## Setup environment for CI e2e tests
 	"$(MAKE)" deploy-tls-test-server
 	@echo "CI setup complete (3 gateways: mcp-gateway, e2e-1, e2e-2)"
 
-# Deploy test servers for CI
+# Deploy test servers for CI (TEST_SERVER_IMAGE_SOURCE selects build vs pull)
 .PHONY: deploy-test-servers-ci
-deploy-test-servers-ci: kind-load-test-servers ## Deploy test servers for CI
+deploy-test-servers-ci: load-test-servers ## Deploy test servers for CI
 	$(KUBECTL) apply -k config/test-servers/
 	"$(MAKE)" wait-test-servers
 

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -1,10 +1,38 @@
 # CI-specific targets for GitHub Actions
 
+# How the gateway/controller images reach the Kind cluster: "build" (default)
+# builds them locally first, "prebuilt" only loads images already present in
+# the local container engine (CI builds them in a workflow step so the builds
+# get buildx gha layer caching).
+GATEWAY_IMAGE_SOURCE ?= build
+
+.PHONY: ci-gateway-images
+ifeq ($(GATEWAY_IMAGE_SOURCE),prebuilt)
+ci-gateway-images: load-image
+else ifeq ($(GATEWAY_IMAGE_SOURCE),build)
+ci-gateway-images: build-and-load-image
+else
+$(error GATEWAY_IMAGE_SOURCE must be "build" or "prebuilt", got "$(GATEWAY_IMAGE_SOURCE)")
+endif
+
+# redis lives in mcp-system, so the namespace must exist before the controller
+# overlay applies it again (idempotent) later in ci-setup
+.PHONY: ci-deploy-redis
+ci-deploy-redis:
+	$(KUBECTL) apply -f config/mcp-gateway/overlays/ci/namespace.yaml
+	"$(MAKE)" deploy-redis
+
+# the installs are independent and each carries its own readiness wait, so run
+# them in parallel; the slowest one bounds the phase
+.PHONY: ci-install-infra
+ci-install-infra:
+	"$(MAKE)" -j4 istio-install metallb-install cert-manager-install ci-deploy-redis
+
 # CI setup for e2e tests
 # Deploys e2e gateways (gateway-1, gateway-2) and controller only
 # Tests create their own MCPGatewayExtensions
 .PHONY: ci-setup
-ci-setup: setup-cluster-base ## Setup environment for CI e2e tests
+ci-setup: tools kind-create-cluster ci-gateway-images gateway-api-install ci-install-infra install-crd ## Setup environment for CI e2e tests
 	@echo "Setting up CI environment..."
 	# Deploy standard mcp-gateway (mcp.127-0-0-1.sslip.io)
 	"$(MAKE)" deploy-gateway
@@ -12,11 +40,9 @@ ci-setup: setup-cluster-base ## Setup environment for CI e2e tests
 	"$(MAKE)" deploy-e2e-gateways
 	# Deploy controller only (no MCPGatewayExtension)
 	"$(MAKE)" deploy-controller-only
-	# Deploy Redis for session cache tests
-	"$(MAKE)" deploy-redis
 	# Deploy and wait for test servers
 	"$(MAKE)" deploy-test-servers-ci
-	# Deploy TLS test server (installs cert-manager, creates CA, issues cert)
+	# Deploy TLS test server (cert-manager already installed, creates CA, issues cert)
 	"$(MAKE)" deploy-tls-test-server
 	@echo "CI setup complete (3 gateways: mcp-gateway, e2e-1, e2e-2)"
 

--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -40,29 +40,22 @@ test-e2e-cleanup: ## Clean up e2e test resources
 test-e2e-watch: test-e2e-deps ## Run e2e tests in watch mode for development
 	$(GINKGO) watch -v --tags=e2e ./tests/e2e
 
-# CI-specific target that assumes cluster exists
+# CI-specific target that assumes cluster exists.
+# Debug logging is baked into config/mcp-gateway/overlays/ci/, no post-deploy patch needed.
 .PHONY: test-e2e-ci
-test-e2e-ci: test-e2e-deps enable-debug-logging ## Run PR-gate e2e tests in CI (excludes slow tier 2 suites, fail fast)
+test-e2e-ci: test-e2e-deps ## Run PR-gate e2e tests in CI (excludes slow tier 2 suites, fail fast)
 	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --fail-fast $(E2E_GINKGO_SKIP_TIER2) ./tests/e2e
 
 .PHONY: test-e2e-ci-full
-test-e2e-ci-full: test-e2e-deps enable-debug-logging ## Run all e2e tests in CI (tier 1 + 2, full run reports every failure)
+test-e2e-ci-full: test-e2e-deps ## Run all e2e tests in CI (tier 1 + 2, full run reports every failure)
 	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) ./tests/e2e
 
 # run only auth-focused tests (CI runs this after ci-auth-setup)
 .PHONY: test-e2e-auth-ci
-test-e2e-auth-ci: test-e2e-deps enable-debug-logging ## Run auth e2e tests only (requires ci-auth-setup)
+test-e2e-auth-ci: test-e2e-deps ## Run auth e2e tests only (requires ci-auth-setup)
 	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --fail-fast --focus="AuthPolicy" ./tests/e2e
 
 .PHONY: test-e2e-https
-test-e2e-https: test-e2e-deps enable-debug-logging ## Run HTTPS-focused E2E tests (requires cert-manager + MCP_PAT)
+test-e2e-https: test-e2e-deps ## Run HTTPS-focused E2E tests (requires cert-manager + MCP_PAT)
 	@echo "Running HTTPS MCP backend E2E tests..."
 	$(GINKGO) -v --tags=e2e --timeout=$(E2E_TIMEOUT) --fail-fast --focus="\[HTTPS\]" ./tests/e2e
-
-.PHONY: enable-debug-logging
-enable-debug-logging: ## Enable debug logging on controller and wait for restart
-	@echo "Enabling debug logging on mcp-gateway-controller..."
-	kubectl patch deployment mcp-gateway-controller -n mcp-system --type='json' \
-		-p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["./mcp_controller", "--log-level=-4"]}]'
-	@echo "Waiting for controller rollout..."
-	kubectl rollout status deployment/mcp-gateway-controller -n mcp-system --timeout=120s

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"strconv"
 
 	"github.com/go-logr/logr"
 
@@ -123,6 +124,13 @@ func main() {
 
 	brokerRouterImage := goenv.GetDefault("RELATED_IMAGE_ROUTER_BROKER", controller.DefaultBrokerRouterImage)
 	brokerRouterLogLevel := goenv.GetDefault("BROKER_ROUTER_LOG_LEVEL", "")
+	// the broker parses --log-level as an integer, so a bad value here would
+	// crash-loop the data plane rather than the controller; fail fast instead
+	if brokerRouterLogLevel != "" {
+		if _, err := strconv.Atoi(brokerRouterLogLevel); err != nil {
+			panic("invalid BROKER_ROUTER_LOG_LEVEL " + strconv.Quote(brokerRouterLogLevel) + " : must be an integer")
+		}
+	}
 
 	if err = (&controller.MCPGatewayExtensionReconciler{
 		Client:                mgr.GetClient(),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,6 +122,7 @@ func main() {
 	}
 
 	brokerRouterImage := goenv.GetDefault("RELATED_IMAGE_ROUTER_BROKER", controller.DefaultBrokerRouterImage)
+	brokerRouterLogLevel := goenv.GetDefault("BROKER_ROUTER_LOG_LEVEL", "")
 
 	if err = (&controller.MCPGatewayExtensionReconciler{
 		Client:                mgr.GetClient(),
@@ -130,6 +131,7 @@ func main() {
 		ConfigWriterDeleter:   &configReaderWriter,
 		MCPExtFinderValidator: mcpExtFinderValidator,
 		BrokerRouterImage:     brokerRouterImage,
+		BrokerRouterLogLevel:  brokerRouterLogLevel,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		panic("unable to start manager : " + err.Error())
 	}

--- a/config/mcp-gateway/overlays/ci/kustomization.yaml
+++ b/config/mcp-gateway/overlays/ci/kustomization.yaml
@@ -33,6 +33,8 @@ patches:
         path: /subjects/0/namespace
         value: mcp-system
   # use locally-built broker image in CI (kustomize images: only patches image: fields)
+  # and enable debug logging on the controller and the broker-router it deploys,
+  # so CI needs no post-deploy patches and rollouts to turn it on
   - target:
       group: apps
       version: v1
@@ -48,6 +50,11 @@ patches:
           spec:
             containers:
               - name: mcp-controller
+                command:
+                  - ./mcp_controller
+                  - --log-level=-4
                 env:
                   - name: RELATED_IMAGE_ROUTER_BROKER
                     value: ghcr.io/kuadrant/mcp-gateway:latest
+                  - name: BROKER_ROUTER_LOG_LEVEL
+                    value: "-4"

--- a/docs/release-notes/0.0.8.md
+++ b/docs/release-notes/0.0.8.md
@@ -1,0 +1,13 @@
+# Release Notes — 0.0.8
+
+## Breaking Changes
+
+### Broker-router `--log-level` is now controller-managed
+
+The controller now owns the `--log-level` flag on the broker-router deployment it manages. Previously a `--log-level` value patched directly onto the deployment was preserved across reconciles as a user flag; it is now reconciled away on the next update.
+
+**Migration**: Set the `BROKER_ROUTER_LOG_LEVEL` environment variable on the controller deployment instead (e.g. `-4` for debug). The controller passes the value to the broker-router as `--log-level` and reconciles it like any other managed flag. When the variable is unset, the broker-router runs at its default log level.
+
+```bash
+kubectl set env deployment/mcp-gateway-controller -n mcp-system BROKER_ROUTER_LOG_LEVEL=-4
+```

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -49,6 +49,7 @@ var managedCommandFlags = []string{
 	"--mcp-gateway-public-host",
 	"--mcp-router-key",
 	"--enable-url-elicitation",
+	"--log-level",
 }
 
 // managedEnvVarNames are the env var names the controller owns and reconciles.
@@ -85,6 +86,9 @@ func (r *MCPGatewayExtensionReconciler) buildBrokerRouterDeployment(mcpExt *mcpv
 	command = append(command, "--mcp-gateway-public-host="+publicHost)
 	if mcpExt.Spec.URLElicitation == mcpv1alpha1.URLElicitationEnabled {
 		command = append(command, "--enable-url-elicitation")
+	}
+	if r.BrokerRouterLogLevel != "" {
+		command = append(command, "--log-level="+r.BrokerRouterLogLevel)
 	}
 
 	envVars := []corev1.EnvVar{

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -85,10 +85,20 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			modify: func(d *appsv1.Deployment) {
 				d.Spec.Template.Spec.Containers[0].Command = append(
 					d.Spec.Template.Spec.Containers[0].Command,
-					"--log-level=debug",
+					"--discovery-tools-enabled=false",
 				)
 			},
 			expected: false,
+		},
+		{
+			name: "managed log-level flag added triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].Command = append(
+					d.Spec.Template.Spec.Containers[0].Command,
+					"--log-level=-4",
+				)
+			},
+			expected: true,
 		},
 		{
 			name: "managed flag added triggers update",
@@ -580,7 +590,7 @@ func TestMergeCommand_StripsLegacyRouterKeyFlag(t *testing.T) {
 		"--mcp-broker-public-address=0.0.0.0:8080",
 		"--mcp-gateway-public-host=example.com",
 		"--mcp-router-key=deadbeefcafebabe",
-		"--log-level=debug",
+		"--discovery-tools-enabled=false",
 	}
 	got := mergeCommand(desired, existing)
 	for _, arg := range got {
@@ -588,14 +598,70 @@ func TestMergeCommand_StripsLegacyRouterKeyFlag(t *testing.T) {
 			t.Errorf("mergeCommand should strip legacy --mcp-router-key, got %v", got)
 		}
 	}
-	foundLogLevel := false
+	foundUserFlag := false
 	for _, arg := range got {
-		if arg == "--log-level=debug" {
-			foundLogLevel = true
+		if arg == "--discovery-tools-enabled=false" {
+			foundUserFlag = true
 		}
 	}
-	if !foundLogLevel {
+	if !foundUserFlag {
 		t.Errorf("mergeCommand should preserve unrelated user flags, got %v", got)
+	}
+}
+
+// TestBuildBrokerRouterDeployment_LogLevel verifies the broker --log-level
+// flag is emitted only when the controller is configured with one
+// (BROKER_ROUTER_LOG_LEVEL env var).
+func TestBuildBrokerRouterDeployment_LogLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel string
+		want     string
+	}{
+		{
+			name:     "no log-level flag when unset",
+			logLevel: "",
+			want:     "",
+		},
+		{
+			name:     "log-level flag emitted when set",
+			logLevel: "-4",
+			want:     "--log-level=-4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &MCPGatewayExtensionReconciler{
+				BrokerRouterImage:    "test-image:v1",
+				BrokerRouterLogLevel: tt.logLevel,
+			}
+			mcpExt := &mcpv1alpha1.MCPGatewayExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ext",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPGatewayExtensionSpec{
+					TargetRef: mcpv1alpha1.MCPGatewayExtensionTargetReference{
+						Name:      "my-gateway",
+						Namespace: "gateway-system",
+					},
+				},
+			}
+
+			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080))
+			command := deployment.Spec.Template.Spec.Containers[0].Command
+
+			var got string
+			for _, arg := range command {
+				if strings.HasPrefix(arg, "--log-level=") {
+					got = arg
+				}
+			}
+			if got != tt.want {
+				t.Errorf("log-level flag = %q, want %q (command %v)", got, tt.want, command)
+			}
+		})
 	}
 }
 
@@ -1352,8 +1418,13 @@ func TestFilterManagedFlags(t *testing.T) {
 		},
 		{
 			name:    "user flags stripped",
-			command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug", "--cache-connection-string=redis://localhost"},
+			command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--discovery-tools-enabled=false", "--cache-connection-string=redis://localhost"},
 			want:    []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+		},
+		{
+			name:    "managed log-level flag kept",
+			command: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=-4"},
+			want:    []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=-4"},
 		},
 		{
 			name:    "empty command",
@@ -1393,8 +1464,20 @@ func TestMergeCommand(t *testing.T) {
 		{
 			name:     "preserves user flags from existing",
 			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
-			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug"},
-			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--discovery-tools-enabled=false"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--discovery-tools-enabled=false"},
+		},
+		{
+			name:     "managed log-level replaced by desired value",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=-4"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=0"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=-4"},
+		},
+		{
+			name:     "managed log-level stripped when not desired",
+			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=-4"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
 		},
 		{
 			name:     "updates managed flag and preserves user flags",
@@ -1405,8 +1488,8 @@ func TestMergeCommand(t *testing.T) {
 		{
 			name:     "multiple user flags preserved",
 			desired:  []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080"},
-			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug", "--session-length=3600"},
-			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--log-level=debug", "--session-length=3600"},
+			existing: []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--discovery-tools-enabled=false", "--session-length=3600"},
+			want:     []string{"./mcp_gateway", "--mcp-broker-public-address=0.0.0.0:8080", "--discovery-tools-enabled=false", "--session-length=3600"},
 		},
 		{
 			name:     "existing has no flags",

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -109,6 +109,9 @@ type MCPGatewayExtensionReconciler struct {
 	ConfigWriterDeleter   ConfigWriterDeleter
 	MCPExtFinderValidator MCPGatewayExtensionFinderValidator
 	BrokerRouterImage     string
+	// BrokerRouterLogLevel, when non-empty, is passed to the broker-router
+	// as --log-level (sourced from the BROKER_ROUTER_LOG_LEVEL env var)
+	BrokerRouterLogLevel string
 }
 
 // +kubebuilder:rbac:groups=mcp.kuadrant.io,resources=mcpgatewayextensions,verbs=get;list;watch;update

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -158,6 +158,9 @@ var _ = BeforeSuite(func() {
 		g.Expect(err).NotTo(HaveOccurred())
 	}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
+	// debug logging on the gateway comes from the controller's
+	// BROKER_ROUTER_LOG_LEVEL env var (set in the CI overlay), so no
+	// post-deploy patch and rollout is needed here
 	By("waiting for broker/router deployment to be ready")
 	Eventually(func(g Gomega) {
 		deployment := &appsv1.Deployment{}
@@ -165,11 +168,6 @@ var _ = BeforeSuite(func() {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(deployment.Status.ReadyReplicas).To(BeNumerically(">=", 1))
 	}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-	By("enabling debug logging on the gateway")
-	Expect(AddDeploymentCommandFlag(ctx, SystemNamespace, "mcp-gateway", "--log-level=-4")).To(Succeed())
-	Expect(WaitForDeploymentReady(ctx, SystemNamespace, "mcp-gateway")).To(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("URL Elicitation", Ordered, func() {
+var _ = Describe("URL Elicitation", Ordered, ContinueOnFailure, func() {
 	var (
 		testResources []client.Object
 		prefix        string

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -13,17 +13,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("URL Elicitation", func() {
+var _ = Describe("URL Elicitation", Ordered, func() {
 	var (
 		testResources []client.Object
 		prefix        string
 	)
 
-	BeforeEach(func() {
+	// toggling elicitation on the MCPGatewayExtension rolls out the gateway
+	// deployment, so do it once for the whole container rather than per spec
+	BeforeAll(func() {
 		By("Enabling URL elicitation on the MCPGatewayExtension")
 		Expect(SetURLElicitation(SystemNamespace, MCPExtensionName, true)).To(Succeed())
 		Expect(WaitForDeploymentReady(context.Background(), SystemNamespace, "mcp-gateway")).To(Succeed())
+	})
 
+	AfterAll(func() {
+		By("Disabling URL elicitation on the MCPGatewayExtension")
+		Expect(SetURLElicitation(SystemNamespace, MCPExtensionName, false)).To(Succeed())
+		Expect(WaitForDeploymentReady(context.Background(), SystemNamespace, "mcp-gateway")).To(Succeed())
+	})
+
+	BeforeEach(func() {
 		By("Pre-cleaning credential secret from prior runs")
 		cred := BuildCredentialSecret("url-elicit-cred", "test-api-key-secret-token")
 		CleanupResource(ctx, k8sClient, cred)
@@ -51,10 +61,6 @@ var _ = Describe("URL Elicitation", func() {
 			CleanupResource(ctx, k8sClient, to)
 		}
 		testResources = nil
-
-		By("Disabling URL elicitation on the MCPGatewayExtension")
-		Expect(SetURLElicitation(SystemNamespace, MCPExtensionName, false)).To(Succeed())
-		Expect(WaitForDeploymentReady(context.Background(), SystemNamespace, "mcp-gateway")).To(Succeed())
 	})
 
 	It("[Happy,URLElicitation] URL elicitation triggers on missing token for elicitation-capable client", func() {


### PR DESCRIPTION
**Breaking change**: `--log-level` on the broker-router deployment is now a controller-managed flag. An operator-patched `--log-level` on the managed deployment gets reconciled away; set `BROKER_ROUTER_LOG_LEVEL` on the controller instead. Release notes entry included (`docs/release-notes/0.0.8.md`).

## Summary

- Cuts PR-gate e2e wall time from ~32-37m to an expected ~26-28m. Measured breakdown showed ~10-11m of `ci-setup` (of which ~7m image builds) plus ~23m of ginkgo; this PR removes the rebuild of 11 test-server images already published to ghcr.io (pulled in parallel via `ctr` inside the Kind node, with automatic fallback to local builds when a PR touches `tests/servers/**` or `internal/tests/**`), adds buildx `type=gha` caching for the gateway/controller images, parallelises the infra installs, sources CI debug logging from the CI overlay instead of two post-deploy rollouts, and hoists the url_elicitation extension toggle from per-spec to per-container (12 rollouts to 2).
- Nightly keeps its single sequential full-suite job, with the same image caching applied.
- Local behaviour unchanged: `TEST_SERVER_IMAGE_SOURCE`/`GATEWAY_IMAGE_SOURCE` default to `build` and the default `ci-setup` path is byte-identical. Note: local `make test-e2e` now runs the gateway at info level (debug comes from the CI overlay); intentional.

## Test evidence

- `make test-unit`: pass (includes new controller tests for managed `--log-level` add/replace/strip)
- `make lint` (pinned golangci-lint v2.4.0): 0 issues
- `go vet -tags=e2e ./tests/e2e/...`: clean
- actionlint on both changed workflows: clean
- `kubectl kustomize config/mcp-gateway/overlays/ci/`: renders `--log-level=-4` + `BROKER_ROUTER_LOG_LEVEL`
- `make -n` matrix: defaults build 13 images as before; CI mode builds 0 and pulls
- e2e itself: validated by this PR's own CI run (wall time is the acceptance signal)

Closes #1117. Follow-on (pre-baked node image, lighter PR test scope): #1120.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The controller now manages broker-router logging configuration via the `BROKER_ROUTER_LOG_LEVEL` environment variable.

* **Documentation**
  * Added release notes documenting the logging configuration changes with migration guidance.

* **Chores**
  * Enhanced CI/CD image building and test infrastructure for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->