### PR TITLE
write MCPVirtualServer config to all MCPGatewayExtension namespaces

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -136,10 +136,11 @@ func main() {
 	}
 
 	if err = (&controller.MCPVirtualServerReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		DirectAPIReader:    mgr.GetAPIReader(),
-		ConfigReaderWriter: &configReaderWriter,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		DirectAPIReader:       mgr.GetAPIReader(),
+		ConfigReaderWriter:    &configReaderWriter,
+		MCPExtNamespaceLister: mcpExtFinderValidator,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		panic("unable to start manager : " + err.Error())
 	}

--- a/internal/controller/mcpgatewayextension.go
+++ b/internal/controller/mcpgatewayextension.go
@@ -115,6 +115,24 @@ type MCPGatewayExtensionFinderValidator interface {
 	FindValidMCPGatewayExtsForGateway(ctx context.Context, g *gatewayv1.Gateway) ([]*mcpv1alpha1.MCPGatewayExtension, error)
 }
 
+// ListMCPGatewayExtensionNamespaces returns the namespace of every active MCPGatewayExtension.
+// VirtualServer config must be written to all of them so every gateway instance receives the
+// full virtual server list regardless of which namespace the MCPVirtualServer lives in.
+func (r *MCPGatewayExtensionValidator) ListMCPGatewayExtensionNamespaces(ctx context.Context) ([]string, error) {
+	list := &mcpv1alpha1.MCPGatewayExtensionList{}
+	if err := r.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("failed to list MCPGatewayExtensions: %w", err)
+	}
+	namespaces := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		if list.Items[i].DeletionTimestamp != nil {
+			continue
+		}
+		namespaces = append(namespaces, list.Items[i].Namespace)
+	}
+	return namespaces, nil
+}
+
 // httpRouteAttachesToListener checks whether an HTTPRoute is attached to the listener
 // targeted by an MCPGatewayExtension. An HTTPRoute attaches to a listener if:
 //  1. The HTTPRoute parentRef has a sectionName that resolves to a listener sharing

--- a/internal/controller/mcpvirtualserver_controller.go
+++ b/internal/controller/mcpvirtualserver_controller.go
@@ -2,18 +2,21 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
@@ -24,13 +27,19 @@ type VirtualServerConfigReaderWriter interface {
 	WriteVirtualServerConfig(ctx context.Context, virtualServers []config.VirtualServerConfig, namespaceName types.NamespacedName) error
 }
 
+// MCPExtNamespaceLister lists namespaces of all active MCPGatewayExtensions.
+type MCPExtNamespaceLister interface {
+	ListMCPGatewayExtensionNamespaces(ctx context.Context) ([]string, error)
+}
+
 // MCPVirtualServerReconciler reconciles a MCPVirtualServer object
 type MCPVirtualServerReconciler struct {
 	client.Client
-	DirectAPIReader    client.Reader
-	Scheme             *runtime.Scheme
-	log                *slog.Logger
-	ConfigReaderWriter VirtualServerConfigReaderWriter
+	DirectAPIReader       client.Reader
+	Scheme                *runtime.Scheme
+	log                   *slog.Logger
+	ConfigReaderWriter    VirtualServerConfigReaderWriter
+	MCPExtNamespaceLister MCPExtNamespaceLister
 }
 
 var defaultRequeueTime = time.Second * 2
@@ -58,8 +67,8 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to generate virtual server config during deletion %w", err)
 			}
-			if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, config.DefaultNamespaceName); err != nil {
-				if errors.IsConflict(err) {
+			if err := r.writeVirtualServerConfig(ctx, vsConfig); err != nil {
+				if apierrors.IsConflict(err) {
 					return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
 				}
 				return ctrl.Result{}, fmt.Errorf("mcpvirtualserver failed to write virtual server config during deletion %w", err)
@@ -75,7 +84,7 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if !controllerutil.ContainsFinalizer(mcpVS, mcpGatewayFinalizer) {
 		if controllerutil.AddFinalizer(mcpVS, mcpGatewayFinalizer) {
 			if err := r.Update(ctx, mcpVS); err != nil {
-				if errors.IsConflict(err) {
+				if apierrors.IsConflict(err) {
 					logger.V(1).Info("mcpvirtualserver conflict err requeuing")
 					return ctrl.Result{RequeueAfter: defaultRequeueTime}, err
 				}
@@ -92,8 +101,8 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	logger.V(1).Info("mcpvirtualserver writing config")
-	if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, config.DefaultNamespaceName); err != nil {
-		if errors.IsConflict(err) {
+	if err := r.writeVirtualServerConfig(ctx, vsConfig); err != nil {
+		if apierrors.IsConflict(err) {
 			logger.Info("mcpvirtualserver conflict on updating the config for virtual servers will retry in 5 seconds")
 			return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
 		}
@@ -102,6 +111,31 @@ func (r *MCPVirtualServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger.V(1).Info("mcpvirtualserver reconcile complete", "name", mcpVS.Name, "namespace", mcpVS.Namespace)
 	// update status of virtual server
 	return ctrl.Result{}, nil
+}
+
+// writeVirtualServerConfig writes vsConfig to the config secret of every MCPGatewayExtension namespace.
+// MCPVirtualServer config must reach all gateway instances, not just the default namespace.
+// Errors are collected and all namespaces are attempted before returning so a single bad namespace
+// (quota, webhook) does not block config delivery to the rest.
+func (r *MCPVirtualServerReconciler) writeVirtualServerConfig(ctx context.Context, vsConfig []config.VirtualServerConfig) error {
+	namespaces, err := r.MCPExtNamespaceLister.ListMCPGatewayExtensionNamespaces(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list mcpgatewayextension namespaces: %w", err)
+	}
+	var conflicts, hard []error
+	for _, ns := range namespaces {
+		if err := r.ConfigReaderWriter.WriteVirtualServerConfig(ctx, vsConfig, config.NamespaceName(ns)); err != nil {
+			if apierrors.IsConflict(err) {
+				conflicts = append(conflicts, fmt.Errorf("namespace %s: %w", ns, err))
+			} else {
+				hard = append(hard, fmt.Errorf("namespace %s: %w", ns, err))
+			}
+		}
+	}
+	if len(hard) > 0 {
+		return errors.Join(hard...)
+	}
+	return errors.Join(conflicts...)
 }
 
 func (r *MCPVirtualServerReconciler) generateVirtualServerConfig(ctx context.Context) ([]config.VirtualServerConfig, error) {
@@ -133,6 +167,30 @@ func (r *MCPVirtualServerReconciler) SetupWithManager(_ context.Context, mgr ctr
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1alpha1.MCPVirtualServer{}).
+		// re-reconcile all MCPVirtualServers when an MCPGatewayExtension changes
+		// so config is immediately written to any newly added namespace.
+		Watches(&mcpv1alpha1.MCPGatewayExtension{},
+			handler.EnqueueRequestsFromMapFunc(r.findAllMCPVirtualServers)).
 		Named("mcpvirtualserver").
 		Complete(r)
+}
+
+// findAllMCPVirtualServers enqueues all MCPVirtualServers for reconciliation.
+// Used when MCPGatewayExtension changes so every VS writes config to the updated namespace set.
+func (r *MCPVirtualServerReconciler) findAllMCPVirtualServers(ctx context.Context, _ client.Object) []reconcile.Request {
+	list := &mcpv1alpha1.MCPVirtualServerList{}
+	if err := r.List(ctx, list); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list MCPVirtualServers for MCPGatewayExtension watch — VS reconciles will not be triggered")
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      list.Items[i].Name,
+				Namespace: list.Items[i].Namespace,
+			},
+		})
+	}
+	return requests
 }

--- a/internal/controller/mcpvirtualserver_controller_test.go
+++ b/internal/controller/mcpvirtualserver_controller_test.go
@@ -16,17 +16,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// mockVirtualServerConfigReaderWriter records WriteVirtualServerConfig calls.
-type mockVirtualServerConfigReaderWriter struct {
-	writtenConfigs [][]config.VirtualServerConfig
+// fakeVSConfigWriter records WriteVirtualServerConfig calls for assertion.
+type fakeVSConfigWriter struct {
+	calls []vsWriteCall
 }
 
-func (m *mockVirtualServerConfigReaderWriter) WriteVirtualServerConfig(_ context.Context, virtualServers []config.VirtualServerConfig, _ types.NamespacedName) error {
-	m.writtenConfigs = append(m.writtenConfigs, virtualServers)
+type vsWriteCall struct {
+	namespaceName types.NamespacedName
+	configs       []config.VirtualServerConfig
+}
+
+func (f *fakeVSConfigWriter) WriteVirtualServerConfig(_ context.Context, virtualServers []config.VirtualServerConfig, nn types.NamespacedName) error {
+	f.calls = append(f.calls, vsWriteCall{namespaceName: nn, configs: virtualServers})
 	return nil
 }
 
-func newVirtualServerReconciler(mock *mockVirtualServerConfigReaderWriter, objs ...client.Object) *MCPVirtualServerReconciler {
+// fakeMCPExtLister returns a fixed set of MCPGatewayExtension namespaces.
+type fakeMCPExtLister struct {
+	namespaces []string
+}
+
+func (f *fakeMCPExtLister) ListMCPGatewayExtensionNamespaces(_ context.Context) ([]string, error) {
+	return f.namespaces, nil
+}
+
+func newVirtualServerReconciler(writer *fakeVSConfigWriter, lister *fakeMCPExtLister, objs ...client.Object) *MCPVirtualServerReconciler {
 	scheme := runtime.NewScheme()
 	_ = mcpv1alpha1.AddToScheme(scheme)
 
@@ -36,9 +50,59 @@ func newVirtualServerReconciler(mock *mockVirtualServerConfigReaderWriter, objs 
 		Build()
 
 	return &MCPVirtualServerReconciler{
-		Client:             fakeClient,
-		Scheme:             scheme,
-		ConfigReaderWriter: mock,
+		Client:                fakeClient,
+		Scheme:                scheme,
+		ConfigReaderWriter:    writer,
+		MCPExtNamespaceLister: lister,
+	}
+}
+
+func TestMCPVirtualServerReconciler_writesConfigToAllExtensionNamespaces(t *testing.T) {
+	writer := &fakeVSConfigWriter{}
+	lister := &fakeMCPExtLister{namespaces: []string{"team-a", "team-b"}}
+
+	r := &MCPVirtualServerReconciler{
+		ConfigReaderWriter:    writer,
+		MCPExtNamespaceLister: lister,
+	}
+
+	if err := r.writeVirtualServerConfig(context.Background(), nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(writer.calls) != 2 {
+		t.Fatalf("expected 2 writes, got %d", len(writer.calls))
+	}
+
+	namespaces := map[string]bool{}
+	for _, c := range writer.calls {
+		namespaces[c.namespaceName.Namespace] = true
+	}
+	if !namespaces["team-a"] {
+		t.Error("expected write to team-a namespace")
+	}
+	if !namespaces["team-b"] {
+		t.Error("expected write to team-b namespace")
+	}
+}
+
+func TestMCPVirtualServerReconciler_doesNotWriteToDefaultNamespace(t *testing.T) {
+	writer := &fakeVSConfigWriter{}
+	lister := &fakeMCPExtLister{namespaces: []string{"team-a"}}
+
+	r := &MCPVirtualServerReconciler{
+		ConfigReaderWriter:    writer,
+		MCPExtNamespaceLister: lister,
+	}
+
+	if err := r.writeVirtualServerConfig(context.Background(), nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range writer.calls {
+		if c.namespaceName == config.DefaultNamespaceName {
+			t.Errorf("wrote to hardcoded default namespace %v, should only write to MCPGatewayExtension namespaces", config.DefaultNamespaceName)
+		}
 	}
 }
 
@@ -47,7 +111,6 @@ func newVirtualServerReconciler(mock *mockVirtualServerConfigReaderWriter, objs 
 func TestReconcile_VirtualServerDeletion_WritesConfig(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 
-	// the virtual server being deleted — has DeletionTimestamp and the finalizer
 	deleting := &mcpv1alpha1.MCPVirtualServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "vs-deleting",
@@ -60,7 +123,6 @@ func TestReconcile_VirtualServerDeletion_WritesConfig(t *testing.T) {
 		},
 	}
 
-	// a second virtual server that should remain
 	remaining := &mcpv1alpha1.MCPVirtualServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vs-remaining",
@@ -71,25 +133,22 @@ func TestReconcile_VirtualServerDeletion_WritesConfig(t *testing.T) {
 		},
 	}
 
-	mock := &mockVirtualServerConfigReaderWriter{}
-	r := newVirtualServerReconciler(mock, deleting, remaining)
+	writer := &fakeVSConfigWriter{}
+	lister := &fakeMCPExtLister{namespaces: []string{"mcp-system"}}
+	r := newVirtualServerReconciler(writer, lister, deleting, remaining)
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "vs-deleting", Namespace: "ns"},
 	})
 	require.NoError(t, err)
 
-	// WriteVirtualServerConfig must have been called exactly once during deletion
-	require.Len(t, mock.writtenConfigs, 1, "expected WriteVirtualServerConfig to be called once during deletion")
+	require.Len(t, writer.calls, 1, "expected WriteVirtualServerConfig to be called once during deletion")
 
-	written := mock.writtenConfigs[0]
-
-	// the written config must not contain the deleted virtual server
+	written := writer.calls[0].configs
 	for _, vs := range written {
 		require.NotEqual(t, "ns/vs-deleting", vs.Name, "deleted virtual server must not appear in written config")
 	}
 
-	// the written config must still contain the surviving virtual server
 	found := false
 	for _, vs := range written {
 		if vs.Name == "ns/vs-remaining" {
@@ -117,14 +176,15 @@ func TestReconcile_VirtualServerDeletion_EmptyConfigWhenLast(t *testing.T) {
 		},
 	}
 
-	mock := &mockVirtualServerConfigReaderWriter{}
-	r := newVirtualServerReconciler(mock, last)
+	writer := &fakeVSConfigWriter{}
+	lister := &fakeMCPExtLister{namespaces: []string{"mcp-system"}}
+	r := newVirtualServerReconciler(writer, lister, last)
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "vs-last", Namespace: "ns"},
 	})
 	require.NoError(t, err)
 
-	require.Len(t, mock.writtenConfigs, 1, "expected WriteVirtualServerConfig to be called once during deletion")
-	require.Empty(t, mock.writtenConfigs[0], "config must be empty when the last virtual server is deleted")
+	require.Len(t, writer.calls, 1, "expected WriteVirtualServerConfig to be called once during deletion")
+	require.Empty(t, writer.calls[0].configs, "config must be empty when the last virtual server is deleted")
 }


### PR DESCRIPTION
## Summary

Fixes #722

The `MCPVirtualServerReconciler` was writing virtual server config to the hardcoded `DefaultNamespaceName` (`mcp-system`) instead of to every namespace that has an `MCPGatewayExtension`. In a multi-tenant isolated gateway deployment this meant virtual server config only ever reached the `mcp-system` broker — all other gateway instances were invisible to `MCPVirtualServer` filtering.

- Introduces `MCPExtNamespaceLister` interface with `ListMCPGatewayExtensionNamespaces`, implemented on the existing `MCPGatewayExtensionValidator`
- `writeVirtualServerConfig` fans out `WriteVirtualServerConfig` to every active extension namespace
- Adds a `Watches` on `MCPGatewayExtension` in `SetupWithManager` so all `MCPVirtualServer` resources are re-reconciled immediately when an extension is created or deleted
- Wires `MCPExtNamespaceLister` into the reconciler in `cmd/main.go`

## How to review

Start with `internal/controller/mcpvirtualserver_controller.go` — the interface addition, `writeVirtualServerConfig` helper, and updated `SetupWithManager`. Then `internal/controller/mcpgatewayextension.go` for the `ListMCPGatewayExtensionNamespaces` implementation. Then `cmd/main.go` for the wiring. Tests are in `internal/controller/mcpvirtualserver_controller_test.go`.

## Test plan

- [ ] `go test ./internal/controller/ -run TestMCPVirtualServer` — two new unit tests covering the fan-out behaviour and confirming `DefaultNamespaceName` is never used
- [ ] `make test-unit` — full unit suite passes
- [ ] Manual: deploy two `MCPGatewayExtension` resources in different namespaces, create an `MCPVirtualServer`, confirm the config secret in both namespaces contains the virtual server entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual server configuration is now written to all relevant extension namespaces, improving consistency across environments.
  * Changes to extension resources now trigger updates for virtual server configurations automatically.

* **Bug Fixes**
  * Conflict handling during updates has been made more reliable.
  * Configuration writes now avoid the default namespace when not needed.

* **Tests**
  * Added coverage for multi-namespace config writes and deletion-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->