### PR TITLE
feat: NetworkPolicy templates, chart versioning, OLM dependency removal

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - type: olm.package
-    value:
-      packageName: kuadrant-operator
-      version: ">=1.4.3"

--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-gateway
 description: A Kubernetes gateway for aggregating and routing Model Context Protocol (MCP) servers
 type: application
-version: 0.1.0
-appVersion: "latest"
+version: 0.7.1
+appVersion: "0.7.1"
 home: https://github.com/Kuadrant/mcp-gateway
 sources:
   - https://github.com/Kuadrant/mcp-gateway

--- a/charts/mcp-gateway/templates/networkpolicy-broker-router.yaml
+++ b/charts/mcp-gateway/templates/networkpolicy-broker-router.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-broker-router
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+        - port: 50051
+          protocol: TCP
+  egress:
+    - {}
+{{- end }}

--- a/charts/mcp-gateway/templates/networkpolicy-controller.yaml
+++ b/charts/mcp-gateway/templates/networkpolicy-controller.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.networkPolicy.enabled .Values.controller.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8082
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -101,3 +101,7 @@ mcpGatewayExtension:
     generate: ""
     # The name of the secret containing a pre-existing key pair
     secretName: ""
+
+# Network policies for broker-router and controller pods
+networkPolicy:
+  enabled: false


### PR DESCRIPTION
## Summary

- Add default NetworkPolicy templates for broker-router and controller pods (CONNLINK-1115)
- Fix Helm chart versioning to match release (0.7.1)
- Remove OLMv1-incompatible dependency declaration

Relates to #1226

Closes #1228
Closes #1229
Closes #1230

## Changes

### NetworkPolicy templates (#1228)

Two new Helm chart templates gated by `networkPolicy.enabled` (default: `false`):

- **Broker-router**: allows ingress on 8080/TCP (HTTP) and 50051/TCP (gRPC ext_proc), unrestricted egress (upstream MCP servers are arbitrary)
- **Controller**: allows ingress on 8082/TCP (Prometheus metrics), egress restricted to 443/TCP (kube-apiserver) and 53/TCP+UDP (DNS)

NetworkPolicy is namespace-scoped — each namespace with a broker-router gets its own policy via per-namespace chart rendering.

### Chart versioning (#1229)

Updated `Chart.yaml` version from `0.1.0` to `0.7.1` and appVersion from `"latest"` to `"0.7.1"`.

### OLM dependency removal (#1230)

Deleted `bundle/metadata/dependencies.yaml` which declared `olm.package.required` on `kuadrant-operator >=1.4.3`. This will be rejected under OLMv1.

## Test plan

- [ ] `helm template mcp-gateway charts/mcp-gateway --set networkPolicy.enabled=true` renders both NetworkPolicy resources
- [ ] `helm template mcp-gateway charts/mcp-gateway --set networkPolicy.enabled=false` renders no NetworkPolicy resources
- [ ] `make lint` passes