### PR TITLE
fix: expire elicited user tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Kuadrant/mcp-gateway
 go 1.26.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/caitlinelfring/go-env-default v1.1.0
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/fsnotify/fsnotify v1.9.0
@@ -95,6 +96,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -197,6 +199,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/broker/tokens.go
+++ b/internal/broker/tokens.go
@@ -11,6 +11,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
@@ -25,7 +26,7 @@ const maxTokenLength = 2048
 
 // tokenStore is the subset of UserTokenCache that the token page needs.
 type tokenStore interface {
-	SetUserToken(ctx context.Context, sessionID, serverName, token string) error
+	SetUserToken(ctx context.Context, sessionID, serverName, token string, ttl time.Duration) error
 }
 
 // TokenHandler handles HTTP requests to the /tokens endpoint
@@ -164,7 +165,12 @@ func (h *TokenHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := h.tokenCache.SetUserToken(ctx, entry.SessionID, entry.ServerName, token); err != nil {
+	ttl := gatewaySessionTTL(entry.SessionID)
+	if ttl <= 0 {
+		h.sendError(w, http.StatusBadRequest, "invalid or expired session")
+		return
+	}
+	if err := h.tokenCache.SetUserToken(ctx, entry.SessionID, entry.ServerName, token, ttl); err != nil {
 		h.logger.Error("failed to store user token", "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to store token")
 		return

--- a/internal/broker/tokens_test.go
+++ b/internal/broker/tokens_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
 	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
@@ -21,16 +22,18 @@ import (
 type stubTokenCache struct {
 	mu     sync.Mutex
 	tokens map[string]string
+	ttls   map[string]time.Duration
 }
 
 func newStubTokenCache() *stubTokenCache {
-	return &stubTokenCache{tokens: make(map[string]string)}
+	return &stubTokenCache{tokens: make(map[string]string), ttls: make(map[string]time.Duration)}
 }
 
-func (s *stubTokenCache) SetUserToken(_ context.Context, sessionID, serverName, token string) error {
+func (s *stubTokenCache) SetUserToken(_ context.Context, sessionID, serverName, token string, ttl time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tokens[sessionID+":"+serverName] = token
+	s.ttls[sessionID+":"+serverName] = ttl
 	return nil
 }
 
@@ -39,6 +42,12 @@ func (s *stubTokenCache) GetUserToken(_ context.Context, sessionID, serverName s
 	defer s.mu.Unlock()
 	t, ok := s.tokens[sessionID+":"+serverName]
 	return t, ok
+}
+
+func (s *stubTokenCache) getTTL(_ context.Context, sessionID, serverName string) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ttls[sessionID+":"+serverName]
 }
 
 func buildBearerJWT(sub string) string {
@@ -51,6 +60,14 @@ func buildBearerJWT(sub string) string {
 
 func buildRawJWT(sub string) string {
 	return strings.TrimPrefix(buildBearerJWT(sub), "Bearer ")
+}
+
+func buildSessionJWT(exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	claims := fmt.Sprintf(`{"exp":%d}`, exp.Unix())
+	payload := base64.RawURLEncoding.EncodeToString([]byte(claims))
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fakesig"))
+	return fmt.Sprintf("%s.%s.%s", header, payload, sig)
 }
 
 func setupHandler(t *testing.T) (*TokenHandler, elicitation.Map, *stubTokenCache) {
@@ -173,7 +190,8 @@ func TestTokenHandler_GET_InvalidElicitationID(t *testing.T) {
 func TestTokenHandler_POST_StoresToken(t *testing.T) {
 	handler, eMap, cache := setupHandler(t)
 	ctx := context.Background()
-	id, _ := eMap.Store(ctx, "sess1", "github", "")
+	sessionID := buildSessionJWT(time.Now().Add(time.Hour))
+	id, _ := eMap.Store(ctx, sessionID, "github", "")
 	csrf := getCSRFToken(t, handler, id)
 
 	req := postTokenForm(id, "ghp_secret123", csrf)
@@ -184,15 +202,38 @@ func TestTokenHandler_POST_StoresToken(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	token, ok := cache.GetUserToken(ctx, "sess1", "github")
+	token, ok := cache.GetUserToken(ctx, sessionID, "github")
 	if !ok || token != "ghp_secret123" {
 		t.Fatalf("expected cached token, got ok=%v token=%q", ok, token)
+	}
+	ttl := cache.getTTL(ctx, sessionID, "github")
+	if ttl <= 50*time.Minute || ttl > time.Hour {
+		t.Fatalf("expected token ttl near 1h, got %v", ttl)
 	}
 
 	// elicitation ID should be consumed (single-use)
 	_, ok, _ = eMap.Lookup(ctx, id)
 	if ok {
 		t.Fatal("elicitation entry should have been removed after use")
+	}
+}
+
+func TestTokenHandler_POST_InvalidSessionTTL(t *testing.T) {
+	handler, eMap, cache := setupHandler(t)
+	ctx := context.Background()
+	id, _ := eMap.Store(ctx, "sess1", "github", "")
+	csrf := getCSRFToken(t, handler, id)
+
+	req := postTokenForm(id, "ghp_secret123", csrf)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	_, ok := cache.GetUserToken(ctx, "sess1", "github")
+	if ok {
+		t.Fatal("token should not be stored for invalid session")
 	}
 }
 
@@ -258,7 +299,8 @@ func TestTokenHandler_POST_InvalidTokenCharacters(t *testing.T) {
 func TestTokenHandler_POST_SubMatch(t *testing.T) {
 	handler, eMap, cache := setupHandler(t)
 	ctx := context.Background()
-	id, _ := eMap.Store(ctx, "sess1", "github", "user123")
+	sessionID := buildSessionJWT(time.Now().Add(time.Hour))
+	id, _ := eMap.Store(ctx, sessionID, "github", "user123")
 	csrf := getCSRFToken(t, handler, id)
 
 	req := postTokenForm(id, "ghp_secret", csrf)
@@ -270,7 +312,7 @@ func TestTokenHandler_POST_SubMatch(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	token, ok := cache.GetUserToken(ctx, "sess1", "github")
+	token, ok := cache.GetUserToken(ctx, sessionID, "github")
 	if !ok || token != "ghp_secret" {
 		t.Fatal("expected token stored after sub match")
 	}
@@ -294,7 +336,8 @@ func TestTokenHandler_POST_SubMismatch(t *testing.T) {
 func TestTokenHandler_POST_NoSubInEntry_SkipsCheck(t *testing.T) {
 	handler, eMap, cache := setupHandler(t)
 	ctx := context.Background()
-	id, _ := eMap.Store(ctx, "sess1", "github", "")
+	sessionID := buildSessionJWT(time.Now().Add(time.Hour))
+	id, _ := eMap.Store(ctx, sessionID, "github", "")
 	csrf := getCSRFToken(t, handler, id)
 
 	req := postTokenForm(id, "ghp_secret", csrf)
@@ -305,7 +348,7 @@ func TestTokenHandler_POST_NoSubInEntry_SkipsCheck(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	token, ok := cache.GetUserToken(ctx, "sess1", "github")
+	token, ok := cache.GetUserToken(ctx, sessionID, "github")
 	if !ok || token != "ghp_secret" {
 		t.Fatal("expected token stored when no sub in entry")
 	}

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -1656,7 +1656,7 @@ func TestResolveUpstreamToken_CachedTokenInjected(t *testing.T) {
 	server, validToken := setupTokenResolutionTestServer(t, serverConfigs, map[string]string{"gh_tool": "github"}, tokenMap)
 
 	// pre-populate the user token in the session cache
-	require.NoError(t, server.SessionCache.SetUserToken(context.Background(), validToken, "github", "ghp_cached_token"))
+	require.NoError(t, server.SessionCache.SetUserToken(context.Background(), validToken, "github", "ghp_cached_token", 0))
 
 	req := &MCPRequest{
 		ID: ptr.To(1), JSONRPC: "2.0", Method: "tools/call",

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -497,7 +497,7 @@ func TestHandleResponseHeaders_401DeletesUserToken(t *testing.T) {
 	srv.RoutingConfig.Store(routingConfig)
 
 	// store a user token in the cache
-	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "expired-token"))
+	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "expired-token", 0))
 	tok, ok, err := cache.GetUserToken(context.Background(), gatewaySessionID, serverName)
 	require.NoError(t, err)
 	require.True(t, ok)
@@ -575,7 +575,7 @@ func TestHandleResponseHeaders_401SkipsTokenDeleteWhenNotApplicable(t *testing.T
 			}
 			srv.RoutingConfig.Store(routingConfig)
 
-			require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, tt.serverName, "my-token"))
+			require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, tt.serverName, "my-token", 0))
 
 			requestHeaders := &eppb.HttpHeaders{
 				Headers: &corev3.HeaderMap{
@@ -664,7 +664,7 @@ func TestHandleResponseHeaders_SuccessStatusDoesNotDeleteUserToken(t *testing.T)
 	}
 	srv.RoutingConfig.Store(routingConfig)
 
-	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "valid-token"))
+	require.NoError(t, cache.SetUserToken(context.Background(), gatewaySessionID, serverName, "valid-token", 0))
 
 	requestHeaders := &eppb.HttpHeaders{
 		Headers: &corev3.HeaderMap{

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -34,7 +34,7 @@ type SessionCache interface {
 	KeyExists(ctx context.Context, key string) (bool, error)
 	SetClientElicitation(ctx context.Context, gatewaySessionID string, ttl time.Duration) error
 	GetClientElicitation(ctx context.Context, gatewaySessionID string) (bool, error)
-	SetUserToken(ctx context.Context, sessionID, serverName, token string) error
+	SetUserToken(ctx context.Context, sessionID, serverName, token string, ttl time.Duration) error
 	GetUserToken(ctx context.Context, sessionID, serverName string) (string, bool, error)
 	DeleteUserToken(ctx context.Context, sessionID, serverName string) error
 }

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -146,7 +146,8 @@ func (c *Cache) GetClientElicitation(ctx context.Context, gatewaySessionID strin
 }
 
 // SetUserToken stores a per-user upstream token in the session hash.
-func (c *Cache) SetUserToken(ctx context.Context, sessionID, serverName, token string) error {
+// ttl sets the expiry on the Redis hash key; pass 0 for no expiry (in-memory mode ignores ttl).
+func (c *Cache) SetUserToken(ctx context.Context, sessionID, serverName, token string, ttl time.Duration) error {
 	field := userTokenFieldPrefix + serverName
 	if c.inmemory != nil {
 		c.innerMu.Lock()
@@ -171,7 +172,15 @@ func (c *Cache) SetUserToken(ctx context.Context, sessionID, serverName, token s
 		}
 		value = encrypted
 	}
-	return c.extClient.HSet(ctx, sessionID, field, value).Err()
+	pipe := c.extClient.Pipeline()
+	pipe.HSet(ctx, sessionID, field, value)
+	if ttl > 0 {
+		pipe.Expire(ctx, sessionID, ttl)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetUserToken retrieves a cached upstream token. Returns ("", false, nil) on miss.

--- a/internal/session/cache_test.go
+++ b/internal/session/cache_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	redis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -411,7 +413,7 @@ func TestCache_SetGetDeleteUserToken(t *testing.T) {
 	require.False(t, ok)
 	require.Empty(t, token)
 
-	err = cache.SetUserToken(ctx, "sess1", "server1", "my-pat-token")
+	err = cache.SetUserToken(ctx, "sess1", "server1", "my-pat-token", 0)
 	require.NoError(t, err)
 
 	token, ok, err = cache.GetUserToken(ctx, "sess1", "server1")
@@ -438,7 +440,7 @@ func TestCache_OpaqueTokenNoExpiryCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	opaque := "ghp_abc123XYZ"
-	err = cache.SetUserToken(ctx, "sess1", "github", opaque)
+	err = cache.SetUserToken(ctx, "sess1", "github", opaque, 0)
 	require.NoError(t, err)
 
 	token, ok, err := cache.GetUserToken(ctx, "sess1", "github")
@@ -447,13 +449,36 @@ func TestCache_OpaqueTokenNoExpiryCheck(t *testing.T) {
 	require.Equal(t, opaque, token)
 }
 
+func TestCache_SetUserTokenRedisTTL(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+	cache, err := NewCache(WithRedisClient(client))
+	require.NoError(t, err)
+
+	err = cache.SetUserToken(ctx, "sess1", "github", "ghp_abc123XYZ", time.Hour)
+	require.NoError(t, err)
+
+	ttl, err := client.TTL(ctx, "sess1").Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+
+	redisServer.FastForward(time.Hour + time.Second)
+	_, ok, err := cache.GetUserToken(ctx, "sess1", "github")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func TestCache_ExpiredJWTDeletedOnGet(t *testing.T) {
 	ctx := context.Background()
 	cache, err := NewCache()
 	require.NoError(t, err)
 
 	expired := buildJWT(time.Now().Add(-1 * time.Hour))
-	err = cache.SetUserToken(ctx, "sess1", "server1", expired)
+	err = cache.SetUserToken(ctx, "sess1", "server1", expired, 0)
 	require.NoError(t, err)
 
 	_, ok, err := cache.GetUserToken(ctx, "sess1", "server1")
@@ -472,7 +497,7 @@ func TestCache_ValidJWTReturned(t *testing.T) {
 	require.NoError(t, err)
 
 	valid := buildJWT(time.Now().Add(1 * time.Hour))
-	err = cache.SetUserToken(ctx, "sess1", "server1", valid)
+	err = cache.SetUserToken(ctx, "sess1", "server1", valid, 0)
 	require.NoError(t, err)
 
 	token, ok, err := cache.GetUserToken(ctx, "sess1", "server1")


### PR DESCRIPTION
Fixes Redis-backed URL token elicitation so opaque user tokens expire with the gateway session.

This matters most for opaque PATs, since JWT user tokens are lazily expired on read, but opaque tokens have no embedded expiry. Previously SetUserToken wrote the Redis hash field with HSET only, so if that created the session hash before a backend session was cached, the Redis key had no TTL.

This passes the gateway session TTL from the token handler and applies it when storing the token.

Tested:
- go test ./internal/session
- go test ./internal/broker
- go test ./internal/mcp-router

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added per-session TTL to stored user tokens, enabling automatic expiration (reducing stale/unsafe reuse).

* **Bug Fixes**
  * Token storage now validates TTL and returns an error when TTL is non-positive.
  * Redis-backed session token storage now applies key expiration based on the provided TTL (in-memory behavior remains unchanged).

* **Tests**
  * Updated token and router handler tests to pass/verify TTL, including Redis expiration behavior and invalid TTL scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->