### PR TITLE
docs: exempt bugfixes and security patches from issue-first rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Use codebase-memory-mcp to index and explore the project when available.
 
 ## Contributing
 
-Read `CONTRIBUTING.md` before creating PRs or issues. Every PR must reference an existing issue.
+Read `CONTRIBUTING.md` before creating PRs or issues. Feature, planned or speculative work requires an existing issue; bugfixes and security patches are exempt.
 
 ## Reference
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,17 @@ Thanks for your interest in contributing. Read this document before opening issu
 
 ## Submitting Pull Requests
 
-Every PR must reference an existing GitHub issue. PRs without a linked issue will be closed.
+Feature, planned or speculative work must reference an existing GitHub issue. PRs for such work without a linked issue will be closed.
 
-The workflow:
+Bugfixes and security patches are exempt: open a PR directly, no issue required. If in doubt, file an issue first.
+
+The issue-first workflow:
 
 1. Check existing issues. If one covers your change, comment on it.
-2. If no issue exists, file one. Describe the problem or feature. Wait for discussion before starting work.
+2. If no issue exists, file one. Describe the feature or proposed change. Wait for discussion before starting work.
 3. Once the issue is accepted, implement your change and open a PR referencing the issue (e.g. `Fixes #123` or `Relates to #123`).
 
-PRs that arrive without an associated issue skip the design and prioritisation discussion that protects both contributors and maintainers from wasted effort. File the issue first.
+Such PRs that arrive without an associated issue skip the design and prioritisation discussion that protects both contributors and maintainers from wasted effort. File the issue first.
 
 Additional PR guidance (aligned with [Kuadrant upstream contributing rules](https://kuadrant.io/contributing/#submitting-pull-requests)):
 


### PR DESCRIPTION
## Summary

- #1112 made every PR require a linked issue. Review discussion there flagged that a hard requirement risks deterring good small fixes. Agreed guideline: bugfixes and security patches flow freely; feature, planned or speculative work still needs an issue.
- Updates CONTRIBUTING.md with the exemption and an "if in doubt, file an issue first" tie-breaker, keeps the CLAUDE.md Contributing section consistent (AGENTS.md symlinks to it).

## Test evidence

Docs-only. `cspell` and `make check-newlines` pass; code/test/e2e workflows ignore `*.md` paths.

Closes #1124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pull request submission requirements: feature requests and speculative work require an existing issue reference, while bug fixes and security patches can be submitted directly without an associated issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->