### PR TITLE
fix(broker): stop forwarding `Cookie`/`Proxy-Authorization` to user-specific upstreams

### DIFF
--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -228,8 +228,19 @@ func gatewaySessionTTL(gatewaySessionID string) time.Duration {
 	return ttl
 }
 
+// sensitiveForwardHeaders are client headers that must never be forwarded to
+// upstream MCP servers. cookie and proxy-authorization are scoped to the
+// gateway origin/hop, not the upstream, so forwarding them would leak
+// gateway-scoped credentials to every user-specific upstream queried.
+var sensitiveForwardHeaders = map[string]struct{}{
+	"cookie":              {},
+	"proxy-authorization": {},
+}
+
 // filterUserHeaders returns user headers suitable for forwarding to upstream,
-// stripping internal gateway headers.
+// stripping internal gateway headers and gateway-scoped credentials. the
+// client's Authorization header is intentionally preserved: user-specific
+// servers rely on it to return a per-user tool list.
 func filterUserHeaders(h http.Header) map[string]string {
 	headers := make(map[string]string, len(h))
 	for key, vals := range h {
@@ -238,6 +249,9 @@ func filterUserHeaders(h http.Header) map[string]string {
 			continue
 		}
 		if strings.HasPrefix(lower, "x-mcp-") {
+			continue
+		}
+		if _, sensitive := sensitiveForwardHeaders[lower]; sensitive {
 			continue
 		}
 		if len(vals) > 0 {

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -75,6 +75,17 @@ func TestFilterUserHeaders(t *testing.T) {
 				"Accept": "text/html",
 			},
 		},
+		{
+			name: "strips cookie and proxy-authorization, preserves authorization",
+			input: http.Header{
+				"Cookie":              []string{"session=secret"},
+				"Proxy-Authorization": []string{"Basic abc"},
+				"Authorization":       []string{"Bearer user-token"},
+			},
+			expected: map[string]string{
+				"Authorization": "Bearer user-token",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What

When the broker builds a federated tool list, it forwards the client's request
headers to each `userSpecificList` upstream so the upstream can return a
per-user tool list. `filterUserHeaders` stripped only `mcp-session-id` and
`x-mcp-*`, so it also forwarded `Cookie` and `Proxy-Authorization`.

This adds those two headers to the strip set, so they are never sent to
upstreams. The client's `Authorization` header is intentionally still forwarded
— user-specific servers rely on it for per-user identity.

A case is added to the existing `TestFilterUserHeaders` table covering the new
behaviour.

## Why

`Cookie` and `Proxy-Authorization` are scoped to the gateway origin/hop, not the
upstream. `FetchUserSpecificTools` computes the forwarded headers once and fans
them out to every user-specific upstream concurrently, over direct
broker→upstream connections that bypass Envoy. As a result a client's
gateway-/origin-scoped session cookie was disclosed to every user-specific
upstream queried for a single `tools/list`; a malicious or compromised upstream
could replay it against the gateway origin. `Proxy-Authorization` is a
hop-by-hop credential and must not be proxied either.

Forwarding `Authorization` to upstreams is documented and intended
(`docs/design/security-architecture.md`), so it is left unchanged.

## Changes

- `internal/broker/user_specific_tools.go`: add `sensitiveForwardHeaders`
  (`cookie`, `proxy-authorization`) and skip them in `filterUserHeaders`;
  clarify in the doc comment that `Authorization` is preserved by design.
- `internal/broker/user_specific_tools_test.go`: add a `TestFilterUserHeaders`
  case asserting `Cookie`/`Proxy-Authorization` are stripped and `Authorization`
  is preserved.

## Testing

- `go test ./internal/broker/...` passes.
- `gofmt`/`goimports` clean on the changed files.

## Notes

Security fix, exempt from the issue-first requirement per `CONTRIBUTING.md`.
Tracking issue: #1170. Commit is signed off (`git commit -s`).

Out of scope: whether `Authorization` should reach multiple distinct upstreams
on the user-specific fan-out, and how RFC 8693 token exchange applies on a path
that bypasses Envoy/Authorino — tracked separately for design discussion.

Fixes #1170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by preventing sensitive gateway credentials from being forwarded to upstream servers during user-specific tool operations. The system now filters out cookies and proxy authorization headers to mitigate credential leakage risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->