### PR TITLE
fix: use direct map lookup in GetVirtualServerByHeader

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -360,10 +360,8 @@ func (m *mcpBrokerImpl) RegisteredMCPServers() map[config.UpstreamMCPID]upstream
 func (m *mcpBrokerImpl) GetVirtualServerByHeader(namespaceName string) (config.VirtualServer, error) {
 	m.vsLock.RLock()
 	defer m.vsLock.RUnlock()
-	for _, vs := range m.virtualServers {
-		if vs.Name == namespaceName {
-			return *vs, nil
-		}
+	if vs, ok := m.virtualServers[namespaceName]; ok {
+		return *vs, nil
 	}
 	return config.VirtualServer{}, fmt.Errorf("virtual server %s not found", namespaceName)
 }


### PR DESCRIPTION
## What does this PR do?

`GetVirtualServerByHeader` was iterating over `m.virtualServers` with a linear scan to find a match by `vs.Name`, despite `m.virtualServers` being a `map[string]*config.VirtualServer` already keyed by `vs.Name`. This replaces the O(n) loop with a direct O(1) map lookup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual server header lookup to use a direct match, improving both reliability and performance.
  * Preserved the existing behavior for cases where no matching virtual server is available, including the same “not found” messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->