### PR TITLE
docs: add rule against working on untriaged issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ is centered around milestones:
 2. When issues have a milestone: they are considered `triage/accepted`, and
    need a priority. The priority will default to `priority/normal`.
 
+Do not begin implementation work on an issue until it has been assigned to a milestone. An issue without a milestone has not been accepted or prioritised — starting work on it risks the effort being rejected or superseded. Wait for a maintainer to triage the issue before opening a PR against it.
+
 ### Code of conduct
 
 Participation in the Kuadrant community is governed by the [Kuadrant Community Code of Conduct](https://github.com/Kuadrant/governance/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Adds a rule to the `### Triage` section clarifying that contributors should not begin implementation work on an issue until it has been assigned to a milestone.

- An issue without a milestone has not been accepted or prioritised by maintainers
- Starting work on untriaged issues risks the effort being rejected or superseded
- Closes the gap identified during PR triage where contributors were opening PRs against issues still in the triage queue

## Review notes

Single paragraph added after the existing triage step list, under `### Triage`. No other content changed.

## Test plan

- [ ] Read the new paragraph in context and confirm it is clear to an external contributor