### PR TITLE
fix: remove dead HTTPRoute patch from mcp-system overlay

### DIFF
--- a/config/mcp-gateway/overlays/mcp-system/kustomization.yaml
+++ b/config/mcp-gateway/overlays/mcp-system/kustomization.yaml
@@ -23,14 +23,3 @@ patches:
       - op: replace
         path: /subjects/0/namespace
         value: mcp-system
-
-  # patch HTTPRoute with correct hostname
-  - target:
-      group: gateway.networking.k8s.io
-      version: v1
-      kind: HTTPRoute
-      name: mcp-gateway-route
-    patch: |-
-      - op: replace
-        path: /spec/hostnames/0
-        value: mcp.127-0-0-1.sslip.io


### PR DESCRIPTION
The HTTPRoute patch targeting `mcp-gateway-route` in the `mcp-system` overlay is dead config  the static route was removed in #975, with the controller now creating it at runtime. Kustomize silently ignores the patch, but it should be cleaned up.

Fixes #1203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the gateway deployment overlay so a route-specific override for the `mcp-gateway-route` hostname is no longer applied.
  * Kept the existing access/permissions configuration unchanged to ensure authorization behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->