### PR TITLE
1089 l5 security always set secure flag to true

### DIFF
--- a/internal/broker/tokens.go
+++ b/internal/broker/tokens.go
@@ -85,7 +85,7 @@ func (h *TokenHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 		Value:    csrf,
 		Path:     "/tokens",
 		HttpOnly: true,
-		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 		MaxAge:   120,
 	})


### PR DESCRIPTION
Changes:

CSRF cookie Secure flag is now always true, regardless of X-Forwarded-Proto header

Fixes #1089 (L5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF cookies are now always transmitted over secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->