### PR TITLE
 fix missing params for upstream.MCPNamein filtered_tools_handler

### DIFF
--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -192,7 +192,7 @@ func (broker *mcpBrokerImpl) filterToolsByServerMap(allowedTools map[string][]st
 		}
 		tools := upstream.GetManagedTools()
 		if tools == nil {
-			broker.logger.Debug("no tools registered for upstream server", "server", upstream.MCPName)
+			broker.logger.Debug("no tools registered for upstream server", "server", upstream.MCPName())
 			continue
 		}
 


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect logging in filtered_tools_handler.go by invoking upstream.MCPName() instead of referencing the method value. This ensures the actual upstream MCP server name is included in log messages, improving observability and debugging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect method invocation in debug logging for tool filtering, improving log accuracy for troubleshooting and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->