### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"prefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1alpha1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:latest
-    createdAt: "2026-05-27T17:36:10Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.7.1
+    createdAt: "2026-06-18T12:24:19Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.0.0
+  name: mcp-gateway.v0.7.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -181,8 +181,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:latest
-                    image: ghcr.io/kuadrant/mcp-controller:latest
+                        value: ghcr.io/kuadrant/mcp-gateway:v0.7.1
+                    image: ghcr.io/kuadrant/mcp-controller:v0.7.1
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -242,6 +242,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:latest
+    - image: ghcr.io/kuadrant/mcp-gateway:v0.7.1
       name: router-broker
-  version: 0.0.0
+  version: 0.7.1

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.7.1}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:main
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.7.1
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:latest
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.7.1
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.0.0
+  name: mcp-gateway.v0.7.1
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.0.0
+  version: 0.7.1

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:latest
+          image: ghcr.io/kuadrant/mcp-controller:v0.7.1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:latest
+              value: ghcr.io/kuadrant/mcp-gateway:v0.7.1
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:latest
+          image: ghcr.io/kuadrant/mcp-gateway:v0.7.1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:latest
+          image: ghcr.io/kuadrant/mcp-controller:v0.7.1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-local}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.7.1}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.7.1
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.7.1
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -15,7 +15,7 @@ make olm-install
 Deploy from a release tag using kustomize with a remote ref:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc2
+export MCP_GATEWAY_VERSION=0.7.1
 kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.7.1
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.7.1}
 GIT_REF="v${VERSION}"
 REPO="https://github.com/${GITHUB_ORG}/mcp-gateway"
 RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/mcp-gateway/${GIT_REF}"


### PR DESCRIPTION
Post-release version bump for 0.7.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.7.1 with updated container image tags across deployment configurations.
  * Updated default version references to 0.7.1 in installation scripts and manifest deployments.

* **Documentation**
  * Updated installation guides and quick-start documentation to reference version 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->