### PR TITLE
Add PR focus workflow for contributor PR management

### DIFF
--- a/.github/workflows/pr-focus.yaml
+++ b/.github/workflows/pr-focus.yaml
@@ -22,7 +22,8 @@ jobs:
 
             console.log(`Checking PR #${pr.number} by ${author}`);
 
-            // check if author has write or admin access
+            // skip maintainers (write/admin). if the API call fails (e.g. fork
+            // contributor who isn't a collaborator), treat them as non-maintainer.
             try {
               const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
@@ -47,6 +48,7 @@ jobs:
               state: 'open',
               sort: 'created',
               direction: 'asc',
+              per_page: 100,
             });
 
             const otherActivePRs = openPRs.filter(p =>

--- a/.github/workflows/pr-focus.yaml
+++ b/.github/workflows/pr-focus.yaml
@@ -1,0 +1,94 @@
+name: PR Focus
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  check:
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check contributor PR focus
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            console.log(`Checking PR #${pr.number} by ${author}`);
+
+            // check if author has write or admin access
+            try {
+              const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              const permission = permissionLevel.permission;
+              console.log(`${author} has ${permission} permission`);
+              if (permission === 'admin' || permission === 'write') {
+                console.log('Author is a maintainer, skipping');
+                return;
+              }
+            } catch (error) {
+              // not a collaborator at all, continue with the check
+              console.log(`${author} is not a collaborator`);
+            }
+
+            // find other non-draft PRs by the same author
+            const { data: openPRs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'asc',
+            });
+
+            const otherActivePRs = openPRs.filter(p =>
+              p.user.login === author &&
+              !p.draft &&
+              p.number !== pr.number
+            );
+
+            if (otherActivePRs.length === 0) {
+              console.log('No other active PRs from this author');
+              return;
+            }
+
+            console.log(`Found ${otherActivePRs.length} other active PR(s) from ${author}`);
+
+            const prLinks = otherActivePRs.map(p => `- #${p.number}`).join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                `Thanks for the contribution, @${author}! You currently have other non-draft PR(s) open:`,
+                '',
+                prLinks,
+                '',
+                'To help us review and merge changes as efficiently as possible, we ask contributors to focus on one PR at a time. Activity on this project can be high, and maintainers have other priorities outside the project, so having a single active PR helps everyone get changes landed faster.',
+                '',
+                'This PR has been moved to draft. Once your other PR(s) are merged or closed, mark this one as ready for review and we will take a look.',
+                '',
+                '> [!NOTE]',
+                '> This is an experimental process and may change or need manual intervention while we trial it.',
+              ].join('\n'),
+            });
+
+            // convert to draft using GraphQL (REST API does not support this)
+            await github.graphql(`
+              mutation($id: ID!) {
+                convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                  pullRequest { id }
+                }
+              }
+            `, { id: pr.node_id });
+
+            console.log(`PR #${pr.number} converted to draft`);

--- a/.github/workflows/pr-focus.yaml
+++ b/.github/workflows/pr-focus.yaml
@@ -1,8 +1,8 @@
-name: PR Focus
+name: "PR Focus: One Active PR Per Contributor"
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   check:
@@ -63,6 +63,22 @@ jobs:
             }
 
             console.log(`Found ${otherActivePRs.length} other active PR(s) from ${author}`);
+
+            // skip if we already left this comment on this PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 50,
+            });
+            const alreadyCommented = comments.some(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('focus on one PR at a time')
+            );
+            if (alreadyCommented) {
+              console.log('Already commented on this PR, skipping');
+              return;
+            }
 
             const prLinks = otherActivePRs.map(p => `- #${p.number}`).join('\n');
 


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that asks external contributors to focus on one non-draft PR at a time
- When a non-maintainer opens a PR (or moves one from draft to ready), the workflow checks if they have other non-draft PRs open
- If they do, it leaves a comment explaining the rationale and converts the new PR to draft
- Maintainers (write/admin access) and bots are excluded

> [!NOTE]
> This is experimental and may change or need manual intervention while we trial it.

## Test plan

- [ ] Verify workflow triggers on `opened` and `ready_for_review` events
- [ ] Verify maintainers (write/admin) are not affected
- [ ] Verify bot PRs are skipped
- [ ] Verify comment is posted and PR is converted to draft when a second non-draft PR is opened by a non-maintainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated enforcement of single active pull request per contributor to maintain focus during review cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->