### PR TITLE
Post-release: bump version to 0.7.1, update release branch naming

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -15,7 +15,7 @@ Parse the version to determine:
 - **Final release**: no suffix (e.g., `0.6.0`)
 - **Patch release**: patch > 0 and no suffix (e.g., `0.6.1`)
 
-Extract the major.minor.patch for the release branch name (`release-X.Y.Z`).
+Extract the major.minor for the release branch name (`release-X.Y`).
 
 ## Remote layout
 
@@ -61,21 +61,21 @@ git fetch upstream
 
 Check if the release branch exists on upstream:
 ```bash
-git ls-remote --heads upstream release-X.Y.Z
+git ls-remote --heads upstream release-X.Y
 ```
 
 **If it exists**, check it out and create the working branch:
 ```bash
-git checkout release-X.Y.Z
-git pull upstream release-X.Y.Z
+git checkout release-X.Y
+git pull upstream release-X.Y
 git checkout -b release-{VERSION}
 ```
 
 **If it does not exist** (new minor release), tell the user:
 
-> The release branch `release-X.Y.Z` doesn't exist on upstream yet. Create it via the GitHub UI:
+> The release branch `release-X.Y` doesn't exist on upstream yet. Create it via the GitHub UI:
 > 1. Go to https://github.com/Kuadrant/mcp-gateway
-> 2. Click the branch dropdown, type `release-X.Y.Z`, and select **Create branch: release-X.Y.Z from main**
+> 2. Click the branch dropdown, type `release-X.Y`, and select **Create branch: release-X.Y from main**
 >
 > Let me know when that's done and I'll continue.
 
@@ -117,9 +117,9 @@ STOP here. Do not push. Do not create a PR. Tell the user:
 > git push -u origin release-{VERSION}
 > ```
 >
-> Then create a PR targeting the `release-X.Y.Z` branch on Kuadrant/mcp-gateway:
+> Then create a PR targeting the `release-X.Y` branch on Kuadrant/mcp-gateway:
 > ```
-> gh pr create --repo Kuadrant/mcp-gateway --base release-X.Y.Z \
+> gh pr create --repo Kuadrant/mcp-gateway --base release-X.Y \
 >   --title "Update version to {VERSION}" \
 >   --body "Version bump for {VERSION} release."
 > ```
@@ -131,7 +131,7 @@ Wait for the user to confirm the PR is merged before proceeding to the next step
 Tell the user to create the release:
 1. Go to https://github.com/Kuadrant/mcp-gateway/releases
 2. Click **Draft a new release**
-3. Click **Choose a tag**, create tag `v{VERSION}`, target the `release-X.Y.Z` branch
+3. Click **Choose a tag**, create tag `v{VERSION}`, target the `release-X.Y` branch
 4. Set title to `v{VERSION}`
 5. Click **Generate release notes**
 6. For RCs: check **Set as a pre-release**
@@ -161,6 +161,7 @@ helm show chart oci://ghcr.io/kuadrant/charts/mcp-gateway --version ${VERSION} >
 Skip this step for RC releases.
 
 For final releases, main needs a version bump so docs and scripts reference the latest release.
+Docs on main are published to docs.kuadrant.io, so version references must point to the latest released version.
 
 ```bash
 git checkout main && git pull upstream main

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: ghcr.io/kuadrant/mcp-controller:latest
-    createdAt: "2026-05-27T17:36:10Z"
+    createdAt: "2026-06-25T14:19:00Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.7.1}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:main
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.7.1
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:latest
+          image: ghcr.io/kuadrant/mcp-gateway:v0.7.1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:latest
+          image: ghcr.io/kuadrant/mcp-controller:v0.7.1
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-local}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.7.1}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.7.1
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.7.1
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -15,7 +15,7 @@ make olm-install
 Deploy from a release tag using kustomize with a remote ref:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.6.0-rc2
+export MCP_GATEWAY_VERSION=0.7.1
 kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.5.1
+export MCP_GATEWAY_VERSION=0.7.1
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.5.1}
+VERSION=${MCP_GATEWAY_VERSION:-0.7.1}
 GIT_REF="v${VERSION}"
 REPO="https://github.com/${GITHUB_ORG}/mcp-gateway"
 RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/mcp-gateway/${GIT_REF}"


### PR DESCRIPTION
## Summary
- Bump all version references to 0.7.1 (post-release version bump for docs.kuadrant.io)
- Update release process to use `release-X.Y` branch naming instead of `release-X.Y.Z` (patch releases share the same branch)
- Add note explaining why the post-release bump exists (docs publishing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation, quick-start, OpenShift, and OLM guidance to use MCP Gateway version `0.7.1`.
  * Clarified release branch naming to use `release-X.Y` and added a note about where final release docs are published.

* **Chores**
  * Updated default version references in helper scripts and deployment manifests to `v0.7.1`.
  * Refreshed release-related manifest metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->