### PR TITLE
Add s390x platform support in workflows

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -129,7 +129,7 @@ jobs:
         with:
           context: .
           file: ./${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: ${{ github.event_name != 'pull_request' }}
           provenance: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -197,7 +197,7 @@ jobs:
         with:
           context: .
           file: ./bundle.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: |
@@ -251,7 +251,7 @@ jobs:
         with:
           context: ./catalog
           file: ./catalog/mcp-gateway-catalog.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: |


### PR DESCRIPTION
## Summary
Adds s390x (IBM Z) architecture support to CI workflow.

## Changes
- Added `linux/s390x` to platform lists in `.github/workflows/images.yaml` (3 lines)

## Testing
- ✅ Built all 4 images for s390x using GitHub Actions
- ✅ Deployed to OpenShift on IBM Z hardware
- ✅ Verified MCP protocol functionality
- ✅ Confirmed architecture: `uname -m` returns s390x

## Impact
- Minimal change (3 lines)
- No code modifications required
- Base images already support s390x
- Enables deployment on IBM Z and LinuxONE systems

Tested on IBM Z mainframe with OpenShift 4.x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended Docker image builds to support IBM System z architecture (linux/s390x) in addition to existing AMD64 and ARM64 platforms. Updates applied across main, bundle, and catalog image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->