### PR TITLE
fix: restore automountServiceAccountToken=false on broker-router deployment reconcile

### DIFF
--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -400,6 +400,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Contex
 		existingContainer.ReadinessProbe = desiredContainer.ReadinessProbe
 		existingDeployment.Spec.Template.Spec.Containers[0] = existingContainer
 		existingDeployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes
+		existingDeployment.Spec.Template.Spec.AutomountServiceAccountToken = deployment.Spec.Template.Spec.AutomountServiceAccountToken
 		if err := r.Update(ctx, existingDeployment); err != nil {
 			return false, fmt.Errorf("failed to update deployment: %w", err)
 		}
@@ -506,6 +507,10 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 
 	if desiredContainer.Image != existingContainer.Image {
 		return true, fmt.Sprintf("image changed: %q -> %q", existingContainer.Image, desiredContainer.Image)
+	}
+	if !equality.Semantic.DeepEqual(desired.Spec.Template.Spec.AutomountServiceAccountToken, existing.Spec.Template.Spec.AutomountServiceAccountToken) {
+		return true, fmt.Sprintf("automountServiceAccountToken changed: %v -> %v",
+			existing.Spec.Template.Spec.AutomountServiceAccountToken, desired.Spec.Template.Spec.AutomountServiceAccountToken)
 	}
 	// only compare flags the controller manages; user-added flags are preserved
 	desiredCmd := filterManagedFlags(desiredContainer.Command)


### PR DESCRIPTION
Fixes broker-router Deployment reconciliation to compare and restore thepod-level `automountServiceAccountToken` field, which the controller intendsto keep `false` for security but previously did not enforce on existingDeployments.

## Details

`internal/controller/broker_router.go`:
- `deploymentNeedsUpdate`: added a comparison of`Spec.Template.Spec.AutomountServiceAccountToken` between desired and
  existing, right after the image check. Drift is reported with the old/new values.
- `reconcileBrokerRouter` update path: added`existingDeployment.Spec.Template.Spec.AutomountServiceAccountToken deployment.Spec.Template.Spec.AutomountServiceAccountToken` alongside the other container/pod field patches.