### PR TITLE
fix(e2e): add missing CreateAuthorizedPromptsJWT helper to release branch

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,3 +45,5 @@ jobs:
       - name: Run make unit test
         run: |
           make test-unit
+      - name: Verify e2e tests compile
+        run: go build -tags e2e ./tests/e2e/...

--- a/tests/e2e/jwt_helpers.go
+++ b/tests/e2e/jwt_helpers.go
@@ -37,10 +37,18 @@ func GetTestHeaderPublicKey() string {
 // CreateAuthorizedCapabilitiesJWT creates a signed JWT for the x-mcp-authorized header
 // allowedTools is a map of server namespace/name to list of tool names
 func CreateAuthorizedCapabilitiesJWT(allowedTools map[string][]string) (string, error) {
+	return createCapabilitiesJWT(map[string]map[string][]string{"tools": allowedTools})
+}
+
+// CreateAuthorizedPromptsJWT creates a signed JWT for the x-mcp-authorized header
+// allowedPrompts is a map of server namespace/name to list of unprefixed prompt
+// names; the broker re-applies the server prefix when filtering prompts/list
+func CreateAuthorizedPromptsJWT(allowedPrompts map[string][]string) (string, error) {
+	return createCapabilitiesJWT(map[string]map[string][]string{"prompts": allowedPrompts})
+}
+
+func createCapabilitiesJWT(capabilities map[string]map[string][]string) (string, error) {
 	keyBytes := []byte(testHeaderSigningKey)
-	capabilities := map[string]map[string][]string{
-		"tools": allowedTools,
-	}
 	claimPayload, err := json.Marshal(capabilities)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal allowed capabilities: %w", err)


### PR DESCRIPTION
## Summary

Cherry-pick of hairpin TLS fixes (#1159) brought in test code referencing `CreateAuthorizedPromptsJWT`, but the function was added on main in #1118 and never cherry-picked to `release-0.7.0`. This caused a compile error: `./happy_path_test.go:1122:20: undefined: CreateAuthorizedPromptsJWT`

**Fixes:**
- Adds `CreateAuthorizedPromptsJWT` and refactors `CreateAuthorizedCapabilitiesJWT` to share a `createCapabilitiesJWT` helper, matching main
- Adds an e2e compile check step (`go build -tags e2e ./tests/e2e/...`) to the existing unit test job in `tests.yaml` -- catches this class of error on release branch PRs without needing a cluster

Companion PR for main: #1183