### PR TITLE
fix: correct Sever  Server typo in method and variable names

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -41,8 +41,8 @@ type MCPBroker interface {
 	//RegisteredServers returns the map of registered servers
 	RegisteredMCPServers() map[config.UpstreamMCPID]upstream.ActiveMCPServer
 
-	// GetVirtualSeverByHeader returns a virtual server definition based on a header where the header is the namespaced/name of the virtual server resource
-	GetVirtualSeverByHeader(namespaceName string) (config.VirtualServer, error)
+	// GetVirtualServerByHeader returns a virtual server definition based on a header where the header is the namespaced/name of the virtual server resource
+	GetVirtualServerByHeader(namespaceName string) (config.VirtualServer, error)
 
 	// ValidateAllServers performs comprehensive validation of all registered servers and returns status
 	ValidateAllServers() StatusResponse
@@ -357,7 +357,7 @@ func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]upstream
 	return m.mcpServers
 }
 
-func (m *mcpBrokerImpl) GetVirtualSeverByHeader(namespaceName string) (config.VirtualServer, error) {
+func (m *mcpBrokerImpl) GetVirtualServerByHeader(namespaceName string) (config.VirtualServer, error) {
 	m.vsLock.RLock()
 	defer m.vsLock.RUnlock()
 	for _, vs := range m.virtualServers {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -103,8 +103,8 @@ func TestOnConfigChange(t *testing.T) {
 		t.Fatalf("expected server 1 to be registered")
 	}
 
-	vs, err := b.GetVirtualSeverByHeader("test/test")
-	require.Nil(t, err, "error should be nil from GetVirtualSeverByHeader")
+	vs, err := b.GetVirtualServerByHeader("test/test")
+	require.Nil(t, err, "error should be nil from GetVirtualServerByHeader")
 	if vs.Name != "test/test" {
 		t.Fatalf("expected virtual server to have same name")
 	}
@@ -134,19 +134,19 @@ func TestOnConfigChange_VirtualServerRemoval(t *testing.T) {
 	conf.VirtualServers = []*config.VirtualServer{vs1, vs2}
 	b.OnConfigChange(context.TODO(), conf)
 
-	_, err := b.GetVirtualSeverByHeader("ns/vs-one")
+	_, err := b.GetVirtualServerByHeader("ns/vs-one")
 	require.NoError(t, err, "vs-one should be present after first config")
-	_, err = b.GetVirtualSeverByHeader("ns/vs-two")
+	_, err = b.GetVirtualServerByHeader("ns/vs-two")
 	require.NoError(t, err, "vs-two should be present after first config")
 
 	// remove vs-one from the config (simulates MCPVirtualServer deletion)
 	conf.VirtualServers = []*config.VirtualServer{vs2}
 	b.OnConfigChange(context.TODO(), conf)
 
-	_, err = b.GetVirtualSeverByHeader("ns/vs-one")
+	_, err = b.GetVirtualServerByHeader("ns/vs-one")
 	require.Error(t, err, "vs-one should be removed after config update")
 
-	remaining, err := b.GetVirtualSeverByHeader("ns/vs-two")
+	remaining, err := b.GetVirtualServerByHeader("ns/vs-two")
 	require.NoError(t, err, "vs-two should still be present")
 	require.Equal(t, "ns/vs-two", remaining.Name)
 
@@ -154,7 +154,7 @@ func TestOnConfigChange_VirtualServerRemoval(t *testing.T) {
 	conf.VirtualServers = []*config.VirtualServer{}
 	b.OnConfigChange(context.TODO(), conf)
 
-	_, err = b.GetVirtualSeverByHeader("ns/vs-two")
+	_, err = b.GetVirtualServerByHeader("ns/vs-two")
 	require.Error(t, err, "vs-two should be removed after empty config")
 }
 

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -111,7 +111,7 @@ func (broker *mcpBrokerImpl) applyVirtualServerFilterForPrompts(headers http.Hea
 	}
 
 	virtualServerID := headerValues[0]
-	vs, err := broker.GetVirtualSeverByHeader(virtualServerID)
+	vs, err := broker.GetVirtualServerByHeader(virtualServerID)
 	if err != nil {
 		broker.logger.Error("failed to get virtual server for prompt filtering", "error", err)
 		return prompts

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -219,7 +219,7 @@ func (broker *mcpBrokerImpl) applyVirtualServerFilter(headers http.Header, tools
 	virtualServerID := headerValues[0]
 	broker.logger.Debug("applying virtual server filter", "virtualServer", virtualServerID)
 
-	vs, err := broker.GetVirtualSeverByHeader(virtualServerID)
+	vs, err := broker.GetVirtualServerByHeader(virtualServerID)
 	if err != nil {
 		broker.logger.Error("failed to get virtual server", "error", err)
 		return tools

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -732,8 +732,8 @@ func (m *mockBrokerImpl) GetServerInfo(tool string) (*config.MCPServer, error) {
 	return nil, fmt.Errorf("failed to get server %q for tool %q", svrName, tool)
 }
 
-// GetVirtualSeverByHeader implements broker.MCPBroker.
-func (m *mockBrokerImpl) GetVirtualSeverByHeader(_ string) (config.VirtualServer, error) {
+// GetVirtualServerByHeader implements broker.MCPBroker.
+func (m *mockBrokerImpl) GetVirtualServerByHeader(_ string) (config.VirtualServer, error) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
Fixes a recurring typo across the codebase where "Sever" was used instead of "Server".

Changes:
- Rename `GetVirtualSeverByHeader` → `GetVirtualServerByHeader` in:
  - `internal/broker/broker.go` (interface + implementation)
  - `internal/broker/filtered_prompts_handler.go`
  - `internal/broker/filtered_tools_handler.go`
  - `internal/broker/broker_test.go`
  - `internal/mcp-router/response_handlers_test.go`
- Rename `initializeMCPSeverSession` → `initializeMCPServerSession` and
  `remoteMCPSeverSession` → `remoteMCPServerSession` in:
  - `internal/mcp-router/request_handlers.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected method naming inconsistency in virtual server lookup functionality across internal handlers for consistency with the broker interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->