### PR TITLE
fix(ci): add multi-stage builds to test server Dockerfiles

### DIFF
--- a/tests/servers/api-key-server/Dockerfile
+++ b/tests/servers/api-key-server/Dockerfile
@@ -13,4 +13,6 @@ COPY *.go ./
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /api-key-server
 
+FROM alpine:latest
+COPY --from=builder /api-key-server /api-key-server
 CMD ["/api-key-server"]

--- a/tests/servers/custom-response-server/Dockerfile
+++ b/tests/servers/custom-response-server/Dockerfile
@@ -13,5 +13,6 @@ COPY *.go ./
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server
 
-# CMD ["/mcp-test-server", "--http", "0.0.0.0:9090"]
+FROM alpine:latest
+COPY --from=builder /mcp-test-server /mcp-test-server
 CMD ["/mcp-test-server"]

--- a/tests/servers/oidc-server/Dockerfile
+++ b/tests/servers/oidc-server/Dockerfile
@@ -13,4 +13,6 @@ COPY *.go ./
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /oidc-server
 
+FROM alpine:latest
+COPY --from=builder /oidc-server /oidc-server
 CMD ["/oidc-server"]

--- a/tests/servers/server1/Dockerfile
+++ b/tests/servers/server1/Dockerfile
@@ -13,5 +13,6 @@ COPY *.go ./
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server
 
-# CMD ["/mcp-test-server", "--http", "0.0.0.0:9090"]
+FROM alpine:latest
+COPY --from=builder /mcp-test-server /mcp-test-server
 CMD ["/mcp-test-server"]

--- a/tests/servers/server2/Dockerfile
+++ b/tests/servers/server2/Dockerfile
@@ -14,5 +14,6 @@ COPY tests/servers/server2/ tests/servers/server2/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server ./tests/servers/server2/
 
-# CMD ["/mcp-test-server", "--http", "0.0.0.0:9090"]
+FROM alpine:latest
+COPY --from=builder /mcp-test-server /mcp-test-server
 CMD ["/mcp-test-server"]

--- a/tests/servers/user-specific-server/Dockerfile
+++ b/tests/servers/user-specific-server/Dockerfile
@@ -14,4 +14,6 @@ COPY tests/servers/user-specific-server/ tests/servers/user-specific-server/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server ./tests/servers/user-specific-server/
 
+FROM alpine:latest
+COPY --from=builder /mcp-test-server /mcp-test-server
 CMD ["/mcp-test-server"]


### PR DESCRIPTION
Fixes #1176

## Summary
- Six Go test server Dockerfiles were missing a runtime stage, shipping the full `golang:1.25-alpine` image (~300MB each) instead of just the static binary on `alpine:latest` (~10-15MB)
- Adds `FROM alpine:latest` runtime stages to: api-key-server, custom-response-server, oidc-server, server1, server2, user-specific-server
- Matches the pattern already used by broken-server, custom-path-server, and tls-server
- Reduces total image size loaded into Kind by ~1.7GB, mitigating `no space left on device` failures in CI

## Test plan
- [ ] Conformance tests pass (images load into Kind without disk exhaustion)
- [ ] E2E tests pass (test servers start and respond correctly with the smaller images)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker configurations for multiple test server images to reduce container size and improve deployment efficiency by using streamlined runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->