### PR TITLE
fix(broker): report served tool/prompt count on upstream status error path

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -525,6 +525,13 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
+		// report the tools/prompts actually being served, not a stale count: 0 when they were
+		// removed (connect/ping failure, rejected server), or the cached count when a transient
+		// tools/list error leaves the previously served set in place.
+		man.toolsLock.RLock()
+		man.status.TotalTools = len(man.tools)
+		man.status.TotalPrompts = len(man.prompts)
+		man.toolsLock.RUnlock()
 		return
 	}
 	man.status.TotalTools = toolCount

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -420,6 +420,44 @@ func TestMCPManager_setStatus_ProtocolVersions(t *testing.T) {
 	}
 }
 
+// TestMCPManager_setStatus_ErrorReportsServedCount checks the error path reports the count of
+// tools/prompts actually being served rather than leaving a stale count from the last healthy
+// cycle. When the server goes not-ready and its tools were removed the count must drop to 0; when
+// a transient list error leaves the cached set in place the count must stay accurate.
+func TestMCPManager_setStatus_ErrorReportsServedCount(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("clears count when tools were removed", func(t *testing.T) {
+		mock := newMockMCP("test-server", "test_")
+		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		// simulate a prior healthy cycle that reported tools, then a failure that removed them
+		manager.status.TotalTools = 5
+		manager.status.TotalPrompts = 2
+
+		manager.setStatus(fmt.Errorf("connection lost"), 0, 0, nil, nil)
+
+		assert.False(t, manager.status.Ready)
+		assert.Equal(t, 0, manager.status.TotalTools, "removed tools should drop the count to 0")
+		assert.Equal(t, 0, manager.status.TotalPrompts, "removed prompts should drop the count to 0")
+	})
+
+	t.Run("keeps count when tools are still served", func(t *testing.T) {
+		mock := newMockMCP("test-server", "test_")
+		manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+		require.NoError(t, err)
+		// a transient tools/list error leaves the previously served set in place
+		manager.tools = make([]mcp.Tool, 3)
+		manager.prompts = make([]mcp.Prompt, 2)
+
+		manager.setStatus(fmt.Errorf("list failed"), 3, 0, nil, nil)
+
+		assert.False(t, manager.status.Ready)
+		assert.Equal(t, 3, manager.status.TotalTools, "still-served tools should keep their count")
+		assert.Equal(t, 2, manager.status.TotalPrompts, "still-served prompts should keep their count")
+	})
+}
+
 func TestPrefixedName(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
Fixes #1164

When an upstream connection or ping fails, `manage()` removes the server's tools and prompts and then calls `setStatus` to mark it not ready. `setStatus` returned early on the error path without updating `TotalTools`/`TotalPrompts`, so the status kept the count from the last healthy cycle. The controller surfaces that value as `status.discoveredTools` (the `Tools` printer column), so `kubectl get mcpserverregistration` showed a server as `Ready=False` while still listing its old tool count.

This reports the count actually being served on the error path:

- `0` when the tools were removed (connect/ping failure, rejected server)
- the cached count when a transient `tools/list` error leaves the previously served set in place (default `FilterOut` policy), so a momentary list blip doesn't wrongly report 0 while tools are still served

The read is guarded by the existing `toolsLock`, which no `setStatus` caller holds, so there's no deadlock. It lines up with the success path, where `toolCount == len(man.tools)`.

Test: `TestMCPManager_setStatus_ErrorReportsServedCount` covers both cases (removed → 0, still served → keeps count). It fails on the old behaviour and passes with the fix.

Noted on the issue that the MCPServerRegistration/Status endpoint coupling is changing soon — happy for this to be superseded by that work; sending it as a small interim fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of tool and prompt counts during error states, ensuring proper status reporting when the system encounters operational issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->