### PR TITLE
Drop auto-draft conversion from PR focus workflow

### DIFF
--- a/.github/workflows/pr-focus.yaml
+++ b/.github/workflows/pr-focus.yaml
@@ -93,20 +93,15 @@ jobs:
                 '',
                 'To help us review and merge changes as efficiently as possible, we ask contributors to focus on one PR at a time. Activity on this project can be high, and maintainers have other priorities outside the project, so having a single active PR helps everyone get changes landed faster.',
                 '',
-                'This PR has been moved to draft. Once your other PR(s) are merged or closed, mark this one as ready for review and we will take a look.',
+                'Please convert this PR to draft while your other PR(s) are in review. Once they are merged or closed, mark this one as ready for review and we will take a look.',
                 '',
                 '> [!NOTE]',
                 '> This is an experimental process and may change or need manual intervention while we trial it.',
               ].join('\n'),
             });
 
-            // convert to draft using GraphQL (REST API does not support this)
-            await github.graphql(`
-              mutation($id: ID!) {
-                convertPullRequestToDraft(input: { pullRequestId: $id }) {
-                  pullRequest { id }
-                }
-              }
-            `, { id: pr.node_id });
-
-            console.log(`PR #${pr.number} converted to draft`);
+            // GITHUB_TOKEN cannot call convertPullRequestToDraft (GraphQL returns FORBIDDEN
+            // for all integration tokens, not just forks). A PAT would work but is tied to a
+            // user account, requires token management and rotation, and the draft conversion
+            // would appear as that user rather than github-actions[bot]. For now, we ask the
+            // contributor to convert to draft themselves.


### PR DESCRIPTION
## Summary

- Removes the `convertPullRequestToDraft` GraphQL mutation that fails with `FORBIDDEN` for all integration tokens
- Updates the comment to ask the contributor to convert to draft themselves
- Documents why auto-draft isn't feasible with `GITHUB_TOKEN` (and why a PAT isn't worth the tradeoff

Fixes the failure seen in https://github.com/Kuadrant/mcp-gateway/actions/runs/27843993268/job/82409068939?pr=1141

## Test plan

- [ ] Verify workflow runs without errors on a non-maintainer PR with another open PR
- [ ] Verify comment asks contributor to convert to draft (no auto-conversion)
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR workflow messaging to instruct contributors to manually convert their PR to draft when multiple PRs by the same author are in review, replacing automatic conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->