### PR TITLE
per-server SNI for hairpin TLS connections

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -81,7 +81,7 @@ type app struct {
 	jwtMgr         *session.JWTManager
 	elicitMap      idmap.Map
 	tokenElicitMap elicitation.Map
-	hairpinClient  *http.Client
+	hairpinPool    *clients.HairpinClientPool
 	mcpBroker      broker.MCPBroker
 	tokenHandler   http.Handler
 	elicitHandler  http.Handler
@@ -252,15 +252,15 @@ func (a *app) setupSessionInfra(ctx context.Context) {
 }
 
 func (a *app) buildHairpinClient() {
-	hc, err := clients.BuildHairpinHTTPClient(
+	pool, err := clients.BuildHairpinHTTPClientPool(
 		a.brokerCfg.privateHost,
 		a.brokerCfg.publicHost,
 		a.brokerCfg.gatewayCACert,
 	)
 	if err != nil {
-		panic("failed to build hairpin HTTP client: " + err.Error())
+		panic("failed to build hairpin HTTP client pool: " + err.Error())
 	}
-	a.hairpinClient = hc
+	a.hairpinPool = pool
 }
 
 func (a *app) registerObservers() {

--- a/cmd/mcp-broker-router/router.go
+++ b/cmd/mcp-broker-router/router.go
@@ -15,7 +15,7 @@ func (a *app) createRouter() {
 		Logger:              a.logger.With("component", "router"),
 		JWTManager:          a.jwtMgr,
 		InitForClient:       clients.Initialize,
-		HairpinHTTPClient:   a.hairpinClient,
+		HairpinClientPool:   a.hairpinPool,
 		SessionCache:        a.sessionCache,
 		ElicitationMap:      a.elicitMap,
 		TokenElicitationMap: a.tokenElicitMap,

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -109,6 +109,20 @@ kubectl patch deployment mcp-gateway -n mcp-system --type=json -p '[
 
 The operator preserves user-added volumes, volume mounts, and command flags across reconciliations.
 
+#### Supported TLS Configurations
+
+The gateway uses TLS termination (`tls.mode: Terminate`) on HTTPS listeners. Envoy decrypts incoming TLS, processes the request (ext_proc, AuthPolicy), then forwards **plain HTTP** to backends. This affects which backend setups work:
+
+**Fully supported — tool discovery and tool calls work:**
+
+- **HTTP listener → HTTP backend** — no TLS involved.
+- **HTTPS listener → HTTP backend** — Envoy terminates client TLS, forwards HTTP to backend. Requires `--gateway-ca-cert` if the listener uses a private CA.
+- **HTTPS listener → external HTTPS backend (with DestinationRule)** — Envoy terminates client TLS, then a DestinationRule configures TLS origination to the external service. See [External MCP Servers](./external-mcp-server.md).
+
+**Partial support — tool discovery works, tool calls require additional configuration:**
+
+- **Any listener → internal HTTPS backend (`caCertSecretRef`)** — the broker connects directly to the backend using the CA cert, so tool discovery works. However, `tools/call` is routed through Envoy, which sends plain HTTP to the TLS backend after termination. The backend rejects the non-TLS connection. To enable `tools/call`, create an Istio DestinationRule with TLS origination for that service — the same pattern used for [external MCP servers](./external-mcp-server.md). See the [Istio documentation on destination rule TLS settings](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ClientTLSSettings) for configuring `credentialName` with a custom CA certificate.
+
 The `--mcp-gateway-public-host` flag tells the router which `Host` header to expect on incoming requests, so it avoids rewriting it during routing.
 
 The **EnvoyFilter** is configured to intercept traffic on the listener's port and route it through the ext_proc (external processor) running on port 50051.

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -12,13 +12,62 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
-	mcprouter "github.com/Kuadrant/mcp-gateway/internal/mcp-router"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// HairpinClientPool manages *http.Client instances for hairpin requests,
+// keyed by TLS ServerName (SNI). For HTTP or when all servers share the
+// same listener, a single default client is used. When a server attaches
+// to a different HTTPS listener, a client with that server's SNI is
+// created on demand and cached.
+type HairpinClientPool struct {
+	defaultClient *http.Client
+	baseTLSConfig *tls.Config // nil for HTTP
+	mu            sync.RWMutex
+	clients       map[string]*http.Client
+}
+
+// Get returns an *http.Client with the appropriate TLS ServerName.
+// If sniOverride is empty, the default client (gateway hostname SNI) is returned.
+func (p *HairpinClientPool) Get(sniOverride string) *http.Client {
+	if sniOverride == "" || p.baseTLSConfig == nil {
+		return p.defaultClient
+	}
+
+	sni := sniOverride
+	if h, _, err := net.SplitHostPort(sniOverride); err == nil {
+		sni = h
+	}
+
+	// double-checked locking: read lock for the fast path (concurrent readers),
+	// then write lock with a re-check to avoid duplicate creation when multiple
+	// goroutines race past the read lock simultaneously
+	p.mu.RLock()
+	c, ok := p.clients[sni]
+	p.mu.RUnlock()
+	if ok {
+		return c
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c, ok = p.clients[sni]; ok {
+		return c
+	}
+
+	cfg := p.baseTLSConfig.Clone()
+	cfg.ServerName = sni
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = cfg
+	c = &http.Client{Transport: t}
+	p.clients[sni] = c
+	return c
+}
 
 // buildHairpinURL composes the hairpin URL the broker uses to send the internal
 // initialize request back through the gateway. gatewayHost may be either a
@@ -34,21 +83,17 @@ func buildHairpinURL(gatewayHost, mcpPath string) string {
 	return "http://" + gatewayHost + mcpPath
 }
 
-// Initialize will create a new initialize and initialized request and return the associated http client for connection management
-// This method makes a request back to the gateway setting the target mcp server to initialize. We hairpin through the gateway to ensure any Auth applied to that host is triggered for the call.
-// The initToken is a short-lived JWT bound to conf.Hostname that the router will validate when the hairpin request re-enters the gateway.
-func Initialize(ctx context.Context, gatewayHost, initToken string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool, hairpinHTTPClient *http.Client) (*client.Client, error) {
-	// force the initialize to hairpin back through envoy with a token that
-	// proves the request originated from the gateway's own router.
-	passThroughHeaders[mcprouter.RoutingKey] = initToken
-	passThroughHeaders["mcp-init-host"] = conf.Hostname
-
+// Initialize will create a new initialize and initialized request and return the associated http client for connection management.
+// This method makes a request back through the gateway to ensure any AuthPolicy is triggered.
+// The caller must set the routing key and mcp-init-host headers in passThroughHeaders before calling.
+func Initialize(ctx context.Context, gatewayHost string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool, hairpinClientPool *HairpinClientPool) (*client.Client, error) {
 	mcpPath, err := conf.Path()
 	if err != nil {
 		return nil, err
 	}
 
 	url := buildHairpinURL(gatewayHost, mcpPath)
+	hairpinHTTPClient := hairpinClientPool.Get(conf.Hostname)
 
 	httpClient, err := client.NewStreamableHttpClient(url,
 		transport.WithHTTPHeaders(passThroughHeaders),
@@ -80,18 +125,22 @@ func Initialize(ctx context.Context, gatewayHost, initToken string, conf *config
 	return httpClient, nil
 }
 
-// BuildHairpinHTTPClient returns an *http.Client for hairpin requests. For HTTPS
-// private hosts it configures TLS with ServerName set to publicHost so the
-// handshake verifies the cert SANs against the public hostname while the TCP
-// connection goes to the internal address. For plain HTTP it returns http.DefaultClient.
-func BuildHairpinHTTPClient(privateHost, publicHost, caCertPath string) (*http.Client, error) {
+// BuildHairpinHTTPClientPool returns a HairpinClientPool for hairpin requests.
+// For HTTPS private hosts it configures TLS with the publicHost as the default
+// ServerName (SNI). Servers on a different HTTPS listener can obtain a client
+// with a different SNI via pool.Get(serverHostname).
+// For plain HTTP it returns a pool whose default client has no TLS.
+func BuildHairpinHTTPClientPool(privateHost, publicHost, caCertPath string) (*HairpinClientPool, error) {
 	if !strings.HasPrefix(strings.ToLower(privateHost), "https://") {
-		return &http.Client{}, nil
+		return &HairpinClientPool{
+			defaultClient: &http.Client{},
+			clients:       make(map[string]*http.Client),
+		}, nil
 	}
 
-	pool, err := x509.SystemCertPool()
+	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		pool = x509.NewCertPool()
+		certPool = x509.NewCertPool()
 	}
 
 	if caCertPath != "" {
@@ -99,22 +148,26 @@ func BuildHairpinHTTPClient(privateHost, publicHost, caCertPath string) (*http.C
 		if err != nil {
 			return nil, fmt.Errorf("failed to read gateway CA cert: %w", err)
 		}
-		if !pool.AppendCertsFromPEM(pem) {
+		if !certPool.AppendCertsFromPEM(pem) {
 			return nil, fmt.Errorf("failed to parse gateway CA cert PEM")
 		}
 	}
 
-	// TLS ServerName must be a bare hostname, never host:port
-	serverName := publicHost
+	defaultSNI := publicHost
 	if h, _, err := net.SplitHostPort(publicHost); err == nil {
-		serverName = h
+		defaultSNI = h
 	}
 
-	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.TLSClientConfig = &tls.Config{
+	baseCfg := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		RootCAs:    pool,
-		ServerName: serverName,
+		RootCAs:    certPool,
+		ServerName: defaultSNI,
 	}
-	return &http.Client{Transport: t}, nil
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = baseCfg
+	return &HairpinClientPool{
+		defaultClient: &http.Client{Transport: t},
+		baseTLSConfig: baseCfg,
+		clients:       make(map[string]*http.Client),
+	}, nil
 }

--- a/internal/clients/clients_test.go
+++ b/internal/clients/clients_test.go
@@ -5,6 +5,7 @@ package clients
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -65,7 +66,6 @@ func TestInitialize(t *testing.T) {
 	testCases := []struct {
 		name               string
 		gatewayHost        string
-		routerKey          string
 		conf               *config.MCPServer
 		passThroughHeaders map[string]string
 		expectedError      bool
@@ -73,7 +73,6 @@ func TestInitialize(t *testing.T) {
 		{
 			name:        "standard initialization",
 			gatewayHost: "%invalid",
-			routerKey:   "router-key-123",
 			conf: &config.MCPServer{
 				Name:     "test-server",
 				Prefix:   "test_",
@@ -87,7 +86,11 @@ func TestInitialize(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, err := Initialize(context.Background(), tc.gatewayHost, tc.routerKey, tc.conf, tc.passThroughHeaders, false, nil)
+			pool := &HairpinClientPool{
+				defaultClient: &http.Client{},
+				clients:       make(map[string]*http.Client),
+			}
+			client, err := Initialize(context.Background(), tc.gatewayHost, tc.conf, tc.passThroughHeaders, false, pool)
 			if tc.expectedError {
 				require.Error(t, err)
 				return
@@ -99,42 +102,87 @@ func TestInitialize(t *testing.T) {
 	}
 }
 
-func TestBuildHairpinHTTPClient(t *testing.T) {
-	t.Run("returns plain client for HTTP private host", func(t *testing.T) {
-		c, err := BuildHairpinHTTPClient("http://gw.svc:8080", "mcp.example.com", "")
+func TestBuildHairpinHTTPClientPool(t *testing.T) {
+	t.Run("returns plain pool for HTTP private host", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("http://gw.svc:8080", "mcp.example.com", "")
 		require.NoError(t, err)
-		require.NotNil(t, c)
+		require.NotNil(t, pool)
+		require.Nil(t, pool.baseTLSConfig)
+		require.NotNil(t, pool.Get(""))
 	})
 
-	t.Run("returns plain client for bare host without scheme", func(t *testing.T) {
-		c, err := BuildHairpinHTTPClient("gw.svc:8080", "mcp.example.com", "")
+	t.Run("returns plain pool for bare host without scheme", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("gw.svc:8080", "mcp.example.com", "")
 		require.NoError(t, err)
-		require.NotNil(t, c)
+		require.NotNil(t, pool)
+		require.Nil(t, pool.baseTLSConfig)
 	})
 
-	t.Run("HTTPS sets ServerName and TLS minimum version", func(t *testing.T) {
-		c, err := BuildHairpinHTTPClient("https://gw.svc:443", "mcp.example.com", "")
+	t.Run("HTTPS sets default ServerName and TLS minimum version", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com", "")
 		require.NoError(t, err)
-		require.NotNil(t, c)
+		require.NotNil(t, pool)
 
+		c := pool.Get("")
 		tr, ok := c.Transport.(*http.Transport)
 		require.True(t, ok)
 		require.Equal(t, "mcp.example.com", tr.TLSClientConfig.ServerName)
-		require.Equal(t, uint16(0x0303), tr.TLSClientConfig.MinVersion) // tls.VersionTLS12
+		require.Equal(t, uint16(tls.VersionTLS12), tr.TLSClientConfig.MinVersion)
 	})
 
 	t.Run("HTTPS strips port from publicHost for ServerName", func(t *testing.T) {
-		c, err := BuildHairpinHTTPClient("https://gw.svc:443", "mcp.example.com:8443", "")
+		pool, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com:8443", "")
 		require.NoError(t, err)
-		require.NotNil(t, c)
 
+		c := pool.Get("")
 		tr, ok := c.Transport.(*http.Transport)
 		require.True(t, ok)
 		require.Equal(t, "mcp.example.com", tr.TLSClientConfig.ServerName)
 	})
 
+	t.Run("Get with override returns client with different SNI", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com", "")
+		require.NoError(t, err)
+
+		defaultClient := pool.Get("")
+		overrideClient := pool.Get("server.mcp-alt.local")
+		require.NotEqual(t, defaultClient, overrideClient)
+
+		tr, ok := overrideClient.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.Equal(t, "server.mcp-alt.local", tr.TLSClientConfig.ServerName)
+	})
+
+	t.Run("Get with override strips port", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com", "")
+		require.NoError(t, err)
+
+		c := pool.Get("server.mcp-alt.local:8443")
+		tr, ok := c.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.Equal(t, "server.mcp-alt.local", tr.TLSClientConfig.ServerName)
+	})
+
+	t.Run("Get with override is cached", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com", "")
+		require.NoError(t, err)
+
+		c1 := pool.Get("server.mcp-alt.local")
+		c2 := pool.Get("server.mcp-alt.local")
+		require.Same(t, c1, c2)
+	})
+
+	t.Run("Get with override on HTTP pool returns default", func(t *testing.T) {
+		pool, err := BuildHairpinHTTPClientPool("http://gw.svc:8080", "mcp.example.com", "")
+		require.NoError(t, err)
+
+		defaultClient := pool.Get("")
+		overrideClient := pool.Get("server.mcp-alt.local")
+		require.Same(t, defaultClient, overrideClient)
+	})
+
 	t.Run("errors on non-existent CA cert path", func(t *testing.T) {
-		_, err := BuildHairpinHTTPClient("https://gw.svc:443", "mcp.example.com", "/nonexistent/ca.crt")
+		_, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com", "/nonexistent/ca.crt")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read gateway CA cert")
 	})
@@ -144,7 +192,7 @@ func TestBuildHairpinHTTPClient(t *testing.T) {
 		badCert := filepath.Join(tmpDir, "bad.crt")
 		require.NoError(t, os.WriteFile(badCert, []byte("not a certificate"), 0600))
 
-		_, err := BuildHairpinHTTPClient("https://gw.svc:443", "mcp.example.com", badCert)
+		_, err := BuildHairpinHTTPClientPool("https://gw.svc:443", "mcp.example.com", badCert)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to parse gateway CA cert PEM")
 	})

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -696,11 +696,10 @@ func (s *ExtProcServer) initializeMCPServerSession(ctx context.Context, mcpReq *
 		if mcpReq.Headers != nil {
 			// We don't want to pass through any pseudo routing headers (:authority,
 			// :path, etc.), the gateway-bound mcp-session-id, or the router-internal
-			// headers (mcp-init-host, router-key) which we set ourselves below via
-			// clients.Initialize. Dropping the router-internal headers here is
-			// defense-in-depth so a client-supplied value can never reach the
-			// hairpin request even if the override in clients.Initialize is later
-			// refactored. Everything else is passed through for custom headers.
+			// headers (mcp-init-host, router-key) which we set ourselves below.
+			// Dropping the router-internal headers here is defense-in-depth so a
+			// client-supplied value can never reach the hairpin request.
+			// Everything else is passed through for custom headers.
 			for _, h := range mcpReq.Headers.Headers {
 				key := strings.ToLower(h.Key)
 				if strings.HasPrefix(key, ":") ||
@@ -753,7 +752,9 @@ func (s *ExtProcServer) initializeMCPServerSession(ctx context.Context, mcpReq *
 			mcpotel.SpanError(initSpan, err, "failed to generate backend-init token")
 			return "", NewRouterErrorf(500, "failed to generate backend-init token: %w", err)
 		}
-		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, initToken, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation, s.HairpinHTTPClient)
+		passThroughHeaders[RoutingKey] = initToken
+		passThroughHeaders["mcp-init-host"] = mcpServerConfig.Hostname
+		clientHandle, err := s.InitForClient(ctx, s.RoutingConfig.MCPGatewayInternalHostname, mcpServerConfig, passThroughHeaders, mcpReq.clientElicitation, s.HairpinClientPool)
 		if err != nil {
 			s.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
 			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -15,6 +14,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Kuadrant/mcp-gateway/internal/clients"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
@@ -182,7 +182,7 @@ func TestHandleRequestBody(t *testing.T) {
 	require.True(t, sessionAdded)
 
 	// Mock InitForClient - should not be called since session exists
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *http.Client) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *clients.HairpinClientPool) (*client.Client, error) {
 		// This should not be called in this test since session exists in cache
 		return nil, fmt.Errorf("InitForClient should not be called when session exists")
 	}
@@ -1216,7 +1216,7 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	var captured map[string]string
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, headers map[string]string, _ bool, _ *http.Client) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, headers map[string]string, _ bool, _ *clients.HairpinClientPool) (*client.Client, error) {
 		captured = make(map[string]string, len(headers))
 		for k, v := range headers {
 			captured[k] = v
@@ -1275,10 +1275,13 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 	require.NotContains(t, captured, ":authority", "pseudo-header must not be forwarded")
 	require.NotContains(t, captured, ":path", "pseudo-header must not be forwarded")
 	require.NotContains(t, captured, "mcp-session-id", "gateway session id must not be forwarded")
-	require.NotContains(t, captured, "mcp-init-host", "router-internal header must not leak from client input")
-	require.NotContains(t, captured, RoutingKey, "router-internal header must not leak from client input")
 	require.NotContains(t, captured, "x-mcp-authorized", "broker-only filtering header must not reach upstream")
 	require.NotContains(t, captured, "x-mcp-virtualserver", "broker-only filtering header must not reach upstream")
+
+	// router-key and mcp-init-host must be set by the router (not from client input)
+	require.Contains(t, captured, RoutingKey, "router must set the routing key")
+	require.NotEqual(t, "attacker-supplied-key", captured[RoutingKey], "client-supplied router-key must be overwritten")
+	require.Equal(t, "backend.example.com", captured["mcp-init-host"], "mcp-init-host must be set to the server hostname, not client-supplied value")
 
 	// custom headers and authorization are passed through
 	require.Equal(t, "custom-value", captured["x-custom-header"])
@@ -1440,7 +1443,7 @@ func TestHandlePromptGet(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, sessionAdded)
 
-	mockInitForClient := func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *http.Client) (*client.Client, error) {
+	mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *clients.HairpinClientPool) (*client.Client, error) {
 		return nil, fmt.Errorf("InitForClient should not be called when session exists")
 	}
 
@@ -1543,7 +1546,7 @@ func setupTokenResolutionTestServer(t *testing.T, serverConfigs []*config.MCPSer
 		JWTManager:   jwtManager,
 		Logger:       logger,
 		SessionCache: cache,
-		InitForClient: func(_ context.Context, _, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *http.Client) (*client.Client, error) {
+		InitForClient: func(_ context.Context, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *clients.HairpinClientPool) (*client.Client, error) {
 			return nil, fmt.Errorf("should not be called")
 		},
 		Broker:              newMockBroker(serverConfigs, toolMap),

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
+	"github.com/Kuadrant/mcp-gateway/internal/clients"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
@@ -39,9 +39,8 @@ type SessionCache interface {
 }
 
 // InitForClient defines a function for initializing an MCP server for a client.
-// initToken is a short-lived JWT minted by the router and validated again when
-// the hairpin request re-enters the gateway.
-type InitForClient func(ctx context.Context, gatewayHost, initToken string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool, hairpinHTTPClient *http.Client) (*client.Client, error)
+// The caller sets routing headers (router-key, mcp-init-host) in passThroughHeaders before calling.
+type InitForClient func(ctx context.Context, gatewayHost string, conf *config.MCPServer, passThroughHeaders map[string]string, clientElicitation bool, hairpinClientPool *clients.HairpinClientPool) (*client.Client, error)
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {
@@ -53,7 +52,7 @@ type ExtProcServer struct {
 	ElicitationMap      idmap.Map
 	TokenElicitationMap elicitation.Map
 	MaxRequestBodySize  int
-	HairpinHTTPClient   *http.Client
+	HairpinClientPool   *clients.HairpinClientPool
 	ElicitationEnabled  bool
 	//TODO this should not be needed
 	Broker broker.MCPBroker

--- a/tests/e2e/custom_tls_test.go
+++ b/tests/e2e/custom_tls_test.go
@@ -15,9 +15,12 @@ import (
 	"time"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	istiov1beta1 "istio.io/api/networking/v1beta1"
+	istionetv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,42 +91,13 @@ var _ = Describe("Custom TLS Configuration", Ordered, func() {
 		testResources = []client.Object{}
 	})
 
-	It("[HTTPS] [Happy] broker connects to TLS upstream with custom CA certificate", func() {
-		By("Extracting CA cert from cert-manager secret")
-		caSecret := &corev1.Secret{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{
-			Name: caKeypairSecret, Namespace: certManagerNS,
-		}, caSecret)).To(Succeed())
-		caCertPEM, ok := caSecret.Data["ca.crt"]
-		Expect(ok).To(BeTrue(), "cert-manager CA secret should have ca.crt key")
-		Expect(caCertPEM).NotTo(BeEmpty())
-
-		By("Creating labeled CA secret in test namespace")
-		labeledCA := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      caLabeledSecret,
-				Namespace: TestServerNameSpace,
-				Labels: map[string]string{
-					"mcp.kuadrant.io/secret": "true",
-					"e2e":                    "test",
-				},
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				"ca.crt": caCertPEM,
-			},
-		}
-		_ = k8sClient.Delete(ctx, labeledCA)
-		Expect(k8sClient.Create(ctx, labeledCA)).To(Succeed())
-		testResources = append(testResources, labeledCA)
-
-		By("Creating MCPServerRegistration with caCertSecretRef targeting the TLS server")
-		registration := NewTestResources("custom-tls", k8sClient).
-			ForInternalService(tlsServerName, tlsServerPort).
-			WithHostname(tlsServerHostname).
-			WithPrefix("tls_e2e_").
+	It("[HTTPS] [Happy] broker connects to TLS upstream and tools/call works via hairpin SNI", func() {
+		By("Registering a plain HTTP backend via the HTTPS listener")
+		registration := NewTestResources("tls-hairpin", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
+			WithHostname("hairpin-test.mcp-gateway.local").
+			WithPrefix("tls_hp_").
 			WithSectionName(tlsListenerName).
-			WithCACertSecretRef(caLabeledSecret, "ca.crt").
 			Build()
 		testResources = append(testResources, registration.GetObjects()...)
 		registeredServer := registration.Register(ctx)
@@ -133,14 +107,31 @@ var _ = Describe("Custom TLS Configuration", Ordered, func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(Succeed())
 		}, TestTimeoutConfigSync, TestRetryInterval).Should(Succeed())
 
-		By("Verifying tools with tls_e2e_ prefix are present")
+		By("Verifying tools with tls_hp_ prefix are present via tools/list")
 		Eventually(func(g Gomega) {
 			toolsList, err := mcpGatewayClient.ListTools(ctx, mcpgo.ListToolsRequest{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(toolsList).NotTo(BeNil())
-			g.Expect(verifyMCPServerRegistrationToolsPresent("tls_e2e_", toolsList)).To(BeTrue(),
-				"tools with prefix tls_e2e_ should exist")
+			g.Expect(verifyMCPServerRegistrationToolsPresent("tls_hp_", toolsList)).To(BeTrue(),
+				"tools with prefix tls_hp_ should exist")
 		}, TestTimeoutConfigSync, TestRetryInterval).Should(Succeed())
+
+		By("Invoking tools/call — hairpin uses server hostname as SNI for correct filter chain selection")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, mcpgo.CallToolRequest{
+				Params: mcpgo.CallToolParams{
+					Name:      "tls_hp_greet",
+					Arguments: map[string]string{"name": "hairpin-sni-test"},
+				},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res).NotTo(BeNil())
+			g.Expect(res.IsError).To(BeFalse(), "tools/call should succeed via hairpin with server hostname SNI")
+			g.Expect(len(res.Content)).To(BeNumerically(">=", 1))
+			content, ok := res.Content[0].(mcpgo.TextContent)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(content.Text).To(ContainSubstring("hairpin-sni-test"))
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 	})
 
 	It("[HTTPS] [Negative] broker rejects TLS upstream with wrong CA certificate", func() {
@@ -202,6 +193,122 @@ var _ = Describe("Custom TLS Configuration", Ordered, func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(verifyMCPServerRegistrationToolsPresent("tls_wrong_", toolsList)).To(BeFalse(),
 				"tools with prefix tls_wrong_ should NOT exist")
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[HTTPS] [Happy] tools/call to internal TLS backend fails without DestinationRule, succeeds with it", func() {
+		By("Extracting CA cert from cert-manager secret")
+		caSecret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name: caKeypairSecret, Namespace: certManagerNS,
+		}, caSecret)).To(Succeed())
+		caCertPEM := caSecret.Data["ca.crt"]
+		Expect(caCertPEM).NotTo(BeEmpty())
+
+		By("Creating labeled CA secret in test namespace")
+		labeledCA := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      UniqueName("tls-dr-ca"),
+				Namespace: TestServerNameSpace,
+				Labels: map[string]string{
+					"mcp.kuadrant.io/secret": "true",
+					"e2e":                    "test",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{"ca.crt": caCertPEM},
+		}
+		_ = k8sClient.Delete(ctx, labeledCA)
+		Expect(k8sClient.Create(ctx, labeledCA)).To(Succeed())
+		testResources = append(testResources, labeledCA)
+
+		By("Creating MCPServerRegistration targeting the TLS server (no DestinationRule yet)")
+		registration := NewTestResources("tls-dr", k8sClient).
+			ForInternalService(tlsServerName, tlsServerPort).
+			WithHostname(tlsServerHostname).
+			WithPrefix("tls_dr_").
+			WithSectionName(tlsListenerName).
+			WithCACertSecretRef(labeledCA.Name, "ca.crt").
+			Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready (broker connects directly)")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(Succeed())
+		}, TestTimeoutConfigSync, TestRetryInterval).Should(Succeed())
+
+		By("Verifying tools/list succeeds (broker discovers tools directly)")
+		Eventually(func(g Gomega) {
+			toolsList, err := mcpGatewayClient.ListTools(ctx, mcpgo.ListToolsRequest{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(verifyMCPServerRegistrationToolsPresent("tls_dr_", toolsList)).To(BeTrue())
+		}, TestTimeoutConfigSync, TestRetryInterval).Should(Succeed())
+
+		By("Attempting tools/call without DestinationRule — Envoy sends plain HTTP to TLS backend")
+		toolName := "tls_dr_echo_tls"
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, mcpgo.CallToolRequest{
+				Params: mcpgo.CallToolParams{
+					Name:      toolName,
+					Arguments: map[string]string{"message": "should-fail"},
+				},
+			})
+			// the hairpin initialize also routes through Envoy, so the plain-HTTP-to-TLS
+			// mismatch can surface as either a transport error (500 from failed init) or
+			// an MCP-level error (isError=true). Both prove the backend rejected it.
+			failed := err != nil || (res != nil && res.IsError)
+			g.Expect(failed).To(BeTrue(),
+				"tools/call should fail: Envoy forwards plain HTTP to a TLS-only backend")
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		By("Creating DestinationRule with TLS origination for the TLS server")
+		tlsServerFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", tlsServerName, TestServerNameSpace)
+		dr := &istionetv1beta1.DestinationRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      UniqueName("tls-origination"),
+				Namespace: TestServerNameSpace,
+				Labels:    map[string]string{"e2e": "test"},
+			},
+			Spec: istiov1beta1.DestinationRule{
+				Host: tlsServerFQDN,
+				TrafficPolicy: &istiov1beta1.TrafficPolicy{
+					Tls: &istiov1beta1.ClientTLSSettings{
+						Mode:               istiov1beta1.ClientTLSSettings_SIMPLE,
+						Sni:                tlsServerFQDN,
+						InsecureSkipVerify: &wrappers.BoolValue{Value: true},
+					},
+				},
+			},
+		}
+		_ = k8sClient.Delete(ctx, dr)
+		Expect(k8sClient.Create(ctx, dr)).To(Succeed())
+		testResources = append(testResources, dr)
+
+		By("Reconnecting MCP client for fresh session after DestinationRule creation")
+		_ = mcpGatewayClient.Close()
+		Eventually(func(g Gomega) {
+			var err error
+			mcpGatewayClient, err = NewMCPGatewayClientWithNotifications(ctx, gatewayURL, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		By("Calling tools/call — Envoy re-encrypts via DestinationRule TLS origination")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, mcpgo.CallToolRequest{
+				Params: mcpgo.CallToolParams{
+					Name:      toolName,
+					Arguments: map[string]string{"message": "tls-origination-test"},
+				},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res).NotTo(BeNil())
+			g.Expect(res.IsError).To(BeFalse(),
+				"tools/call should succeed with DestinationRule TLS origination")
+			g.Expect(len(res.Content)).To(BeNumerically(">=", 1))
+			content, ok := res.Content[0].(mcpgo.TextContent)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(content.Text).To(ContainSubstring("tls-origination-test"))
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 	})
 })

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -298,6 +298,11 @@
 - When an MCPServerRegistration has a `caCertSecretRef` pointing to a CA certificate that did NOT sign the upstream server's certificate, the broker should fail the TLS handshake and the MCPServerRegistration should be in a not-ready state. No tools with the server's prefix should appear in the tools list.
 - **Runs on PR CI** — same dependencies as the happy path test above.
 
+### [HTTPS] [Happy] broker connects to TLS upstream and tools/call works via hairpin SNI
+
+- When a plain HTTP backend is registered on an HTTPS listener with a server-specific hostname, `tools/list` should discover tools and `tools/call` should succeed. The hairpin initialize request must use the server's hostname as TLS SNI so the gateway selects the correct filter chain and route table for that server.
+- **Runs on PR CI.** Skips if cert-manager or the TLS test server are absent.
+
 ### [HTTPS] [HTTPS_EXTERNAL] External GitHub MCP server discovers tools over public TLS
 
 - Registers the GitHub MCP server (`api.githubcopilot.com`) as an external hostname backend with a PAT credential. Verifies the broker connects over HTTPS, discovers at least one tool, and the config contains an `https://` URL.
@@ -308,6 +313,11 @@
 - Registers an internal MCP server and verifies tools/list works end-to-end when the gateway is fronted by a real publicly-trusted TLS certificate. Connects via the HTTPS gateway URL and confirms tools with the expected prefix are discoverable.
 - **Cannot run on Kind.** Requires a cluster with a TLS-terminating load balancer and a publicly trusted wildcard certificate (e.g. OpenShift with Let's Encrypt). Previously manually verified on OpenShift 4.20 (see #450).
 - **Skips unless** `E2E_HTTPS_REAL_CERTS=true` and `E2E_SCHEME=https`.
+
+### [HTTPS] [Happy] tools/call to internal TLS backend fails without DestinationRule, succeeds with it
+
+- When an MCPServerRegistration with `caCertSecretRef` targets an internal TLS backend, `tools/list` should succeed because the broker connects directly. However, `tools/call` should fail because the gateway forwards plain HTTP to the TLS backend after terminating the client's TLS. After creating a DestinationRule with TLS origination for the same service, `tools/call` should succeed because the gateway re-encrypts traffic to the backend.
+- **Runs on PR CI.** Skips if cert-manager or the TLS test server are absent.
 
 Both external tests are tagged `[HTTPS_EXTERNAL]` and skip on PR CI. Run them manually for sanity checks (e.g. before releases):
 
@@ -329,7 +339,8 @@ make test-e2e-https
 
 | Test | PR CI | Manual / release sanity |
 |------|-------|-------------------------|
-| Private CA (happy + negative) | Yes | Yes |
+| Private CA + hairpin SNI (happy + negative) | Yes | Yes |
+| DestinationRule TLS origination | Yes | Yes |
 | GitHub external | Skipped | Yes (needs `GITHUB_MCP_PAT`) |
 | Real public certs | Skipped | Yes (needs real TLS cluster) |
 


### PR DESCRIPTION
- Replace single *http.Client hairpin with HairpinClientPool that caches per-SNI clients
- Initialize uses the server HTTPRoute hostname as TLS ServerName so Envoy selects the correct filter chain
- Add e2e tests for HTTPS hairpin use cases and DestinationRule TLS origination
- Document supported TLS configurations in the install guide

Fixes #

#1155 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection handling for backend servers with multiple hostnames.
  * Fixed support for internal HTTPS backends by enabling TLS origination workaround via Istio DestinationRule.

* **Documentation**
  * Enhanced "Supported TLS Configurations" section with clearer guidance on TLS termination behavior and workarounds for internal HTTPS backends.

* **Tests**
  * Expanded e2e test coverage for TLS scenarios, including hostname-based routing and DestinationRule-driven TLS origination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->