### PR TITLE
fix: mark UserSpecificList scale-down test Serial to stop 503 flakes

### DIFF
--- a/tests/e2e/user_specific_list_test.go
+++ b/tests/e2e/user_specific_list_test.go
@@ -20,7 +20,10 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 	)
 
 	BeforeEach(func() {
-		_ = ScaleDeployment(ctx, TestServerNameSpace, userSpecificMCPTestServer, 1)
+		Expect(ScaleDeployment(ctx, TestServerNameSpace, userSpecificMCPTestServer, 1)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, userSpecificMCPTestServer)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 	})
 
 	AfterEach(func() {
@@ -224,7 +227,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		GinkgoWriter.Printf("baseline standard tool count: %d\n", baselineCount)
 	})
 
-	It("[UserSpecificList] user-specific server down does not break tools/list", func() {
+	It("[UserSpecificList] user-specific server down does not break tools/list", Serial, func() {
 		By("Creating a standard server registration")
 		stdReg := NewMCPServerResourcesWithDefaults("uspec-degrade", k8sClient).
 			WithPrefix("std_").Build()
@@ -264,6 +267,9 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 
 		By("Scaling user-specific server back up for other tests")
 		Expect(ScaleDeployment(ctx, TestServerNameSpace, userSpecificMCPTestServer, 1)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(WaitForDeploymentReady(ctx, TestServerNameSpace, userSpecificMCPTestServer)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 	})
 
 	It("[UserSpecificList] tool call routing works for user-specific tools", func() {


### PR DESCRIPTION
## Summary
- Add `Serial` to the scale-down test in `user_specific_list_test.go` so it cannot run in parallel with tool-call tests across Ginkgo processes (`E2E_PROCS=4`)
- Wait for `mcp-test-user-specific-server` readiness after scale-up in `BeforeEach` and at test teardown

Fixes #1242

## Root cause
The scale-down test scales `mcp-test-user-specific-server` to 0 while other parallel specs call tools against the same backend, causing intermittent Envoy 503 responses.

## Test plan
- [x] `make lint-go` (Go lint checks passed)
- [x] `make test-unit`
- [x] `go test -tags=e2e -c ./tests/e2e` (compiles)
- [ ] Full e2e reproduction requires Kind cluster (`make test-e2e-ci E2E_PROCS=4`); CI will validate on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of user-specific gateway flows by waiting for backend readiness after scaling changes.
  * Reduced flaky behavior in list and tools checks by better synchronizing deployment recovery during end-to-end tests.
* **Tests**
  * Updated end-to-end coverage for user-specific server up/down scenarios to run more deterministically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->