### PR TITLE
fix: update broken documentation links

### DIFF
--- a/docs/design/isolated-gateway-deployment.md
+++ b/docs/design/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ To support this deployment model and inform the controller of the expected state
 
 This resource signals to the controller that any MCP configuration built from MCPServerRegistrations targeting HTTPRoutes attached to that gateway should be placed in the well-known secret within the same namespace as the MCPGatewayExtension resource.
 
-The MCPGatewayExtension can target Gateway API `Gateway` resources in any namespace. To ensure cross-namespace targeting is authorized, the requirement of a [ReferenceGrant](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) in the targeted gateway's namespace will be enforced unless the MCPGatewayExtension resource is in the same namespace as the Gateway (see diagram below).
+The MCPGatewayExtension can target Gateway API `Gateway` resources in any namespace. To ensure cross-namespace targeting is authorized, the requirement of a [ReferenceGrant](https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/) in the targeted gateway's namespace will be enforced unless the MCPGatewayExtension resource is in the same namespace as the Gateway (see diagram below).
 
 **Example Resources:**
 

--- a/docs/guides/url-elicitation.md
+++ b/docs/guides/url-elicitation.md
@@ -142,7 +142,7 @@ JWT tokens are also checked for expiry before use — an expired JWT is treated 
 - **CSRF protection**: The token page uses a cookie-based CSRF token. The GET response sets a `csrf` cookie and includes a matching hidden form field. The POST handler validates that the cookie and form values match, preventing cross-site form submissions.
 - **Single-use entries**: Each elicitation ID can only be claimed once — submitting the form consumes the entry, providing anti-replay protection.
 
-> **Note:** The MCP specification includes a [phishing warning](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/elicitation) about URL elicitation. Ensure your users understand they should only enter tokens on URLs they trust.
+> **Note:** The MCP specification includes a [phishing warning](https://modelcontextprotocol.io/specification/draft/client/elicitation) about URL elicitation. Ensure your users understand they should only enter tokens on URLs they trust.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Fixes two broken links flagged by the weekly link checker CI:

- `docs/design/isolated-gateway-deployment.md`: Gateway API moved ReferenceGrant docs from `/api-types/` to `/reference/api-types/`
- `docs/guides/url-elicitation.md`: MCP spec restructured elicitation docs from versioned `/2025-06-18/basic/utilities/elicitation` to `/draft/client/elicitation`

## Test plan

- [ ] Link checker CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several documentation links to point to the latest reference locations.
  * Improved consistency in security-related guidance by refreshing outdated specification links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->