### PR TITLE
fix: use BUFFERED request body mode for reliable ClearRouteCache

### DIFF
--- a/config/istio/envoyfilter.yaml
+++ b/config/istio/envoyfilter.yaml
@@ -32,7 +32,7 @@ spec:
             processing_mode:
               request_header_mode: 'SEND'
               response_header_mode: 'SEND'
-              request_body_mode: 'STREAMED'
+              request_body_mode: 'BUFFERED'
               response_body_mode: 'NONE'
               request_trailer_mode: 'SKIP'
               response_trailer_mode: 'SKIP'

--- a/docs/design/routing.md
+++ b/docs/design/routing.md
@@ -14,6 +14,18 @@ MCP Gateway router component as ext_proc intercept all requests hitting the /mcp
 ![](./images/mcp-gateway-routing.jpg)
 
 
+### ext_proc Processing Mode
+
+The router uses `BUFFERED` request body mode. Envoy buffers the entire request body before forwarding it to the ext_proc filter. This is required because the router mutates headers (`:authority`) and clears the route cache in the body processing phase to re-route `tools/call` requests to backend MCP servers.
+
+From the [Envoy ext_proc proto documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto):
+
+> "When responding to an HttpBody request, header mutations will only take effect if the current processing mode for the body is BUFFERED."
+
+In `STREAMED` mode, header mutations and `ClearRouteCache` in the body phase are silently ignored. This causes intermittent routing failures where requests intended for backend MCP servers are handled by the broker instead.
+
+This limits request body size to Envoy's `per_connection_buffer_limit_bytes` (default 1MB). MCP JSON-RPC requests are small, so this is not a practical constraint.
+
 ### The Router
 
 The router component is configured to know about the different backend MCP Servers that have been registered. This MCPServer configuration is managed by the MCP Gateway Controller component. The router should also be configured with the public listener hostname via `required` flag `--mcp-gateway-public-host`. The router intercepts all requests to the gateway MCP listener before routing has happened and based on its configuration decides whether the request should be processed by the MCP Broker or configure the routing to ensure the request is sent to the correct MCP Server. The router only re-routes `tools/calls` but validates all calls hitting the MCP gateway listener to ensure clients cannot explicitly bypass the broker (note they can never bypass the router).

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -47,6 +47,7 @@ func NewUpstreamMCP(config *config.MCPServer) *MCPServer {
 	up.headers = map[string]string{
 		"user-agent":        "mcp-broker",
 		"gateway-server-id": string(up.ID()),
+		"x-client-id":       "broker",
 	}
 	if up.Credential != "" {
 		up.headers["Authorization"] = up.Credential

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -94,6 +94,7 @@ func Initialize(ctx context.Context, gatewayHost string, conf *config.MCPServer,
 
 	url := buildHairpinURL(gatewayHost, mcpPath)
 	hairpinHTTPClient := hairpinClientPool.Get(conf.Hostname)
+	passThroughHeaders["x-client-id"] = "lazyinit"
 
 	httpClient, err := client.NewStreamableHttpClient(url,
 		transport.WithHTTPHeaders(passThroughHeaders),

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -735,7 +735,7 @@ func (r *MCPGatewayExtensionReconciler) buildEnvoyFilter(mcpExt *mcpv1alpha1.MCP
 			"processing_mode": map[string]any{
 				"request_header_mode":   "SEND",
 				"response_header_mode":  "SEND",
-				"request_body_mode":     "STREAMED",
+				"request_body_mode":     "BUFFERED",
 				"response_body_mode":    "NONE",
 				"request_trailer_mode":  "SKIP",
 				"response_trailer_mode": "SKIP",

--- a/internal/mcp-router/response_handlers.go
+++ b/internal/mcp-router/response_handlers.go
@@ -17,9 +17,7 @@ func (s *ExtProcServer) HandleResponseHeaders(ctx context.Context, responseHeade
 	s.Logger.DebugContext(ctx, "[EXT-PROC] HandleResponseHeaders response headers for session mapping...", "responseHeaders", responseHeaders)
 
 	s.Logger.DebugContext(ctx, "[EXT-PROC] HandleResponseHeaders ", "mcp-session-id", getSingleValueHeader(responseHeaders.Headers, sessionHeader))
-	//"gateway session id"
 	gatewaySessionID := getSingleValueHeader(requestHeaders.Headers, sessionHeader)
-	// we always want to respond with the original mcp-session-id to the client
 	if gatewaySessionID != "" {
 		responseHeaderBuilder.WithMCPSession(gatewaySessionID)
 	}

--- a/internal/tests/server2/server2.go
+++ b/internal/tests/server2/server2.go
@@ -136,9 +136,16 @@ func RunServer(transport, port string, streamOpts ...server.StreamableHTTPOption
 		log.Printf("Client %s disconnected", session.SessionID())
 	})
 
-	// Add request hooks
-	hooks.AddBeforeAny(func(_ context.Context, _ any, method mcp.MCPMethod, _ any) {
-		log.Printf("Processing %s request", method)
+	hooks.AddBeforeAny(func(ctx context.Context, _ any, method mcp.MCPMethod, _ any) {
+		sessionID := "-"
+		if s := server.ClientSessionFromContext(ctx); s != nil {
+			sessionID = s.SessionID()
+		}
+		log.Printf("Processing %s session=%s", method, sessionID)
+	})
+
+	hooks.AddOnSuccess(func(_ context.Context, _ any, method mcp.MCPMethod, _ any, _ any) {
+		log.Printf("Completed %s", method)
 	})
 
 	hooks.AddOnError(func(_ context.Context, _ any, method mcp.MCPMethod, _ any, err error) {
@@ -176,7 +183,7 @@ func RunServer(transport, port string, streamOpts ...server.StreamableHTTPOption
 			s,
 			streamOpts...,
 		)
-		mux.Handle("/mcp", streamableHTTPServer)
+		mux.Handle("/mcp", logResponse(streamableHTTPServer))
 
 		// For testing session ID invalidation
 		mux.HandleFunc("/admin/forget", forgetFuncFactory(s))
@@ -213,6 +220,36 @@ func RunServer(transport, port string, streamOpts ...server.StreamableHTTPOption
 				return nil
 			}, nil
 	}
+}
+
+type responseRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func logResponse(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		reqSession := r.Header.Get("Mcp-Session-Id")
+		if reqSession == "" {
+			reqSession = "-"
+		}
+		respSession := rec.Header().Get("Mcp-Session-Id")
+		if respSession == "" {
+			respSession = "-"
+		}
+		clientID := r.Header.Get("X-Client-Id")
+		if clientID == "" {
+			clientID = "-"
+		}
+		log.Printf("%s %s %d req-session=%s resp-session=%s x-client-id=%s", r.Method, r.URL.Path, rec.status, reqSession, respSession, clientID)
+	})
 }
 
 func helloHandler(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
STREAMED body mode causes Envoy to silently ignore header mutations and ClearRouteCache in the ext_proc body phase. This led to intermittent (~15-25%) routing failures where hairpin initialize requests were handled by the broker instead of the backend MCP server.

BUFFERED mode guarantees the route cache clear takes effect before Envoy selects an upstream. Limited to 1MB request body (Envoy default) which is sufficient for MCP JSON-RPC payloads.

Also adds x-client-id header to broker and lazyinit requests, and improves server2 test server logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling so routing mutations are applied more reliably, reducing intermittent `tools/call` routing failures.
  * Added default client identifiers to outbound MCP requests for more consistent tracking and handling.

* **Documentation**
  * Expanded routing guidance with details on request body buffering and its impact on routing behavior and request size limits.

* **Chores**
  * Enhanced server-side logging for MCP requests and responses to make session and client activity easier to trace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->