### PR TITLE
ci: pre-baked e2e node image and lighter PR-gate test scope

### DIFF
--- a/.github/workflows/ci-node-image.yaml
+++ b/.github/workflows/ci-node-image.yaml
@@ -1,0 +1,112 @@
+name: Bake CI Node Image
+
+# bakes the e2e infra and test-server images into a kindest/node image
+# (build/ci-node/Dockerfile) tagged with the content hash printed by
+# utils/ci-node-image-hash.sh. the e2e workflows compute the same hash and
+# use the image when the tag exists, falling back to stock kindest/node and
+# the standard pull path on a miss, so a missing or failed bake can only make
+# e2e slower, never wrong.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'build/istio.mk'
+      - 'build/cert-manager.mk'
+      - 'build/metallb.mk'
+      - 'build/gateway-api.mk'
+      - 'build/tools.mk'
+      - 'build/ci-node.mk'
+      - 'build/ci-node/Dockerfile'
+      - 'config/istio/istio.yaml'
+      - 'config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml'
+      - 'tests/servers/**'
+      - 'internal/tests/**'
+      - 'utils/ci-node-image-hash.sh'
+      - '.github/workflows/ci-node-image.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository }}
+
+jobs:
+  bake-ci-node-image:
+    name: Bake CI Node Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Compute image ref
+        id: image
+        run: |
+          image="$(make -s print-ci-node-image CI_NODE_IMAGE="${REGISTRY}/${IMAGE_PREFIX,,}/ci-node")"
+          echo "ref=$image" >> "$GITHUB_OUTPUT"
+          echo "baked image ref: $image"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for existing image
+        id: exists
+        run: |
+          if docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "${{ steps.image.outputs.ref }} already published, nothing to do"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # test-images.yaml republishes the test-server :latest tags on pushes
+      # that touch their sources; pulling mid-publish would bake a stale mix,
+      # so wait for any run on this commit to finish first. failing here is
+      # safe: e2e just falls back to the standard pull path
+      - name: Wait for test-server image publish
+        if: steps.exists.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for _ in $(seq 1 60); do
+            status="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-images.yaml --commit "$GITHUB_SHA" --json status --jq '[.[].status] | join(",")' || echo unknown)"
+            case "$status" in
+              *queued*|*in_progress*|*waiting*|*pending*|*requested*|unknown)
+                echo "test-images run(s) for $GITHUB_SHA: ${status:-none}; waiting..."
+                sleep 20
+                ;;
+              *)
+                echo "no in-flight test-images run for $GITHUB_SHA"
+                exit 0
+                ;;
+            esac
+          done
+          echo "ERROR: timed out waiting for test-images.yaml on $GITHUB_SHA; refusing to bake a possibly stale image"
+          exit 1
+
+      # the bake unpacks ~15 images on top of a multi-GB base; reclaim the
+      # preinstalled toolchains so the build cannot exhaust the runner disk
+      - name: Free runner disk space
+        if: steps.exists.outputs.published != 'true'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          docker system prune -af >/dev/null
+          df -h /
+
+      # the target creates its own buildx builder with the security.insecure
+      # entitlement and pushes straight from it
+      - name: Bake and push CI node image
+        if: steps.exists.outputs.published != 'true'
+        run: make ci-node-image-build CI_NODE_IMAGE="${REGISTRY}/${IMAGE_PREFIX,,}/ci-node" CI_NODE_IMAGE_PUSH=true

--- a/.github/workflows/ci-node-image.yaml
+++ b/.github/workflows/ci-node-image.yaml
@@ -71,29 +71,31 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # test-images.yaml republishes the test-server :latest tags on pushes
-      # that touch their sources; pulling mid-publish would bake a stale mix,
-      # so wait for any run on this commit to finish first. failing here is
-      # safe: e2e just falls back to the standard pull path
+      # test-images.yaml republishes the test-server :latest tags from main;
+      # pulling mid-publish would permanently bake a stale mix under a valid
+      # hash, and an in-flight run may belong to an earlier push than the one
+      # that triggered this bake, so wait until no run on main is active at
+      # all (test-images only pushes :latest from main, so this stays cheap).
+      # failing here is safe: e2e just falls back to the standard pull path
       - name: Wait for test-server image publish
         if: steps.exists.outputs.published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           for _ in $(seq 1 60); do
-            status="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-images.yaml --commit "$GITHUB_SHA" --json status --jq '[.[].status] | join(",")' || echo unknown)"
+            status="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-images.yaml --branch main --json status --jq '[.[].status] | join(",")' || echo unknown)"
             case "$status" in
               *queued*|*in_progress*|*waiting*|*pending*|*requested*|unknown)
-                echo "test-images run(s) for $GITHUB_SHA: ${status:-none}; waiting..."
+                echo "active test-images run(s) on main: ${status:-unknown}; waiting..."
                 sleep 20
                 ;;
               *)
-                echo "no in-flight test-images run for $GITHUB_SHA"
+                echo "no in-flight test-images run on main"
                 exit 0
                 ;;
             esac
           done
-          echo "ERROR: timed out waiting for test-images.yaml on $GITHUB_SHA; refusing to bake a possibly stale image"
+          echo "ERROR: timed out waiting for test-images.yaml on main; refusing to bake a possibly stale image"
           exit 1
 
       # the bake unpacks ~15 images on top of a multi-GB base; reclaim the

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -48,8 +48,10 @@ jobs:
         with:
           node-version: "24"
 
+      # create with the pinned bin/kind and node image so the make load
+      # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+        run: make kind-create-cluster-ci
 
       - name: Setup CI environment
         run: |

--- a/.github/workflows/e2e-auth.yaml
+++ b/.github/workflows/e2e-auth.yaml
@@ -21,8 +21,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # create with the pinned bin/kind and node image so the make load
+      # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+        run: make kind-create-cluster-ci
 
       - name: Setup CI environment
         run: make ci-setup

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -106,12 +106,16 @@ jobs:
           cache-from: type=gha,scope=controller-image
           cache-to: type=gha,mode=max,scope=controller-image
 
+      # create with the pinned bin/kind and node image so the make load
+      # targets (same bin/kind) can always load into the node's containerd;
+      # the runner-preinstalled kind's default node moved to a containerd
+      # config version the pinned bin/kind cannot load into
       - name: Create Kind cluster
         run: |
           if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
-            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml --image "${{ steps.ci-node.outputs.image }}"
+            make kind-create-cluster-ci KIND_CLUSTER_IMAGE="${{ steps.ci-node.outputs.image }}"
           else
-            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+            make kind-create-cluster-ci
           fi
 
       - name: Setup CI environment

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -38,6 +38,35 @@ jobs:
           echo "source=$source" >> "$GITHUB_OUTPUT"
           echo "test-server image source: $source"
 
+      # ci-node-image.yaml bakes the e2e infra and test-server images into a
+      # kindest/node image tagged with a content hash of the version pins
+      # (utils/ci-node-image-hash.sh). on a hit the cluster boots from it and
+      # the test-server pulls are skipped; on a miss or probe failure this run
+      # uses stock kindest/node and the standard pull path. a locally-built
+      # test-server source always wins so source changes are never masked.
+      - name: Probe baked CI node image
+        id: ci-node
+        env:
+          DETECTED_TEST_SERVER_SOURCE: ${{ steps.test-server-images.outputs.source }}
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          image="$(make -s print-ci-node-image)"
+          hit=false
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            hit=true
+          fi
+          source="$DETECTED_TEST_SERVER_SOURCE"
+          if [ "$hit" = "true" ] && [ "$source" = "pull" ]; then
+            source=baked
+          fi
+          {
+            echo "hit=$hit"
+            echo "image=$image"
+            echo "test-server-source=$source"
+          } >> "$GITHUB_OUTPUT"
+          echo "baked CI node image: $image (hit=$hit), test-server image source: $source"
+
       - name: Compute image build LDFLAGS
         id: ldflags
         run: echo "ldflags=$(make -s print-ldflags)" >> "$GITHUB_OUTPUT"
@@ -67,10 +96,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=controller-image
 
       - name: Create Kind cluster
-        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+        run: |
+          if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
+            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml --image "${{ steps.ci-node.outputs.image }}"
+          else
+            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+          fi
 
       - name: Setup CI environment
-        run: make ci-setup GATEWAY_IMAGE_SOURCE=prebuilt TEST_SERVER_IMAGE_SOURCE=${{ steps.test-server-images.outputs.source }}
+        run: make ci-setup GATEWAY_IMAGE_SOURCE=prebuilt TEST_SERVER_IMAGE_SOURCE=${{ steps.ci-node.outputs.test-server-source }}
 
       - name: Run full E2E suite
         run: make test-e2e-ci-full

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -13,6 +13,11 @@ jobs:
   e2e-tests-full:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # packages: read lets the baked CI node image probe see GITHUB_TOKEN-
+    # published ghcr packages, which default to private
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout
@@ -50,11 +55,17 @@ jobs:
           DETECTED_TEST_SERVER_SOURCE: ${{ steps.test-server-images.outputs.source }}
           GHCR_TOKEN: ${{ github.token }}
         run: |
-          image="$(make -s print-ci-node-image)"
+          # any probe failure (including the hash computation) must fall back
+          # to stock kindest/node rather than fail the run
           hit=false
-          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
-          if docker manifest inspect "$image" >/dev/null 2>&1; then
-            hit=true
+          if image="$(make -s print-ci-node-image 2>/dev/null)"; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              hit=true
+            fi
+          else
+            image=""
+            echo "could not compute baked CI node image ref, using stock kindest/node"
           fi
           source="$DETECTED_TEST_SERVER_SOURCE"
           if [ "$hit" = "true" ] && [ "$source" = "pull" ]; then

--- a/.github/workflows/e2e-on-demand.yaml
+++ b/.github/workflows/e2e-on-demand.yaml
@@ -110,8 +110,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # create with the pinned bin/kind and node image so the make load
+      # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+        run: make kind-create-cluster-ci
 
       - name: Setup CI environment
         run: make ci-setup

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,6 +29,13 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # packages: read lets the baked CI node image probe see GITHUB_TOKEN-
+    # published ghcr packages, which default to private; pull-requests: read
+    # keeps the PR changed-files lookup in the detection step working
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -90,11 +97,17 @@ jobs:
           DETECTED_TEST_SERVER_SOURCE: ${{ steps.test-server-images.outputs.source }}
           GHCR_TOKEN: ${{ github.token }}
         run: |
-          image="$(make -s print-ci-node-image)"
+          # any probe failure (including the hash computation) must fall back
+          # to stock kindest/node rather than fail the run
           hit=false
-          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
-          if docker manifest inspect "$image" >/dev/null 2>&1; then
-            hit=true
+          if image="$(make -s print-ci-node-image 2>/dev/null)"; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              hit=true
+            fi
+          else
+            image=""
+            echo "could not compute baked CI node image ref, using stock kindest/node"
           fi
           source="$DETECTED_TEST_SERVER_SOURCE"
           if [ "$hit" = "true" ] && [ "$source" = "pull" ]; then

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,6 +78,35 @@ jobs:
           echo "source=$source" >> "$GITHUB_OUTPUT"
           echo "test-server image source: $source"
 
+      # ci-node-image.yaml bakes the e2e infra and test-server images into a
+      # kindest/node image tagged with a content hash of the version pins
+      # (utils/ci-node-image-hash.sh). on a hit the cluster boots from it and
+      # the test-server pulls are skipped; on a miss or probe failure this run
+      # uses stock kindest/node and the standard pull path. a locally-built
+      # test-server source always wins so PR changes are never masked.
+      - name: Probe baked CI node image
+        id: ci-node
+        env:
+          DETECTED_TEST_SERVER_SOURCE: ${{ steps.test-server-images.outputs.source }}
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          image="$(make -s print-ci-node-image)"
+          hit=false
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            hit=true
+          fi
+          source="$DETECTED_TEST_SERVER_SOURCE"
+          if [ "$hit" = "true" ] && [ "$source" = "pull" ]; then
+            source=baked
+          fi
+          {
+            echo "hit=$hit"
+            echo "image=$image"
+            echo "test-server-source=$source"
+          } >> "$GITHUB_OUTPUT"
+          echo "baked CI node image: $image (hit=$hit), test-server image source: $source"
+
       - name: Compute image build LDFLAGS
         id: ldflags
         run: echo "ldflags=$(make -s print-ldflags)" >> "$GITHUB_OUTPUT"
@@ -107,10 +136,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=controller-image
 
       - name: Create Kind cluster
-        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+        run: |
+          if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
+            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml --image "${{ steps.ci-node.outputs.image }}"
+          else
+            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+          fi
 
       - name: Setup CI environment
-        run: make ci-setup GATEWAY_IMAGE_SOURCE=prebuilt TEST_SERVER_IMAGE_SOURCE=${{ steps.test-server-images.outputs.source }}
+        run: make ci-setup GATEWAY_IMAGE_SOURCE=prebuilt TEST_SERVER_IMAGE_SOURCE=${{ steps.ci-node.outputs.test-server-source }}
 
       - name: Run E2E tests
         run: make test-e2e-ci

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -148,12 +148,16 @@ jobs:
           cache-from: type=gha,scope=controller-image
           cache-to: type=gha,mode=max,scope=controller-image
 
+      # create with the pinned bin/kind and node image so the make load
+      # targets (same bin/kind) can always load into the node's containerd;
+      # the runner-preinstalled kind's default node moved to a containerd
+      # config version the pinned bin/kind cannot load into
       - name: Create Kind cluster
         run: |
           if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
-            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml --image "${{ steps.ci-node.outputs.image }}"
+            make kind-create-cluster-ci KIND_CLUSTER_IMAGE="${{ steps.ci-node.outputs.image }}"
           else
-            kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+            make kind-create-cluster-ci
           fi
 
       - name: Setup CI environment

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,9 @@ kind-load-tls-server: kind build-tls-server ## Build TLS test server image local
 
 # How test server images reach the Kind cluster: "build" (default) builds them
 # locally and loads via kind load, "pull" fetches the pre-built images published
-# to ghcr.io on merges to main. CI uses pull unless the change touches
+# to ghcr.io on merges to main, "baked" skips loading entirely because the
+# cluster was created from the baked CI node image (build/ci-node/Dockerfile)
+# that already carries them. CI uses pull or baked unless the change touches
 # tests/servers/** or internal/tests/**, which are not published from PRs.
 TEST_SERVER_IMAGE_SOURCE ?= build
 
@@ -430,8 +432,13 @@ load-tls-server: kind-pull-tls-server
 else ifeq ($(TEST_SERVER_IMAGE_SOURCE),build)
 load-test-servers: kind-load-test-servers
 load-tls-server: kind-load-tls-server
+else ifeq ($(TEST_SERVER_IMAGE_SOURCE),baked)
+load-test-servers:
+	@echo "Test server images pre-seeded in the baked CI node image, skipping load"
+load-tls-server:
+	@echo "TLS test server image pre-seeded in the baked CI node image, skipping load"
 else
-$(error TEST_SERVER_IMAGE_SOURCE must be "build" or "pull", got "$(TEST_SERVER_IMAGE_SOURCE)")
+$(error TEST_SERVER_IMAGE_SOURCE must be "build", "pull" or "baked", got "$(TEST_SERVER_IMAGE_SOURCE)")
 endif
 
 # Deploy TLS test server with cert-manager CA chain

--- a/Makefile
+++ b/Makefile
@@ -358,12 +358,8 @@ kind-load-test-servers: kind build-test-servers ## Build test server images loca
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-custom-response-server:latest)
 	$(call load-image,ghcr.io/kuadrant/mcp-gateway/test-user-specific-server:latest)
 
-# Pre-built test server images published to ghcr.io by .github/workflows/test-images.yaml
-TEST_SERVER_IMAGE_REPO ?= ghcr.io/kuadrant/mcp-gateway
-TEST_SERVER_IMAGE_TAG ?= latest
-TEST_SERVER_IMAGES = test-server1 test-server2 test-server3 test-api-key-server \
-	test-broken-server test-custom-path-server test-oidc-server \
-	test-everything-server test-custom-response-server test-user-specific-server
+# TEST_SERVER_IMAGE_REPO/TAG and TEST_SERVER_IMAGES live in build/ci-node.mk
+# so the baked CI node image tag hashes them
 
 # pull pre-built images straight into containerd on the kind node, in parallel,
 # avoiding both the local rebuild and the docker save + kind load tax.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Also sets up an Istio Gateway API Gateway with the everything test server behind
 ```bash
 make local-env-setup
 
-# Or with custom ports (defaults: 8001->30080->8080 for MCP Broker/Gateway, 8002->30089->8002 for Keycloak)
+# Or with custom ports (defaults: 8001->30080->8080 for MCP Broker/Gateway, 8002->30081->8002 for Keycloak)
 KIND_HOST_PORT_MCP_GATEWAY=8090 KIND_HOST_PORT_KEYCLOAK=8453 make local-env-setup
 ```
 

--- a/build/ci-node.mk
+++ b/build/ci-node.mk
@@ -6,6 +6,17 @@
 
 CI_NODE_IMAGE ?= ghcr.io/kuadrant/mcp-gateway/ci-node
 CI_NODE_DOCKERFILE = build/ci-node/Dockerfile
+
+# Pre-built test server images published to ghcr.io by
+# .github/workflows/test-images.yaml. defined here rather than in the root
+# Makefile (whose kind-pull targets reference them) so retagging or renaming
+# a published image changes the baked image hash and forces a rebake.
+TEST_SERVER_IMAGE_REPO ?= ghcr.io/kuadrant/mcp-gateway
+TEST_SERVER_IMAGE_TAG ?= latest
+TEST_SERVER_IMAGES = test-server1 test-server2 test-server3 test-api-key-server \
+	test-broken-server test-custom-path-server test-oidc-server \
+	test-everything-server test-custom-response-server test-user-specific-server
+
 # buildx builder with the security.insecure entitlement: containerd's layer
 # extraction in the bake RUN step needs mount(2), which plain builds deny
 CI_NODE_BUILDER = mcp-ci-node-baker
@@ -48,8 +59,9 @@ ci-node-image-build: ## Bake e2e infra and test server images into a kind node i
 	done; \
 	tag="$$(./utils/ci-node-image-hash.sh)"; \
 	if [ "$(CI_NODE_IMAGE_PUSH)" = "true" ]; then output_flag="--push"; else output_flag="--load"; fi; \
-	$(CONTAINER_ENGINE) buildx create --name $(CI_NODE_BUILDER) --driver docker-container \
-		--buildkitd-flags '--allow-insecure-entitlement security.insecure' >/dev/null 2>&1 || true; \
+	$(CONTAINER_ENGINE) buildx inspect $(CI_NODE_BUILDER) >/dev/null 2>&1 \
+		|| $(CONTAINER_ENGINE) buildx create --name $(CI_NODE_BUILDER) --driver docker-container \
+			--buildkitd-flags '--allow-insecure-entitlement security.insecure'; \
 	echo "Baking $(CI_NODE_IMAGE):$$tag ($$output_flag)"; \
 	$(CONTAINER_ENGINE) buildx build --builder $(CI_NODE_BUILDER) --allow security.insecure $$output_flag \
 		-f $(CI_NODE_DOCKERFILE) \

--- a/build/ci-node.mk
+++ b/build/ci-node.mk
@@ -1,0 +1,59 @@
+# Baked CI node image: kindest/node pre-seeded with the e2e infra and
+# test-server images (see build/ci-node/Dockerfile). the tag is a content
+# hash of everything that determines the baked image, computed by
+# utils/ci-node-image-hash.sh and shared between the bake workflow and the
+# e2e consumers. this file is itself a hash input, so changes here rebake.
+
+CI_NODE_IMAGE ?= ghcr.io/kuadrant/mcp-gateway/ci-node
+CI_NODE_DOCKERFILE = build/ci-node/Dockerfile
+# buildx builder with the security.insecure entitlement: containerd's layer
+# extraction in the bake RUN step needs mount(2), which plain builds deny
+CI_NODE_BUILDER = mcp-ci-node-baker
+# true pushes straight from the builder (CI), false loads into the local
+# docker image store
+CI_NODE_IMAGE_PUSH ?= false
+
+.PHONY: print-ci-node-image-tag
+print-ci-node-image-tag: # print the content-hash tag for the baked CI node image
+	@./utils/ci-node-image-hash.sh
+
+.PHONY: print-ci-node-image
+print-ci-node-image: # print the fully qualified baked CI node image ref
+	@echo "$(CI_NODE_IMAGE):$$(./utils/ci-node-image-hash.sh)"
+
+# istiod/proxyv2 track the Istio CR (spec.version), redis tracks its
+# deployment manifest, everything else tracks the pinned make variables, so
+# versions have a single source of truth. image repos are pinned here:
+# istiod/proxyv2 repos come from the sail operator's version mapping, the
+# sail operator repo from its helm chart values, metallb and cert-manager
+# repos from their pinned install manifests. requires docker buildx.
+.PHONY: ci-node-image-build
+ci-node-image-build: ## Bake e2e infra and test server images into a kind node image
+	@set -e; \
+	istio_version="$$(awk '$$1 == "version:" { print $$2; exit }' config/istio/istio.yaml)"; \
+	test -n "$$istio_version" || { echo "ERROR: could not read spec.version from config/istio/istio.yaml"; exit 1; }; \
+	redis_image="$$(awk '$$1 == "image:" { print $$2; exit }' config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml)"; \
+	test -n "$$redis_image" || { echo "ERROR: could not read image from config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml"; exit 1; }; \
+	refs="gcr.io/istio-release/pilot:$${istio_version#v} \
+		gcr.io/istio-release/proxyv2:$${istio_version#v} \
+		quay.io/sail-dev/sail-operator:$(SAIL_VERSION) \
+		quay.io/jetstack/cert-manager-controller:v$(CERT_MANAGER_VERSION) \
+		quay.io/jetstack/cert-manager-cainjector:v$(CERT_MANAGER_VERSION) \
+		quay.io/jetstack/cert-manager-webhook:v$(CERT_MANAGER_VERSION) \
+		quay.io/metallb/controller:$(METALLB_VERSION) \
+		quay.io/metallb/speaker:$(METALLB_VERSION) \
+		$$redis_image"; \
+	for img in $(TEST_SERVER_IMAGES) test-tls-server; do \
+		refs="$$refs $(TEST_SERVER_IMAGE_REPO)/$$img:$(TEST_SERVER_IMAGE_TAG)"; \
+	done; \
+	tag="$$(./utils/ci-node-image-hash.sh)"; \
+	if [ "$(CI_NODE_IMAGE_PUSH)" = "true" ]; then output_flag="--push"; else output_flag="--load"; fi; \
+	$(CONTAINER_ENGINE) buildx create --name $(CI_NODE_BUILDER) --driver docker-container \
+		--buildkitd-flags '--allow-insecure-entitlement security.insecure' >/dev/null 2>&1 || true; \
+	echo "Baking $(CI_NODE_IMAGE):$$tag ($$output_flag)"; \
+	$(CONTAINER_ENGINE) buildx build --builder $(CI_NODE_BUILDER) --allow security.insecure $$output_flag \
+		-f $(CI_NODE_DOCKERFILE) \
+		--build-arg KIND_NODE_IMAGE="$(KIND_NODE_IMAGE)" \
+		--build-arg BAKED_IMAGE_REFS="$$refs" \
+		-t "$(CI_NODE_IMAGE):$$tag" \
+		build/ci-node

--- a/build/ci-node/Dockerfile
+++ b/build/ci-node/Dockerfile
@@ -29,7 +29,8 @@ RUN --security=insecure \
         ctr --namespace k8s.io images ls >/dev/null 2>&1 && break; \
         sleep 1; \
     done; \
-    ctr --namespace k8s.io images ls >/dev/null; \
+    ctr --namespace k8s.io images ls >/dev/null 2>&1 \
+        || { echo "ERROR: containerd failed to start"; cat /var/log/containerd-bake.log; exit 1; }; \
     pids=""; \
     for ref in ${BAKED_IMAGE_REFS}; do \
         ( ctr --namespace k8s.io images pull "${ref}" >/dev/null \

--- a/build/ci-node/Dockerfile
+++ b/build/ci-node/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1-labs
+
+# kindest/node with the e2e infra and test-server images pre-seeded into the
+# containerd content store. built by `make ci-node-image-build` (which
+# composes BAKED_IMAGE_REFS from the pinned make variables and manifests),
+# published by .github/workflows/ci-node-image.yaml under the tag printed by
+# utils/ci-node-image-hash.sh, and consumed by the e2e workflows on a tag hit.
+# kubeadm init and the installs still run normally at cluster create time;
+# only the image pulls become no-ops. on a tag miss e2e falls back to stock
+# kindest/node and the standard pull path.
+
+ARG KIND_NODE_IMAGE
+FROM ${KIND_NODE_IMAGE}
+
+# space-separated image refs to seed
+ARG BAKED_IMAGE_REFS
+
+# containerd is not running during build, so start it for the duration of the
+# RUN step, pull in parallel with one retry each (mirroring the Makefile's
+# pull-images-into-kind macro) and stop it cleanly so the image store the
+# layer captures is consistent. layer extraction mounts tmpmounts under
+# /var/lib/containerd, hence --security=insecure (granted by the buildx
+# builder ci-node-image-build creates)
+RUN --security=insecure \
+    [ -n "${BAKED_IMAGE_REFS}" ] || { echo "BAKED_IMAGE_REFS not set"; exit 1; }; \
+    containerd >/var/log/containerd-bake.log 2>&1 & \
+    containerd_pid=$!; \
+    for _ in $(seq 1 30); do \
+        ctr --namespace k8s.io images ls >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    ctr --namespace k8s.io images ls >/dev/null; \
+    pids=""; \
+    for ref in ${BAKED_IMAGE_REFS}; do \
+        ( ctr --namespace k8s.io images pull "${ref}" >/dev/null \
+            || { echo "Retrying pull of ${ref}..."; sleep 2; \
+                ctr --namespace k8s.io images pull "${ref}" >/dev/null; } ) & \
+        pids="${pids} $!"; \
+    done; \
+    rc=0; \
+    for pid in ${pids}; do wait "${pid}" || rc=1; done; \
+    [ "${rc}" -eq 0 ] || { echo "ERROR: failed to pull one or more images"; exit 1; }; \
+    echo "Seeded images:"; \
+    ctr --namespace k8s.io images ls -q; \
+    kill "${containerd_pid}"; \
+    wait "${containerd_pid}" || true

--- a/build/kind.mk
+++ b/build/kind.mk
@@ -2,6 +2,20 @@
 
 KIND_CLUSTER_NAME ?= mcp-gateway
 
+# node image for CI clusters; the baked CI node image overrides this on a
+# bake hit. defaults to the pinned KIND_NODE_IMAGE so it always matches the
+# bin/kind the load targets use.
+KIND_CLUSTER_IMAGE ?= $(KIND_NODE_IMAGE)
+
+# CI cluster creation uses the same pinned kind binary and node image as the
+# make load targets. creating with the runner-preinstalled kind broke when
+# its default node image moved to a containerd config version the pinned
+# bin/kind cannot load into (kindest/node v1.36.1 ships containerd config
+# version 4; kind v0.29.0 supports 2 and 3).
+.PHONY: kind-create-cluster-ci
+kind-create-cluster-ci: kind # Create the CI kind cluster with the pinned kind binary and node image
+	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config config/kind/cluster-ci.yaml --image "$(KIND_CLUSTER_IMAGE)"
+
 .PHONY: kind-create-cluster
 kind-create-cluster: kind # Create the "mcp-gateway" kind cluster.
 	@./utils/generate-placeholder-ca.sh

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -2,9 +2,10 @@
 
 KIND = bin/kind
 KIND_VERSION = v0.29.0
-# default node image for KIND_VERSION above, used as the base of the baked CI
-# node image (build/ci-node/Dockerfile); keep in lockstep when bumping kind,
-# digest included as the kind release notes require
+# default node image for KIND_VERSION above, used for CI cluster creation
+# (kind-create-cluster-ci) and as the base of the baked CI node image
+# (build/ci-node/Dockerfile); keep in lockstep when bumping kind, digest
+# included as the kind release notes require
 KIND_NODE_IMAGE = kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 $(KIND):
 	GOBIN=$(PWD)/bin go install sigs.k8s.io/kind@$(KIND_VERSION)

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -2,6 +2,10 @@
 
 KIND = bin/kind
 KIND_VERSION = v0.29.0
+# default node image for KIND_VERSION above, used as the base of the baked CI
+# node image (build/ci-node/Dockerfile); keep in lockstep when bumping kind,
+# digest included as the kind release notes require
+KIND_NODE_IMAGE = kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 $(KIND):
 	GOBIN=$(PWD)/bin go install sigs.k8s.io/kind@$(KIND_VERSION)
 

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -62,8 +62,9 @@ gateway:
   nodePort:
     # Create a NodePort service for the Gateway
     create: false
-    # NodePort for the MCP port
-    mcpPort: 30471
+    # NodePort for the MCP port (keep inside the k8s static subrange
+    # 30000-30085 so dynamic nodePort allocation will not collide with it)
+    mcpPort: 30071
     # Status port configuration (Istio health check port)
     statusPort:
       enabled: false

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -37,7 +37,7 @@ nodes:
   - containerPort: 30080
     hostPort: 8001
     protocol: TCP
-  - containerPort: 30089
+  - containerPort: 30081
     hostPort: 8002
     protocol: TCP
 EOF

--- a/config/e2e/nodeport.yaml
+++ b/config/e2e/nodeport.yaml
@@ -1,3 +1,6 @@
+# nodePort values pinned inside the k8s static subrange (30000-30085, KEP-3668)
+# so dynamic allocations (e.g. istio-generated per-gateway loadbalancer services)
+# will not draw them first. must match extraPortMappings in config/kind/cluster*.yaml.
 ---
 apiVersion: v1
 kind: Service
@@ -14,7 +17,7 @@ spec:
   ports:
     - appProtocol: http
       name: mcp
-      nodePort: 30472
+      nodePort: 30072
       port: 8080
       protocol: TCP
       targetPort: 8080
@@ -38,7 +41,7 @@ spec:
   ports:
     - appProtocol: http
       name: mcp
-      nodePort: 30471
+      nodePort: 30071
       port: 8080
       protocol: TCP
       targetPort: 8080
@@ -63,7 +66,7 @@ spec:
   ports:
     - appProtocol: http
       name: team-a-mcp
-      nodePort: 30473
+      nodePort: 30073
       port: 8080
       protocol: TCP
       targetPort: 8080
@@ -88,7 +91,7 @@ spec:
   ports:
     - appProtocol: http
       name: team-b-mcp
-      nodePort: 30474
+      nodePort: 30074
       port: 8081
       protocol: TCP
       targetPort: 8081

--- a/config/istio/gateway/nodeport.yaml
+++ b/config/istio/gateway/nodeport.yaml
@@ -1,3 +1,6 @@
+# nodePort values pinned inside the k8s static subrange (30000-30085, KEP-3668)
+# so dynamic allocations (e.g. istio-generated per-gateway loadbalancer services)
+# will not draw them first. must match extraPortMappings in config/kind/cluster*.yaml.
 ---
 apiVersion: v1
 kind: Service
@@ -20,7 +23,7 @@ spec:
     targetPort: 8080
   - appProtocol: http
     name: keycloak
-    nodePort: 30089
+    nodePort: 30081
     port: 8002
     protocol: TCP
     targetPort: 8002

--- a/config/kind/cluster-ci.yaml
+++ b/config/kind/cluster-ci.yaml
@@ -14,22 +14,24 @@ nodes:
     apiVersion: kubelet.config.k8s.io/v1beta1
     kind: KubeletConfiguration
     syncFrequency: "10s"
+  # containerPorts are pinned nodePort values; keep inside 30000-30085 (k8s static
+  # subrange, KEP-3668) so dynamic nodePort allocation will not collide with them
   extraPortMappings:
   - containerPort: 30080 # mcp-gateway (standard)
     hostPort: 8001
     protocol: TCP
-  - containerPort: 30089 # keycloak
+  - containerPort: 30081 # keycloak
     hostPort: 8002
     protocol: TCP
-  - containerPort: 30471 # e2e-2 gateway
+  - containerPort: 30071 # e2e-2 gateway
     hostPort: 8003
     protocol: TCP
-  - containerPort: 30472 # e2e-1 gateway
+  - containerPort: 30072 # e2e-1 gateway
     hostPort: 8004
     protocol: TCP
-  - containerPort: 30473 # shared-gateway team-a
+  - containerPort: 30073 # shared-gateway team-a
     hostPort: 8005
     protocol: TCP
-  - containerPort: 30474 # shared-gateway team-b
+  - containerPort: 30074 # shared-gateway team-b
     hostPort: 8006
     protocol: TCP

--- a/config/kind/cluster.yaml
+++ b/config/kind/cluster.yaml
@@ -25,28 +25,30 @@ nodes:
         oidc-username-claim: preferred_username
         oidc-groups-claim: groups
         oidc-ca-file: /etc/kubernetes/pki/keycloak-ca.crt
+  # containerPorts are pinned nodePort values; keep inside 30000-30085 (k8s static
+  # subrange, KEP-3668) so dynamic nodePort allocation will not collide with them
   extraPortMappings:
   - containerPort: 30080 # mcp-gateway (standard)
     hostPort: 8001
     protocol: TCP
-  - containerPort: 30089 # keycloak port
+  - containerPort: 30081 # keycloak port
     hostPort: 8002
     protocol: TCP
-  - containerPort: 30471 # e2e-2 gateway
+  - containerPort: 30071 # e2e-2 gateway
     hostPort: 8003
     protocol: TCP
-  - containerPort: 30472 # e2e-1 gateway
+  - containerPort: 30072 # e2e-1 gateway
     hostPort: 8004
     protocol: TCP
-  - containerPort: 30473 # shared-gateway team-a
+  - containerPort: 30073 # shared-gateway team-a
     hostPort: 8005
     protocol: TCP
-  - containerPort: 30474 # shared-gateway team-b
+  - containerPort: 30074 # shared-gateway team-b
     hostPort: 8006
     protocol: TCP
-  - containerPort: 30475 # demo team-a
+  - containerPort: 30075 # demo team-a
     hostPort: 8007
     protocol: TCP
-  - containerPort: 30476 # demo team-b
+  - containerPort: 30076 # demo team-b
     hostPort: 8008
     protocol: TCP

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -274,10 +274,10 @@ helm upgrade -i team-b-mcp-gateway ./charts/mcp-gateway \
   --set mcpGatewayExtension.gatewayRef.name=team-b-gateway \
   --set mcpGatewayExtension.gatewayRef.namespace=gateway-system \
   --set gateway.nodePort.create=true \
-  --set gateway.nodePort.mcpPort=30471
+  --set gateway.nodePort.mcpPort=30071
 ```
 
-> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30471) to host ports.
+> **Note:** Kind clusters require `extraPortMappings` in the cluster config for NodePorts to be reachable from the host. Your Kind config must map the chosen container ports (30080, 30071) to host ports. Pick NodePorts inside the Kubernetes static subrange (30000-30085 for the default port range) so dynamic NodePort allocation will not collide with them.
 
 ## Next Steps: Register MCP Servers
 

--- a/docs/release-notes/0.0.8.md
+++ b/docs/release-notes/0.0.8.md
@@ -11,3 +11,13 @@ The controller now owns the `--log-level` flag on the broker-router deployment i
 ```bash
 kubectl set env deployment/mcp-gateway-controller -n mcp-system BROKER_ROUTER_LOG_LEVEL=-4
 ```
+
+### Helm default for `gateway.nodePort.mcpPort` changed from 30471 to 30071
+
+Pinned NodePorts now live inside the Kubernetes static subrange (30000-30085 for the default 30000-32767 port range), which dynamic NodePort allocation avoids. 30471 sat in the dynamic band and could be randomly allocated to another service first, making the pinned claim fail.
+
+**Migration**: If you relied on the default and have host port mappings (e.g. Kind `extraPortMappings`) pointing at 30471, either update the mapping to container port 30071, or pin the old port explicitly:
+
+```bash
+helm upgrade ... --set gateway.nodePort.mcpPort=30471
+```

--- a/project-words.txt
+++ b/project-words.txt
@@ -29,6 +29,7 @@ BMCPS
 boltdb
 btlspolicy
 buger
+buildkitd
 buildx
 cainjector
 caitlinelfring
@@ -82,6 +83,7 @@ envoyfilters
 envoyproxy
 envsubst
 envtest
+esac
 eppb
 erlene
 errcheck
@@ -146,6 +148,7 @@ healthz
 HKDF
 HMAC
 hostaliases
+hostedtoolcache
 hostnames
 hrpp
 htmlcov
@@ -176,6 +179,7 @@ istios
 istiotypev
 istiov
 Jacb
+jetstack
 josharian
 joshdk
 jsonparser
@@ -308,6 +312,7 @@ printcolumn
 procv
 promptname
 protoc
+proxyv
 pubout
 python3
 pytime
@@ -316,6 +321,7 @@ qwen
 randfill
 rbody
 readyz
+rebake
 referencegrant
 referencegrants
 refgrant
@@ -374,6 +380,7 @@ testprefix
 testwithcoverage
 tidwall
 tkennon
+tmpmounts
 Toddbgd
 tokenelicitation
 toolhive

--- a/project-words.txt
+++ b/project-words.txt
@@ -43,6 +43,7 @@ clientelicitation
 clientgoscheme
 clientregistration
 clusterserviceversion
+coderabbit
 configmap
 CONNLINK
 controllerutil

--- a/project-words.txt
+++ b/project-words.txt
@@ -335,6 +335,7 @@ regpour
 regset
 regslow
 regtime
+retagging
 retval
 rhcl
 Rkfdsw

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -66,6 +66,8 @@ nodes:
   - containerPort: 30080
     hostPort: 8001
     protocol: TCP
+  # 30089 matches the pinned VERSION's release manifests; becomes 30081 once
+  # the default VERSION includes the nodeport renumbering
   - containerPort: 30089 # keycloak
     hostPort: 8002
     protocol: TCP

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -21,7 +21,6 @@ const (
 	TestTimeoutLong       = time.Minute * 5
 	TestTimeoutConfigSync = time.Minute * 6
 	TestRetryInterval     = time.Second * 1
-	TestRetryFast         = time.Second * 2
 )
 
 // Namespace and resource name constants

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -20,7 +20,7 @@ const (
 	TestTimeoutShort      = time.Second * 45
 	TestTimeoutLong       = time.Minute * 5
 	TestTimeoutConfigSync = time.Minute * 6
-	TestRetryInterval     = time.Second * 5
+	TestRetryInterval     = time.Second * 1
 	TestRetryFast         = time.Second * 2
 )
 

--- a/tests/e2e/elicitation_test.go
+++ b/tests/e2e/elicitation_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Elicitation", func() {
 		Expect(responseText).To(ContainSubstring("User declined"))
 	})
 
-	It("[Elicitation] should error when calling elicitation tool without handler", func() {
+	It("[Full][Elicitation] should error when calling elicitation tool without handler", func() {
 		toolName := fmt.Sprintf("%strigger-elicitation-request", prefix)
 
 		By("Creating a standard client without elicitation handler")

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -502,23 +502,27 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(len(allToolsAgain.Tools)).To(BeNumerically(">", 1), "expected more than 1 tool without virtual server header")
 	})
 
-	It("[Happy] should send notifications/tools/list_changed to connected clients when MCPServerRegistration is registered", func() {
+	It("[Happy] should send list_changed notifications to connected clients when a server with tools and prompts is registered", func() {
 		// NOTE on notifications. A notification is sent when servers are removed during clean up as this effects tools list also.
 		// as the list_changed notification is broadcast, this can mean clients in other tests receive additional notifications
 		// for that reason we only assert we received at least one rather than a set number
 		By("Creating clients with notification handlers and different sessions")
 		client1Notification := false
 		client1, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
-			GinkgoWriter.Println("client 1 received notification registration", j.Method)
-			client1Notification = true
+			if strings.Contains(j.Method, "list_changed") {
+				GinkgoWriter.Println("client 1 received notification registration", j.Method)
+				client1Notification = true
+			}
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = client1.Close() }()
 
 		client2Notification := false
 		client2, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
-			GinkgoWriter.Println("client 2 received notification registration", j.Method)
-			client2Notification = true
+			if strings.Contains(j.Method, "list_changed") {
+				GinkgoWriter.Println("client 2 received notification registration", j.Method)
+				client2Notification = true
+			}
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = client2.Close() }()
@@ -526,8 +530,9 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(client2.sessionID).NotTo(BeEmpty())
 		Expect(client1.sessionID).NotTo(Equal(client2.sessionID))
 
-		By("registering a new MCPServerRegistration")
-		registration := NewMCPServerResourcesWithDefaults("notification-test", k8sClient).Build()
+		By("registering a new MCPServerRegistration pointing to server1 which has both tools and prompts")
+		registration := NewMCPServerResourcesWithDefaults("notification-test", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("notif_").Build()
 		testResources = append(testResources, registration.GetObjects()...)
 		registeredServer := registration.Register(ctx)
 
@@ -536,20 +541,21 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
-		// We do this to wait for the tools to show up as we know then that the gateway has done its work
+		// We do this to wait for the tools and prompts to show up as we know then that the gateway has done its work
 		Eventually(func(g Gomega) {
 			toolsList, err := mcpGatewayClient.ListTools(ctx, mcp.ListToolsRequest{})
 			g.Expect(err).Error().NotTo(HaveOccurred())
 			g.Expect(toolsList).NotTo(BeNil())
 			g.Expect(verifyMCPServerRegistrationToolsPresent(registeredServer.Spec.Prefix, toolsList)).To(BeTrueBecause("%s should exist", registeredServer.Spec.Prefix))
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
+		WaitForPromptsWithPrefix(ctx, mcpGatewayClient, registeredServer.Spec.Prefix)
 
-		By("Verifying both clients received notifications/tools/list_changed within 1 minutes")
+		By("Verifying both clients received list_changed notifications within 1 minutes")
 		Eventually(func(g Gomega) {
 			_, err := client1.ListTools(ctx, mcp.ListToolsRequest{})
 			Expect(err).NotTo(HaveOccurred())
 			g.Expect(client1Notification).To(BeTrue(), "client1 should have received a notification within 1 minutes")
-			g.Expect(client2Notification).To(BeTrue(), "client1 should have received a notification within 1 minutes")
+			g.Expect(client2Notification).To(BeTrue(), "client2 should have received a notification within 1 minutes")
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
 	})
 
@@ -824,10 +830,12 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(msg).To(ContainSubstring("unsupported protocol version"))
 	})
 
-	It("[Happy] should report tool conflicts in MCPServerRegistration status when same prefix is used", func() {
-
-		By("Creating first MCPServerRegistration with a specific prefix")
-		registration1 := NewMCPServerResourcesWithDefaults("conflict-test-1", k8sClient).
+	It("[Happy] should report tool and prompt conflicts in MCPServerRegistration status when same prefix is used", func() {
+		// server1 has both tools (greet, time, headers, slow, add_tool) and a
+		// "greet" prompt, so registering it twice under the same prefix
+		// produces both tool and prompt name conflicts in one cycle
+		By("Creating first MCPServerRegistration with a specific prefix pointing to server1")
+		registration1 := NewMCPServerResources("conflict-test-1", "conflict-s1.mcp.local", sharedMCPTestServer1, 9090, k8sClient).
 			WithPrefix("conflict_").Build()
 		testResources = append(testResources, registration1.GetObjects()...)
 		server1 := registration1.Register(ctx)
@@ -837,16 +845,16 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
-		By("Creating second MCPServerRegistration with the SAME prefix pointing to server2")
-		registration2 := NewMCPServerResourcesWithDefaults("conflict-test-2", k8sClient).
+		By("Creating second MCPServerRegistration with the SAME prefix pointing to server1 via a different hostname")
+		registration2 := NewMCPServerResources("conflict-test-2", "conflict-s2.mcp.local", sharedMCPTestServer1, 9090, k8sClient).
 			WithPrefix("conflict_").Build()
 		testResources = append(testResources, registration2.GetObjects()...)
 		server2 := registration2.Register(ctx)
 
-		By("Verifying at least one MCPServerRegistration reports tool conflict in status")
-		// Both servers have tools like "time", "headers" etc.
-		// With the same prefix, they would produce "conflict_time", "conflict_headers" etc.
-		// At least one server should report a conflict.
+		By("Verifying at least one MCPServerRegistration reports the conflict in status")
+		// Both registrations expose the same tool and prompt names under the
+		// same prefix ("conflict_time", "conflict_greet" etc), so at least
+		// one server should report a conflict.
 		Eventually(func(g Gomega) {
 			// Check if either server reports a conflict
 			msg1, err1 := GetMCPServerRegistrationStatusMessage(ctx, k8sClient, server1.Name, server1.Namespace)
@@ -860,7 +868,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 
 			// At least one should contain conflict-related message
 			hasConflict := strings.Contains(msg1, "conflict") || strings.Contains(msg2, "conflict")
-			g.Expect(hasConflict).To(BeTrue(), "expected at least one server to report tool conflict")
+			g.Expect(hasConflict).To(BeTrue(), "expected at least one server to report a conflict")
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 
@@ -1092,85 +1100,6 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			g.Expect(filteredTools).NotTo(BeNil())
 			g.Expect(len(filteredTools.Tools)).To(Equal(1), "expected exactly 1 tool from virtual server")
 			g.Expect(filteredTools.Tools[0].Name).To(Equal(allowedTool))
-		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
-	})
-
-	It("[Happy] should send notifications to connected clients when server with prompts is registered", func() {
-		By("Creating clients with notification handlers")
-		client1Notification := false
-		client1, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
-			if strings.Contains(j.Method, "list_changed") {
-				GinkgoWriter.Println("client 1 received notification", j.Method)
-				client1Notification = true
-			}
-		})
-		Expect(err).NotTo(HaveOccurred())
-		defer func() { _ = client1.Close() }()
-
-		client2Notification := false
-		client2, err := NewMCPGatewayClientWithNotifications(ctx, gatewayURL, func(j mcp.JSONRPCNotification) {
-			if strings.Contains(j.Method, "list_changed") {
-				GinkgoWriter.Println("client 2 received notification", j.Method)
-				client2Notification = true
-			}
-		})
-		Expect(err).NotTo(HaveOccurred())
-		defer func() { _ = client2.Close() }()
-
-		By("Registering a new MCPServerRegistration with prompts")
-		registration := NewMCPServerResourcesWithDefaults("prompt-notification-test", k8sClient).
-			WithBackendTarget(sharedMCPTestServer1, 9090).WithPrefix("pnotif_").Build()
-		testResources = append(testResources, registration.GetObjects()...)
-		registeredServer := registration.Register(ctx)
-
-		By("Waiting for the server to become ready")
-		Eventually(func(g Gomega) {
-			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
-		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
-
-		By("Waiting for prompts to show up")
-		WaitForPromptsWithPrefix(ctx, mcpGatewayClient, registeredServer.Spec.Prefix)
-
-		By("Verifying both clients received list_changed notifications")
-		Eventually(func(g Gomega) {
-			_, err := client1.ListPrompts(ctx, mcp.ListPromptsRequest{})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(client1Notification).To(BeTrue(), "client1 should have received a list_changed notification")
-			g.Expect(client2Notification).To(BeTrue(), "client2 should have received a list_changed notification")
-		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
-	})
-
-	It("[Happy] should report prompt conflicts in MCPServerRegistration status when same prefix is used", func() {
-		By("Creating first MCPServerRegistration with a specific prefix pointing to server1")
-		registration1 := NewMCPServerResources("prompt-conflict-1", "pconflict-s1.mcp.local", sharedMCPTestServer1, 9090, k8sClient).
-			WithPrefix("pconflict_").Build()
-		testResources = append(testResources, registration1.GetObjects()...)
-		server1 := registration1.Register(ctx)
-
-		By("Ensuring first server becomes ready")
-		Eventually(func(g Gomega) {
-			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
-		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
-
-		By("Creating second MCPServerRegistration with the SAME prefix pointing to server1 via different hostname")
-		registration2 := NewMCPServerResources("prompt-conflict-2", "pconflict-s2.mcp.local", sharedMCPTestServer1, 9090, k8sClient).
-			WithPrefix("pconflict_").Build()
-		testResources = append(testResources, registration2.GetObjects()...)
-		server2 := registration2.Register(ctx)
-
-		By("Verifying at least one MCPServerRegistration reports conflict in status")
-		Eventually(func(g Gomega) {
-			msg1, err1 := GetMCPServerRegistrationStatusMessage(ctx, k8sClient, server1.Name, server1.Namespace)
-			msg2, err2 := GetMCPServerRegistrationStatusMessage(ctx, k8sClient, server2.Name, server2.Namespace)
-
-			g.Expect(err1).NotTo(HaveOccurred())
-			g.Expect(err2).NotTo(HaveOccurred())
-
-			GinkgoWriter.Println("Server1 status:", msg1)
-			GinkgoWriter.Println("Server2 status:", msg2)
-
-			hasConflict := strings.Contains(msg1, "conflict") || strings.Contains(msg2, "conflict")
-			g.Expect(hasConflict).To(BeTrue(), "expected at least one server to report prompt conflict")
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -808,7 +808,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
 	})
 
-	It("[Happy] should report invalid protocol version in MCPServerRegistration status", func() {
+	It("[Full] should report invalid protocol version in MCPServerRegistration status", func() {
 		By("Creating an MCPServerRegistration pointing to the broken server with wrong protocol version")
 		// The broken server is already deployed with --failure-mode=protocol
 		registration := NewMCPServerResourcesWithDefaults("protocol-status-test", k8sClient).
@@ -872,7 +872,7 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 
-	It("[Happy] should allow multiple MCP Servers without prefixes", func() {
+	It("[Full] should allow multiple MCP Servers without prefixes", func() {
 		By("Creating HTTPRoutes and MCP Servers")
 		// create httproutes for test servers that should already be deployed
 		registration := NewMCPServerResources("same-prefix", "everything-server.mcp.local", "everything-server", 9090, k8sClient).

--- a/tests/e2e/multi_gateway_test.go
+++ b/tests/e2e/multi_gateway_test.go
@@ -33,7 +33,7 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		}
 	})
 
-	It("[Happy] MCPGatewayExtension with invalid sectionName is rejected", func() {
+	It("[Full] MCPGatewayExtension with invalid sectionName is rejected", func() {
 		// Use TestServerNameSpace (mcp-test) which doesn't have an existing MCPGatewayExtension
 		// We need to create a ReferenceGrant first to allow cross-namespace reference
 		By("Creating a ReferenceGrant to allow cross-namespace reference")
@@ -64,7 +64,7 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		Expect(msg).To(ContainSubstring("listener"))
 	})
 
-	It("[Happy] Second MCPGatewayExtension in same namespace is rejected", func() {
+	It("[Full] Second MCPGatewayExtension in same namespace is rejected", func() {
 		// The default MCPGatewayExtension in SystemNamespace (mcp-system) is already running
 		// Creating a second one in the same namespace should fail
 
@@ -89,7 +89,7 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		Expect(msg).To(ContainSubstring("already has MCPGatewayExtension"))
 	})
 
-	It("[Happy] MCPGatewayExtension targeting non-existent Gateway should report invalid status", func() {
+	It("[Full] MCPGatewayExtension targeting non-existent Gateway should report invalid status", func() {
 		By("Creating an MCPGatewayExtension targeting a non-existent Gateway")
 		mcpExt := NewMCPGatewayExtensionBuilder("test-invalid-gateway", TestServerNameSpace).
 			WithTarget("non-existent-gateway", GatewayNamespace).

--- a/tests/e2e/oauth_protected_resource_test.go
+++ b/tests/e2e/oauth_protected_resource_test.go
@@ -30,40 +30,7 @@ var _ = Describe("OAuth Protected Resource via CRD", func() {
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 	})
 
-	It("[Happy] serves oauth-protected-resource metadata from CRD config", func() {
-		By("Capturing deployment generation before patching")
-		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, deploymentName)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Setting oauthProtectedResource on the MCPGatewayExtension")
-		Expect(SetOAuthProtectedResource(ctx, SystemNamespace, MCPExtensionName, []string{authServer})).To(Succeed())
-
-		By("Waiting for the deployment to roll out with OAUTH env vars")
-		Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, deploymentName, 1, gen)).To(Succeed())
-
-		By("Fetching /.well-known/oauth-protected-resource")
-		wellKnownURL := strings.TrimSuffix(gatewayURL, "/mcp") + "/.well-known/oauth-protected-resource"
-		Eventually(func(g Gomega) {
-			resp, err := getMCPHTTPClient().Get(wellKnownURL)
-			g.Expect(err).NotTo(HaveOccurred())
-			defer func() { _ = resp.Body.Close() }()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-
-			body, err := io.ReadAll(resp.Body)
-			g.Expect(err).NotTo(HaveOccurred())
-
-			var metadata map[string]interface{}
-			g.Expect(json.Unmarshal(body, &metadata)).To(Succeed())
-			g.Expect(metadata).To(HaveKey("authorization_servers"))
-			servers, ok := metadata["authorization_servers"].([]interface{})
-			g.Expect(ok).To(BeTrue())
-			g.Expect(servers).To(ContainElement(authServer))
-			g.Expect(metadata).To(HaveKey("resource"))
-			g.Expect(metadata).To(HaveKey("bearer_methods_supported"))
-		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-	})
-
-	It("[Happy] reverts to defaults after oauthProtectedResource is removed", func() {
+	It("[Happy] serves oauth-protected-resource metadata from CRD config and reverts to defaults after removal", func() {
 		By("Capturing deployment generation before patching")
 		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, deploymentName)
 		Expect(err).NotTo(HaveOccurred())
@@ -87,9 +54,12 @@ var _ = Describe("OAuth Protected Resource via CRD", func() {
 
 			var metadata map[string]interface{}
 			g.Expect(json.Unmarshal(body, &metadata)).To(Succeed())
+			g.Expect(metadata).To(HaveKey("authorization_servers"))
 			servers, ok := metadata["authorization_servers"].([]interface{})
 			g.Expect(ok).To(BeTrue())
 			g.Expect(servers).To(ContainElement(authServer))
+			g.Expect(metadata).To(HaveKey("resource"))
+			g.Expect(metadata).To(HaveKey("bearer_methods_supported"))
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 		By("Capturing deployment generation before removing config")

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -45,7 +45,7 @@
 
 ### [Happy] Test notifications are received when a notifications/tools/list_changed notification is sent
 
-- When an MCPServerRegistration is registered with the MCP Gateway, a `notifications/tools/list_changed` should be sent to any clients connected to the MCP Gateway. This notification should work for a single connected client as well as multiple connected clients. They should all receive the same notification at least once. The clients should receive these notifications within one minute of the MCPServerRegistration having reached a ready state.
+- When an MCPServerRegistration is registered with the MCP Gateway, a `list_changed` notification should be sent to any clients connected to the MCP Gateway. One spec registers a server exposing both tools and prompts (server1) and covers the registration-driven notification for both lists. This notification should work for a single connected client as well as multiple connected clients. They should all receive the same notification at least once. The clients should receive these notifications within one minute of the MCPServerRegistration having reached a ready state.
 
 - When a registered backend MCP Server, emits a `notifications/tools/list_changed` a notification should be received by the connected clients. When the clients receive this notification they should get a changed tools/list. 
 
@@ -70,8 +70,6 @@
 ### [Happy] MCP Server status
 
 - When a backend MCPServerRegistration is added but the backend MCP is invalid because it doesn't meet the protocol version the status of the MCPServerRegistration resource should report the reason for the MCPSever being invalid
-
-- When a backend MCPServerRegistration is added but the backend MCP is invalid because it has conflicting tools due to tool name overlap with another server that has been added, the status of the MCPServerRegistration resource should report the reason for the MCPSever being invalid
 
 - When a backend MCPServerRegistration is added but the backend MCP is invalid because the broker cannot connect to the the backend MCP server, the MCPServerRegistration resource should report the reason for the MCPSever being invalid
 
@@ -171,13 +169,9 @@
 
 - When a client sends a prompts/get request with a prompt name that does not match any registered server, the gateway should return a JSON-RPC error with code -32602 (Invalid params).
 
-### [Happy] Prompt notifications on registration
+### [Happy] Tool and prompt conflicts with same prefix
 
-- When an MCPServerRegistration is registered with a backend MCP server that has prompts, a `list_changed` notification should be sent to any clients connected to the MCP Gateway. Multiple connected clients should all receive the notification. The clients should receive these notifications within one minute of the MCPServerRegistration having reached a ready state.
-
-### [Happy] Prompt conflicts with same prefix
-
-- When two MCPServerRegistrations with the same prefix point to backends that both have prompts with the same name (e.g., both have a "greet" prompt producing "pconflict_greet"), at least one MCPServerRegistration should report a conflict in its status. This mirrors the tool conflict behavior where overlapping prefixed names cause a conflict.
+- When two MCPServerRegistrations with the same prefix point to a backend that has both tools and prompts (e.g. server1, where both registrations produce "conflict_time" and "conflict_greet"), at least one MCPServerRegistration should report a conflict in its status. One two-server cycle covers both the tool and the prompt name overlap behaviour.
 
 ### [Auth] JWT-filtered prompts/list with Keycloak
 
@@ -203,9 +197,9 @@
 
 - When a client connects to the gateway without an elicitation handler and calls a tool that triggers an elicitation request, the call should result in an error. The error may be a transport error or an error indicated in the tool result.
 
-### [Happy,URLElicitation] URL elicitation triggers on missing token for elicitation-capable client
+### [Happy,URLElicitation] URL elicitation triggers on missing token; server without tokenURLElicitation is unaffected
 
-- When an elicitation-capable client calls a tool on an MCPServerRegistration that has `tokenURLElicitation` configured but the client has no cached token, the gateway should return a -32042 URLElicitationRequired error containing a URL pointing to the token page. The response should be an SSE JSON-RPC error with code -32042 and a `data.url` field.
+- When an elicitation-capable client calls a tool on an MCPServerRegistration that has `tokenURLElicitation` configured but the client has no cached token, the gateway should return a -32042 URLElicitationRequired error containing a URL pointing to the token page. The response should be an SSE JSON-RPC error with code -32042 and a `data.url` field. The same spec registers a second server without `tokenURLElicitation` or a credentialRef and verifies a tool call to it from the same session proceeds without any token resolution or -32042 error.
 
 ### [Happy,URLElicitation] Full round-trip: token page submit then retry succeeds
 
@@ -223,25 +217,13 @@
 
 - When a client has a valid cached token and an established backend session, and the upstream server rejects a subsequent tool call with 401 (simulated via `X-Force-Auth-Reject` header on the api-key-server), the gateway should delete the cached token and pass the 401 through. The next tool call should trigger a fresh -32042 elicitation error. The client can then re-submit the correct token and retry successfully.
 
-### [Happy,URLElicitation] Server without tokenURLElicitation is unaffected
-
-- When an MCPServerRegistration does NOT have `tokenURLElicitation` configured and the backend does not require auth, tool calls should proceed without any token resolution or -32042 errors, regardless of whether the client declares elicitation capability.
-
 ### [Happy] discover_tools returns correct metadata for registered servers
 
 - When an MCPServerRegistration is created with `category` and `hint` fields, calling `discover_tools` should return a server entry containing the correct categories, hint, and prefixed tool names.
 
-### [Happy] discover_tools category filter returns only matching servers (case-insensitive)
+### [Happy] discover_tools category filtering: case-insensitive match, multi-category match, no match
 
-- When multiple servers are registered with different categories, calling `discover_tools` with a `category` parameter should return only servers whose category list contains a case-insensitive match. Servers with non-matching categories should be excluded from the response.
-
-### [Happy] discover_tools multi-category server matched by either category value
-
-- When an MCPServerRegistration has multiple categories (e.g. `["dining", "reservations"]`), calling `discover_tools` with either category as the filter should return that server.
-
-### [Happy] discover_tools returns empty servers for non-matching category
-
-- When `discover_tools` is called with a category value that no registered server has, the response should contain no servers matching that category.
+- One spec registers a multi-category server (e.g. `["Dining", "reservations"]`) and a single-category messaging server once, then exercises three filters: a lowercase `dining` filter should return the multi-category server (case-insensitive match) and exclude the messaging server; a `reservations` filter should also return the multi-category server (matched by either category value); a category value no registered server has should match neither server.
 
 ### [Happy] discover_tools respects auth filtering
 
@@ -251,9 +233,9 @@
 
 - When a client sends requests with an `X-Mcp-Virtualserver` header, `discover_tools` should only return tools that the MCPVirtualServer allows. Servers with no allowed tools should be excluded.
 
-### [Happy] select_tools scopes subsequent tools/list
+### [Happy] select_tools scopes, re-scopes, and resets within one session
 
-- When a client calls `select_tools` with a list of tool names, subsequent `tools/list` requests should return only those tools (plus the discover_tools and select_tools meta-tools).
+- One spec drives a single session through the full scope lifecycle: calling `select_tools` with a list of tool names should make subsequent `tools/list` requests return only those tools (plus the discover_tools and select_tools meta-tools); calling `select_tools` again should completely replace the first selection; calling it with an empty tools array should reset the session scope so `tools/list` returns the full tool set again.
 
 ### [Happy] select_tools returns error for invalid tool name
 
@@ -262,14 +244,6 @@
 ### [Happy] select_tools all-or-nothing with partial valid list
 
 - When `select_tools` is called with a list containing both valid and invalid tool names, the entire selection should fail. No partial scope should be applied.
-
-### [Happy] select_tools re-scoping replaces previous selection
-
-- When `select_tools` is called twice in the same session, the second selection should completely replace the first. The `tools/list` response should reflect only the most recent selection.
-
-### [Happy] select_tools empty list resets to full tool set
-
-- When `select_tools` is called with an empty tools array, the session scope should be reset to the full tool set. Subsequent `tools/list` should return all tools.
 
 ### [Happy] notifications/tools/list_changed delivered after select_tools
 
@@ -344,13 +318,9 @@ make test-e2e-https
 | GitHub external | Skipped | Yes (needs `GITHUB_MCP_PAT`) |
 | Real public certs | Skipped | Yes (needs real TLS cluster) |
 
-### [Happy] OAuth protected resource metadata served from CRD config
+### [Happy] OAuth protected resource metadata served from CRD config and reverted after removal
 
-- When an MCPGatewayExtension has `spec.oauthProtectedResource` configured with at least one authorization server, the controller should inject `OAUTH_*` env vars into the broker-router deployment and the `/.well-known/oauth-protected-resource` endpoint should return the configured metadata as JSON. The response should contain `authorization_servers`, `resource`, and `bearer_methods_supported` fields.
-
-### [Happy] OAuth protected resource reverts to defaults after removal
-
-- When `oauthProtectedResource` is removed from the MCPGatewayExtension spec, the controller should remove the OAUTH env vars from the broker-router deployment. After the deployment rolls out, the `/.well-known/oauth-protected-resource` endpoint should still respond but `authorization_servers` should revert to an empty array (the broker's built-in default when no OAUTH env vars are set).
+- When an MCPGatewayExtension has `spec.oauthProtectedResource` configured with at least one authorization server, the controller should inject `OAUTH_*` env vars into the broker-router deployment and the `/.well-known/oauth-protected-resource` endpoint should return the configured metadata as JSON. The response should contain `authorization_servers`, `resource`, and `bearer_methods_supported` fields. When `oauthProtectedResource` is then removed from the spec, the controller should remove the OAUTH env vars; after the deployment rolls out, the endpoint should still respond but `authorization_servers` should revert to an empty array (the broker's built-in default when no OAUTH env vars are set). One spec covers the serve and revert halves in a single configure-remove cycle.
 
 ### [Happy,UserSpecificList] User sees their own tools merged with cached tools
 

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -109,6 +109,10 @@
 
 - When a namespace already has one MCPGatewayExtension that is Ready, and a second MCPGatewayExtension is created in the same namespace, the second extension should be marked as Invalid with a status message indicating a conflict. Only one MCPGatewayExtension is allowed per namespace, and the oldest by creation timestamp wins.
 
+### [Full] MCPGatewayExtension targeting non-existent Gateway is rejected
+
+- When an MCPGatewayExtension is created with a `targetRef` pointing to a Gateway that does not exist, the extension should be marked as Invalid with a status message indicating the invalid configuration.
+
 ### [multi-gateway] Shared Gateway with team isolation via sectionName
 
 - Given a Gateway with two listeners configured for different teams:

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -67,15 +67,18 @@
 
 - When a backend MCP Server becomes unavailable, the gateway should no longer show its tools in the tools/list response and a notification should be sent to the client within one minute. When the MCP Server becomes available again, the tools/list should be updated to include the tools again. While unavailable any tools/call should result in a 503 response
 
-### [Happy] MCP Server status
+### [Full] MCP Server status
 
 - When a backend MCPServerRegistration is added but the backend MCP is invalid because it doesn't meet the protocol version the status of the MCPServerRegistration resource should report the reason for the MCPSever being invalid
 
 - When a backend MCPServerRegistration is added but the backend MCP is invalid because the broker cannot connect to the the backend MCP server, the MCPServerRegistration resource should report the reason for the MCPSever being invalid
 
-### [Happy] Multiple MCP Servers without prefix
+### [Full] Multiple MCP Servers without prefix
 
 - When two servers with no prefix are used, the gateway sees and forwards both tools correctly.
+
+### [Happy] Prefix conflict resolved by adding a prefix
+
 - When two servers with no prefix conflict and one is then modified to have a specified prefix via the MCPServer resource, both tools should become available via the gateway and capable of being invoked
 
 ### [multi-gateway] Multiple Isolated MCP Gateways deployed to the same cluster
@@ -90,7 +93,7 @@
 
 - When an MCPGatewayExtension is deleted, the MCPGatewayExtension condition should be removed from the Gateway's listener status. The Gateway should no longer show the MCPGatewayExtension condition for that listener.
 
-### [Happy] MCPGatewayExtension with invalid sectionName is rejected
+### [Full] MCPGatewayExtension with invalid sectionName is rejected
 
 - When an MCPGatewayExtension is created with a `targetRef.sectionName` that does not match any listener on the Gateway, the extension should be marked as Invalid with a status message containing "listener not found". No EnvoyFilter or broker-router deployment should be created.
 
@@ -102,7 +105,7 @@
 
 - When an MCPGatewayExtension targets a listener that has `allowedRoutes.namespaces.from: Same` and the MCPGatewayExtension is in a different namespace than the Gateway, the extension should be marked as Invalid with a status message indicating the namespace is not allowed.
 
-### [Happy] Second MCPGatewayExtension in same namespace is rejected
+### [Full] Second MCPGatewayExtension in same namespace is rejected
 
 - When a namespace already has one MCPGatewayExtension that is Ready, and a second MCPGatewayExtension is created in the same namespace, the second extension should be marked as Invalid with a status message indicating a conflict. Only one MCPGatewayExtension is allowed per namespace, and the oldest by creation timestamp wins.
 
@@ -193,7 +196,7 @@
 
 - When a client connects to the gateway with an elicitation handler that declines requests, and calls a tool that triggers an elicitation request, the gateway should broker the elicitation between the upstream server and the client. The tool response should indicate that the user declined.
 
-### [Happy] Elicitation without handler errors
+### [Full] Elicitation without handler errors
 
 - When a client connects to the gateway without an elicitation handler and calls a tool that triggers an elicitation request, the call should result in an error. The error may be a transport error or an error indicated in the tool result.
 
@@ -205,7 +208,7 @@
 
 - When an elicitation-capable client receives a -32042 error, it should be able to GET the token page URL, POST the token via the form with the elicitation_id, then retry the tool call. On retry the cached token should be injected by the router as an Authorization header and the upstream server should receive it and return a successful tool response.
 
-### [URLElicitation] Cached token reused across multiple tool calls
+### [Full][URLElicitation] Cached token reused across multiple tool calls
 
 - After a token has been submitted via the token page, subsequent tool calls to the same server from the same session should reuse the cached token without triggering a new -32042 error. The upstream server should receive the token on each call.
 
@@ -225,7 +228,7 @@
 
 - One spec registers a multi-category server (e.g. `["Dining", "reservations"]`) and a single-category messaging server once, then exercises three filters: a lowercase `dining` filter should return the multi-category server (case-insensitive match) and exclude the messaging server; a `reservations` filter should also return the multi-category server (matched by either category value); a category value no registered server has should match neither server.
 
-### [Happy] discover_tools respects auth filtering
+### [Full] discover_tools respects auth filtering
 
 - When a client sends requests with an `X-Mcp-Authorized` JWT that restricts visible tools, `discover_tools` should only return tools that the JWT authorises. Servers with no authorised tools should be excluded entirely.
 
@@ -249,15 +252,15 @@
 
 - When a client with SSE notification support calls `select_tools`, a `notifications/tools/list_changed` notification should be delivered to that client over the SSE channel.
 
-### [Happy] discovery-tools-enabled=false hides meta-tools
+### [Full] discovery-tools-enabled=false hides meta-tools
 
 - When the broker is started with `--discovery-tools-enabled=false`, `tools/list` should not include `discover_tools` or `select_tools`. Calling these tools should return an error.
 
-### [Happy] discovery-tool-threshold=0 means never hide
+### [Full] discovery-tool-threshold=0 means never hide
 
 - When the threshold is 0 (default), all real tools should be visible alongside the meta-tools regardless of how many tools are registered.
 
-### [Happy] threshold above: only meta-tools shown
+### [Full] threshold above: only meta-tools shown
 
 - When the `--discovery-tool-threshold` is set to a value lower than the number of registered tools, `tools/list` should return only the meta-tools. After using `select_tools` to scope down, the selected tools should become visible.
 
@@ -269,7 +272,7 @@
 
 - When two concurrent `select_tools` calls are made on the same session, the result should be a consistent single scope (one of the two wins), not a corrupted mixed state.
 
-### [Happy] controller re-reconciles when category/hint updated
+### [Full] controller re-reconciles when category/hint updated
 
 - When the `category` or `hint` fields on a live MCPServerRegistration are updated, the controller should re-reconcile and the broker should reflect the new metadata in subsequent `discover_tools` calls. The old category should no longer match.
 

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Tool Discovery", func() {
 			var err error
 			mcpGatewayClient, err = NewMCPGatewayClientWithNotifications(ctx, gatewayURL, nil)
 			g.Expect(err).NotTo(HaveOccurred())
-		}, TestTimeoutMedium, TestRetryFast).Should(Succeed())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 	}
 
 	AfterEach(func() {
@@ -101,7 +101,7 @@ var _ = Describe("Tool Discovery", func() {
 				g.Expect(found.Categories).To(ContainElement("messaging"))
 				g.Expect(found.Hint).To(Equal("provides messaging tools"))
 				g.Expect(found.Tools).NotTo(BeEmpty())
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 
 		It("filters servers by category: case-insensitive match, multi-category match by either value, no match for unknown category", func() {
@@ -152,20 +152,20 @@ var _ = Describe("Tool Discovery", func() {
 				hasMulti, hasMsg := discoverByCategory(g, "dining")
 				g.Expect(hasMulti).To(BeTrue(), "multi-category server should match 'dining' case-insensitively")
 				g.Expect(hasMsg).To(BeFalse(), "messaging server tools should not be returned")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("filtering by 'reservations' should also match the multi-category server")
 			Eventually(func(g Gomega) {
 				hasMulti, _ := discoverByCategory(g, "reservations")
 				g.Expect(hasMulti).To(BeTrue(), "server should match when filtering by 'reservations'")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("filtering by a non-existent category should match neither server")
 			Eventually(func(g Gomega) {
 				hasMulti, hasMsg := discoverByCategory(g, "nonexistent_xyz")
 				g.Expect(hasMulti).To(BeFalse(), "no tools should match nonexistent category")
 				g.Expect(hasMsg).To(BeFalse(), "no tools should match nonexistent category")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 
 		// nightly-only: discover_tools shares applyAuthorizedCapabilitiesFilter
@@ -198,7 +198,7 @@ var _ = Describe("Tool Discovery", func() {
 				sessionID, initErr = mcpInitialize(ctx, gatewayURL, map[string]string{"X-Mcp-Authorized": jwtToken})
 				g.Expect(initErr).NotTo(HaveOccurred())
 				g.Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, map[string]string{"X-Mcp-Authorized": jwtToken})).To(Succeed())
-			}, TestTimeoutMedium, TestRetryFast).Should(Succeed())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, nil, map[string]string{"X-Mcp-Authorized": jwtToken})
@@ -214,7 +214,7 @@ var _ = Describe("Tool Discovery", func() {
 				}
 				g.Expect(serverTools).To(HaveLen(1), "only the authorised tool should appear")
 				g.Expect(serverTools[0]).To(Equal("discauth_hello_world"))
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 
 		It("respects MCPVirtualServer scoping in discover_tools", func() {
@@ -257,7 +257,7 @@ var _ = Describe("Tool Discovery", func() {
 				}
 				g.Expect(serverTools).To(HaveLen(1))
 				g.Expect(serverTools[0]).To(Equal(allowedTool))
-			}, TestTimeoutMedium, TestRetryFast).Should(Succeed())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -308,13 +308,14 @@ var _ = Describe("Tool Discovery", func() {
 			Eventually(func(g Gomega) {
 				_, tools, err := mcpListTools(ctx, gatewayURL, sessionID, nil)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(tools).To(ContainElement(tool1), "selected tool should be in the list")
 				for _, t := range tools {
 					if isBrokerMetaTool(t) {
 						continue
 					}
 					g.Expect(t).To(Equal(tool1), "only selected tool and meta-tools should be returned")
 				}
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("re-scoping to a different tool")
 			status, result, err = mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{tool2}, nil)
@@ -326,13 +327,14 @@ var _ = Describe("Tool Discovery", func() {
 			Eventually(func(g Gomega) {
 				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
 				g.Expect(listErr).NotTo(HaveOccurred())
+				g.Expect(tools).To(ContainElement(tool2), "re-scoped tool should be in the list")
 				for _, t := range tools {
 					if isBrokerMetaTool(t) {
 						continue
 					}
 					g.Expect(t).To(Equal(tool2), "only re-scoped tool should be in the list")
 				}
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("resetting scope with empty list")
 			status, result, err = mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{}, nil)
@@ -345,7 +347,7 @@ var _ = Describe("Tool Discovery", func() {
 				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
 				g.Expect(listErr).NotTo(HaveOccurred())
 				g.Expect(len(tools)).To(Equal(fullToolCount), "full tool set should be restored after reset")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 
 		It("returns error for invalid tool name (all-or-nothing)", func() {
@@ -434,7 +436,7 @@ var _ = Describe("Tool Discovery", func() {
 			By("verifying notification was received")
 			Eventually(func() bool {
 				return receivedNotification.Load()
-			}, TestTimeoutShort, TestRetryFast).Should(BeTrue(),
+			}, TestTimeoutShort, TestRetryInterval).Should(BeTrue(),
 				"should have received notifications/tools/list_changed after select_tools")
 		})
 	})
@@ -462,7 +464,7 @@ var _ = Describe("Tool Discovery", func() {
 				sessionID, initErr = mcpInitialize(ctx, gatewayURL, nil)
 				g.Expect(initErr).NotTo(HaveOccurred())
 				g.Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
-			}, TestTimeoutMedium, TestRetryFast).Should(Succeed())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 			By("verifying discover_tools and select_tools are not in tools/list")
 			Eventually(func(g Gomega) {
@@ -472,7 +474,7 @@ var _ = Describe("Tool Discovery", func() {
 					"discover_tools should not be listed when discovery is disabled")
 				g.Expect(tools).NotTo(ContainElement("select_tools"),
 					"select_tools should not be listed when discovery is disabled")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("calling discover_tools should return an error")
 			_, _, rawBody, err := mcpRawPost(ctx, gatewayURL, sessionID,
@@ -549,7 +551,7 @@ var _ = Describe("Tool Discovery", func() {
 				sessionID, initErr = mcpInitialize(ctx, gatewayURL, nil)
 				g.Expect(initErr).NotTo(HaveOccurred())
 				g.Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
-			}, TestTimeoutMedium, TestRetryFast).Should(Succeed())
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 			By("verifying only meta-tools are shown (above threshold)")
 			Eventually(func(g Gomega) {
@@ -562,7 +564,7 @@ var _ = Describe("Tool Discovery", func() {
 						g.Expect(t).To(BeEmpty(), "no real tools should be visible above threshold, found: "+t)
 					}
 				}
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("using select_tools to scope down, tools should become visible")
 			status, _, selectErr := mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{"thtest_hello_world"}, nil)
@@ -579,7 +581,7 @@ var _ = Describe("Tool Discovery", func() {
 					}
 				}
 				g.Expect(hasSelected).To(BeTrue(), "selected tool should be visible after scoping")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -635,7 +637,7 @@ var _ = Describe("Tool Discovery", func() {
 				}
 				g.Expect(isoTools).To(BeNumerically(">", 1),
 					"session2 should still see all tools, not be affected by session1's scope")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 
 		It("concurrent select_tools calls on same session do not corrupt state", func() {
@@ -705,7 +707,7 @@ var _ = Describe("Tool Discovery", func() {
 					"concurrent select_tools should result in a consistent single-tool scope")
 				g.Expect(nonMetaTools[0]).To(Or(Equal(tool1), Equal(tool2)),
 					"the winning tool should be one of the two selected tools")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -746,7 +748,7 @@ var _ = Describe("Tool Discovery", func() {
 					}
 				}
 				g.Expect(hasTools).To(BeTrue(), "server should be discoverable with initial category")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("updating category and hint on the live MCPServerRegistration")
 			Eventually(func(g Gomega) {
@@ -758,7 +760,7 @@ var _ = Describe("Tool Discovery", func() {
 				fresh.Spec.Category = []string{"updated-category"}
 				fresh.Spec.Hint = "updated hint"
 				g.Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 
 			By("waiting for reconciliation to propagate the updated metadata")
 			Eventually(func(g Gomega) {
@@ -786,7 +788,7 @@ var _ = Describe("Tool Discovery", func() {
 							"old category should no longer match after update")
 					}
 				}
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
 		})
 	})
 })

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -168,7 +168,9 @@ var _ = Describe("Tool Discovery", func() {
 			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
 		})
 
-		It("respects auth filtering in discover_tools", func() {
+		// nightly-only: discover_tools shares applyAuthorizedCapabilitiesFilter
+		// with tools/list, which the PR-gate JWT filtering spec exercises
+		It("[Full] respects auth filtering in discover_tools", func() {
 			SetupTrustedHeadersAuth(ctx, k8sClient)
 
 			By("registering a server")
@@ -438,7 +440,7 @@ var _ = Describe("Tool Discovery", func() {
 	})
 
 	Context("flags", func() {
-		It("hides meta-tools when discovery-tools-enabled=false", func() {
+		It("[Full] hides meta-tools when discovery-tools-enabled=false", func() {
 			deploymentName := "mcp-gateway"
 
 			By("adding --discovery-tools-enabled=false flag to deployment")
@@ -479,7 +481,7 @@ var _ = Describe("Tool Discovery", func() {
 			_ = rawBody // the tool should not exist, so the response will be an error
 		})
 
-		It("threshold=0 means never hide (all tools visible alongside meta-tools)", func() {
+		It("[Full] threshold=0 means never hide (all tools visible alongside meta-tools)", func() {
 			// threshold defaults to 0, so all real tools plus meta-tools should be visible
 			By("registering a server")
 			reg := NewMCPServerResourcesWithDefaults("thresh-zero", k8sClient).
@@ -515,7 +517,7 @@ var _ = Describe("Tool Discovery", func() {
 	})
 
 	Context("threshold", func() {
-		It("above threshold: only meta-tools shown; below threshold: all tools visible", func() {
+		It("[Full] above threshold: only meta-tools shown; below threshold: all tools visible", func() {
 			deploymentName := "mcp-gateway"
 
 			By("registering a server so we have tools to count")
@@ -712,7 +714,7 @@ var _ = Describe("Tool Discovery", func() {
 			newGatewayClient()
 		})
 
-		It("controller re-reconciles when category and hint are updated", func() {
+		It("[Full] controller re-reconciles when category and hint are updated", func() {
 			By("registering a server with initial category and hint")
 			reg := NewMCPServerResourcesWithDefaults("reconfig-test", k8sClient).
 				WithPrefix("reconf_").

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -104,130 +104,67 @@ var _ = Describe("Tool Discovery", func() {
 			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
 		})
 
-		It("filters servers by category (case-insensitive)", func() {
-			By("registering two servers with different categories")
-			reg1 := NewMCPServerResourcesWithDefaults("cat-filter-1", k8sClient).
-				WithPrefix("catfilt1_").
-				WithCategory("Dining").
+		It("filters servers by category: case-insensitive match, multi-category match by either value, no match for unknown category", func() {
+			By("registering a multi-category server and a messaging server")
+			regMulti := NewMCPServerResourcesWithDefaults("multi-cat", k8sClient).
+				WithPrefix("multicat_").
+				WithCategory("Dining", "reservations").
 				Build()
-			testResources = append(testResources, reg1.GetObjects()...)
-			s1 := reg1.Register(ctx)
+			testResources = append(testResources, regMulti.GetObjects()...)
+			sMulti := regMulti.Register(ctx)
 
-			reg2 := NewMCPServerResourcesWithDefaults("cat-filter-2", k8sClient).
-				WithPrefix("catfilt2_").
+			regMsg := NewMCPServerResourcesWithDefaults("cat-filter-msg", k8sClient).
+				WithPrefix("catmsg_").
 				WithCategory("messaging").
 				Build()
-			testResources = append(testResources, reg2.GetObjects()...)
-			s2 := reg2.Register(ctx)
+			testResources = append(testResources, regMsg.GetObjects()...)
+			sMsg := regMsg.Register(ctx)
 
 			By("waiting for both servers to be ready")
 			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, s1.Name, s1.Namespace)).To(Succeed())
-				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, s2.Name, s2.Namespace)).To(Succeed())
-			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "catfilt1_")
-			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "catfilt2_")
-
-			By("filtering by 'dining' (lowercase) should return only the Dining server")
-			sessionID := mcpGatewayClient.GetSessionId()
-			Eventually(func(g Gomega) {
-				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, map[string]any{"category": "dining"}, nil)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(resp).NotTo(BeNil())
-
-				hasPrefix1 := false
-				hasPrefix2 := false
-				for _, s := range resp.Servers {
-					for _, t := range s.Tools {
-						if strings.HasPrefix(t, "catfilt1_") {
-							hasPrefix1 = true
-						}
-						if strings.HasPrefix(t, "catfilt2_") {
-							hasPrefix2 = true
-						}
-					}
-				}
-				g.Expect(hasPrefix1).To(BeTrue(), "dining server tools should be returned")
-				g.Expect(hasPrefix2).To(BeFalse(), "messaging server tools should not be returned")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
-		})
-
-		It("matches multi-category server by either category value", func() {
-			By("registering a server with multiple categories")
-			reg := NewMCPServerResourcesWithDefaults("multi-cat", k8sClient).
-				WithPrefix("multicat_").
-				WithCategory("dining", "reservations").
-				Build()
-			testResources = append(testResources, reg.GetObjects()...)
-			server := reg.Register(ctx)
-
-			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, sMulti.Name, sMulti.Namespace)).To(Succeed())
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, sMsg.Name, sMsg.Namespace)).To(Succeed())
 			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "multicat_")
+			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "catmsg_")
 
 			sessionID := mcpGatewayClient.GetSessionId()
-
-			By("filtering by 'dining' should match")
-			Eventually(func(g Gomega) {
-				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, map[string]any{"category": "dining"}, nil)
-				g.Expect(err).NotTo(HaveOccurred())
-				hasTools := false
-				for _, s := range resp.Servers {
-					for _, t := range s.Tools {
-						if strings.HasPrefix(t, "multicat_") {
-							hasTools = true
-						}
-					}
-				}
-				g.Expect(hasTools).To(BeTrue(), "server should match when filtering by 'dining'")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
-
-			By("filtering by 'reservations' should also match")
-			Eventually(func(g Gomega) {
-				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, map[string]any{"category": "reservations"}, nil)
-				g.Expect(err).NotTo(HaveOccurred())
-				hasTools := false
-				for _, s := range resp.Servers {
-					for _, t := range s.Tools {
-						if strings.HasPrefix(t, "multicat_") {
-							hasTools = true
-						}
-					}
-				}
-				g.Expect(hasTools).To(BeTrue(), "server should match when filtering by 'reservations'")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
-		})
-
-		It("returns empty servers array for non-matching category", func() {
-			By("registering a server with a known category")
-			reg := NewMCPServerResourcesWithDefaults("no-match-cat", k8sClient).
-				WithPrefix("nomatch_").
-				WithCategory("messaging").
-				Build()
-			testResources = append(testResources, reg.GetObjects()...)
-			server := reg.Register(ctx)
-
-			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
-			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "nomatch_")
-
-			sessionID := mcpGatewayClient.GetSessionId()
-			By("filtering by a non-existent category")
-			Eventually(func(g Gomega) {
-				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, map[string]any{"category": "nonexistent_xyz"}, nil)
+			discoverByCategory := func(g Gomega, category string) (hasMulti, hasMsg bool) {
+				_, resp, err := mcpCallDiscoverTools(ctx, gatewayURL, sessionID, map[string]any{"category": category}, nil)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).NotTo(BeNil())
-				// no server should have tools matching this filter
 				for _, s := range resp.Servers {
 					for _, t := range s.Tools {
-						g.Expect(t).NotTo(HavePrefix("nomatch_"), "no tools should match nonexistent category")
+						if strings.HasPrefix(t, "multicat_") {
+							hasMulti = true
+						}
+						if strings.HasPrefix(t, "catmsg_") {
+							hasMsg = true
+						}
 					}
 				}
+				return hasMulti, hasMsg
+			}
+
+			By("filtering by 'dining' (lowercase) should match the Dining category and exclude the messaging server")
+			Eventually(func(g Gomega) {
+				hasMulti, hasMsg := discoverByCategory(g, "dining")
+				g.Expect(hasMulti).To(BeTrue(), "multi-category server should match 'dining' case-insensitively")
+				g.Expect(hasMsg).To(BeFalse(), "messaging server tools should not be returned")
+			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+
+			By("filtering by 'reservations' should also match the multi-category server")
+			Eventually(func(g Gomega) {
+				hasMulti, _ := discoverByCategory(g, "reservations")
+				g.Expect(hasMulti).To(BeTrue(), "server should match when filtering by 'reservations'")
+			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+
+			By("filtering by a non-existent category should match neither server")
+			Eventually(func(g Gomega) {
+				hasMulti, hasMsg := discoverByCategory(g, "nonexistent_xyz")
+				g.Expect(hasMulti).To(BeFalse(), "no tools should match nonexistent category")
+				g.Expect(hasMsg).To(BeFalse(), "no tools should match nonexistent category")
 			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
 		})
 
@@ -323,7 +260,7 @@ var _ = Describe("Tool Discovery", func() {
 	})
 
 	Context("select_tools", func() {
-		It("scopes subsequent tools/list to selected tools", func() {
+		It("scopes tools/list to the selection, replaces the scope on re-select, and resets on empty list", func() {
 			By("registering a server")
 			reg := NewMCPServerResourcesWithDefaults("select-scope", k8sClient).
 				WithPrefix("selscope_").
@@ -340,7 +277,8 @@ var _ = Describe("Tool Discovery", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
 
-			By("waiting for tools to appear")
+			By("waiting for tools to appear and recording the full tool count")
+			var fullToolCount int
 			Eventually(func(g Gomega) {
 				_, tools, err := mcpListTools(ctx, gatewayURL, sessionID, nil)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -352,11 +290,14 @@ var _ = Describe("Tool Discovery", func() {
 					}
 				}
 				g.Expect(hasPrefix).To(BeTrue())
+				fullToolCount = len(tools)
 			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-			selectedTool := "selscope_hello_world"
+			tool1 := "selscope_hello_world"
+			tool2 := "selscope_time"
+
 			By("calling select_tools with one tool")
-			status, result, err := mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{selectedTool}, nil)
+			status, result, err := mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{tool1}, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal(200))
 			Expect(result.Status).To(ContainSubstring("scope set"))
@@ -369,8 +310,39 @@ var _ = Describe("Tool Discovery", func() {
 					if isBrokerMetaTool(t) {
 						continue
 					}
-					g.Expect(t).To(Equal(selectedTool), "only selected tool and meta-tools should be returned")
+					g.Expect(t).To(Equal(tool1), "only selected tool and meta-tools should be returned")
 				}
+			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+
+			By("re-scoping to a different tool")
+			status, result, err = mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{tool2}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(200))
+			Expect(result.Status).To(ContainSubstring("scope set"))
+
+			By("verifying only the re-scoped tool (and meta-tools) is now in tools/list")
+			Eventually(func(g Gomega) {
+				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
+				g.Expect(listErr).NotTo(HaveOccurred())
+				for _, t := range tools {
+					if isBrokerMetaTool(t) {
+						continue
+					}
+					g.Expect(t).To(Equal(tool2), "only re-scoped tool should be in the list")
+				}
+			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
+
+			By("resetting scope with empty list")
+			status, result, err = mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(200))
+			Expect(result.Status).To(ContainSubstring("reset"))
+
+			By("verifying full tool set is restored")
+			Eventually(func(g Gomega) {
+				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
+				g.Expect(listErr).NotTo(HaveOccurred())
+				g.Expect(len(tools)).To(Equal(fullToolCount), "full tool set should be restored after reset")
 			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
 		})
 
@@ -426,125 +398,6 @@ var _ = Describe("Tool Discovery", func() {
 				"entire select should fail when any tool is invalid")
 		})
 
-		It("re-scoping replaces previous selection", func() {
-			By("registering a server")
-			reg := NewMCPServerResourcesWithDefaults("select-rescope", k8sClient).
-				WithPrefix("rescp_").
-				Build()
-			testResources = append(testResources, reg.GetObjects()...)
-			server := reg.Register(ctx)
-
-			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
-			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-			sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
-
-			Eventually(func(g Gomega) {
-				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
-				g.Expect(listErr).NotTo(HaveOccurred())
-				hasPrefix := false
-				for _, t := range tools {
-					if strings.HasPrefix(t, "rescp_") {
-						hasPrefix = true
-						break
-					}
-				}
-				g.Expect(hasPrefix).To(BeTrue())
-			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-			tool1 := "rescp_hello_world"
-			tool2 := "rescp_time"
-
-			By("selecting tool1")
-			status, result, err := mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{tool1}, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(status).To(Equal(200))
-			Expect(result.Status).To(ContainSubstring("scope set"))
-
-			By("re-scoping to tool2")
-			status, result, err = mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{tool2}, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(status).To(Equal(200))
-			Expect(result.Status).To(ContainSubstring("scope set"))
-
-			By("verifying only tool2 (and meta-tools) is now in tools/list")
-			Eventually(func(g Gomega) {
-				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
-				g.Expect(listErr).NotTo(HaveOccurred())
-				for _, t := range tools {
-					if isBrokerMetaTool(t) {
-						continue
-					}
-					g.Expect(t).To(Equal(tool2), "only re-scoped tool should be in the list")
-				}
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
-		})
-
-		It("empty list resets to full tool set", func() {
-			By("registering a server")
-			reg := NewMCPServerResourcesWithDefaults("select-reset", k8sClient).
-				WithPrefix("selrst_").
-				Build()
-			testResources = append(testResources, reg.GetObjects()...)
-			server := reg.Register(ctx)
-
-			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
-			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-			sessionID, err := mcpInitialize(ctx, gatewayURL, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mcpNotifyInitialized(ctx, gatewayURL, sessionID, nil)).To(Succeed())
-
-			var fullToolCount int
-			Eventually(func(g Gomega) {
-				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
-				g.Expect(listErr).NotTo(HaveOccurred())
-				hasPrefix := false
-				for _, t := range tools {
-					if strings.HasPrefix(t, "selrst_") {
-						hasPrefix = true
-						break
-					}
-				}
-				g.Expect(hasPrefix).To(BeTrue())
-				fullToolCount = len(tools)
-			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-			By("scoping down to one tool")
-			status, _, err := mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{"selrst_hello_world"}, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(status).To(Equal(200))
-
-			By("verifying scope is applied")
-			Eventually(func(g Gomega) {
-				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
-				g.Expect(listErr).NotTo(HaveOccurred())
-				nonMetaCount := 0
-				for _, t := range tools {
-					if !isBrokerMetaTool(t) {
-						nonMetaCount++
-					}
-				}
-				g.Expect(nonMetaCount).To(Equal(1))
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
-
-			By("resetting scope with empty list")
-			status, result, err := mcpCallSelectTools(ctx, gatewayURL, sessionID, []string{}, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(status).To(Equal(200))
-			Expect(result.Status).To(ContainSubstring("reset"))
-
-			By("verifying full tool set is restored")
-			Eventually(func(g Gomega) {
-				_, tools, listErr := mcpListTools(ctx, gatewayURL, sessionID, nil)
-				g.Expect(listErr).NotTo(HaveOccurred())
-				g.Expect(len(tools)).To(Equal(fullToolCount), "full tool set should be restored after reset")
-			}, TestTimeoutShort, TestRetryFast).Should(Succeed())
-		})
 	})
 
 	Context("notifications", func() {

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -63,8 +63,21 @@ var _ = Describe("URL Elicitation", Ordered, ContinueOnFailure, func() {
 		testResources = nil
 	})
 
-	It("[Happy,URLElicitation] URL elicitation triggers on missing token for elicitation-capable client", func() {
+	It("[Happy,URLElicitation] URL elicitation triggers on missing token for elicitation-capable client; server without tokenURLElicitation is unaffected", func() {
 		toolName := fmt.Sprintf("%shello_world", prefix)
+
+		By("Registering a second server WITHOUT tokenURLElicitation or credentialRef")
+		registration2 := NewMCPServerResourcesWithDefaults("urlelicit-nocfg", k8sClient).
+			WithBackendTarget(sharedMCPTestServer1, 9090).
+			WithPrefix("uenone_").
+			Build()
+		testResources = append(testResources, registration2.GetObjects()...)
+		registeredServer2 := registration2.Register(ctx)
+		toolName2 := fmt.Sprintf("%sgreet", registeredServer2.Spec.Prefix)
+
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer2.Name, registeredServer2.Namespace)).To(BeNil())
+		}, TestTimeoutConfigSync, TestRetryInterval).To(Succeed())
 
 		By("Initializing with elicitation capability")
 		var sessionID string
@@ -77,14 +90,15 @@ var _ = Describe("URL Elicitation", Ordered, ContinueOnFailure, func() {
 
 		Expect(mcpNotifyInitialized(context.Background(), gatewayURL, sessionID, nil)).To(Succeed())
 
-		By("Waiting for tools to be available")
+		By("Waiting for tools from both servers to be available")
 		Eventually(func(g Gomega) {
 			_, tools, err := mcpListTools(context.Background(), gatewayURL, sessionID, nil)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(tools).To(ContainElement(toolName))
+			g.Expect(tools).To(ContainElement(toolName2))
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-		By("Calling tool — should get -32042 with elicitation URL")
+		By("Calling tool on the elicitation server — should get -32042 with elicitation URL")
 		status, body, _, err := mcpCallToolRaw(gatewayURL, sessionID, toolName, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal(200))
@@ -97,6 +111,13 @@ var _ = Describe("URL Elicitation", Ordered, ContinueOnFailure, func() {
 		elicitURL, err := extractElicitationURL(sseErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(elicitURL).To(ContainSubstring("elicitation_id="))
+
+		By("Calling tool on the server without tokenURLElicitation — should succeed without elicitation, no -32042")
+		directStatus, directContent, err := mcpCallTool(context.Background(), gatewayURL, sessionID, toolName2, map[string]any{"name": "direct"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(directStatus).To(Equal(200))
+		Expect(directContent).NotTo(BeEmpty())
+		Expect(directContent[0].Text).To(ContainSubstring("Hi direct"))
 	})
 
 	It("[Happy,URLElicitation] Full round-trip: token page submit then retry succeeds", func() {
@@ -380,44 +401,4 @@ var _ = Describe("URL Elicitation", Ordered, ContinueOnFailure, func() {
 		Expect(finalContent[0].Text).To(ContainSubstring("Hello"))
 	})
 
-	It("[Happy,URLElicitation] Server without tokenURLElicitation is unaffected", func() {
-		By("Registering a server WITHOUT tokenURLElicitation or credentialRef")
-		registration2 := NewMCPServerResourcesWithDefaults("urlelicit-nocfg", k8sClient).
-			WithBackendTarget(sharedMCPTestServer1, 9090).
-			WithPrefix("uenone_").
-			Build()
-		testResources = append(testResources, registration2.GetObjects()...)
-		registeredServer2 := registration2.Register(ctx)
-		prefix2 := registeredServer2.Spec.Prefix
-
-		Eventually(func(g Gomega) {
-			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer2.Name, registeredServer2.Namespace)).To(BeNil())
-		}, TestTimeoutConfigSync, TestRetryInterval).To(Succeed())
-
-		toolName2 := fmt.Sprintf("%sgreet", prefix2)
-
-		By("Initializing with elicitation capability")
-		var sessionID string
-		Eventually(func(g Gomega) {
-			var err error
-			sessionID, err = mcpInitializeWithElicitation(gatewayURL, nil)
-			g.Expect(err).NotTo(HaveOccurred())
-		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
-
-		Expect(mcpNotifyInitialized(context.Background(), gatewayURL, sessionID, nil)).To(Succeed())
-
-		By("Waiting for tools")
-		Eventually(func(g Gomega) {
-			_, tools, err := mcpListTools(context.Background(), gatewayURL, sessionID, nil)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(tools).To(ContainElement(toolName2))
-		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
-
-		By("Calling tool — should succeed without elicitation, no -32042")
-		status, content, err := mcpCallTool(context.Background(), gatewayURL, sessionID, toolName2, map[string]any{"name": "direct"}, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(status).To(Equal(200))
-		Expect(content).NotTo(BeEmpty())
-		Expect(content[0].Text).To(ContainSubstring("Hi direct"))
-	})
 })

--- a/tests/e2e/url_elicitation_test.go
+++ b/tests/e2e/url_elicitation_test.go
@@ -193,7 +193,9 @@ var _ = Describe("URL Elicitation", Ordered, ContinueOnFailure, func() {
 		Expect(retryContent[0].Text).To(ContainSubstring("Hello"))
 	})
 
-	It("[URLElicitation] Cached token reused across multiple tool calls", func() {
+	// nightly-only: the 401-invalidation spec covers cached-token reuse
+	// transitively (its setup call succeeds with the cached token)
+	It("[Full][URLElicitation] Cached token reused across multiple tool calls", func() {
 		toolName := fmt.Sprintf("%shello_world", prefix)
 
 		By("Initializing, triggering -32042, and submitting token")

--- a/utils/ci-node-image-hash.sh
+++ b/utils/ci-node-image-hash.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# prints the content-hash tag for the baked CI node image. single
+# implementation shared by .github/workflows/ci-node-image.yaml (producer)
+# and the e2e workflows (consumers) so the two can never drift.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# everything that determines the baked image content: the version-pinning make
+# files, the manifests whose image refs are baked (the Istio CR pins the
+# istiod/proxyv2 version, the redis deployment pins the redis image), the
+# test-server sources their published images are built from (same paths
+# test-images.yaml triggers on), and the bake implementation itself
+fixed_inputs=(
+	build/istio.mk
+	build/cert-manager.mk
+	build/metallb.mk
+	build/gateway-api.mk
+	build/tools.mk
+	build/ci-node.mk
+	build/ci-node/Dockerfile
+	config/istio/istio.yaml
+	config/mcp-gateway/overlays/mcp-system/redis-deployment.yaml
+	utils/ci-node-image-hash.sh
+)
+
+if command -v sha256sum >/dev/null 2>&1; then
+	sha() { sha256sum "$@"; }
+else
+	sha() { shasum -a 256 "$@"; }
+fi
+
+{
+	printf '%s\n' "${fixed_inputs[@]}"
+	git ls-files tests/servers internal/tests
+} | LC_ALL=C sort -u | while IFS= read -r f; do sha "$f"; done | sha | cut -c1-12


### PR DESCRIPTION
Follow-up to #1117. Two things: a pre-baked kind node image, and a lighter PR-gate suite.

## node image

New `ci-node-image.yaml` bakes the infra and test server images into a `kindest/node` derivative, published as `ci-node:<hash>` (hash of the version-pinning inputs). e2e probes for the tag and boots from it. Miss or probe failure falls back to stock kindest/node + the existing pull path, so the bake can't fail or stale a run.

CI on this PR only exercises the fallback - the tag can't exist until the bake runs from main. After merge: trigger it once via workflow_dispatch, then make the ci-node ghcr package public (GITHUB_TOKEN-published packages default to private, the probe needs read).

## test scope

`TestRetryInterval` was 5s and quantised every `Eventually` - 66/68 spec durations were exact 5s multiples. Now 1s, timeouts unchanged.

84 -> 76 specs: 8 overlapping pairs merged, nothing dropped. 12 demoted to the existing `[Full]` tier. PR gate runs 58 declared (~48 at runtime), nightly still runs everything.

Measured (this PR's two green gate runs, fallback path so no baked image): 18.2-18.7m wall, setup ~5.1m, ginkgo 12.9-13.4m. Post-#1117 baseline (#1121's gate run): 27.0m wall, setup 7.1m, ginkgo 19.7m. So ~8.5m off wall time and ginkgo down 6.3-6.8m against the >=3m acceptance criterion, before the baked image lands. Expect ~12m once it's seeded.

For the longer arc: the five green main e2e runs preceding #1117 ([26809312182](https://github.com/Kuadrant/mcp-gateway/actions/runs/26809312182) through [27268945369](https://github.com/Kuadrant/mcp-gateway/actions/runs/27268945369)) sat at 33.5-42.1m wall with 9.8-10.9m in Setup CI environment. Test scope changed across that window, so setup is the comparable number: ~10-11m -> 7.1m (#1117/#1121) -> ~5.1m (this PR, fallback path), with more to come once the baked image is seeded.

## kind pinning (fixes main)

CI workflows created clusters with the runner-preinstalled kind, while every make load target uses the pinned `bin/kind` (v0.29.0). The runner image has rolled and its kind now defaults to `kindest/node:v1.36.1`, whose containerd ships config version 4; `bin/kind` reads only versions 2 and 3, so the first `load-image` dies with `unknown containerd config version: 4` and ci-setup aborts on a bare cluster. This branch pins cluster creation to `bin/kind` + the pinned node image across the workflows, so create and load always agree.

This has now hit main, not just this PR's first run: the push e2e run at 6e9c9a0 ([27294503634](https://github.com/Kuadrant/mcp-gateway/actions/runs/27294503634)) and the nightly ([27321390763](https://github.com/Kuadrant/mcp-gateway/actions/runs/27321390763)) both fail at load-image with exactly this error. Conformance on the same push passed because the drift is per-runner (not all runners have rolled yet), so main is red-to-flaky until this merges.

## nodeport race

Also folds in the #1123 fix: a main flake where dynamic NodePort allocation (istiod's per-Gateway LoadBalancer services) drew a port pinned by shared-gateway-team-b-np. All pins move into the k8s static subrange (30000-30085, KEP-3668); dynamic allocation draws from 30086+ so they will not collide. Host ports (8001-8008) unchanged. quick-start.sh keeps 30089 until its pinned release ref includes the renumbering.

Closes #1123

## testing

- unit, lint, `go vet -tags=e2e`, actionlint: clean
- ginkgo dry-run: 76 full / 58 PR-gate, name-level diff vs main accounts for every spec
- `make -n` fallback path byte-identical to main
- wall time: runs 27288776697 and 27292435688 on this PR vs run 27272081928 on #1121

Closes #1120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI baked node image pipeline and Makefile support to speed CI and optionally seed test images.
  * Updated CI/E2E workflows to probe/use pre-baked images when available.
  * Pinned default KIND/node image and Kind cluster creation target for more reproducible CI.

* **Tests**
  * Reorganized E2E suites, consolidated cases, and tightened retry timing for faster, more reliable feedback.

* **Docs**
  * Updated quick-start and release notes; adjusted default NodePort values and examples to new pinned ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


