### PR TITLE
fix: align CI Kind cluster setup with pinned binary across all workflows

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -33,6 +33,9 @@ jobs:
   conformance-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout
@@ -48,10 +51,38 @@ jobs:
         with:
           node-version: "24"
 
+      # probe the baked CI node image (content-hash of version pins); on a
+      # miss fall back to stock kindest/node via the default in kind.mk
+      - name: Probe baked CI node image
+        id: ci-node
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          hit=false
+          if image="$(make -s print-ci-node-image 2>/dev/null)"; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              hit=true
+            fi
+          else
+            image=""
+            echo "could not compute baked CI node image ref, using stock kindest/node"
+          fi
+          {
+            echo "hit=$hit"
+            echo "image=$image"
+          } >> "$GITHUB_OUTPUT"
+          echo "baked CI node image: $image (hit=$hit)"
+
       # create with the pinned bin/kind and node image so the make load
       # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: make kind-create-cluster-ci
+        run: |
+          if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
+            make kind-create-cluster-ci KIND_CLUSTER_IMAGE="${{ steps.ci-node.outputs.image }}"
+          else
+            make kind-create-cluster-ci
+          fi
 
       - name: Setup CI environment
         run: |

--- a/.github/workflows/e2e-auth.yaml
+++ b/.github/workflows/e2e-auth.yaml
@@ -11,6 +11,9 @@ jobs:
   e2e-auth-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout
@@ -21,10 +24,38 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # probe the baked CI node image (content-hash of version pins); on a
+      # miss fall back to stock kindest/node via the default in kind.mk
+      - name: Probe baked CI node image
+        id: ci-node
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          hit=false
+          if image="$(make -s print-ci-node-image 2>/dev/null)"; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              hit=true
+            fi
+          else
+            image=""
+            echo "could not compute baked CI node image ref, using stock kindest/node"
+          fi
+          {
+            echo "hit=$hit"
+            echo "image=$image"
+          } >> "$GITHUB_OUTPUT"
+          echo "baked CI node image: $image (hit=$hit)"
+
       # create with the pinned bin/kind and node image so the make load
       # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: make kind-create-cluster-ci
+        run: |
+          if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
+            make kind-create-cluster-ci KIND_CLUSTER_IMAGE="${{ steps.ci-node.outputs.image }}"
+          else
+            make kind-create-cluster-ci
+          fi
 
       - name: Setup CI environment
         run: make ci-setup

--- a/.github/workflows/e2e-on-demand.yaml
+++ b/.github/workflows/e2e-on-demand.yaml
@@ -85,6 +85,9 @@ jobs:
     if: needs.check-permission.outputs.is-member == 'true' && needs.check-permission.outputs.suite != ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Get PR branch
@@ -110,10 +113,38 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # probe the baked CI node image (content-hash of version pins); on a
+      # miss fall back to stock kindest/node via the default in kind.mk
+      - name: Probe baked CI node image
+        id: ci-node
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          hit=false
+          if image="$(make -s print-ci-node-image 2>/dev/null)"; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              hit=true
+            fi
+          else
+            image=""
+            echo "could not compute baked CI node image ref, using stock kindest/node"
+          fi
+          {
+            echo "hit=$hit"
+            echo "image=$image"
+          } >> "$GITHUB_OUTPUT"
+          echo "baked CI node image: $image (hit=$hit)"
+
       # create with the pinned bin/kind and node image so the make load
       # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: make kind-create-cluster-ci
+        run: |
+          if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
+            make kind-create-cluster-ci KIND_CLUSTER_IMAGE="${{ steps.ci-node.outputs.image }}"
+          else
+            make kind-create-cluster-ci
+          fi
 
       - name: Setup CI environment
         run: make ci-setup

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -35,6 +35,8 @@ jobs:
       # Required by benchmark-action to push results to gh-pages and post PR comments
       contents: write
       pull-requests: write
+      # Required to probe the baked CI node image on ghcr.io
+      packages: read
 
     steps:
       - name: Checkout
@@ -45,9 +47,38 @@ jobs:
         with:
           go-version: '1.24'
 
-      # Provision a Kind cluster using the same config as the standard e2e suite
+      # probe the baked CI node image (content-hash of version pins); on a
+      # miss fall back to stock kindest/node via the default in kind.mk
+      - name: Probe baked CI node image
+        id: ci-node
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          hit=false
+          if image="$(make -s print-ci-node-image 2>/dev/null)"; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin >/dev/null 2>&1 || true
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              hit=true
+            fi
+          else
+            image=""
+            echo "could not compute baked CI node image ref, using stock kindest/node"
+          fi
+          {
+            echo "hit=$hit"
+            echo "image=$image"
+          } >> "$GITHUB_OUTPUT"
+          echo "baked CI node image: $image (hit=$hit)"
+
+      # create with the pinned bin/kind and node image so the make load
+      # targets (same bin/kind) can always load into the node's containerd
       - name: Create Kind cluster
-        run: kind create cluster --name mcp-gateway --config config/kind/cluster-ci.yaml
+        run: |
+          if [ "${{ steps.ci-node.outputs.hit }}" = "true" ]; then
+            make kind-create-cluster-ci KIND_CLUSTER_IMAGE="${{ steps.ci-node.outputs.image }}"
+          else
+            make kind-create-cluster-ci
+          fi
 
       # Full gateway stack: Istio, gateway, controller, test servers
       - name: Setup CI environment


### PR DESCRIPTION
## Summary

- GitHub Actions runners updated containerd to config v4, which the runner-preinstalled Kind can't handle. The benchmark workflow was using bare `kind create cluster` instead of the pinned `bin/kind` via `make kind-create-cluster-ci`, causing `kind load image-archive` to fail with `unknown containerd config version: 4`.
- Fixed benchmark and added the CI node image probe step to e2e-on-demand, e2e-auth, and conformance for consistency — all six Kind-using workflows now have the same setup pattern.

## Test evidence

Verified no remaining bare `kind` commands across all workflows:
```
grep -rn 'kind create cluster\|kind load' .github/workflows/ → no results
```

All six workflows now use `make kind-create-cluster-ci` with optional `KIND_CLUSTER_IMAGE` passthrough.

Relates to https://github.com/Kuadrant/mcp-gateway/actions/runs/27692802011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI/CD workflows (conformance tests, e2e auth, e2e on-demand, and performance benchmarks) to explicitly set job-level permissions and optimize test infrastructure by probing for pre-built CI node images when available, with automatic fallback to default cluster creation for improved pipeline efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->