### PR TITLE
fix: add ValidateSingleServer to avoid full scan in handleSingleServerByName

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -47,6 +47,10 @@ type MCPBroker interface {
 	// ValidateAllServers performs comprehensive validation of all registered servers and returns status
 	ValidateAllServers() StatusResponse
 
+	// ValidateSingleServer returns the status of a single server by name (namespace/name format).
+	// Returns the status and true if found, or an empty status and false if not found.
+	ValidateSingleServer(name string) (upstream.ServerValidationStatus, bool)
+
 	// IsReady reports whether the broker can serve traffic.
 	// Returns true when no upstream servers are configured (empty tool list is valid),
 	// or when at least one configured upstream is healthy.
@@ -550,4 +554,18 @@ func (m *mcpBrokerImpl) IsReady() bool {
 		}
 	}
 	return false
+}
+
+// ValidateSingleServer returns the status of a single registered server by name.
+// Accesses m.mcpServers directly rather than calling ValidateAllServers to avoid
+// building the full aggregate response for a single-server lookup.
+func (m *mcpBrokerImpl) ValidateSingleServer(name string) (upstream.ServerValidationStatus, bool) {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+	for _, srv := range m.mcpServers {
+		if status := srv.GetStatus(); status.Name == name {
+			return status, true
+		}
+	}
+	return upstream.ServerValidationStatus{}, false
 }

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -67,6 +67,10 @@ type MCPBroker interface {
 	// ValidateAllServers performs comprehensive validation of all registered servers and returns status
 	ValidateAllServers() StatusResponse
 
+	// ValidateSingleServer returns the status of a single server by name (namespace/name format).
+	// Returns the status and true if found, or an empty status and false if not found.
+	ValidateSingleServer(name string) (upstream.ServerValidationStatus, bool)
+
 	// IsReady reports whether the broker can serve traffic.
 	// Returns true when no upstream servers are configured (empty tool list is valid),
 	// or when at least one configured upstream is healthy.
@@ -1026,4 +1030,18 @@ func (m *mcpBrokerImpl) ServerSupportsVersion(id config.UpstreamMCPID, version s
 	// cache for next time
 	m.serverVersions.Store(id, versions)
 	return slices.Contains(versions, version)
+}
+
+// ValidateSingleServer returns the status of a single registered server by name.
+// Accesses m.mcpServers directly rather than calling ValidateAllServers to avoid
+// building the full aggregate response for a single-server lookup.
+func (m *mcpBrokerImpl) ValidateSingleServer(name string) (upstream.ServerValidationStatus, bool) {
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+	for _, srv := range m.mcpServers {
+		if status := srv.GetStatus(); status.Name == name {
+			return status, true
+		}
+	}
+	return upstream.ServerValidationStatus{}, false
 }

--- a/internal/broker/status.go
+++ b/internal/broker/status.go
@@ -115,26 +115,13 @@ func (h *StatusHandler) handleGetStatus(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *StatusHandler) handleSingleServerByName(_ context.Context, w http.ResponseWriter, serverName string) {
-	//TODO(craig) this should not need to call validate all servers
-	statusResponse := h.broker.ValidateAllServers()
-
-	var serverStatus *upstream.ServerValidationStatus
-
-	// Only support exact match (full namespace/route format)
-	for _, server := range statusResponse.Servers {
-		if server.Name == serverName {
-			serverStatus = &server
-			break
-		}
-	}
-
-	if serverStatus == nil {
+	status, ok := h.broker.ValidateSingleServer(serverName)
+	if !ok {
 		h.sendErrorResponse(w, http.StatusNotFound, fmt.Sprintf("Server '%s' not found. Use format 'namespace/route-name' or check available servers at /status", serverName))
 		return
 	}
-
 	h.logger.Info("Retrieved status for specific server", "serverName", serverName)
-	h.sendJSONResponse(w, http.StatusOK, serverStatus)
+	h.sendJSONResponse(w, http.StatusOK, status)
 }
 
 func (h *StatusHandler) sendJSONResponse(w http.ResponseWriter, statusCode int, data any) {

--- a/internal/broker/status.go
+++ b/internal/broker/status.go
@@ -115,26 +115,13 @@ func (h *StatusHandler) handleGetStatus(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *StatusHandler) handleSingleServerByName(_ context.Context, w http.ResponseWriter, serverName string) {
-	//TODO(craig) this should not need to call validate all servers
-	statusResponse := h.broker.ValidateAllServers()
-
-	var serverStatus *upstream.ServerValidationStatus
-
-	// Only support exact match (full namespace/route format)
-	for _, server := range statusResponse.Servers {
-		if server.Name == serverName {
-			serverStatus = &server
-			break
-		}
-	}
-
-	if serverStatus == nil {
+	status, ok := h.broker.ValidateSingleServer(serverName)
+	if !ok {
 		h.sendErrorResponse(w, http.StatusNotFound, fmt.Sprintf("Server '%s' not found. Use format 'namespace/route-name' or check available servers at /status", serverName))
 		return
 	}
-
-	h.logger.Info("Retrieved status for specific server", "serverName", serverName)
-	h.sendJSONResponse(w, http.StatusOK, serverStatus)
+	h.logger.Debug("Retrieved status for specific server", "serverName", serverName)
+	h.sendJSONResponse(w, http.StatusOK, status)
 }
 
 func (h *StatusHandler) sendJSONResponse(w http.ResponseWriter, statusCode int, data any) {

--- a/internal/broker/status.go
+++ b/internal/broker/status.go
@@ -120,7 +120,7 @@ func (h *StatusHandler) handleSingleServerByName(_ context.Context, w http.Respo
 		h.sendErrorResponse(w, http.StatusNotFound, fmt.Sprintf("Server '%s' not found. Use format 'namespace/route-name' or check available servers at /status", serverName))
 		return
 	}
-	h.logger.Info("Retrieved status for specific server", "serverName", serverName)
+	h.logger.Debug("Retrieved status for specific server", "serverName", serverName)
 	h.sendJSONResponse(w, http.StatusOK, status)
 }
 

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -165,3 +165,50 @@ func TestValidateAllServers(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSingleServer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("server not found when empty", func(t *testing.T) {
+		b := NewBroker(logger).(*mcpBrokerImpl)
+		status, ok := b.ValidateSingleServer("nonexistent")
+		require.False(t, ok)
+		require.Empty(t, status.Name)
+	})
+
+	t.Run("server found", func(t *testing.T) {
+		b := NewBroker(logger).(*mcpBrokerImpl)
+		mgr := createTestManagerForStatus(t, "test-server", nil)
+		mgr.SetStatusForTesting(upstream.ServerValidationStatus{Name: "test-server", Ready: true})
+		b.mcpServers["test-server"] = upstream.NewActiveForTesting(mgr)
+
+		status, ok := b.ValidateSingleServer("test-server")
+		require.True(t, ok)
+		require.Equal(t, "test-server", status.Name)
+		require.True(t, status.Ready)
+
+		_, ok = b.ValidateSingleServer("other-server")
+		require.False(t, ok)
+	})
+
+	t.Run("multiple servers returns matching one", func(t *testing.T) {
+		b := NewBroker(logger).(*mcpBrokerImpl)
+		m1 := createTestManagerForStatus(t, "s1", nil)
+		m1.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s1", Ready: true})
+		b.mcpServers["s1"] = upstream.NewActiveForTesting(m1)
+
+		m2 := createTestManagerForStatus(t, "s2", nil)
+		m2.SetStatusForTesting(upstream.ServerValidationStatus{Name: "s2", Ready: false})
+		b.mcpServers["s2"] = upstream.NewActiveForTesting(m2)
+
+		s1Status, ok := b.ValidateSingleServer("s1")
+		require.True(t, ok)
+		require.Equal(t, "s1", s1Status.Name)
+		require.True(t, s1Status.Ready)
+
+		s2Status, ok := b.ValidateSingleServer("s2")
+		require.True(t, ok)
+		require.Equal(t, "s2", s2Status.Name)
+		require.False(t, s2Status.Ready)
+	})
+}

--- a/internal/mcp-router/response_handlers_test.go
+++ b/internal/mcp-router/response_handlers_test.go
@@ -771,6 +771,9 @@ func (m *mockBrokerImpl) ToolAnnotations(_ config.UpstreamMCPID, _ string) (mcp.
 func (m *mockBrokerImpl) ValidateAllServers() broker.StatusResponse {
 	panic("unimplemented")
 }
+func (m *mockBrokerImpl) ValidateSingleServer(_ string) (upstream.ServerValidationStatus, bool) {
+	return upstream.ServerValidationStatus{}, false
+}
 
 // IsBrokerToolName implements broker.MCPBroker.
 func (m *mockBrokerImpl) IsBrokerToolName(_ string) bool {


### PR DESCRIPTION
fixes #1304 
`handleSingleServerByName` was calling `ValidateAllServers()` to look up a singleserver by name, which iterates every registered upstream, builds a full aggregate`StatusResponse` with health stats and a populated slice, then discards everything
except the one matching entry. This was already flagged by a `//TODO(craig)` commentin the code.

This PR introduces `ValidateSingleServer(name string)` on the `MCPBroker` interface and `mcpBrokerImpl`, which acquires `mcpLock.RLock()` and returns as soon as it findsa name match — avoiding the full scan, the wasted allocation, and the misleading`"Server validation completed"` log line on every single-server status request.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to look up the validation status of a single registered upstream server by name.
  * Matching servers now return their individual status directly.
* **Bug Fixes**
  * Requests for unknown servers continue to return a clear not-found response.
  * Improved single-server status retrieval for more consistent results when multiple upstream servers are registered.
* **Tests**
  * Added coverage for empty registries, matching servers, and multiple-server scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->