### PR TITLE
update docs to call out single listener pattern for https

### DIFF
--- a/docs/design/routing.md
+++ b/docs/design/routing.md
@@ -45,7 +45,11 @@ listeners:
 ```
 
 
-So here we have dedicated port 8080 to MCP requests.  It is strongly recommended to use another port for other workloads so that the router doesn't intercept these requests. In our example gateway we configure a new listener and port for keycloak for example:
+So here we have dedicated port 8080 to MCP requests. With HTTP, multiple listeners on the same port share a single Envoy route table, so the router can re-route `tools/call` requests to backend server routes on either listener.
+
+**HTTPS limitation:** With HTTPS, each listener gets its own TLS filter chain (selected by SNI) with an isolated route table. The router re-routes `tools/call` by rewriting the `:authority` header, but this can only reach routes within the same filter chain. A backend HTTPRoute on a separate HTTPS listener is unreachable. Use a single HTTPS listener with a wildcard hostname for both client and backend traffic.
+
+It is strongly recommended to use another port for other workloads so that the router doesn't intercept these requests. In our example gateway we configure a new listener and port for keycloak for example:
 
 
 ```yaml

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -11,12 +11,12 @@ This guide covers adding the required MCP listeners to your existing Gateway. Th
 
 ## Step 1: Add MCP Listeners to Gateway
 
-MCP Gateway requires two listeners on your Gateway:
+### HTTP (multiple listeners)
+
+With HTTP, you can use two listeners on the same port — one for client traffic and one for backend server routing:
 
 - **`mcp`**: the public-facing listener for MCP client traffic. The hostname must resolve to your Gateway's external address.
 - **`mcps`**: an internal listener used for routing to registered MCP servers. MCPServerRegistration HTTPRoutes attach to this listener. The hostname is a wildcard that does not need to be publicly resolvable.
-
-Patch your Gateway to add both listeners:
 
 ```bash
 kubectl patch gateway your-gateway-name -n your-gateway-namespace --type merge -p '
@@ -43,12 +43,6 @@ Replace `your-gateway-name`, `your-gateway-namespace`, and the `mcp` hostname wi
 
 > **Note:** The patch above replaces all listeners. To preserve existing listeners, use a JSON patch or edit the Gateway directly with `kubectl edit gateway your-gateway-name -n your-gateway-namespace`.
 
-> **Important:** If you installed MCP Gateway using Helm, ensure the `gateway.publicHost` value in your Helm values matches the hostname above. For example:
-> ```bash
-> helm upgrade mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
->   --set gateway.publicHost=mcp.127-0-0-1.sslip.io
-> ```
-
 Verify both listeners were added:
 
 ```bash
@@ -56,6 +50,47 @@ kubectl get gateway your-gateway-name -n your-gateway-namespace -o jsonpath='{.s
 ```
 
 You should see both `mcp` and `mcps` in the output.
+
+### HTTPS (single listener)
+
+With HTTPS, use a **single listener** for both client traffic and backend server routing. Envoy uses TLS SNI to select filter chains, and each HTTPS listener gets its own isolated filter chain with its own route table. When the router handles a `tools/call`, it re-routes the request to the backend by changing the `:authority` header — but this can only reach routes within the same filter chain. A backend HTTPRoute on a separate HTTPS listener is unreachable from the client's filter chain.
+
+```bash
+kubectl patch gateway your-gateway-name -n your-gateway-namespace --type merge -p '
+spec:
+  listeners:
+  - name: mcp-tls
+    hostname: "*.mcp-gateway.example.com"
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+        - kind: Secret
+          name: mcp-gateway-tls-cert
+    allowedRoutes:
+      namespaces:
+        from: All
+'
+```
+
+Use a wildcard hostname so both the public MCP endpoint and backend server HTTPRoutes can attach to the same listener. For example, with `*.mcp-gateway.example.com`, client traffic arrives at `mcp.mcp-gateway.example.com` and backend server routes use hostnames like `server1.mcp-gateway.example.com`.
+
+> **Note:** The patch above replaces all listeners. To preserve existing listeners, use a JSON patch or edit the Gateway directly with `kubectl edit gateway your-gateway-name -n your-gateway-namespace`.
+
+Verify the listener was added:
+
+```bash
+kubectl get gateway your-gateway-name -n your-gateway-namespace -o jsonpath='{.spec.listeners[*].name}'
+```
+
+You should see `mcp-tls` in the output.
+
+> **Important:** If you installed MCP Gateway using Helm, ensure the `gateway.publicHost` value in your Helm values matches the hostname above. For example:
+> ```bash
+> helm upgrade mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+>   --set gateway.publicHost=mcp.127-0-0-1.sslip.io
+> ```
 
 ## Step 2: HTTPRoute (Automatic)
 

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -43,6 +43,12 @@ Replace `your-gateway-name`, `your-gateway-namespace`, and the `mcp` hostname wi
 
 > **Note:** The patch above replaces all listeners. To preserve existing listeners, use a JSON patch or edit the Gateway directly with `kubectl edit gateway your-gateway-name -n your-gateway-namespace`.
 
+> **Important:** If you installed MCP Gateway using Helm, ensure the `gateway.publicHost` value in your Helm values matches the hostname above. For example:
+> ```bash
+> helm upgrade mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+>   --set gateway.publicHost=mcp.127-0-0-1.sslip.io
+> ```
+
 Verify both listeners were added:
 
 ```bash

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -123,6 +123,12 @@ The gateway uses TLS termination (`tls.mode: Terminate`) on HTTPS listeners. Env
 
 - **Any listener → internal HTTPS backend (`caCertSecretRef`)** — the broker connects directly to the backend using the CA cert, so tool discovery works. However, `tools/call` is routed through Envoy, which sends plain HTTP to the TLS backend after termination. The backend rejects the non-TLS connection. To enable `tools/call`, create an Istio DestinationRule with TLS origination for that service — the same pattern used for [external MCP servers](./external-mcp-server.md). See the [Istio documentation on destination rule TLS settings](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ClientTLSSettings) for configuring `credentialName` with a custom CA certificate.
 
+#### HTTPS listener count
+
+With HTTP, multiple listeners can share the same port — the client-facing listener and backend server listeners share a single Envoy route table, so the router can re-route `tools/call` requests to any backend on the same port.
+
+With HTTPS, each listener gets its own TLS filter chain with an isolated route table (selected by SNI). The router re-routes `tools/call` by rewriting the `:authority` header, which can only reach routes within the same filter chain. A backend HTTPRoute on a separate HTTPS listener is unreachable from the client's filter chain. Use a **single HTTPS listener** with a wildcard hostname for both client and backend traffic. See [Configure Gateway Listener and Route](./configure-mcp-gateway-listener-and-router.md) for examples.
+
 The `--mcp-gateway-public-host` flag tells the router which `Host` header to expect on incoming requests, so it avoids rewriting it during routing.
 
 The **EnvoyFilter** is configured to intercept traffic on the listener's port and route it through the ext_proc (external processor) running on port 50051.


### PR DESCRIPTION
## What does this PR do?

Clarify requirements on listeners. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MCP Gateway listener/router guidance to emphasize port usage (including the MCP Gateway on port 8080).
  * Clarified HTTP vs HTTPS routing behavior, noting HTTPS TLS filter-chain isolation and related `:authority` limitations.
  * Added/expanded guidance recommending a single HTTPS listener with a wildcard hostname to support both client and backend routing.
  * Included a new example `kubectl patch` workflow and improved formatting/structure for listener setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->