### PR TITLE
ci: add e2e compile check to test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,3 +45,5 @@ jobs:
       - name: Run make unit test
         run: |
           make test-unit
+      - name: Verify e2e tests compile
+        run: go build -tags e2e ./tests/e2e/...


### PR DESCRIPTION
## Summary

e2e tests use `//go:build e2e`, so `go test ./...` (unit tests) never compiles them. `e2e.yaml` only triggers on PRs to `main`, not `release-*` branches. Result: cherry-picks to release branches get zero e2e coverage -- not even a compile check. This caused a compile error to ship in v0.7.1 (`undefined: CreateAuthorizedPromptsJWT`).

Adds an e2e compile step (`go build -tags e2e ./tests/e2e/...`) to the existing unit test job in `tests.yaml`, which already triggers on `main` and `release-*`. No separate job needed -- just an extra step after `make test-unit`. Fast, no cluster required, catches symbol and import errors.

Whether to extend full e2e runs to release branches is a separate decision.

Companion fix for release-0.7.0: #1182