### PR TITLE
chore: add linux/s390x to test server image CI builds

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -105,6 +105,11 @@ jobs:
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU for multi-arch compilation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: s390x
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -113,7 +118,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add `linux/s390x` to the `test-images.yaml` workflow so test MCP server images are published as multi-arch manifests alongside the main operator images in `images.yaml`
- Add QEMU setup step required for s390x builds on GitHub Actions amd64 runners (test server Dockerfiles use native `go build` without `TARGETARCH` cross-compile)

## Context
The main operator images (`images.yaml`) already build for `linux/amd64,linux/arm64,linux/s390x`. The test server image workflow (`test-images.yaml`) was limited to amd64/arm64 only, which blocks pulling pre-built test images on s390x clusters (e.g. `make kind-pull-test-servers`, e2e fixtures, local dev deployments).

Test server code is arch-neutral (pure Go, `CGO_ENABLED=0`); no application or Dockerfile changes are required.

## Test plan
- [ ] Verify `Build Test Server Images` workflow runs successfully on this PR
- [ ] Confirm published GHCR manifests include `linux/s390x` for at least one test image (e.g. `test-server1`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and publishing container images for an additional architecture.
  * Expanded multi-platform image availability to include `linux/s390x` alongside existing platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->