### PR TITLE
docs: add contributor limits for issues and PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,19 @@ impact and time-sensitivity:
 [GitHub milestones]:https://github.com/Kuadrant/mcp-gateway/milestones
 [GitHub project boards]:https://github.com/orgs/Kuadrant/projects/27/views/1
 
+### Limits for non-maintainer contributors
+
+To keep the issue backlog manageable, contributors who are not maintainers are
+subject to the following limits:
+
+**Issues:** At most 2 open, untriaged issues at any time. You may open
+additional issues once an existing one is closed or has been triaged (assigned
+to a milestone) by the team.
+
+**Pull requests:** At most 1 open PR and 1 open draft PR at any time. PRs
+beyond this limit will be closed. Please prioritise and submit only your most
+important work.
+
 ### Triage
 
 We have some light automation and process around triaging issues. This process


### PR DESCRIPTION
## Summary

- Adds a new **Limits for non-maintainer contributors** section to `CONTRIBUTING.md`
- Non-maintainers are capped at 2 open untriaged issues at any time (more once an existing one is closed or triaged)
- Non-maintainers are capped at 1 open PR and 1 open draft PR; anything over the limit will be closed

## Review

The only change is in `CONTRIBUTING.md`, between the `[GitHub project boards]` link and the `### Triage` section.

## Test plan

- [ ] Read through the new section and confirm the limits are stated clearly and accurately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering limits on open, untriaged issues and open/draft pull requests, plus what happens when those limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->