### PR TITLE
fix: correct actions/github-script SHA in issue-triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -17,7 +17,7 @@ jobs:
       issues: write
     steps:
       - name: Triage issue
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c37999e00 # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             // ------------------------------------------------------


### PR DESCRIPTION
The SHA pinned for `actions/github-script` in the issue-triage workflow is invalid — `60a0d83039c74a4aee543508d2ffcb1c37999e00` does not exist in the `actions/github-script` repository, causing every issue event to fail at job setup.

This replaces it with the correct SHA for the `v8` tag: `ed597411d8f924073f98dfc5c65a23a2325f34cd`.

Fixes the failure introduced by #906: https://github.com/Kuadrant/mcp-gateway/actions/runs/28887775251/job/85692296275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow dependencies to maintain compatibility and stability with the latest tooling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->