### PR TITLE
feat: add controller headless mode

### DIFF
--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -32,6 +32,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_ROUTER_BROKER
               value: {{ include "mcp-gateway.image" . }}
+            {{- if .Values.controller.disableExtensionReconciler }}
+            - name: DISABLE_EXTENSION_RECONCILER
+              value: "true"
+            {{- end }}
           ports:
             - name: health
               containerPort: 8081

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -18,6 +18,8 @@ imageController:
 controller:
   # Enable/disable controller deployment
   enabled: true
+  # Disable the MCPGatewayExtension reconciler (headless mode)
+  disableExtensionReconciler: false
 
 # Broker configuration (applied to broker-router deployed by controller)
 broker:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,6 +103,10 @@ func main() {
 		Logger:          slogger,
 	}
 
+	if err := controller.SetupRequiredIndexes(ctx, mgr.GetFieldIndexer()); err != nil {
+		panic("unable to setup required indexes: " + err.Error())
+	}
+
 	if err = (&controller.MCPReconciler{
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
@@ -113,26 +117,29 @@ func main() {
 		panic("unable to start manager : " + err.Error())
 	}
 
-	brokerRouterImage := goenv.GetDefault("RELATED_IMAGE_ROUTER_BROKER", controller.DefaultBrokerRouterImage)
-	brokerRouterLogLevel := goenv.GetDefault("BROKER_ROUTER_LOG_LEVEL", "")
-	// the broker parses --log-level as an integer, so a bad value here would
-	// crash-loop the data plane rather than the controller; fail fast instead
-	if brokerRouterLogLevel != "" {
-		if _, err := strconv.Atoi(brokerRouterLogLevel); err != nil {
-			panic("invalid BROKER_ROUTER_LOG_LEVEL " + strconv.Quote(brokerRouterLogLevel) + " : must be an integer")
+	disableExtReconciler := os.Getenv("DISABLE_EXTENSION_RECONCILER")
+	if disableExtReconciler == "true" {
+		slogger.Info("Extension reconciler disabled, running in headless mode")
+	} else {
+		brokerRouterImage := goenv.GetDefault("RELATED_IMAGE_ROUTER_BROKER", controller.DefaultBrokerRouterImage)
+		brokerRouterLogLevel := goenv.GetDefault("BROKER_ROUTER_LOG_LEVEL", "")
+		if brokerRouterLogLevel != "" {
+			if _, err := strconv.Atoi(brokerRouterLogLevel); err != nil {
+				panic("invalid BROKER_ROUTER_LOG_LEVEL " + strconv.Quote(brokerRouterLogLevel) + " : must be an integer")
+			}
 		}
-	}
 
-	if err = (&controller.MCPGatewayExtensionReconciler{
-		Client:                mgr.GetClient(),
-		Scheme:                mgr.GetScheme(),
-		DirectAPIReader:       mgr.GetAPIReader(),
-		ConfigWriterDeleter:   &configReaderWriter,
-		MCPExtFinderValidator: mcpExtFinderValidator,
-		BrokerRouterImage:     brokerRouterImage,
-		BrokerRouterLogLevel:  brokerRouterLogLevel,
-	}).SetupWithManager(ctx, mgr); err != nil {
-		panic("unable to start manager : " + err.Error())
+		if err = (&controller.MCPGatewayExtensionReconciler{
+			Client:                mgr.GetClient(),
+			Scheme:                mgr.GetScheme(),
+			DirectAPIReader:       mgr.GetAPIReader(),
+			ConfigWriterDeleter:   &configReaderWriter,
+			MCPExtFinderValidator: mcpExtFinderValidator,
+			BrokerRouterImage:     brokerRouterImage,
+			BrokerRouterLogLevel:  brokerRouterLogLevel,
+		}).SetupWithManager(ctx, mgr); err != nil {
+			panic("unable to start manager : " + err.Error())
+		}
 	}
 
 	if err = (&controller.MCPVirtualServerReconciler{

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -901,16 +901,18 @@ func (r *MCPGatewayExtensionReconciler) enqueueMCPGatewayExtForEnvoyFilter(_ con
 	}}
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *MCPGatewayExtensionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	r.log = slog.New(logr.ToSlogHandler(mgr.GetLogger()))
-	if err := setupIndexExtensionToGateway(ctx, mgr.GetFieldIndexer()); err != nil {
-		return fmt.Errorf("failed to setup manager %w", err)
+// SetupRequiredIndexes registers field indexes needed by MCPReconciler regardless of
+// whether the MCPGatewayExtensionReconciler is enabled.
+func SetupRequiredIndexes(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := setupIndexExtensionToGateway(ctx, indexer); err != nil {
+		return err
 	}
+	return setupIndexExtensionToReferenceGrant(ctx, indexer)
+}
 
-	if err := setupIndexExtensionToReferenceGrant(ctx, mgr.GetFieldIndexer()); err != nil {
-		return fmt.Errorf("failed to setup manager %w", err)
-	}
+// SetupWithManager sets up the controller with the Manager.
+func (r *MCPGatewayExtensionReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
+	r.log = slog.New(logr.ToSlogHandler(mgr.GetLogger()))
 
 	// enqueue mcpgateway extensions when the gateway changes
 	// enqueue when reference grants change

--- a/internal/controller/setup_indexes_test.go
+++ b/internal/controller/setup_indexes_test.go
@@ -1,0 +1,33 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockFieldIndexer struct {
+	calls []string
+}
+
+func (m *mockFieldIndexer) IndexField(_ context.Context, _ client.Object, field string, _ client.IndexerFunc) error {
+	m.calls = append(m.calls, field)
+	return nil
+}
+
+func TestSetupRequiredIndexes(t *testing.T) {
+	indexer := &mockFieldIndexer{}
+	if err := SetupRequiredIndexes(context.Background(), indexer); err != nil {
+		t.Fatalf("SetupRequiredIndexes failed: %v", err)
+	}
+	if len(indexer.calls) != 2 {
+		t.Fatalf("expected 2 index registrations, got %d", len(indexer.calls))
+	}
+	if indexer.calls[0] != gatewayIndexKey {
+		t.Errorf("expected first index to be %q, got %q", gatewayIndexKey, indexer.calls[0])
+	}
+	if indexer.calls[1] != refGrantIndexKey {
+		t.Errorf("expected second index to be %q, got %q", refGrantIndexKey, indexer.calls[1])
+	}
+}


### PR DESCRIPTION
## Summary

- Add `DISABLE_EXTENSION_RECONCILER=true` env var to skip `MCPGatewayExtensionReconciler` registration while keeping `MCPReconciler` and `MCPVirtualServerReconciler` running
- Extract field index setup into exported `SetupRequiredIndexes()` so indexes are registered regardless of whether the extension reconciler is enabled
- Add Helm chart support via `controller.disableExtensionReconciler` value

Closes #1227
Part of #1226

## Test plan

- [x] `make lint` passes
- [x] `make test-unit` passes
- [ ] `make test-controller-integration` passes
- [ ] Deploy with `DISABLE_EXTENSION_RECONCILER=true` and verify MCPReconciler/MCPVirtualServerReconciler still function