### PR TITLE
fix: add Serial decorator to CA Cert Bundle e2e test

### DIFF
--- a/tests/e2e/ca_cert_bundle_test.go
+++ b/tests/e2e/ca_cert_bundle_test.go
@@ -47,7 +47,7 @@ func patchExtensionCACertBundle(ref *mcpv1alpha1.CACertBundleReference) {
 	Expect(k8sClient.Patch(ctx, ext, client.RawPatch(types.MergePatchType, patchBytes))).To(Succeed())
 }
 
-var _ = Describe("CA Cert Bundle", Ordered, func() {
+var _ = Describe("CA Cert Bundle", Ordered, Serial, func() {
 	var (
 		testResources    []client.Object
 		mcpGatewayClient *NotifyingMCPClient


### PR DESCRIPTION
## Summary
- Add `Serial` decorator to CA Cert Bundle e2e test suite, which mutates the shared `MCPGatewayExtension` and can race with other parallel suites

Flagged by CodeRabbit in #1224.

## Test plan
- [ ] Existing e2e tests pass (no behavioural change, just scheduling constraint)