### PR TITLE
feat: umbrella operator integration (kuadrant-operator managed mcp-gateway)

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - type: olm.package
-    value:
-      packageName: kuadrant-operator
-      version: ">=1.4.3"

--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-gateway
 description: A Kubernetes gateway for aggregating and routing Model Context Protocol (MCP) servers
 type: application
-version: 0.1.0
-appVersion: "latest"
+version: 0.7.1
+appVersion: "0.7.1"
 home: https://github.com/Kuadrant/mcp-gateway
 sources:
   - https://github.com/Kuadrant/mcp-gateway

--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-gateway
 description: A Kubernetes gateway for aggregating and routing Model Context Protocol (MCP) servers
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.8.0
+appVersion: "0.8.0"
 home: https://github.com/Kuadrant/mcp-gateway
 sources:
   - https://github.com/Kuadrant/mcp-gateway

--- a/charts/mcp-gateway/templates/networkpolicy-broker-router.yaml
+++ b/charts/mcp-gateway/templates/networkpolicy-broker-router.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-broker-router
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+        - port: 50051
+          protocol: TCP
+  egress:
+    - {}
+{{- end }}

--- a/charts/mcp-gateway/templates/networkpolicy-broker-router.yaml
+++ b/charts/mcp-gateway/templates/networkpolicy-broker-router.yaml
@@ -19,6 +19,8 @@ spec:
           protocol: TCP
         - port: 50051
           protocol: TCP
+        - port: 9090
+          protocol: TCP
   egress:
     - {}
 {{- end }}

--- a/charts/mcp-gateway/templates/networkpolicy-controller.yaml
+++ b/charts/mcp-gateway/templates/networkpolicy-controller.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.networkPolicy.enabled .Values.controller.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8081
+          protocol: TCP
+        - port: 8082
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/charts/mcp-gateway/templates/rbac.yaml
+++ b/charts/mcp-gateway/templates/rbac.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "mcp-gateway.fullname" . }}-controller
+  name: mcp-gateway-controller
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
     component: controller
@@ -127,7 +127,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "mcp-gateway.fullname" . }}-controller
+  name: mcp-gateway-controller
 subjects:
   - kind: ServiceAccount
     name: {{ include "mcp-gateway.controllerServiceAccountName" . }}

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -101,3 +101,7 @@ mcpGatewayExtension:
     generate: ""
     # The name of the secret containing a pre-existing key pair
     secretName: ""
+
+# Network policies for broker-router and controller pods
+networkPolicy:
+  enabled: false


### PR DESCRIPTION
## Summary

mcp-gateway-side changes to align the Helm chart with the kuadrant-operator umbrella operator pattern (RFC 0019). Under this model, kuadrant-operator renders child operator Helm charts at runtime on startup using the Helm Go SDK and applies all resources via SSA.

### Commits

- **feat: add default NetworkPolicy templates to Helm chart (#1228)** — configurable NetworkPolicy templates for broker-router and controller pods, disabled by default
- **fix: update Helm chart version to match release (#1229)** — chart version alignment
- **chore: remove OLM dependency declaration (#1230)** — drop \`bundle/metadata/dependencies.yaml\`; mcp-gateway will no longer ship as a standalone OLM operator
- **fix: hardcode ClusterRole name in Helm chart** — \`mcp-gateway-controller\` is stable and predictable for kuadrant-operator's \`bind/escalate\` \`resourceNames\`; the \`fullname\` helper is appropriate for namespaced resources but not cluster-scoped ones
- **fix: restore ClusterRole to templates/rbac.yaml for standalone Helm install** — ClusterRole stays in \`templates/\` so both standalone \`helm install\` and kuadrant-operator's runtime rendering apply it correctly
- **fix: remove static/clusterroles.yaml** — the split-chart approach (extracting CRDs/ClusterRoles for installer-managed pre-install) is explicitly rejected in RFC 0019 due to OLM GVK conflicts during upgrades

### Design alignment

Per RFC 0019 (merged 2026-07-29), kuadrant-operator applies all child operator resources (CRDs, ClusterRoles, Deployments) at runtime on startup via full chart rendering. Child CRDs are not included in the OLM bundle. The chart is consumed as-is — no splitting, no static extraction.

### NetworkPolicy design

Two NetworkPolicy templates are added, both opt-in via `networkPolicy.enabled` (default: `false`).

**Broker-router** (`networkpolicy-broker-router.yaml`) — selects broker+router pods via `app.kubernetes.io/name`:

| Direction | Ports | Rationale |
|-----------|-------|-----------|
| Ingress | 8080/TCP | Broker HTTP (upstream MCP traffic from Envoy) |
| Ingress | 50051/TCP | Router gRPC ext_proc (from Envoy) |
| Ingress | 9090/TCP | Metrics / health probes |
| Egress | all | Broker must reach arbitrary user-configured upstream MCP servers |

Ingress has no `from:` selector — Envoy's pod identity varies by Gateway provider. Egress is fully open (`{}`) by necessity: upstream server addresses are user-supplied and cannot be enumerated at chart render time.

**Controller** (`networkpolicy-controller.yaml`) — selects controller pods via `controllerSelectorLabels`. Only rendered when `controller.enabled` is also true.

| Direction | Ports | Rationale |
|-----------|-------|-----------|
| Ingress | 8081/TCP | Readiness/liveness probes (kubelet, no pod selector possible) |
| Ingress | 8082/TCP | Metrics |
| Egress | 443/TCP | Kubernetes API server (standard), webhooks, HTTPS |
| Egress | 6443/TCP | Kubernetes API server (OpenShift default port) |
| Egress | 53/TCP+UDP | DNS |

Controller egress is restricted to the minimum needed: kube-apiserver and DNS. Both 443 and 6443 are included to cover kubeadm and OpenShift clusters.

### Related

- Docs PR: #1283
- RFC 0019: https://github.com/Kuadrant/architecture/pull/189
- Epic: #1226

Closes #1228
Closes #1229
Closes #1230
Closes #1232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional network policies for broker-router and controller components, with configurable ingress and egress rules.
  * Added Helm settings to enable or disable these network policies.

* **Improvements**
  * Updated the chart and application version to 0.8.0.
  * Improved controller permissions and resource naming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->