### PR TITLE
fix(broker): keep user-specific tools when the x-mcp-authorized filter runs

### DIFF
--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -125,7 +125,7 @@ func (broker *mcpBrokerImpl) applyAuthorizedCapabilitiesFilter(headers http.Head
 		return tools
 	}
 
-	return broker.filterToolsByServerMap(allowedTools)
+	return broker.filterToolsByServerMap(allowedTools, tools)
 }
 
 // parseAuthorizedCapabilitiesJWT validates and extracts allowed capabilities from the JWT header.
@@ -183,33 +183,31 @@ func (broker *mcpBrokerImpl) findServerByName(name string) upstream.ActiveMCPSer
 	return nil
 }
 
-// filterToolsByServerMap filters tools based on a map of server name to allowed tool names.
-func (broker *mcpBrokerImpl) filterToolsByServerMap(allowedTools map[string][]string) []*mcp.Tool {
-	var filtered []*mcp.Tool
-
+// filterToolsByServerMap keeps the tools whose (server, name) appears in the JWT's
+// allowed-capabilities map. It filters the already-merged tool slice rather than
+// rebuilding from each upstream's cached managed tools: userSpecificList servers
+// cache no managed tools (they are fetched per-request and merged in earlier), so
+// rebuilding would silently drop them.
+func (broker *mcpBrokerImpl) filterToolsByServerMap(allowedTools map[string][]string, tools []*mcp.Tool) []*mcp.Tool {
+	allowed := make(map[string]struct{})
 	for serverName, toolNames := range allowedTools {
 		upstream := broker.findServerByName(serverName)
 		if upstream == nil {
 			broker.logger.Error("upstream not found", "server", serverName)
 			continue
 		}
-		tools := upstream.GetManagedTools()
-		if tools == nil {
-			broker.logger.Debug("no tools registered for upstream server", "server", upstream.MCPName())
-			continue
-		}
-
-		for _, tool := range tools {
-			broker.logger.Debug("checking access", "tool", tool.Name, "against", toolNames)
-			if slices.Contains(toolNames, tool.Name) {
-				broker.logger.Debug("access granted", "tool", tool.Name)
-				t := tool
-				t.Name = fmt.Sprintf("%s%s", upstream.Config().Prefix, t.Name)
-				filtered = append(filtered, &t)
-			}
+		prefix := upstream.Config().Prefix
+		for _, name := range toolNames {
+			allowed[prefix+name] = struct{}{}
 		}
 	}
 
+	var filtered []*mcp.Tool
+	for _, tool := range tools {
+		if _, ok := allowed[tool.Name]; ok {
+			filtered = append(filtered, tool)
+		}
+	}
 	return filtered
 }
 

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -100,6 +100,37 @@ func TestFilteredTools(t *testing.T) {
 			},
 		},
 		{
+			// userSpecificList servers cache no managed tools (fetched per-request and
+			// merged into the result before filtering). The JWT filter must keep them
+			// rather than rebuild the list from cached managed tools, which drops them.
+			Name: "keeps user-specific tools alongside cached tools",
+			FullToolList: &mcp.ListToolsResult{Tools: []*mcp.Tool{
+				{Name: "std_list_repos"},
+				{Name: "us_create_issue", Meta: mcp.Meta{"kuadrant/id": "mcp-test/user-server"}},
+			}},
+			RegisteredMCPServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+				"mcp-test/std-server:std_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
+					"mcp-test/std-server",
+					"std_",
+					[]mcp.Tool{{Name: "list_repos"}},
+				)),
+				"mcp-test/user-server:us_:http://test.local/mcp": upstream.NewActiveForTesting(createTestManager(t,
+					"mcp-test/user-server",
+					"us_",
+					nil,
+				)),
+			},
+			AllowedToolsList: map[string][]string{
+				"mcp-test/std-server":  {"list_repos"},
+				"mcp-test/user-server": {"create_issue"},
+			},
+			enforceFilterList: true,
+			ExpectedTools: []mcp.Tool{
+				{Name: "std_list_repos"},
+				{Name: "us_create_issue"},
+			},
+		},
+		{
 			Name: "test filters tools with same tool name as expected",
 			FullToolList: &mcp.ListToolsResult{Tools: []*mcp.Tool{
 				{Name: "test1_tool"},


### PR DESCRIPTION
## What

`FilterTools` applies the `x-mcp-authorized` capability filter first. When the
header is present, `filterToolsByServerMap` rebuilt the response from each
upstream's cached `GetManagedTools()` rather than filtering the list it was
given.

userSpecificList servers cache no managed tools — `MCPManager` returns early for
them ("tools fetched per-user"), and their tools are merged into the result
per-request by `FetchUserSpecificTools` before filtering. Because the filter read
from the empty managed-tool cache instead of the merged list, every user-specific
tool was silently dropped whenever `x-mcp-authorized` was in play.

This makes the capability filter work on the already-merged slice — the same list
the virtual-server filter already operates on — so user-specific tools allowed by
the JWT are kept.

## Why

The guide documents combining `userSpecificList` with `x-mcp-authorized`
authorization as supported, and says the JWT step "filters the merged list". The
old code reconstructed the list from the managed-tool cache, so for user-specific
servers (which cache nothing) the documented behaviour did not hold and authorized
per-user tools disappeared from `tools/list` with no error.

## Changes

- `internal/broker/filtered_tools_handler.go`: `filterToolsByServerMap` now builds
  the set of allowed prefixed tool names from the JWT and filters the merged tool
  slice, instead of rebuilding from `GetManagedTools()`. Behaviour for standard
  (cached) servers is unchanged; user-specific tools are no longer dropped.
- `internal/broker/filtered_tools_handler_test.go`: add a case covering a
  user-specific server (no cached tools) alongside a standard one, asserting both
  survive the capability filter.

## Testing

- `make test-unit` passes.
- The new test fails on the previous behaviour (user-specific tool dropped) and
  passes with the fix.
- `gofmt` / `goimports` clean on the changed files.

## Notes

Bugfix, exempt from the issue-first requirement per `CONTRIBUTING.md`. Tracking
issue filed for visibility.

Fixes #1219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of authorized tools during JWT-based access checks, ensuring the correct set is returned.
  * Fixed an issue where user-specific tools could be dropped when filtering combined tool sources (including cached tools).
  * Filtering now reliably preserves the expected tool names in the final results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->