### PR TITLE
fix: honor MCPServerRegistration targetRef namespace

### DIFF
--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -24,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
@@ -41,6 +43,8 @@ const (
 	maxCACertSize = 64 * 1024
 	// HTTPRouteIndex used to find MCPServerRegistrations
 	HTTPRouteIndex = "spec.targetRef.httproute"
+	// MCPServerRegistrationReferenceGrantIndex used to find MCPServerRegistrations for ReferenceGrants
+	MCPServerRegistrationReferenceGrantIndex = "spec.targetRef.referencegrant"
 	// ProgrammedHTTPRouteIndex used to find programmed httproutes
 	ProgrammedHTTPRouteIndex = "status.hasProgrammedCondition"
 
@@ -51,6 +55,8 @@ const (
 	// conditionReasonDisabled is the reason used when the MCPServerRegistration is disabled
 	conditionReasonDisabled = "Disabled"
 )
+
+var errReferenceGrantRequired = errors.New("ReferenceGrant required")
 
 // ServerInfo holds server information
 type ServerInfo struct {
@@ -83,6 +89,7 @@ type MCPReconciler struct {
 // +kubebuilder:rbac:groups=mcp.kuadrant.io,resources=mcpserverregistrations/status,verbs=get;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get
 
@@ -140,7 +147,14 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	// get the HTTPRoute and gateway(s) this MCPServerRegistration targets
 	targetRoute, err := r.getTargetHTTPRoute(ctx, mcpsr)
 	if err != nil {
-		if err := r.updateStatus(ctx, mcpsr, false, conditionReasonNotReady, err.Error()); err != nil {
+		statusReason := conditionReasonNotReady
+		if errors.Is(err, errReferenceGrantRequired) {
+			statusReason = mcpv1alpha1.ConditionReasonRefGrantRequired
+			if removeErr := r.ConfigReaderWriter.RemoveMCPServer(ctx, mcpServerName(mcpsr)); removeErr != nil {
+				return ctrl.Result{}, removeErr
+			}
+		}
+		if err := r.updateStatus(ctx, mcpsr, false, statusReason, err.Error()); err != nil {
 			if apierrors.IsConflict(err) {
 				// don't log these as they are just noise
 				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -316,7 +330,21 @@ func (r *MCPReconciler) findValidGatewaysForMCPServer(ctx context.Context, targe
 }
 
 func (r *MCPReconciler) getTargetHTTPRoute(ctx context.Context, mcpsr *mcpv1alpha1.MCPServerRegistration) (*gatewayv1.HTTPRoute, error) {
-	namespaceName := types.NamespacedName{Namespace: mcpsr.Namespace, Name: mcpsr.Spec.TargetRef.Name}
+	targetNamespace := targetRefNamespace(mcpsr.Namespace, mcpsr.Spec.TargetRef)
+	if targetNamespace != mcpsr.Namespace {
+		hasGrant, err := r.hasValidHTTPRouteReferenceGrant(ctx, mcpsr, targetNamespace)
+		if err != nil {
+			return nil, err
+		}
+		if !hasGrant {
+			return nil, fmt.Errorf("%w in %s to allow cross-namespace HTTPRoute reference from %s", errReferenceGrantRequired, targetNamespace, mcpsr.Namespace)
+		}
+	}
+
+	namespaceName := types.NamespacedName{
+		Namespace: targetNamespace,
+		Name:      mcpsr.Spec.TargetRef.Name,
+	}
 	logger := logf.FromContext(ctx).WithValues("method", "getTargetHTTPRoute")
 	logger.V(1).Info("httproute target ", "namespacename ", namespaceName)
 	targetRoute := &gatewayv1.HTTPRoute{}
@@ -325,6 +353,43 @@ func (r *MCPReconciler) getTargetHTTPRoute(ctx context.Context, mcpsr *mcpv1alph
 	}
 	return targetRoute, nil
 
+}
+
+func (r *MCPReconciler) hasValidHTTPRouteReferenceGrant(ctx context.Context, mcpsr *mcpv1alpha1.MCPServerRegistration, targetNamespace string) (bool, error) {
+	refGrantList := &gatewayv1beta1.ReferenceGrantList{}
+	if err := r.List(ctx, refGrantList, client.InNamespace(targetNamespace)); err != nil {
+		return false, fmt.Errorf("failed to list ReferenceGrants: %w", err)
+	}
+	for i := range refGrantList.Items {
+		if referenceGrantAllowsMCPServerRegistrationHTTPRoute(&refGrantList.Items[i], mcpsr) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func referenceGrantAllowsMCPServerRegistrationHTTPRoute(rg *gatewayv1beta1.ReferenceGrant, mcpsr *mcpv1alpha1.MCPServerRegistration) bool {
+	fromAllowed := false
+	for _, from := range rg.Spec.From {
+		if string(from.Group) == mcpv1alpha1.GroupVersion.Group &&
+			string(from.Kind) == "MCPServerRegistration" &&
+			string(from.Namespace) == mcpsr.Namespace {
+			fromAllowed = true
+			break
+		}
+	}
+	if !fromAllowed {
+		return false
+	}
+
+	for _, to := range rg.Spec.To {
+		if string(to.Group) == gatewayv1.GroupVersion.Group &&
+			(to.Kind == "" || string(to.Kind) == "HTTPRoute") &&
+			(to.Name == nil || *to.Name == "" || string(*to.Name) == mcpsr.Spec.TargetRef.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *MCPReconciler) getTargetGatewaysFromParentRef(ctx context.Context, parent *gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
@@ -561,15 +626,21 @@ func (r *MCPReconciler) updateHTTPRouteStatus(ctx context.Context, mcpsr *mcpv1a
 		return nil
 	}
 
-	namespace := mcpsr.Namespace
-	if targetRef.Namespace != "" {
-		namespace = targetRef.Namespace
+	targetNamespace := targetRefNamespace(mcpsr.Namespace, targetRef)
+	if targetNamespace != mcpsr.Namespace {
+		hasGrant, err := r.hasValidHTTPRouteReferenceGrant(ctx, mcpsr, targetNamespace)
+		if err != nil {
+			return err
+		}
+		if !hasGrant && mcpsr.DeletionTimestamp == nil {
+			return nil
+		}
 	}
 
 	httpRoute := &gatewayv1.HTTPRoute{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      targetRef.Name,
-		Namespace: namespace,
+		Namespace: targetNamespace,
 	}, httpRoute)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -659,6 +730,10 @@ func (r *MCPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 		return fmt.Errorf("failed to setup required index from MCPServerRegistration to httproutes %w", err)
 	}
 
+	if err := setupIndexMCPRegistrationToReferenceGrant(ctx, mgr.GetFieldIndexer()); err != nil {
+		return fmt.Errorf("failed to setup required index from MCPServerRegistration to referencegrants %w", err)
+	}
+
 	if err := setupIndexProgrammedHTTPRoutes(ctx, mgr.GetFieldIndexer()); err != nil {
 		return fmt.Errorf("failed to setup required index for programmed httproutes %w", err)
 	}
@@ -683,6 +758,10 @@ func (r *MCPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 			&mcpv1alpha1.MCPGatewayExtension{},
 			handler.EnqueueRequestsFromMapFunc(r.findMCPServerRegistrationsForMCPGatewayExtension),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
+		Watches(
+			&gatewayv1beta1.ReferenceGrant{},
+			handler.EnqueueRequestsFromMapFunc(r.findMCPServerRegistrationsForReferenceGrant),
 		)
 
 	return controller.Complete(r)
@@ -690,6 +769,14 @@ func (r *MCPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 
 func httpRouteIndexValue(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+func mcpServerRegistrationToRefGrantIndexValue(mcpsr mcpv1alpha1.MCPServerRegistration) string {
+	return fmt.Sprintf("%s/MCPServerRegistration/%s", mcpv1alpha1.GroupVersion.Group, mcpsr.Namespace)
+}
+
+func refGrantFromToMCPServerRegistrationIndexValue(from gatewayv1beta1.ReferenceGrantFrom) string {
+	return fmt.Sprintf("%s/%s/%s", from.Group, from.Kind, from.Namespace)
 }
 
 func setupIndexProgrammedHTTPRoutes(ctx context.Context, indexer client.FieldIndexer) error {
@@ -714,17 +801,34 @@ func setupIndexMCPRegistrationToHTTPRoute(ctx context.Context, indexer client.Fi
 		mcpsr := rawObj.(*mcpv1alpha1.MCPServerRegistration)
 		targetRef := mcpsr.Spec.TargetRef
 		if targetRef.Kind == "HTTPRoute" {
-			namespace := targetRef.Namespace
-			if namespace == "" {
-				namespace = mcpsr.Namespace
-			}
-			return []string{httpRouteIndexValue(namespace, targetRef.Name)}
+			return []string{httpRouteIndexValue(targetRefNamespace(mcpsr.Namespace, targetRef), targetRef.Name)}
 		}
 		return []string{}
 	}); err != nil {
 		return err
 	}
 	return nil
+}
+
+func setupIndexMCPRegistrationToReferenceGrant(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &mcpv1alpha1.MCPServerRegistration{}, MCPServerRegistrationReferenceGrantIndex, func(rawObj client.Object) []string {
+		mcpsr := rawObj.(*mcpv1alpha1.MCPServerRegistration)
+		targetRef := mcpsr.Spec.TargetRef
+		if targetRef.Kind == "HTTPRoute" && targetRef.Namespace != "" && targetRef.Namespace != mcpsr.Namespace {
+			return []string{mcpServerRegistrationToRefGrantIndexValue(*mcpsr)}
+		}
+		return []string{}
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func targetRefNamespace(defaultNamespace string, targetRef mcpv1alpha1.TargetReference) string {
+	if targetRef.Namespace != "" {
+		return targetRef.Namespace
+	}
+	return defaultNamespace
 }
 
 // findMCPServerRegistrationsForHTTPRoute finds all MCPServerRegistrations that reference the given HTTPRoute
@@ -752,6 +856,35 @@ func (r *MCPReconciler) findMCPServerRegistrationsForHTTPRoute(ctx context.Conte
 		})
 	}
 
+	return requests
+}
+
+func (r *MCPReconciler) findMCPServerRegistrationsForReferenceGrant(ctx context.Context, obj client.Object) []reconcile.Request {
+	ref, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok || len(ref.Spec.From) == 0 {
+		return nil
+	}
+
+	seen := map[types.NamespacedName]struct{}{}
+	var requests []reconcile.Request
+	for _, from := range ref.Spec.From {
+		mcpsrList := &mcpv1alpha1.MCPServerRegistrationList{}
+		if err := r.List(ctx, mcpsrList,
+			client.MatchingFields{MCPServerRegistrationReferenceGrantIndex: refGrantFromToMCPServerRegistrationIndexValue(from)},
+		); err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to list MCPServerRegistrations for ReferenceGrant")
+			continue
+		}
+
+		for _, mcpsr := range mcpsrList.Items {
+			nn := client.ObjectKeyFromObject(&mcpsr)
+			if _, ok := seen[nn]; ok {
+				continue
+			}
+			seen[nn] = struct{}{}
+			requests = append(requests, reconcile.Request{NamespacedName: nn})
+		}
+	}
 	return requests
 }
 

--- a/internal/controller/mcpserverregistration_controller_test.go
+++ b/internal/controller/mcpserverregistration_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -13,8 +14,17 @@ import (
 	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestMcpsrReferencesSecret(t *testing.T) {
@@ -68,6 +78,323 @@ func TestMcpsrReferencesSecret(t *testing.T) {
 				t.Errorf("mcpsrReferencesSecret() = %v, want %v", got, tt.wantMatch)
 			}
 		})
+	}
+}
+
+func TestGetTargetHTTPRouteUsesTargetRefNamespace(t *testing.T) {
+	tests := []struct {
+		name          string
+		objects       []client.Object
+		targetNS      string
+		wantNamespace string
+		wantErr       string
+	}{
+		{
+			name: "uses targetRef namespace when ReferenceGrant allows it",
+			objects: []client.Object{
+				testHTTPRoute("registrations"),
+				testHTTPRoute("routes"),
+				testMCPServerReferenceGrant(),
+			},
+			targetNS:      "routes",
+			wantNamespace: "routes",
+		},
+		{
+			name: "uses registration namespace when targetRef namespace is empty",
+			objects: []client.Object{
+				testHTTPRoute("registrations"),
+			},
+			wantNamespace: "registrations",
+		},
+		{
+			name: "requires ReferenceGrant for cross namespace route",
+			objects: []client.Object{
+				testHTTPRoute("routes"),
+			},
+			targetNS: "routes",
+			wantErr:  "ReferenceGrant required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := testScheme(t)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				Build()
+
+			r := &MCPReconciler{Client: fakeClient}
+			mcpsr := &mcpv1alpha1.MCPServerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "server",
+					Namespace: "registrations",
+				},
+				Spec: mcpv1alpha1.MCPServerRegistrationSpec{
+					TargetRef: mcpv1alpha1.TargetReference{
+						Name:      "target-route",
+						Namespace: tt.targetNS,
+					},
+				},
+			}
+
+			got, err := r.getTargetHTTPRoute(context.Background(), mcpsr)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("getTargetHTTPRoute() expected error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("getTargetHTTPRoute() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("getTargetHTTPRoute() unexpected error: %v", err)
+			}
+			if got.Namespace != tt.wantNamespace {
+				t.Errorf("getTargetHTTPRoute() namespace = %q, want %q", got.Namespace, tt.wantNamespace)
+			}
+		})
+	}
+}
+
+func TestUpdateHTTPRouteStatusRequiresReferenceGrantForCrossNamespaceCleanup(t *testing.T) {
+	routeStatus := []gatewayv1.RouteParentStatus{
+		{
+			ControllerName: gatewayv1.GatewayController("test.example.com/gateway-controller"),
+			ParentRef: gatewayv1.ParentReference{
+				Name: gatewayv1.ObjectName("gateway"),
+			},
+			Conditions: []metav1.Condition{
+				{
+					Type:   "Programmed",
+					Status: metav1.ConditionTrue,
+					Reason: "InUseByMCPServerRegistration",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		objects        []client.Object
+		wantConditions int
+	}{
+		{
+			name: "removes stale status when ReferenceGrant is missing",
+			objects: []client.Object{
+				testHTTPRouteWithStatus("routes", routeStatus),
+			},
+			wantConditions: 0,
+		},
+		{
+			name: "removes status when ReferenceGrant allows it",
+			objects: []client.Object{
+				testHTTPRouteWithStatus("routes", routeStatus),
+				testMCPServerReferenceGrant(),
+			},
+			wantConditions: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := testScheme(t)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+				Build()
+
+			now := metav1.Now()
+			mcpsr := &mcpv1alpha1.MCPServerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "server",
+					Namespace:         "registrations",
+					DeletionTimestamp: &now,
+				},
+				Spec: mcpv1alpha1.MCPServerRegistrationSpec{
+					TargetRef: mcpv1alpha1.TargetReference{
+						Kind:      "HTTPRoute",
+						Name:      "target-route",
+						Namespace: "routes",
+					},
+				},
+			}
+
+			r := &MCPReconciler{Client: fakeClient}
+			if err := r.updateHTTPRouteStatus(context.Background(), mcpsr); err != nil {
+				t.Fatalf("updateHTTPRouteStatus() unexpected error: %v", err)
+			}
+
+			got := &gatewayv1.HTTPRoute{}
+			if err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "target-route", Namespace: "routes"}, got); err != nil {
+				t.Fatalf("failed to get HTTPRoute: %v", err)
+			}
+			if len(got.Status.Parents[0].Conditions) != tt.wantConditions {
+				t.Fatalf("conditions = %v, want %d conditions", got.Status.Parents[0].Conditions, tt.wantConditions)
+			}
+		})
+	}
+}
+
+func TestFindMCPServerRegistrationsForReferenceGrant(t *testing.T) {
+	scheme := testScheme(t)
+
+	mcpsr := &mcpv1alpha1.MCPServerRegistration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "server",
+			Namespace: "registrations",
+		},
+		Spec: mcpv1alpha1.MCPServerRegistrationSpec{
+			TargetRef: mcpv1alpha1.TargetReference{
+				Kind:      "HTTPRoute",
+				Name:      "target-route",
+				Namespace: "routes",
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mcpsr).
+		WithIndex(&mcpv1alpha1.MCPServerRegistration{}, MCPServerRegistrationReferenceGrantIndex, func(obj client.Object) []string {
+			mcpsr := obj.(*mcpv1alpha1.MCPServerRegistration)
+			return []string{mcpServerRegistrationToRefGrantIndexValue(*mcpsr)}
+		}).
+		Build()
+
+	r := &MCPReconciler{Client: fakeClient}
+	requests := r.findMCPServerRegistrationsForReferenceGrant(context.Background(),
+		testMCPServerReferenceGrant())
+
+	if len(requests) != 1 {
+		t.Fatalf("requests = %v, want one request", requests)
+	}
+	if requests[0].NamespacedName != client.ObjectKeyFromObject(mcpsr) {
+		t.Fatalf("request = %v, want %v", requests[0].NamespacedName, client.ObjectKeyFromObject(mcpsr))
+	}
+}
+
+func TestReconcileRemovesConfigWhenReferenceGrantIsMissing(t *testing.T) {
+	scheme := testScheme(t)
+
+	mcpsr := &mcpv1alpha1.MCPServerRegistration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "server",
+			Namespace:  "registrations",
+			Finalizers: []string{mcpGatewayFinalizer},
+		},
+		Spec: mcpv1alpha1.MCPServerRegistrationSpec{
+			TargetRef: mcpv1alpha1.TargetReference{
+				Kind:      "HTTPRoute",
+				Name:      "target-route",
+				Namespace: "routes",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mcpsr, testHTTPRoute("routes")).
+		WithStatusSubresource(&mcpv1alpha1.MCPServerRegistration{}).
+		Build()
+
+	writer := &testMCPServerConfigReaderWriter{}
+	r := &MCPReconciler{
+		Client:             fakeClient,
+		ConfigReaderWriter: writer,
+	}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "server", Namespace: "registrations"},
+	})
+	if err == nil {
+		t.Fatal("Reconcile() expected error")
+	}
+	if !strings.Contains(err.Error(), "ReferenceGrant required") {
+		t.Fatalf("Reconcile() error = %v, want ReferenceGrant required", err)
+	}
+	if len(writer.removedServers) != 1 || writer.removedServers[0] != "registrations/server" {
+		t.Fatalf("removedServers = %v, want registrations/server", writer.removedServers)
+	}
+
+	got := &mcpv1alpha1.MCPServerRegistration{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "server", Namespace: "registrations"}, got); err != nil {
+		t.Fatalf("failed to get MCPServerRegistration: %v", err)
+	}
+	condition := meta.FindStatusCondition(got.Status.Conditions, "Ready")
+	if condition == nil || condition.Reason != mcpv1alpha1.ConditionReasonRefGrantRequired {
+		t.Fatalf("Ready condition = %v, want reason %q", condition, mcpv1alpha1.ConditionReasonRefGrantRequired)
+	}
+}
+
+type testMCPServerConfigReaderWriter struct {
+	removedServers []string
+}
+
+func (w *testMCPServerConfigReaderWriter) UpsertMCPServer(context.Context, config.MCPServer, types.NamespacedName) error {
+	return nil
+}
+
+func (w *testMCPServerConfigReaderWriter) RemoveMCPServer(_ context.Context, serverName string) error {
+	w.removedServers = append(w.removedServers, serverName)
+	return nil
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayv1.Install(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayv1beta1.Install(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func testHTTPRoute(namespace string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "target-route",
+			Namespace: namespace,
+		},
+	}
+}
+
+func testHTTPRouteWithStatus(namespace string, status []gatewayv1.RouteParentStatus) *gatewayv1.HTTPRoute {
+	httpRoute := testHTTPRoute(namespace)
+	httpRoute.Status.Parents = status
+	return httpRoute
+}
+
+func testMCPServerReferenceGrant() *gatewayv1beta1.ReferenceGrant {
+	routeName := gatewayv1beta1.ObjectName("target-route")
+	return &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-target-route",
+			Namespace: "routes",
+		},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{
+				{
+					Group:     gatewayv1beta1.Group(mcpv1alpha1.GroupVersion.Group),
+					Kind:      "MCPServerRegistration",
+					Namespace: "registrations",
+				},
+			},
+			To: []gatewayv1beta1.ReferenceGrantTo{
+				{
+					Group: gatewayv1beta1.Group(gatewayv1.GroupVersion.Group),
+					Kind:  "HTTPRoute",
+					Name:  &routeName,
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes MCPServerRegistration reconciliation when `spec.targetRef.namespace` points at an HTTPRoute outside the registration namespace.

The API and docs allow this, and the field index/status update paths already account for it, but `getTargetHTTPRoute` always read the route from the MCPServerRegistration namespace.

This updates route lookup to use `targetRef.namespace` when set, with a regression test for cross-namespace refs.

Fixes: #1199

Tested:
- go test ./internal/controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-namespace HTTPRoute handling for MCPServerRegistration by correctly honoring the target reference namespace (with default fallback).
  * Enforced Gateway API ReferenceGrant permissions for both route resolution and HTTPRoute status updates, preventing unauthorized cross-namespace cleanup/config removal.
  * Updated reconciliation to re-process affected MCPServerRegistrations when ReferenceGrants change.

* **Tests**
  * Added/extended unit tests for target-namespace resolution, ReferenceGrant-required error behavior, status cleanup rules, and ReferenceGrant-driven reconcile triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->