### PR TITLE
fix: add /status route to gateway HTTPRoute and fix conformance CI poll

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -98,7 +98,8 @@ jobs:
           echo "Waiting for Gateway to wire up the MCP routes and broker to fetch tools..."
           # wait for the gateway route to be active (non-502/503)
           for i in {1..30}; do
-            HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" ${{ env.MCP_URL }} || echo "000")
+            HTTP_STATUS=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" "${{ env.MCP_URL }}" 2>/dev/null || true)
+            HTTP_STATUS=${HTTP_STATUS:-000}
             if [[ "$HTTP_STATUS" != "000" && "$HTTP_STATUS" != "0" && "$HTTP_STATUS" != "502" && "$HTTP_STATUS" != "503" ]]; then
               echo "Gateway route is active! HTTP Status: $HTTP_STATUS"
               break
@@ -116,7 +117,7 @@ jobs:
           echo "Waiting for broker to discover conformance server tools..."
           STATUS_URL="${MCP_URL%/mcp}/status"
           for i in {1..60}; do
-            TOOLS=$(curl --max-time 5 -s "$STATUS_URL" | grep -o '"totalTools":[0-9]*' | head -1 | cut -d: -f2)
+            TOOLS=$(curl --max-time 5 -s "$STATUS_URL" | jq '[.servers[] | select(.name | contains("conformance")) | .totalTools] | add // 0')
             if [ -n "$TOOLS" ] && [ "$TOOLS" -gt 0 ] 2>/dev/null; then
               echo "Broker has $TOOLS tools from conformance server."
               break

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -650,6 +650,7 @@ func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1alpha
 	pathType := gatewayv1.PathMatchPathPrefix
 	mcpPath := "/mcp"
 	wellKnownPath := "/.well-known/oauth-protected-resource"
+	statusPath := "/status"
 	port := gatewayv1.PortNumber(brokerHTTPPort)
 	gatewayNamespace := gatewayv1.Namespace(mcpExt.Spec.TargetRef.Namespace)
 	sectionName := gatewayv1.SectionName(mcpExt.Spec.TargetRef.SectionName)
@@ -701,6 +702,18 @@ func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1alpha
 					Path: &gatewayv1.HTTPPathMatch{
 						Type:  &pathType,
 						Value: &wellKnownPath,
+					},
+				},
+			},
+			BackendRefs: backendRefs,
+		},
+		{
+			Name: ptr.To(gatewayv1.SectionName("status")),
+			Matches: []gatewayv1.HTTPRouteMatch{
+				{
+					Path: &gatewayv1.HTTPPathMatch{
+						Type:  &pathType,
+						Value: &statusPath,
 					},
 				},
 			},

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1810,8 +1810,8 @@ func TestBuildGatewayHTTPRoute_StripsRouterHeaders(t *testing.T) {
 	}
 
 	route := reconciler.buildGatewayHTTPRoute(mcpExt, "mcp.example.com")
-	if len(route.Spec.Rules) != 2 {
-		t.Fatalf("expected 2 rules, got %d", len(route.Spec.Rules))
+	if len(route.Spec.Rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(route.Spec.Rules))
 	}
 
 	if route.Spec.Rules[0].Name == nil || string(*route.Spec.Rules[0].Name) != "mcp" {
@@ -1819,6 +1819,12 @@ func TestBuildGatewayHTTPRoute_StripsRouterHeaders(t *testing.T) {
 	}
 	if route.Spec.Rules[1].Name == nil || string(*route.Spec.Rules[1].Name) != "well-known" {
 		t.Errorf("expected second rule name = %q, got %v", "well-known", route.Spec.Rules[1].Name)
+	}
+	if route.Spec.Rules[2].Name == nil || string(*route.Spec.Rules[2].Name) != "status" {
+		t.Errorf("expected third rule name = %q, got %v", "status", route.Spec.Rules[2].Name)
+	}
+	if len(route.Spec.Rules[2].Filters) != 0 {
+		t.Errorf("status rule should have no filters, got %d", len(route.Spec.Rules[2].Filters))
 	}
 
 	var found bool


### PR DESCRIPTION
Closes #1213

## Summary

Two fixes for conformance CI broken since #975:

1. **Add `/status` route to the controller-generated HTTPRoute.** #975 removed the static HTTPRoute which had a catch-all `PathPrefix /`. The broker `/status` endpoint is no longer reachable through the gateway. Adds a `/status` rule (no filters, read-only health endpoint) to `buildGatewayHTTPRoute`.

2. **Fix the conformance CI tools poll.** The `grep | head -1` approach grabbed `totalTools` from whichever server appeared first in the `/status` JSON. `test-user-specific-server` reports `totalTools: 0` (per-user fetch) and can appear before `conformance-server`. Replaced with `jq` targeting the conformance server specifically. Also fixed the `HTTP_STATUS: 200000` bug (SSE endpoint causes curl timeout with non-zero exit, which overwrote the valid 200).

## Test evidence

- `make test-unit`: pass
- `make test-controller-integration`: 41/41
- `make lint`: clean
