### PR TITLE
feat: local-env-setup should use HTTPS by default with a self-signed cert

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -27,7 +27,8 @@ concurrency:
 
 env:
   CONFORMANCE_VERSION: "0.1.15"
-  MCP_URL: "http://mcp.127-0-0-1.sslip.io:8001/mcp"
+  MCP_URL: "https://mcp.127-0-0-1.sslip.io:8001/mcp"
+  NODE_TLS_REJECT_UNAUTHORIZED: "0"
 
 jobs:
   conformance-tests:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -89,6 +89,7 @@ jobs:
         run: |
           make ci-setup
           kubectl apply -k config/mcp-gateway/base/ -n mcp-system
+          make patch-broker-local-ca
 
       - name: Deploy conformance server
         run: make deploy-conformance-server

--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,17 @@ deploy-test-servers: kind-load-test-servers ## Deploy test MCP servers for local
 	  echo "Gateway IP: $$GATEWAY_IP"; \
 	  kubectl patch deployment mcp-oidc-server -n mcp-test --type='json' -p="$$(cat config/keycloak/patch-hostaliases.json | envsubst)"
 
+# Patch broker deployment to trust local self-signed CA
+.PHONY: patch-broker-local-ca
+patch-broker-local-ca: ## Patch broker deployment to trust local self-signed CA
+	@echo "Patching broker-router deployment to trust local self-signed CA..."
+	@kubectl wait --for=condition=Available deployment/mcp-gateway -n mcp-system --timeout=120s
+	@kubectl get secret private-ca-keypair -n cert-manager -o jsonpath='{.data.ca\.crt}' | base64 -d > out/certs/ca.crt || true
+	@kubectl create secret generic gateway-ca-bundle -n mcp-system --from-file=ca.crt=out/certs/ca.crt --dry-run=client -o yaml | kubectl apply -f -
+	@kubectl patch deployment mcp-gateway -n mcp-system --type='json' -p='[{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"gateway-ca","secret":{"secretName":"gateway-ca-bundle"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"gateway-ca","mountPath":"/certs/gateway-ca.crt","subPath":"ca.crt","readOnly":true}},{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--gateway-ca-cert=/certs/gateway-ca.crt"}]'
+	@kubectl rollout status deployment mcp-gateway -n mcp-system --timeout=60s
+	@echo "Broker-router patched with local CA"
+
 # Deploy conformance server
 .PHONY: deploy-conformance-server
 deploy-conformance-server: kind-load-conformance-server ## Deploy conformance MCP server
@@ -731,6 +742,7 @@ local-env-setup: setup-cluster-base ## Setup complete local demo environment wit
 	$(KUBECTL) apply -f config/istio/gateway/local-gateway-tls.yaml
 	@$(KUBECTL) wait --for=condition=Ready certificate/mcp-gateway-local-cert -n gateway-system --timeout=60s
 	"$(MAKE)" deploy
+	"$(MAKE)" patch-broker-local-ca
 	"${MAKE}" add-jwt-key
 	# Deploy everything server for local dev (use 'make deploy-test-servers' for all servers)
 	"$(MAKE)" deploy-everything-server

--- a/Makefile
+++ b/Makefile
@@ -806,11 +806,11 @@ info: ## Show quick setup info and useful commands
 
 .PHONY: urls
 urls: ## Show all available service URLs
-	@"$(MAKE)" -s -f build/inspect.mk urls-impl
+	@"$(MAKE)" -s -f build/inspect.mk urls-impl GATEWAY_SCHEME=$(GATEWAY_SCHEME)
 
 .PHONY: status
 status: ## Show status of all MCP components
-	@"$(MAKE)" -s -f build/inspect.mk status-impl
+	@"$(MAKE)" -s -f build/inspect.mk status-impl GATEWAY_SCHEME=$(GATEWAY_SCHEME)
 
 
 ##@ Tools

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ MCP_GATEWAY_SUBDOMAIN ?= mcp
 MCP_GATEWAY_HOST ?= $(MCP_GATEWAY_SUBDOMAIN).127-0-0-1.sslip.io
 MCP_GATEWAY_NAME ?= mcp-gateway
 
+# default scheme for the local gateway URL (override to http for plain HTTP)
+GATEWAY_SCHEME ?= https
+
 # E2E configuration variables
 E2E_DOMAIN ?= 127-0-0-1.sslip.io
 GATEWAY_CLASS_NAME ?= istio
@@ -723,7 +726,10 @@ local-env-setup: setup-cluster-base ## Setup complete local demo environment wit
 	@echo "========================================="
 	@echo "Setting up Local Demo Environment"
 	@echo "========================================="
+	"$(MAKE)" cert-manager-install
 	"$(MAKE)" deploy-gateway
+	$(KUBECTL) apply -f config/istio/gateway/local-gateway-tls.yaml
+	@$(KUBECTL) wait --for=condition=Ready certificate/mcp-gateway-local-cert -n gateway-system --timeout=60s
 	"$(MAKE)" deploy
 	"${MAKE}" add-jwt-key
 	# Deploy everything server for local dev (use 'make deploy-test-servers' for all servers)
@@ -757,7 +763,7 @@ local-env-setup-complete-message:
 	@echo "Local environment setup complete"
 	@echo ""
 	@echo "MCP Gateway is available at:"
-	@echo "  http://$(MCP_GATEWAY_HOST):$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"
+	@echo "  $(GATEWAY_SCHEME)://$(MCP_GATEWAY_HOST):$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"
 	@echo ""
 	@echo "Run 'make urls' to see all service URLs."
 	@echo "Run 'make info' for more setup info."

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -41,6 +41,8 @@ ci-setup: tools kind-create-cluster ci-gateway-images gateway-api-install ci-ins
 	# gateway HTTPS cert (mcp-gateway-tls-cert) and the TLS test server cert.
 	# Must run before deploy-gateway so the mcp-tls listener has its cert ready.
 	"$(MAKE)" deploy-tls-test-server
+	$(KUBECTL) apply -f config/istio/gateway/local-gateway-tls.yaml
+	@$(KUBECTL) wait --for=condition=Ready certificate/mcp-gateway-local-cert -n gateway-system --timeout=60s
 	# Deploy standard mcp-gateway (includes mcp-tls HTTPS listener)
 	"$(MAKE)" deploy-gateway
 	# Deploy e2e gateways (gateway-1, gateway-2)

--- a/build/dev.mk
+++ b/build/dev.mk
@@ -44,10 +44,10 @@ dev-logs-gateway: # Watch logs from the Istio gateway
 .PHONY: dev-test
 dev-test: # Test MCP request through the gateway
 	@echo "Testing MCP request through gateway..."
-	curl -X POST \
+	curl -k -X POST \
 		-H "Content-Type: application/json" \
 		-d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}' \
-		http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp
+		$(GATEWAY_SCHEME)://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp
 
 # Clean up port forwards
 .PHONY: dev-stop-forward

--- a/build/info.mk
+++ b/build/info.mk
@@ -10,7 +10,7 @@ info-impl:
 	@echo "      Requires: Go 1.20+ for some tool installations."
 	@echo ""
 	@echo "Service URLs:"
-	@echo "  Gateway:     http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
+	@echo "  Gateway:     $(GATEWAY_SCHEME)://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
 	@echo "  Keycloak:    https://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"
 	@echo ""
 	@echo "Quick Start Commands:"

--- a/build/inspect.mk
+++ b/build/inspect.mk
@@ -28,7 +28,7 @@ endef
 # URLs for services
 urls-impl:
 	@echo "=== MCP Gateway URLs ==="
-	@echo "Gateway: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
+	@echo "Gateway: $(GATEWAY_SCHEME)://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)"
 	@echo "Keycloak: https://keycloak.127-0-0-1.sslip.io:$(KIND_HOST_PORT_KEYCLOAK)"
 
 ##@ Inspection
@@ -61,11 +61,11 @@ inspect-everything-server: ## Open MCP Inspector for test everything server
 .PHONY: inspect-gateway
 inspect-gateway: ## Open MCP Inspector for the gateway
 	@echo "Opening MCP Inspector for gateway"; \
-	echo "URL: http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
+	echo "URL: $(GATEWAY_SCHEME)://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
 	echo ""; \
 	MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@0.21.1 & \
 	sleep 2; \
-	$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
+	$(open) "http://localhost:6274/?transport=streamable-http&serverUrl=$(GATEWAY_SCHEME)://mcp.127-0-0-1.sslip.io:$(KIND_HOST_PORT_MCP_GATEWAY)/mcp"; \
 	echo "Press Ctrl+C to stop and cleanup"; \
 	wait
 

--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -12,8 +12,13 @@ spec:
   listeners:
     - name: mcp # gateway listener
       hostname: 'mcp.127-0-0-1.sslip.io' #public accessibly MCP host one used by client
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All

--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -23,57 +23,97 @@ spec:
         namespaces:
           from: All
     - name: mcps
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       hostname: '*.mcp.local' # this hostname can be any wildcard. It is here to simplify routing, ensure the MCP Server routes attach to this listener only, can be protected by the AuthPolicy and routed to via envoy and the MCPRouter.
       allowedRoutes:
         namespaces:
           from: All #any namespace can register an MCP server route
     - name: mcp-server1-route-ext
       hostname: 'server1.127-0-0-1.sslip.io'
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All
     - name: mcp-server2-route-ext
       hostname: 'server2.127-0-0-1.sslip.io'
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All
     - name: mcp-server3-route-ext
       hostname: 'server3.127-0-0-1.sslip.io'
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All
     - name: mcp-api-key-server-route-ext
       hostname: 'api-key-server.127-0-0-1.sslip.io'
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All
     - name: mcp-oidc-server-route-ext
       hostname: 'oidc-server.127-0-0-1.sslip.io'
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All
     - name: mcp-everything-server-route-ext
       hostname: 'everything-server.127-0-0-1.sslip.io'
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       allowedRoutes:
         namespaces:
           from: All
     - name: mcps-https
-      port: 8080
-      protocol: HTTP
+      port: 8443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: mcp-gateway-local-cert
       hostname: '*.mcp-tls.local'
       allowedRoutes:
         namespaces:

--- a/config/istio/gateway/local-gateway-tls.yaml
+++ b/config/istio/gateway/local-gateway-tls.yaml
@@ -1,0 +1,54 @@
+# cert-manager resources for local gateway HTTPS.
+# reuses the same private CA chain as config/test-servers/tls-server-cert-manager.yaml.
+# applied by: make local-env-setup (after cert-manager-install)
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrap
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: private-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: "MCP Gateway Test CA"
+  secretName: private-ca-keypair
+  duration: 8760h
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: ClusterIssuer
+    group: cert-manager.io
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: private-ca-issuer
+spec:
+  ca:
+    secretName: private-ca-keypair
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mcp-gateway-local-cert
+  namespace: gateway-system
+spec:
+  secretName: mcp-gateway-local-cert
+  duration: 8760h
+  dnsNames:
+    - "mcp.127-0-0-1.sslip.io"
+  issuerRef:
+    name: private-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  privateKey:
+    algorithm: ECDSA
+    size: 256

--- a/config/istio/gateway/local-gateway-tls.yaml
+++ b/config/istio/gateway/local-gateway-tls.yaml
@@ -45,6 +45,9 @@ spec:
   duration: 8760h
   dnsNames:
     - "mcp.127-0-0-1.sslip.io"
+    - "*.127-0-0-1.sslip.io"
+    - "*.mcp.local"
+    - "*.mcp-tls.local"
   issuerRef:
     name: private-ca-issuer
     kind: ClusterIssuer

--- a/config/istio/gateway/nodeport.yaml
+++ b/config/istio/gateway/nodeport.yaml
@@ -21,15 +21,9 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: 8443
-  - appProtocol: https
-    name: mcps
-    nodePort: 30082
-    port: 8443
-    protocol: TCP
-    targetPort: 8443
   - appProtocol: http
     name: keycloak
-    nodePort: 30081
+    nodePort: 30089
     port: 8002
     protocol: TCP
     targetPort: 8002

--- a/config/istio/gateway/nodeport.yaml
+++ b/config/istio/gateway/nodeport.yaml
@@ -15,12 +15,12 @@ spec:
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Cluster
   ports:
-  - appProtocol: http
+  - appProtocol: https
     name: mcp
     nodePort: 30080
-    port: 8080
+    port: 8443
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8443
   - appProtocol: https
     name: mcps
     nodePort: 30082

--- a/config/samples/mcpserverregistration-conformance-server.yaml
+++ b/config/samples/mcpserverregistration-conformance-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     mcp.kuadrant.io/managed: 'true'
 spec:
+  path: /mcp
   # prefix: conformance_ # conformance test suite expects no prefix
   targetRef:
     # MCP Conformance Server - TypeScript SDK based conformance test server

--- a/config/test-servers/conformance-server/conformance-server-httproute.yaml
+++ b/config/test-servers/conformance-server/conformance-server-httproute.yaml
@@ -10,6 +10,7 @@ spec:
       namespace: gateway-system
   hostnames:
     - 'conformance-server.mcp.local'
+    - 'mcp.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:

--- a/internal/mcp-router/request_handlers.go
+++ b/internal/mcp-router/request_handlers.go
@@ -563,7 +563,6 @@ func (s *ExtProcServer) routeToUpstream(ctx context.Context, span trace.Span, mc
 		return calculatedResponse.Build()
 	}
 	headers.WithPath(path)
-	headers.WithContentLength(len(body))
 	if mcpReq.Streaming {
 		s.Logger.DebugContext(ctx, "returning streaming response")
 		calculatedResponse.WithStreamingResponse(headers.Build(), body, internalOnlyHeaders...)

--- a/internal/mcp-router/request_handlers_test.go
+++ b/internal/mcp-router/request_handlers_test.go
@@ -233,7 +233,7 @@ func TestHandleRequestBody(t *testing.T) {
 	require.IsType(t, &eppb.ProcessingResponse_RequestBody{}, resp[0].Response)
 	rb := resp[0].Response.(*eppb.ProcessingResponse_RequestBody)
 	require.NotNil(t, rb.RequestBody.Response)
-	require.Len(t, rb.RequestBody.Response.HeaderMutation.SetHeaders, 7)
+	require.Len(t, rb.RequestBody.Response.HeaderMutation.SetHeaders, 6)
 	require.Equal(t, "x-mcp-method", rb.RequestBody.Response.HeaderMutation.SetHeaders[0].Header.Key)
 	require.Equal(t, []uint8("tools/call"), rb.RequestBody.Response.HeaderMutation.SetHeaders[0].Header.RawValue)
 	require.Equal(t, "x-mcp-toolname", rb.RequestBody.Response.HeaderMutation.SetHeaders[1].Header.Key)
@@ -246,7 +246,6 @@ func TestHandleRequestBody(t *testing.T) {
 	require.Equal(t, []uint8("localhost"), rb.RequestBody.Response.HeaderMutation.SetHeaders[4].Header.RawValue)
 	require.Equal(t, ":path", rb.RequestBody.Response.HeaderMutation.SetHeaders[5].Header.Key)
 	require.Equal(t, []uint8("/mcp"), rb.RequestBody.Response.HeaderMutation.SetHeaders[5].Header.RawValue)
-	require.Equal(t, "content-length", rb.RequestBody.Response.HeaderMutation.SetHeaders[6].Header.Key)
 
 	// internal-only headers must be stripped before forwarding to upstream
 	require.Contains(t, rb.RequestBody.Response.HeaderMutation.RemoveHeaders, "x-mcp-authorized")

--- a/tests/e2e/builders.go
+++ b/tests/e2e/builders.go
@@ -659,7 +659,7 @@ func NewMCPGatewayExtensionSetup(k8sClient client.Client) *MCPGatewayExtensionSe
 		k8sClient:        k8sClient,
 		gatewayName:      GatewayName,
 		gatewayNamespace: GatewayNamespace,
-		listenerPort:     8080,
+		listenerPort:     8443,
 	}
 }
 
@@ -1002,7 +1002,7 @@ func NewMCPGatewayExtensionBuilder(name, namespace string) *MCPGatewayExtensionB
 	return &MCPGatewayExtensionBuilder{
 		name:         name,
 		namespace:    namespace,
-		listenerPort: 8080,
+		listenerPort: 8443,
 	}
 }
 

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -80,7 +80,7 @@ var (
 
 // gateway URLs - on Kind use localhost port mappings, on real clusters derive from public hosts
 var (
-	gatewayURL      = goenv.GetDefault("GATEWAY_URL", gatewayURLDefault(gatewayPublicHost, "https://mcp.mcp-gateway.local:8009/mcp"))
+	gatewayURL      = goenv.GetDefault("GATEWAY_URL", gatewayURLDefault(gatewayPublicHost, "https://mcp.mcp-gateway.local:8001/mcp"))
 	E2E1GatewayURL  = goenv.GetDefault("E2E1_GATEWAY_URL", gatewayURLDefault(E2E1PublicHost, "http://localhost:8004/mcp"))
 	TeamAGatewayURL = goenv.GetDefault("TEAM_A_GATEWAY_URL", gatewayURLDefault(TeamAPublicHost, "http://localhost:8005/mcp"))
 	TeamBGatewayURL = goenv.GetDefault("TEAM_B_GATEWAY_URL", gatewayURLDefault(TeamBPublicHost, "http://localhost:8006/mcp"))


### PR DESCRIPTION

The e2e test infrastructure already uses HTTPS with a private CA certificate, but `make local-setup-env` still defaults to plain HTTP. This PR updates the local development environment to match the e2e setup and use HTTPS by default with a self-signed certificate.

Closes #1142

## Changes
- Add `config/istio/gateway/local-gateway-tls.yaml` to provision a self-signed CA and TLS certificate for the local gateway
- Modify the gateway `mcp` listener to default to `HTTPS` with TLS termination
- Update NodePort config to map port `30080` to the new `8443` HTTPS listener
- Update `local-env-setup` Makefile target to install `cert-manager` and apply the local TLS resources
- Update CI `ci-setup` target to also apply the new TLS resource so the gateway programs successfully
- Add `GATEWAY_SCHEME` variable (defaulting to `https`) to update all CLI URL output references (inspect, info, dev)

Existing users can still override to plain HTTP by running `make local-env-setup GATEWAY_SCHEME=http`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway now operates over HTTPS with automatic local TLS certificate provisioning and management.

* **Chores**
  * Updated gateway and NodePort mappings to use HTTPS (port 8443, port 30080 for MCP) instead of HTTP (port 8080).
  * Switched local/dev/inspection and printed URLs to respect the selected gateway scheme.
  * Improved CI/conformance HTTPS connectivity by updating the conformance endpoint and CI TLS handling.

* **Tests**
  * Updated e2e gateway listener port and default test URL fallbacks to match HTTPS.

* **Documentation**
  * Updated the MCP server registration sample to include the `/mcp` path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->