### PR TITLE
fix(broker-router): honor `--log-level=4` (warn) instead of defaulting to debug

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func init() {
 func main() {
 	var loglevel int
 	var logFormat string
-	flag.IntVar(&loglevel, "log-level", int(slog.LevelInfo), "log level: 0=info, 8=error, -4=debug")
+	flag.IntVar(&loglevel, "log-level", int(slog.LevelInfo), "log level: 0=info, 4=warn, 8=error, -4=debug")
 	flag.StringVar(&logFormat, "log-format", "txt", "log format: txt or json")
 	flag.Parse()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,17 +59,8 @@ func main() {
 	flag.StringVar(&logFormat, "log-format", "txt", "log format: txt or json")
 	flag.Parse()
 
-	loggerOpts := &slog.HandlerOptions{}
-	switch loglevel {
-	case 0:
-		loggerOpts.Level = slog.LevelInfo
-	case 8:
-		loggerOpts.Level = slog.LevelError
-	case -4:
-		loggerOpts.Level = slog.LevelDebug
-	default:
-		loggerOpts.Level = slog.LevelDebug
-	}
+	// flag value is a raw slog.Level (info=0, warn=4, error=8, debug=-4)
+	loggerOpts := &slog.HandlerOptions{Level: slog.Level(loglevel)}
 
 	var slogger *slog.Logger
 	if logFormat == "json" {

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -172,16 +172,8 @@ func parseFlags() *app {
 
 func (a *app) setupLogger() (*slog.HandlerOptions, bool) {
 	opts := &slog.HandlerOptions{}
-	switch a.brokerCfg.logLevel {
-	case 0:
-		opts.Level = slog.LevelInfo
-	case 8:
-		opts.Level = slog.LevelError
-	case -4:
-		opts.Level = slog.LevelDebug
-	default:
-		opts.Level = slog.LevelDebug
-	}
+	// flag value is a raw slog.Level (info=0, warn=4, error=8, debug=-4)
+	opts.Level = slog.Level(a.brokerCfg.logLevel)
 
 	jsonFormat := a.brokerCfg.logFormat == "json"
 	a.logger = mcpotel.NewTracingLogger(os.Stdout, opts, jsonFormat, nil)

--- a/cmd/mcp-broker-router/main_test.go
+++ b/cmd/mcp-broker-router/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestSetupLoggerLevelMapping(t *testing.T) {
+	cases := []struct {
+		name  string
+		level int
+		want  slog.Level
+	}{
+		{"info", 0, slog.LevelInfo},
+		{"warn", 4, slog.LevelWarn},
+		{"error", 8, slog.LevelError},
+		{"debug", -4, slog.LevelDebug},
+		{"arbitrary", 2, slog.Level(2)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &app{}
+			a.brokerCfg.logLevel = tc.level
+			opts, _ := a.setupLogger()
+			if got := opts.Level.Level(); got != tc.want {
+				t.Errorf("log-level=%d: got %v, want %v", tc.level, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`setupLogger()` selected the slog level with a switch that only handled `0`
(info), `8` (error), and `-4` (debug). The `--log-level` flag help advertises
`4=warn`, but `4` had no case and fell through to `default`, which set
`slog.LevelDebug`. As a result, requesting warn produced the most verbose log
level instead.

This replaces the switch with a direct conversion from the flag value to
`slog.Level`, so all slog levels (including warn) are honored:

```go
opts.Level = slog.Level(a.brokerCfg.logLevel)
```

A unit test is added for the level mapping (`setupLogger` was previously
untested).

## Why

The flag value is already a raw `slog.Level` (`Info=0`, `Warn=4`, `Error=8`,
`Debug=-4`), so `4` is valid, documented input. Mapping it to debug means an
operator asking for warn gets the noisiest level instead: more log volume, more
risk of sensitive data at debug, and extra work on the broker/router hot paths.
The level is reachable in normal operation because the controller forwards
`BROKER_ROUTER_LOG_LEVEL` to `--log-level` (see `docs/release-notes/0.0.8.md`).

## Changes

- `cmd/mcp-broker-router/main.go`: map `--log-level` directly to `slog.Level` in
  `setupLogger()`.
- `cmd/main.go`: same fix for the controller binary, which had the identical
  switch.
- `cmd/mcp-broker-router/main_test.go`: add a test covering info/warn/error/debug
  and an arbitrary value.

## Testing

- `make test-unit` passes.
- `gofmt`/`goimports` clean on the changed files.

## Notes

Bugfix, exempt from the issue-first requirement per `CONTRIBUTING.md`. Tracking
issue: #1143. Commit is signed off (`git commit -s`).

Fixes #1143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `--log-level` help text to document the expected numeric values.
* **Refactor**
  * Simplified and standardized log level handling so configured integer values are applied consistently to the logger.
* **Tests**
  * Added unit tests validating log level behavior for debug, info, warn, error, and an arbitrary/unexpected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->