### PR TITLE
fix: prevent standalone SSE failures killing broker upstream sessions

### DIFF
--- a/docs/design/backend-mcp-management.md
+++ b/docs/design/backend-mcp-management.md
@@ -63,13 +63,12 @@ sequenceDiagram
   Server->>Manager: initialize response
   Note right of Manager: Validate protocol version<br/>and capabilities
   Manager->>Server: POST /mcp "notifications/initialized"
-  Note right of Manager: Subscribe to state change<br/>notifications via SSE
-  Manager->>Server: GET /mcp [SSE connection]
+  Manager->>Server: GET /mcp [supervised notification watcher]
+  Note right of Manager: Watcher failure never fails<br/>the session; re-list backstops
   Manager->>Server: POST /mcp "tools/list"
   Server->>Manager: tools/list response
   Manager->>Broker: Register discovered tools
-  Manager->>Manager: Periodic health checks
-  Manager->>Server: [monitor for notifications]
+  Manager->>Manager: Periodic health checks and re-list
   Controller->>Broker: Fetch status updates /status
 ```
 
@@ -79,36 +78,37 @@ The `MCPManager` is responsible for managing a single upstream MCP server connec
 
 1. **Initialization**: Establishes connection, validates protocol version and capabilities
 2. **Discovery**: Fetches initial tool list and registers tools with the broker
-3. **Notification Subscription**: Sets up SSE connection for state change events
-4. **Health Monitoring**: Periodically checks connection health and reconnects if needed
-5. **Notification Handling**: Processes state change notifications and forwards them to the broker
-6. **Graceful Shutdown**: Cleans up connections and resources when stopped
+3. **Health Monitoring**: Periodically checks connection health, re-lists tools/prompts, and reconnects if needed
+4. **Notification Handling**: Reacts to `list_changed` notifications from the notification watcher with an immediate re-list
+5. **Graceful Shutdown**: Cleans up connections, including the notification watcher, when stopped
 
-### State Change Notifications
+### Upstream Freshness
 
-The MCPManager subscribes to state change notifications from the upstream MCP server:
+The MCP Go SDK opens the standalone GET SSE stream synchronously inside `Connect` on a detached context and treats its failure as session-fatal, so a single upstream that mishandles the GET would block connection establishment for minutes and then poison the session. The SDK therefore never owns that stream (`DisableStandaloneSSE` is set, matching the router's hairpin client).
 
-- `notifications/tools/list_changed`
-- `notifications/resources/list_changed`
-- `notifications/prompts/list_changed`
-- `notifications/roots/list_changed`
+Instead, each connected session runs a broker-owned **notification watcher** that holds the standalone GET stream with the broker's failure semantics:
 
-When a notification is received, the MCPManager:
-1. Updates its internal state (e.g., re-fetches tool list)
-2. Forwards the notification to the broker
-3. The broker forwards it to all connected clients
+- Failures are never fatal to the session: the watcher retries forever with capped exponential backoff (aligned with the manager's backoff)
+- A `405`/`404` response, or a `200` without an SSE content type, means the upstream does not offer the stream: the watcher stops permanently, the session is unaffected
+- `notifications/tools/list_changed` and `notifications/prompts/list_changed` trigger an immediate re-list through the manager's existing refresh path
+- Server pings delivered on the stream are answered, so keepalive-enabled upstreams do not consider the broker session dead
+- The watcher resumes with `Last-Event-ID` when the upstream supplies event ids
+- The watcher uses the same HTTP client as all other upstream calls (auth headers, TLS trust pool, response header timeout)
 
-For more details, see the [notifications design documentation](./notifications.md).
+The manager additionally re-lists tools and prompts on every health tick regardless of the upstream's `listChanged` capability. This poll backstop is deliberate: upstreams without event replay do not buffer notifications sent while the stream is down (reconnect windows lose events), and the watcher stops permanently for upstreams that do not offer the stream at all. Push keeps updates immediate; the tick bounds worst-case staleness at the ticker interval (default 1 minute) in every failure mode.
+
+For `userSpecificList` servers the manager's health session still starts a watcher like any other connected session; only the per-user sessions do not run one, as their tool lists are fetched per request, leaving no cached state for a notification to refresh and nothing consuming server pushes.
+
+For client-facing notification forwarding, see the [notifications design documentation](./notifications.md).
 
 ### Error Handling and Retry Logic
 
 The MCPManager implements exponential backoff retry for:
 - Initial connection failures
+- Ping (health check) failures
 - Discovery failures
-- Health check failures
-- Notification connection drops
 
-Retries are handled in background routines to avoid blocking the main broker operations.
+On connection or ping failure the manager keeps serving its cached tools and prompts, dropping them only after three consecutive failed checks (`maxConsecutiveFailures`), avoiding client-visible tool churn on transient blips. Retries are handled in background routines to avoid blocking the main broker operations.
 
 ### Status and Health
 

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -4,7 +4,7 @@
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| `notifications/tools/list_changed` (upstream detection) | Implemented | MCPManager detects and re-fetches tools |
+| `notifications/tools/list_changed` (upstream detection) | Implemented | Pushed over the broker-owned notification watcher, backstopped by the periodic re-list; see below |
 | `notifications/tools/list_changed` (client forwarding) | Implemented | MCP Go SDK dispatch, filtered per session by the broker's targeting middleware; E2E tested |
 | Progress updates (streamed in tool call POST) | Implemented | Handled by the MCP Go SDK; covered by `tools-call-with-progress` conformance test |
 | Elicitation request/response routing (form mode) | Implemented | JSON-RPC request ID mapping; E2E tested |
@@ -47,7 +47,7 @@ Progress updates are streamed as events within tool call POST responses by the M
 
 The MCP Gateway supports two distinct types of notification mechanisms:
 
-1. **State Change Events**: Notifications that are safe to send to all connected clients (e.g., `notifications/tools/list_changed`, `notifications/resources/list_changed`, `notifications/prompts/list_changed`, `notifications/roots/list_changed`). These are received via persistent Server-Sent Events (SSE) connections the broker maintains to all backend MCP servers using the broker's configured authentication credentials.
+1. **State Change Events**: Notifications that are safe to send to all connected clients (e.g., `notifications/tools/list_changed`, `notifications/resources/list_changed`, `notifications/prompts/list_changed`, `notifications/roots/list_changed`). The broker receives these over a standalone GET SSE stream it holds to each connected upstream using the broker's configured authentication credentials. The stream is owned by a broker-side **notification watcher** rather than the MCP Go SDK: watcher failures never affect the session, and the MCPManager's periodic re-list backstops freshness. See [backend MCP management](./backend-mcp-management.md#upstream-freshness) for the rationale and failure semantics.
 
 2. **Client-Specific Events**: Events related to specific client sessions that are streamed as part of tool call POST responses:
    - Progress updates for long-running tool calls
@@ -61,7 +61,7 @@ The broker maintains a Server-Sent Events (SSE) connection with each connected c
 
 #### State Change Events
 
-> **Implementation Note**: The `notifications/tools/list_changed` event is fully implemented. The MCPManager detects this notification from upstream servers and re-fetches the tool list. The MCP Go SDK handles forwarding state change notifications to all connected clients via their GET SSE connections. Other state change events (`resources/list_changed`, `prompts/list_changed`, `roots/list_changed`) are not applicable as the gateway currently only federates tools.
+> **Implementation Note**: The `notifications/tools/list_changed` event is fully implemented. The notification watcher (`internal/broker/upstream/notification_watcher.go`) receives upstream pushes and triggers an immediate re-list; the MCPManager's periodic health tick re-list backstops any push the watcher misses. The MCP Go SDK handles forwarding state change notifications to all connected clients via their GET SSE connections. Other state change events (`resources/list_changed`, `prompts/list_changed`, `roots/list_changed`) are not applicable as the gateway currently only federates tools.
 
 State change events are notifications that are safe and appropriate to send to all connected clients. The gateway supports the following state change events:
 
@@ -80,17 +80,17 @@ sequenceDiagram
   participant Server1 as MCP Server 1
   participant Server2 as MCP Server 2
 
-  Note over Gateway, Server2: State change event channel establishment
+  Note over Gateway, Server2: Broker session establishment
   Gateway ->> Server1: POST /mcp "initialize" (broker auth)
   Server1 -->> Gateway: initialize response (capabilities)
   Gateway ->> Server1: POST /mcp "notifications/initialized"
-  Gateway ->> Server1: GET /mcp
-  Server1 -->> Gateway: SSE connection established
+  Gateway ->> Server1: GET /mcp [notification watcher]
+  Server1 -->> Gateway: SSE stream established
   Gateway ->> Server2: POST /mcp "initialize" (broker auth)
   Server2 -->> Gateway: initialize response (capabilities)
   Gateway ->> Server2: POST /mcp "notifications/initialized"
-  Gateway ->> Server2: GET /mcp
-  Server2 -->> Gateway: SSE connection established
+  Gateway ->> Server2: GET /mcp [notification watcher]
+  Server2 -->> Gateway: SSE stream established
   Note over Client1, Gateway: Client notifications connection
   Client1 ->> Gateway: POST /mcp "initialize"
   Client1 ->> Gateway: POST /mcp "notifications/initialized"
@@ -100,30 +100,27 @@ sequenceDiagram
   Client2 ->> Gateway: POST /mcp "notifications/initialized"
   Client2 ->> Gateway: GET /mcp
   Gateway -->> Client2: SSE connection established
-  Note over Server2, Client1: State change events
+  Note over Server2, Client1: State change events (push, re-list backstop)
   Server1 -->> Gateway: notifications/tools/list_changed
-  Gateway -->> Client1: forward notification
-  Gateway -->> Client2: forward notification
-  Server2 -->> Gateway: notifications/prompts/list_changed
-  Gateway -->> Client1: forward notification
-  Gateway -->> Client2: forward notification
+  Gateway ->> Server1: POST /mcp "tools/list" (immediate re-list)
+  Server1 -->> Gateway: tools/list response (changed)
+  Gateway -->> Client1: notifications/tools/list_changed
+  Gateway -->> Client2: notifications/tools/list_changed
 ```
 
-1. **Capability Checking**: When a backend MCP server is discovered, the broker first sends an `initialize` request using the broker's configured authentication credentials. The broker checks the `initialize` response to determine which state change event [capabilities](https://modelcontextprotocol.io/specification/2025-06-18/server/resources) the server supports (e.g., `notifications/tools/list_changed`, `notifications/resources/list_changed`, etc.).
+1. **Capability Checking**: When a backend MCP server is discovered, the broker first sends an `initialize` request using the broker's configured authentication credentials and validates the protocol version and declared [capabilities](https://modelcontextprotocol.io/specification/2025-06-18/server/resources).
 
-2. **Persistent Broker Connections**: For each backend MCP server that supports state change events, the broker establishes a persistent GET connection:
-   - Sends a `notifications/initialized` notification
-   - Establishes a GET `/mcp` connection for receiving SSE notifications
-   
-   These connections remain open for the lifetime of the backend server connection. The broker must implement reconnection logic to handle cases where connections are dropped due to server restarts, session invalidation, or network issues.
+2. **Notification Watching**: After each session is established, a broker-owned notification watcher opens a GET `/mcp` SSE stream to the upstream. Watcher failures never affect the session: transient errors retry forever with capped backoff, and upstreams that do not offer the stream (405/404 or non-SSE responses) stop the watcher permanently while the session carries on.
 
-3. **Event Reception and Forwarding**: When a backend MCP server sends a state change event (e.g., `notifications/tools/list_changed`), the broker receives it via the persistent connection and forwards it to all currently connected clients via their respective GET connections.
+3. **Re-list and Diff**: A pushed `list_changed` triggers an immediate re-list; the MCPManager also re-lists on its periodic health tick as a backstop, since notifications sent while the stream is down are not buffered by upstreams without event replay. Either way the result is diffed against the cached set and applied to the gateway's tool registry.
 
-4. **Client Response**: Clients typically respond to `list_changed` notifications by making a new `tools/list`, `resources/list`, `prompts/list`, or `roots/list` request to refresh their understanding of available primitives.
+4. **Forwarding**: When the re-list changes the gateway's tool registry, the MCP Go SDK dispatches `notifications/tools/list_changed` to all currently connected clients via their respective GET connections.
 
-**Why Broker Auth for State Change Events:**
+5. **Client Response**: Clients typically respond to `list_changed` notifications by making a new `tools/list`, `resources/list`, `prompts/list`, or `roots/list` request to refresh their understanding of available primitives.
 
-The broker uses its own authentication credentials (configured at startup) rather than client credentials because state change events are not tied to any specific client session, must be received even when no clients have made tool calls yet, and allows the broker to maintain a single persistent connection per backend server rather than per client.
+**Why Broker Auth for State Change Detection:**
+
+The broker uses its own authentication credentials (configured at startup) rather than client credentials because state changes are not tied to any specific client session, must be detected even when no clients have made tool calls yet, and this allows the broker to maintain a single session and notification stream per backend server rather than per client.
 
 #### Gateway-Initiated Notifications: Targeting and the Sentinel Tool
 
@@ -306,11 +303,11 @@ The request ID mapping created for the original `elicitation/create` is cleaned 
 ### Implementation Considerations
 
 1. **Connection Management**: The broker must efficiently manage multiple concurrent connections:
-   - One persistent GET connection per backend MCP server (for state change events)
+   - One session plus one watched GET stream per backend MCP server (state change events, backstopped by the periodic re-list)
    - One GET connection per connected client (for receiving state change events)
    - Long-running POST connections for tool calls that emit progress updates or elicitations
 
-2. **Capability Detection**: The broker must check the `initialize` response from each backend MCP server to determine which state change event capabilities are supported before establishing GET notification connections.
+2. **Capability Detection**: The broker must check the `initialize` response from each backend MCP server to validate the protocol version and declared capabilities.
 
 3. **Request ID Mapping**: The router maintains a mapping table for elicitation request IDs that includes:
    - Gateway-assigned request ID (random UUID)

--- a/docs/design/prompts-federation.md
+++ b/docs/design/prompts-federation.md
@@ -112,7 +112,7 @@ The implementation follows the same pattern as tools throughout. Each component 
 
 #### Upstream Client (`internal/broker/upstream/mcp.go`)
 
-Add `ListPrompts()` and `SupportsPromptsListChanged()` to the `MCP` interface. These wrap the mcp-go client methods and check the initialize response capabilities.
+Add `ListPrompts()` and `SupportsPromptsListChanged()` to the `MCP` interface. These wrap the client methods and check the initialize response capabilities. The capability accessor no longer gates fetching: the manager re-lists on every timer tick as the backstop for the notification watcher.
 
 #### MCPManager (`internal/broker/upstream/manager.go`)
 
@@ -283,7 +283,7 @@ Behavioral decisions made during implementation:
 - **Transient failure handling**: A `getPrompts` or `getTools` listing failure preserves existing capabilities. Capabilities are only removed on connect/ping failure (server unreachable) or graceful shutdown.
 - **Conflict handling**: Both tool and prompt conflicts preserve existing capabilities and set error status, rather than removing all capabilities.
 - **Notification granularity**: `notifications/tools/list_changed` and `notifications/prompts/list_changed` are delivered via separate channels (`toolEvents`, `promptEvents`) with buffer of 1 each, preventing cross-type interference. A tool notification only re-fetches tools, not prompts, and vice versa.
-- **Fetch optimization**: `shouldFetchPrompts` mirrors `shouldFetchTools`. When a server supports `prompts/list_changed`, prompts are not re-fetched on timer ticks if already discovered.
+- **Fetch scoping**: `shouldFetchPrompts` mirrors `shouldFetchTools`. A prompt notification re-fetches only prompts, and every timer tick re-lists as the freshness backstop for the notification watcher.
 - **Shared routing**: `HandleToolCall` and `HandlePromptGet` share a `routeToUpstream` method for session lookup, lazy initialization, body marshaling, path resolution, and response building.
 - **Hairpin headers**: During lazy session initialization, `x-mcp-toolname` and `x-mcp-promptname` are only set when non-empty, preventing AuthPolicy rules from firing on irrelevant capability types.
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -475,7 +475,7 @@ func (m *mcpBrokerImpl) startManagers(ctx context.Context, servers []*config.MCP
 		if _, ok := m.mcpServers[mcpServer.ID()]; ok {
 			continue
 		}
-		manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer, m.gatewayCACertPEM), m.gatewayServer, m.gatewayServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
+		manager, err := upstream.NewUpstreamMCPManager(upstream.NewUpstreamMCP(mcpServer, m.gatewayCACertPEM, m.logger.With("sub-component", "mcp-upstream")), m.gatewayServer, m.gatewayServer, m.logger.With("sub-component", "mcp-manager"), m.managerTickerInterval, m.invalidToolPolicy)
 		if err != nil {
 			m.logger.ErrorContext(ctx, "failed to create manager", "server id", mcpServer.ID(), "error", err)
 			continue

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -300,7 +300,7 @@ func createTestManagerMCP(t *testing.T, serverName, prefix string, tools []mcp.T
 		Name:   serverName,
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
-	}, "")
+	}, "", nil)
 	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)
@@ -309,7 +309,7 @@ func createTestManagerMCP(t *testing.T, serverName, prefix string, tools []mcp.T
 
 func createTestManagerUserSpecific(t *testing.T, cfg config.MCPServer) *upstream.MCPManager {
 	t.Helper()
-	mcpServer := upstream.NewUpstreamMCP(&cfg, "")
+	mcpServer := upstream.NewUpstreamMCP(&cfg, "", nil)
 	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	return manager

--- a/internal/broker/discovery_test.go
+++ b/internal/broker/discovery_test.go
@@ -28,7 +28,7 @@ func createTestManagerWithMeta(t *testing.T, serverName, prefix string, tools []
 		URL:      "http://test.local/mcp",
 		Category: category,
 		Hint:     hint,
-	}, "")
+	}, "", nil)
 	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)

--- a/internal/broker/filtered_prompts_handler_test.go
+++ b/internal/broker/filtered_prompts_handler_test.go
@@ -21,7 +21,7 @@ func createPromptTestManager(t *testing.T, serverName, prefix string, prompts []
 		Name:   serverName,
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
-	}, "")
+	}, "", nil)
 	manager, _ := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	manager.SetPromptsForTesting(prompts)
 	return manager

--- a/internal/broker/filtered_tools_handler_test.go
+++ b/internal/broker/filtered_tools_handler_test.go
@@ -60,7 +60,7 @@ func createTestManager(t *testing.T, serverName, prefix string, tools []mcp.Tool
 		Name:   serverName,
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
-	}, "")
+	}, "", nil)
 	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	// populate tools directly for testing (this requires accessing internal state)

--- a/internal/broker/status_test.go
+++ b/internal/broker/status_test.go
@@ -34,7 +34,7 @@ func createTestManagerForStatus(t *testing.T, serverName string, tools []mcp.Too
 		Name:   serverName,
 		Prefix: "test_",
 		URL:    "http://test.local/mcp",
-	}, "")
+	}, "", nil)
 	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)

--- a/internal/broker/tags_handler_test.go
+++ b/internal/broker/tags_handler_test.go
@@ -153,7 +153,7 @@ func createTestManagerWithTags(t *testing.T, serverName, prefix string, tools []
 		Prefix: prefix,
 		URL:    "http://test.local/mcp",
 		Tags:   tags,
-	}, "")
+	}, "", nil)
 	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 	manager.SetToolsForTesting(tools)

--- a/internal/broker/upstream/hints_test.go
+++ b/internal/broker/upstream/hints_test.go
@@ -101,7 +101,7 @@ func TestToolHintsTee_EndToEnd(t *testing.T) {
 			ts := httptest.NewServer(handler)
 			defer ts.Close()
 
-			up := NewUpstreamMCP(&config.MCPServer{Name: "up", URL: ts.URL, Prefix: "up_"}, "")
+			up := NewUpstreamMCP(&config.MCPServer{Name: "up", URL: ts.URL, Prefix: "up_"}, "", nil)
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			require.NoError(t, up.Connect(ctx, func() {}))

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -203,10 +203,21 @@ type MCPManager struct {
 	promptEvents chan struct{}
 	done         chan struct{} // closed when the event loop exits
 	status       ServerValidationStatus
+
+	// consecutiveFailures counts connect/ping failures since the last
+	// healthy pass. only touched from the event loop goroutine.
+	consecutiveFailures int
 }
 
 // DefaultTickerInterval is the default interval for backend health checks
 const DefaultTickerInterval = time.Minute * 1
+
+// maxConsecutiveFailures is the number of consecutive connect/ping failures
+// tolerated before cached tools and prompts are dropped from the gateway.
+// tool calls route directly to the backend via envoy, so serving a cached
+// list through a transient upstream blip is no worse than the staleness
+// already allowed between health ticks, and avoids client-visible churn.
+const maxConsecutiveFailures = 3
 
 // NewUpstreamMCPManager creates a new MCPManager for managing a single upstream MCP server.
 // The addTools and removeTools callbacks are used to update the gateway's tool registry.
@@ -366,6 +377,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.removeAllTools()
 		man.removeAllPrompts()
 		_ = man.mcp.Disconnect()
+		man.consecutiveFailures = 0
 		man.setStatus(fmt.Errorf("server is disabled"), 0, 0, nil, nil)
 		return
 	}
@@ -375,28 +387,15 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	// during connect the client will validate the protocol. So we don't have a separate validate requirement currently. If a client already exists it will be re-used.
 	man.logger.DebugContext(ctx, "attempting to connect", "upstream mcp server", man.mcp.ID())
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
-		err = fmt.Errorf("failed to connect to upstream mcp %s removing tools : %w", man.mcp.ID(), err)
-		man.recordBackendError(span, err)
-		man.logger.ErrorContext(ctx, "connection failed", "upstream mcp server", man.mcp.ID(), "error", err)
-		man.removeAllTools()
-		man.removeAllPrompts()
-		// we call disconnect here as we may have connected but failed to initialize
-		_ = man.mcp.Disconnect()
-		man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+		man.handleConnectionFailure(ctx, span, fmt.Errorf("failed to connect to upstream mcp %s : %w", man.mcp.ID(), err), numberOfTools, numberOfPrompts)
 		return
 	}
 	// there may be an active client so we also ping
 	if err := man.mcp.Ping(ctx); err != nil {
-		// if we fail to ping we disconnect to ensure a fresh connection next time around
-		err = fmt.Errorf("upstream mcp failed to ping server %s removing tools : %w", man.mcp.ID(), err)
-		man.recordBackendError(span, err)
-		man.logger.ErrorContext(ctx, "ping failed", "upstream mcp server", man.mcp.ID(), "error", err)
-		man.removeAllTools()
-		man.removeAllPrompts()
-		_ = man.mcp.Disconnect()
-		man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+		man.handleConnectionFailure(ctx, span, fmt.Errorf("upstream mcp failed to ping server %s : %w", man.mcp.ID(), err), numberOfTools, numberOfPrompts)
 		return
 	}
+	man.consecutiveFailures = 0
 
 	if man.mcp.GetConfig().UserSpecificList {
 		man.logger.Debug("userSpecificList server healthy, tools fetched per-user", "upstream mcp server", man.mcp.ID())
@@ -535,25 +534,19 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	}
 }
 
+// shouldFetchTools reports whether this event warrants a tools/list.
+// list-changed pushes from the notification watcher trigger an immediate
+// fetch; the timer re-list backstops them regardless of the upstream's
+// listChanged capability, since the watcher stops permanently for
+// upstreams without the stream and events sent while it reconnects are
+// lost unless the upstream replays them.
 func (man *MCPManager) shouldFetchTools(event eventType) bool {
-	// fetch if no support for tools list change notifications
-	if !man.mcp.SupportsToolsListChanged() {
-		return true
-	}
-	if event == eventTypeToolNotification {
-		return true
-	}
-	return event == eventTypeTimer && len(man.serverTools) == 0
+	return event == eventTypeTimer || event == eventTypeToolNotification
 }
 
+// shouldFetchPrompts mirrors shouldFetchTools for prompts.
 func (man *MCPManager) shouldFetchPrompts(event eventType) bool {
-	if !man.mcp.SupportsPromptsListChanged() {
-		return true
-	}
-	if event == eventTypePromptNotification {
-		return true
-	}
-	return event == eventTypeTimer && len(man.serverPrompts) == 0
+	return event == eventTypeTimer || event == eventTypePromptNotification
 }
 
 // GetStatus returns the current status of the MCP Server
@@ -587,15 +580,45 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	}
 }
 
+// handleConnectionFailure records a connect/ping failure and backs off the
+// retry. cached tools and prompts stay served through transient failures
+// and are only dropped once the failure persists across
+// maxConsecutiveFailures attempts; the session is torn down either way so
+// the next attempt starts fresh.
+func (man *MCPManager) handleConnectionFailure(ctx context.Context, span trace.Span, err error, numberOfTools, numberOfPrompts int) {
+	man.consecutiveFailures++
+	man.recordBackendError(span, err)
+	man.logger.ErrorContext(ctx, "upstream connection failure", "upstream mcp server", man.mcp.ID(), "error", err, "consecutive failures", man.consecutiveFailures)
+	if man.consecutiveFailures >= maxConsecutiveFailures {
+		man.logger.ErrorContext(ctx, "failure threshold reached, removing tools and prompts", "upstream mcp server", man.mcp.ID(), "threshold", maxConsecutiveFailures)
+		man.removeAllTools()
+		man.removeAllPrompts()
+	}
+	_ = man.mcp.Disconnect()
+	man.setStatus(err, numberOfTools, numberOfPrompts, nil, nil)
+	man.applyBackoff()
+}
+
 func (man *MCPManager) resetBackoff() {
 	man.backoff = man.baseBackoff
-	man.ticker.Reset(man.tickerInterval)
+	man.resetTicker(man.tickerInterval)
 }
 
 func (man *MCPManager) applyBackoff() {
 	duration := man.backoff.Step()
 	man.logger.Debug("applying backoff", "duration", duration, "upstream mcp server", man.mcp.ID())
-	man.ticker.Reset(duration)
+	man.resetTicker(duration)
+}
+
+// resetTicker re-arms the ticker and drops a tick that fired while manage
+// was in flight, so the new interval applies instead of an immediate
+// re-run. only called from the event loop goroutine.
+func (man *MCPManager) resetTicker(d time.Duration) {
+	man.ticker.Reset(d)
+	select {
+	case <-man.ticker.C:
+	default:
+	}
 }
 
 func (man *MCPManager) recordBackendError(span trace.Span, err error) {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -539,6 +539,114 @@ func TestMCPManager_manage_PingError(t *testing.T) {
 	assert.Contains(t, status.Message, "ping")
 }
 
+// regression: the connect and ping failure paths returned before the
+// backoff was applied, so an unreachable upstream retried at raw ticker
+// cadence forever.
+func TestMCPManager_manage_ConnectionFailureAppliesBackoff(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	tests := []struct {
+		name string
+		fail func(m *MockMCP)
+		heal func(m *MockMCP)
+	}{
+		{
+			name: "connect failure",
+			fail: func(m *MockMCP) { m.connectErr = fmt.Errorf("connection refused") },
+			heal: func(m *MockMCP) { m.connectErr = nil },
+		},
+		{
+			name: "ping failure",
+			fail: func(m *MockMCP) { m.pingErr = fmt.Errorf("ping timeout") },
+			heal: func(m *MockMCP) { m.pingErr = nil },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := newMockMCP("test-server", "test_")
+			gateway := newMockToolsAdderDeleter()
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, time.Minute, mcpv1alpha1.InvalidToolPolicyFilterOut)
+			require.NoError(t, err)
+
+			tt.fail(mock)
+			manager.manage(context.Background(), eventTypeTimer)
+
+			assert.False(t, manager.GetStatus().Ready)
+			assert.NotEqual(t, manager.baseBackoff, manager.backoff, "failure must consume a backoff step")
+
+			tt.heal(mock)
+			manager.manage(context.Background(), eventTypeTimer)
+
+			assert.True(t, manager.GetStatus().Ready)
+			assert.Equal(t, manager.baseBackoff, manager.backoff, "success must reset the backoff")
+		})
+	}
+}
+
+// transient connect/ping failures must not thrash the gateway registry:
+// cached tools and prompts stay served until the failure persists across
+// maxConsecutiveFailures attempts.
+func TestMCPManager_manage_RetainsToolsUntilFailureThreshold(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx := context.Background()
+	mock := newMockMCP("test-server", "test_")
+	mock.tools = []mcp.Tool{validTool("tool1")}
+	mock.hasPromptsCap = true
+	mock.prompts = []mcp.Prompt{{Name: "prompt1"}}
+	gateway := newMockToolsAdderDeleter()
+	promptsGateway := newMockPromptsAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, promptsGateway, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	manager.manage(ctx, eventTypeTimer)
+	require.Len(t, gateway.tools, 1)
+	require.Len(t, promptsGateway.prompts, 1)
+
+	mock.connectErr = fmt.Errorf("connection refused")
+	for i := 1; i < maxConsecutiveFailures; i++ {
+		manager.manage(ctx, eventTypeTimer)
+		assert.False(t, manager.GetStatus().Ready, "failure %d: status must go not ready", i)
+		assert.Len(t, gateway.tools, 1, "failure %d: tools must be retained below the threshold", i)
+		assert.Len(t, promptsGateway.prompts, 1, "failure %d: prompts must be retained below the threshold", i)
+	}
+
+	manager.manage(ctx, eventTypeTimer)
+	assert.Empty(t, gateway.tools, "tools must be dropped once the failure threshold is reached")
+	assert.Empty(t, promptsGateway.prompts, "prompts must be dropped once the failure threshold is reached")
+}
+
+func TestMCPManager_manage_FailureCountResetsOnSuccess(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx := context.Background()
+	mock := newMockMCP("test-server", "test_")
+	mock.tools = []mcp.Tool{validTool("tool1")}
+	gateway := newMockToolsAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	manager.manage(ctx, eventTypeTimer)
+	require.Len(t, gateway.tools, 1)
+
+	// two failures, then a recovery
+	mock.connectErr = fmt.Errorf("connection refused")
+	manager.manage(ctx, eventTypeTimer)
+	manager.manage(ctx, eventTypeTimer)
+	mock.connectErr = nil
+	manager.manage(ctx, eventTypeTimer)
+	require.True(t, manager.GetStatus().Ready)
+
+	// two more failures: the earlier streak must not count against these
+	mock.connectErr = fmt.Errorf("connection refused")
+	manager.manage(ctx, eventTypeTimer)
+	manager.manage(ctx, eventTypeTimer)
+	assert.Len(t, gateway.tools, 1, "failure count must reset on success")
+
+	// a third consecutive failure crosses the threshold
+	manager.manage(ctx, eventTypeTimer)
+	assert.Empty(t, gateway.tools)
+}
+
 func TestMCPManager_manage_ListToolsError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	mock := newMockMCP("test-server", "test_")
@@ -744,14 +852,14 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 		expectedShouldFetch     bool
 	}{
 		{
-			name:                    "no tools list change support always fetch on timer",
+			name:                    "no tools list change support fetch on timer",
 			supportsToolsListChange: false,
 			hasExistingTools:        true,
 			eventType:               eventTypeTimer,
 			expectedShouldFetch:     true,
 		},
 		{
-			name:                    "no tools list change support always fetch on notification",
+			name:                    "no tools list change support fetch on notification",
 			supportsToolsListChange: false,
 			hasExistingTools:        true,
 			eventType:               eventTypeToolNotification,
@@ -765,11 +873,14 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			expectedShouldFetch:     true,
 		},
 		{
-			name:                    "with tools list change support skip fetch on timer when tools exist",
+			// the standalone SSE stream to upstreams is disabled, so
+			// list-changed pushes cannot be relied on; the timer re-list
+			// is the freshness fallback regardless of capability
+			name:                    "with tools list change support fetch on timer when tools exist",
 			supportsToolsListChange: true,
 			hasExistingTools:        true,
 			eventType:               eventTypeTimer,
-			expectedShouldFetch:     false,
+			expectedShouldFetch:     true,
 		},
 		{
 			name:                    "with tools list change support fetch on timer when no tools",
@@ -777,6 +888,13 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 			hasExistingTools:        false,
 			eventType:               eventTypeTimer,
 			expectedShouldFetch:     true,
+		},
+		{
+			name:                    "prompt notification does not fetch tools",
+			supportsToolsListChange: true,
+			hasExistingTools:        true,
+			eventType:               eventTypePromptNotification,
+			expectedShouldFetch:     false,
 		},
 	}
 
@@ -798,7 +916,7 @@ func TestMCPManager_shouldFetchTools(t *testing.T) {
 	}
 }
 
-func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *testing.T) {
+func TestMCPManager_manage_FetchesOnTimerWhenToolsListChangeSupported(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	mock := newMockMCP("test-server", "test_")
 	mock.tools = []mcp.Tool{validTool("tool1")}
@@ -807,23 +925,19 @@ func TestMCPManager_manage_SkipsFetchOnTimerWhenToolsListChangeSupported(t *test
 	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, mcpv1alpha1.InvalidToolPolicyFilterOut)
 	require.NoError(t, err)
 
-	// First call with notification - should fetch and add tools
+	// first call with notification - should fetch and add tools
 	manager.manage(context.Background(), eventTypeToolNotification)
 	assert.Equal(t, 1, gateway.addCalls, "should add tools on notification")
 	assert.Len(t, gateway.tools, 1)
 
-	// Update mock tools - simulating a change on the server
+	// update mock tools - simulating a change on the server
 	mock.tools = []mcp.Tool{validTool("tool1"), validTool("tool2")}
 
-	// Timer event - should skip fetching since we support notifications and have tools
+	// timer event - must pick up the change: with the standalone SSE stream
+	// disabled the periodic re-list is the only freshness mechanism
 	manager.manage(context.Background(), eventTypeTimer)
-	assert.Equal(t, 1, gateway.addCalls, "should not fetch tools on timer when notifications supported")
-	assert.Len(t, gateway.tools, 1, "tools should remain unchanged")
-
-	// Notification event - should fetch and update tools
-	manager.manage(context.Background(), eventTypeToolNotification)
-	assert.Equal(t, 2, gateway.addCalls, "should fetch tools on notification")
-	assert.Len(t, gateway.tools, 2, "tools should be updated")
+	assert.Equal(t, 2, gateway.addCalls, "should fetch tools on timer")
+	assert.Len(t, gateway.tools, 2, "timer re-list should pick up upstream change")
 }
 
 func TestMCPManager_manage_OnlyCallsAddDeleteWhenNeeded(t *testing.T) {

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -17,8 +18,8 @@ import (
 
 // Transport-level timeouts for upstream HTTP clients. We bound connection
 // establishment and response-header reads instead of setting http.Client.Timeout,
-// because the streamable HTTP client reuses the same client for the long-lived
-// SSE listen stream, which must not be capped.
+// because the same client carries the long-lived SSE notification stream,
+// which must not be capped.
 var (
 	defaultTLSHandshakeTimeout   = 10 * time.Second
 	defaultResponseHeaderTimeout = 30 * time.Second
@@ -36,6 +37,12 @@ type MCPServer struct {
 	headers          map[string]string
 	init             *mcp.InitializeResult
 	gatewayCACertPEM string
+	logger           *slog.Logger
+
+	// notification watcher state for the current session, guarded by
+	// clientMu; at most one watcher per connected session
+	watcher       *notificationWatcher
+	watcherCancel context.CancelFunc
 
 	// toolHints preserves raw annotation fidelity from the last tools/list
 	// exchange, keyed by served (prefixed) tool name. populated by the
@@ -50,11 +57,16 @@ type MCPServer struct {
 	notifyHandler func(method string)
 }
 
-// NewUpstreamMCP creates a new MCPServer instance from the provided configuration.
-func NewUpstreamMCP(config *config.MCPServer, gatewayCACertPEM string) *MCPServer {
+// NewUpstreamMCP creates a new MCPServer instance from the provided
+// configuration. A nil logger discards output.
+func NewUpstreamMCP(config *config.MCPServer, gatewayCACertPEM string, logger *slog.Logger) *MCPServer {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
 	up := &MCPServer{
 		MCPServer:        config,
 		gatewayCACertPEM: gatewayCACertPEM,
+		logger:           logger,
 	}
 	up.headers = map[string]string{
 		"user-agent":        "mcp-broker",
@@ -75,9 +87,8 @@ func (up *MCPServer) buildHTTPClient() (*http.Client, error) {
 	base := http.DefaultTransport.(*http.Transport).Clone()
 	base.TLSHandshakeTimeout = defaultTLSHandshakeTimeout
 	base.ExpectContinueTimeout = defaultExpectContinueTimeout
-	// bounds header wait only, not SSE body streaming. without it an
-	// upstream that never answers the standalone SSE GET hangs Connect
-	// forever (the SDK opens that GET synchronously with no deadline).
+	// bounds header wait only, not SSE body streaming. without it a silent
+	// upstream wedges the manager on any POST (initialize, tools/list).
 	base.ResponseHeaderTimeout = defaultResponseHeaderTimeout
 
 	if up.gatewayCACertPEM != "" || up.CACert != "" {
@@ -214,6 +225,14 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 		Endpoint:   up.URL,
 		HTTPClient: httpC,
 		MaxRetries: 3,
+		// the sdk opens the standalone GET SSE stream synchronously inside
+		// Connect on a context detached from ours and treats its failure as
+		// session-fatal (MaxRetries x ResponseHeaderTimeout blocked, ~125s).
+		// upstreams that mishandle the GET must not poison the session, so
+		// the sdk never owns that stream: the broker's notification watcher
+		// holds it with non-fatal semantics, and the manager's periodic
+		// re-list backstops freshness.
+		DisableStandaloneSSE: true,
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{
@@ -256,6 +275,8 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 	// store the initialize result
 	up.init = session.InitializeResult()
 
+	up.startNotificationWatcher(ctx, httpC, session)
+
 	// register notification and connection-lost handlers after session is
 	// assigned so OnConnectionLost can start session.Wait() immediately
 	onConnection()
@@ -263,8 +284,47 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 	return nil
 }
 
+// startNotificationWatcher watches the upstream's standalone SSE stream
+// for the lifetime of the session. ctx is the manager's: cancellation on
+// manager stop ends the watch even without an explicit Disconnect.
+func (up *MCPServer) startNotificationWatcher(ctx context.Context, httpC *http.Client, session *mcp.ClientSession) {
+	watchCtx, cancel := context.WithCancel(ctx)
+	w := &notificationWatcher{
+		endpoint:   up.URL,
+		httpClient: httpC,
+		// the sdk exposes the server-assigned Mcp-Session-Id directly;
+		// empty for stateless upstreams, which then see a bare GET
+		sessionID:       session.ID(),
+		protocolVersion: up.init.ProtocolVersion,
+		serverID:        string(up.ID()),
+		notify:          up.notify,
+		logger:          up.logger,
+		done:            make(chan struct{}),
+	}
+	up.clientMu.Lock()
+	up.watcher = w
+	up.watcherCancel = cancel
+	up.clientMu.Unlock()
+	go w.watch(watchCtx)
+}
+
+// stopNotificationWatcher cancels the current watcher, if any, and waits
+// for its goroutine to exit. must not be called holding clientMu.
+func (up *MCPServer) stopNotificationWatcher() {
+	up.clientMu.Lock()
+	w, cancel := up.watcher, up.watcherCancel
+	up.watcher, up.watcherCancel = nil, nil
+	up.clientMu.Unlock()
+	if cancel != nil {
+		cancel()
+		<-w.done
+	}
+}
+
 // Disconnect closes the connection to the upstream MCP server.
 func (up *MCPServer) Disconnect() error {
+	up.stopNotificationWatcher()
+
 	up.clientMu.Lock()
 	defer up.clientMu.Unlock()
 

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"time"
@@ -34,7 +35,7 @@ func TestNewUpstreamMCP(t *testing.T) {
 		State:    string(mcpv1alpha1.ServerStateEnabled),
 		Hostname: "dummy",
 	}
-	up := NewUpstreamMCP(&testServer, "")
+	up := NewUpstreamMCP(&testServer, "", nil)
 	require.NotNil(t, up)
 	require.Equal(t, testServer, up.GetConfig())
 }
@@ -72,7 +73,7 @@ func TestMCPServer_IsEnabled(t *testing.T) {
 				Name:  "test",
 				State: tc.state,
 			}
-			up := NewUpstreamMCP(&server, "")
+			up := NewUpstreamMCP(&server, "", nil)
 			require.Equal(t, tc.expected, up.IsEnabled())
 		})
 	}
@@ -87,7 +88,7 @@ func TestNewUpstreamMCP_WithCACert(t *testing.T) {
 		Hostname: "dummy",
 		CACert:   "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
 	}
-	up := NewUpstreamMCP(&testServer, "")
+	up := NewUpstreamMCP(&testServer, "", nil)
 	require.NotNil(t, up)
 	cfg := up.GetConfig()
 	require.Equal(t, testServer.CACert, cfg.CACert)
@@ -150,7 +151,7 @@ func TestBuildHTTPClient_NoCACert(t *testing.T) {
 	up := NewUpstreamMCP(&config.MCPServer{
 		Name: "no-ca",
 		URL:  "http://localhost:8080/mcp",
-	}, "")
+	}, "", nil)
 	client, err := up.buildHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, client, "should always return a client with timeouts set")
@@ -163,47 +164,56 @@ func TestBuildHTTPClient_NoCACert(t *testing.T) {
 	require.True(t, ok, "base transport should be *http.Transport")
 	require.Equal(t, defaultTLSHandshakeTimeout, tr.TLSHandshakeTimeout)
 	// bounds header wait only; SSE bodies stream untouched. zero here lets a
-	// silent upstream hang Connect forever via the standalone SSE GET.
+	// silent upstream wedge the manager on any POST (initialize, tools/list).
 	require.Equal(t, defaultResponseHeaderTimeout, tr.ResponseHeaderTimeout)
 }
 
-// regression: an upstream that accepts the standalone SSE GET but never sends
-// response headers must not hang Connect forever. observed with a test server
-// whose logging middleware swallowed Flush: the manager goroutine wedged, the
-// server never became ready, and readiness flapping took down the data plane.
-func TestConnectBoundedWhenUpstreamNeverAnswersSSE(t *testing.T) {
+// regression: the sdk opens a standalone GET SSE stream synchronously inside
+// Connect, on a context detached from the connect context, and treats its
+// failure as session-fatal after MaxRetries attempts each bounded only by
+// ResponseHeaderTimeout (~125s blocked, then a dead session). the sdk stream
+// is disabled and the GET belongs to the broker's notification watcher, so
+// an upstream that swallows GETs (seen with proxies and logging middleware
+// that eat Flush) must not delay or fail Connect at all, and the watcher
+// must keep retrying without harming the session.
+func TestConnectNotBlockedByStandaloneSSE(t *testing.T) {
 	old := defaultResponseHeaderTimeout
-	defaultResponseHeaderTimeout = 100 * time.Millisecond
+	defaultResponseHeaderTimeout = 50 * time.Millisecond
 	defer func() { defaultResponseHeaderTimeout = old }()
+	oldBackoff := watchBackoff
+	watchBackoff.Duration = 20 * time.Millisecond
+	defer func() { watchBackoff = oldBackoff }()
 
-	s := mcp.NewServer(&mcp.Implementation{Name: "hangs-sse", Version: "0.0.1"}, nil)
+	s := mcp.NewServer(&mcp.Implementation{Name: "swallows-gets", Version: "0.0.1"}, nil)
 	inner := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return s }, nil)
+	var gets atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			<-r.Context().Done() // swallow the standalone SSE GET, send nothing
+			gets.Add(1)
+			<-r.Context().Done() // swallow the GET, send nothing
 			return
 		}
 		inner.ServeHTTP(w, r)
 	}))
 	defer srv.Close()
 
-	up := NewUpstreamMCP(&config.MCPServer{Name: "hangs-sse", URL: srv.URL}, "")
-	done := make(chan error, 1)
-	go func() {
-		done <- up.Connect(context.Background(), func() {})
-	}()
+	up := NewUpstreamMCP(&config.MCPServer{Name: "swallows-gets", URL: srv.URL}, "", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 
-	// worst case is the SDK's standalone SSE retry cycle (~10s with backoff
-	// and jitter); anything past 30s means Connect is hung again
-	select {
-	case err := <-done:
-		// connect may fail outright or return a poisoned session; either is
-		// fine, the invariant is that it returns
-		t.Logf("Connect returned: %v", err)
-	case <-time.After(30 * time.Second):
-		t.Fatal("Connect hung waiting for standalone SSE response headers")
-	}
-	_ = up.Disconnect()
+	start := time.Now()
+	require.NoError(t, up.Connect(ctx, func() {}), "connect must not depend on the standalone SSE GET")
+	require.Less(t, time.Since(start), 5*time.Second, "connect must not wait on the standalone GET")
+	defer func() { _ = up.Disconnect() }()
+
+	_, err := up.ListTools(ctx)
+	require.NoError(t, err)
+
+	// the watcher owns the GET and keeps retrying non-fatally
+	require.Eventually(t, func() bool { return gets.Load() >= 2 }, 10*time.Second, 10*time.Millisecond,
+		"watcher should retry the swallowed GET")
+	_, err = up.ListTools(ctx)
+	require.NoError(t, err, "session must stay healthy while the GET is swallowed")
 }
 
 func TestBuildHTTPClient_WithValidCACert(t *testing.T) {
@@ -213,7 +223,7 @@ func TestBuildHTTPClient_WithValidCACert(t *testing.T) {
 		Name:   "with-ca",
 		URL:    "https://localhost:8443/mcp",
 		CACert: string(caPEM),
-	}, "")
+	}, "", nil)
 	client, err := up.buildHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, client, "should return custom client when CACert configured")
@@ -224,7 +234,7 @@ func TestBuildHTTPClient_WithInvalidPEM(t *testing.T) {
 		Name:   "bad-ca",
 		URL:    "https://localhost:8443/mcp",
 		CACert: "not-valid-pem-data",
-	}, "")
+	}, "", nil)
 	_, err := up.buildHTTPClient()
 	require.Error(t, err, "should error on invalid PEM")
 	require.Contains(t, err.Error(), "failed to parse CA certificate")
@@ -245,7 +255,7 @@ func TestBuildHTTPClient_TLSConnection(t *testing.T) {
 		Name:   "tls-test",
 		URL:    srv.URL + "/mcp",
 		CACert: string(caPEM),
-	}, "")
+	}, "", nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, httpClient)
@@ -272,7 +282,7 @@ func TestBuildHTTPClient_TLSConnectionFailsWithoutCA(t *testing.T) {
 	up := NewUpstreamMCP(&config.MCPServer{
 		Name: "no-ca-test",
 		URL:  srv.URL + "/mcp",
-	}, "")
+	}, "", nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, httpClient, "client is always returned, only TLS pool varies")
@@ -300,7 +310,7 @@ func TestBuildHTTPClient_WrongCACertFailsTLS(t *testing.T) {
 		Name:   "wrong-ca-test",
 		URL:    srv.URL + "/mcp",
 		CACert: string(wrongCaPEM),
-	}, "")
+	}, "", nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, httpClient)
@@ -329,7 +339,7 @@ func TestBuildHTTPClient_MultiCertBundle(t *testing.T) {
 		Name:   "bundle-test",
 		URL:    srv.URL + "/mcp",
 		CACert: string(bundle),
-	}, "")
+	}, "", nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, httpClient)
@@ -360,7 +370,7 @@ func TestResponseHeaderTimeoutDoesNotKillEstablishedSSE(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	up := NewUpstreamMCP(&config.MCPServer{Name: "sse-alive", URL: srv.URL}, "")
+	up := NewUpstreamMCP(&config.MCPServer{Name: "sse-alive", URL: srv.URL}, "", nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 
@@ -377,37 +387,24 @@ func TestResponseHeaderTimeoutDoesNotKillEstablishedSSE(t *testing.T) {
 	require.Contains(t, string(body), "data: late")
 }
 
-// regression: OnNotification used to be a no-op before Connect (nil client)
-// and was only wired after the session was live, leaving a gap where
-// list-changed notifications were silently dropped. the manager registers
-// the handler before connecting; deliveries must work in that order.
+// regression: OnNotification used to be a no-op before Connect (nil client),
+// silently dropping list-changed deliveries. handlers are now stored on the
+// upstream and dispatched via middleware wired into every client before its
+// session connects. with the standalone SSE stream disabled the only push
+// channel left is a request-scoped stream, so the wiring is exercised at the
+// dispatch layer here; end-to-end refresh is covered by the manager tests.
 func TestOnNotification_RegisteredBeforeConnect(t *testing.T) {
-	srv := mcp.NewServer(&mcp.Implementation{Name: "up", Version: "0.0.1"}, &mcp.ServerOptions{
-		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{ListChanged: true}},
-	})
-	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	up := NewUpstreamMCP(&config.MCPServer{Name: "up", URL: ts.URL}, "")
-	got := make(chan string, 4)
+	up := NewUpstreamMCP(&config.MCPServer{Name: "up", URL: "http://unused/mcp"}, "", nil)
+	got := make(chan string, 1)
 	up.OnNotification(func(method string) { got <- method })
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	require.NoError(t, up.Connect(ctx, func() {}))
-	defer func() { _ = up.Disconnect() }()
-
-	srv.AddTool(&mcp.Tool{Name: "late", InputSchema: map[string]any{"type": "object"}},
-		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return &mcp.CallToolResult{}, nil
-		})
+	up.notify("notifications/tools/list_changed")
 
 	select {
 	case method := <-got:
 		require.Equal(t, "notifications/tools/list_changed", method)
-	case <-time.After(10 * time.Second):
-		t.Fatal("notification never reached a handler registered before Connect")
+	default:
+		t.Fatal("handler registered before Connect was not dispatched")
 	}
 }
 
@@ -425,7 +422,7 @@ func TestBuildHTTPClient_GatewayCACertBundle(t *testing.T) {
 	up := NewUpstreamMCP(&config.MCPServer{
 		Name: "gw-ca-test",
 		URL:  srv.URL + "/mcp",
-	}, string(caPEM))
+	}, string(caPEM), nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 
@@ -453,7 +450,7 @@ func TestBuildHTTPClient_GatewayCAPlusPerServerCA(t *testing.T) {
 		Name:   "combined-ca-test",
 		URL:    srv.URL + "/mcp",
 		CACert: string(serverCAPEM),
-	}, string(gwCAPEM))
+	}, string(gwCAPEM), nil)
 	httpClient, err := up.buildHTTPClient()
 	require.NoError(t, err)
 
@@ -469,7 +466,7 @@ func TestBuildHTTPClient_InvalidGatewayCACert(t *testing.T) {
 	up := NewUpstreamMCP(&config.MCPServer{
 		Name: "bad-gw-ca",
 		URL:  "https://localhost:8443/mcp",
-	}, "not-valid-pem")
+	}, "not-valid-pem", nil)
 	_, err := up.buildHTTPClient()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "gateway CA certificate bundle")

--- a/internal/broker/upstream/notification_watcher.go
+++ b/internal/broker/upstream/notification_watcher.go
@@ -1,0 +1,249 @@
+package upstream
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// the sdk's own standalone SSE stream is disabled on broker transports
+// because it opens the GET synchronously inside Connect on a detached
+// context and treats any failure as session-fatal. this watcher rebuilds
+// the stream at the broker's layer, where the failure semantics are ours:
+// never fatal to the session, infinite reconnects with capped backoff, and
+// a permanent stop only when the upstream says it does not offer the
+// stream. it exists purely to push tools/prompts list-changed
+// notifications into the manager's existing refresh path; the periodic
+// re-list remains the freshness backstop because events sent while the
+// stream is down are not buffered by upstreams without event replay.
+
+// watchBackoff paces stream reconnects, aligned with the manager's
+// backoff: growth stops at the cap but retries never do. var so tests can
+// shrink it.
+var watchBackoff = wait.Backoff{
+	Duration: 1 * time.Second,
+	Factor:   2,
+	Jitter:   0.1,
+	Steps:    10,
+	Cap:      DefaultTickerInterval,
+}
+
+// maxSSELineBytes bounds a single SSE line; larger frames abort the scan
+// and force a reconnect rather than an unbounded allocation.
+const maxSSELineBytes = 1 << 20
+
+// notificationWatcher holds an upstream standalone SSE stream open for one
+// connected session, dispatching list-changed notifications to the
+// upstream's handler. everything it needs is captured at construction so
+// the watch goroutine never touches MCPServer state.
+type notificationWatcher struct {
+	endpoint        string
+	httpClient      *http.Client
+	sessionID       string
+	protocolVersion string
+	serverID        string
+	notify          func(method string)
+	logger          *slog.Logger
+
+	// streamsEstablished counts healthy streams entered; read by tests to
+	// know the server has bound the stream before triggering events.
+	streamsEstablished atomic.Int64
+	done               chan struct{} // closed when the watch goroutine exits
+}
+
+// watch runs until ctx is cancelled or the upstream reports it does not
+// offer a standalone stream. all other failures retry forever with capped
+// backoff and never affect the session.
+func (w *notificationWatcher) watch(ctx context.Context) {
+	defer close(w.done)
+	bo := watchBackoff
+	lastEventID := ""
+	for {
+		resp, err := w.get(ctx, lastEventID)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			w.logger.Debug("upstream notification stream request failed, retrying", "upstream mcp server", w.serverID, "error", err)
+			if !sleepCtx(ctx, bo.Step()) {
+				return
+			}
+			continue
+		}
+		ct := resp.Header.Get("Content-Type")
+		switch {
+		case resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotFound:
+			// the upstream does not offer the standalone stream; stop for
+			// good, the session is unaffected and the ticker re-list keeps
+			// tools fresh
+			discardBody(resp)
+			w.logger.Info("upstream does not offer a standalone notification stream, watcher stopped", "upstream mcp server", w.serverID, "status", resp.StatusCode)
+			return
+		case resp.StatusCode != http.StatusOK:
+			discardBody(resp)
+			w.logger.Debug("unexpected status for upstream notification stream, retrying", "upstream mcp server", w.serverID, "status", resp.StatusCode)
+			// drop the replay cursor: some servers reject resumption they
+			// cannot honour, which would otherwise poison every retry
+			lastEventID = ""
+			if !sleepCtx(ctx, bo.Step()) {
+				return
+			}
+			continue
+		case !isEventStream(ct):
+			// a 200 without an SSE content type means the server answers
+			// GET with something else entirely; treat as not offering the
+			// stream, matching the sdk
+			discardBody(resp)
+			w.logger.Info("upstream returned non-SSE content for notification stream, watcher stopped", "upstream mcp server", w.serverID, "content-type", ct)
+			return
+		}
+
+		bo = watchBackoff // healthy stream: start the next backoff cycle fresh
+		w.streamsEstablished.Add(1)
+		w.logger.Debug("upstream notification stream established", "upstream mcp server", w.serverID)
+		lastEventID = w.consumeStream(ctx, resp.Body, lastEventID)
+		_ = resp.Body.Close()
+		if ctx.Err() != nil {
+			return
+		}
+		w.logger.Debug("upstream notification stream ended, reconnecting", "upstream mcp server", w.serverID)
+		if !sleepCtx(ctx, bo.Step()) {
+			return
+		}
+	}
+}
+
+// get issues the standalone GET. the shared upstream http client injects
+// auth headers and the TLS trust pool; ResponseHeaderTimeout bounds the
+// header wait without capping the stream body.
+func (w *notificationWatcher) get(ctx context.Context, lastEventID string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	w.setSessionHeaders(req)
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	return w.httpClient.Do(req)
+}
+
+func (w *notificationWatcher) setSessionHeaders(req *http.Request) {
+	if w.sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", w.sessionID)
+	}
+	if w.protocolVersion != "" {
+		req.Header.Set("Mcp-Protocol-Version", w.protocolVersion)
+	}
+}
+
+// consumeStream reads SSE frames until the stream ends or ctx is
+// cancelled, returning the last event id seen for resumption against
+// upstreams that support replay. only data and id fields matter here:
+// event names are irrelevant to json-rpc payloads and server retry hints
+// are ignored in favour of our own backoff.
+func (w *notificationWatcher) consumeStream(ctx context.Context, body io.Reader, lastEventID string) string {
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 0, 64*1024), maxSSELineBytes)
+	var data []string
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case line == "":
+			if len(data) > 0 {
+				w.dispatch(ctx, strings.Join(data, "\n"))
+				data = data[:0]
+			}
+		case strings.HasPrefix(line, "data:"):
+			data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		case strings.HasPrefix(line, "id:"):
+			lastEventID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+		}
+	}
+	return lastEventID
+}
+
+// jsonrpcFrame is the minimal shape needed to route a stream payload.
+type jsonrpcFrame struct {
+	ID     json.RawMessage `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+}
+
+func (w *notificationWatcher) dispatch(ctx context.Context, payload string) {
+	var frame jsonrpcFrame
+	if err := json.Unmarshal([]byte(payload), &frame); err != nil {
+		w.logger.Debug("ignoring unparseable notification stream payload", "upstream mcp server", w.serverID, "error", err)
+		return
+	}
+	switch frame.Method {
+	case notificationToolsListChanged, notificationPromptsListChanged:
+		w.logger.Debug("received upstream notification", "upstream mcp server", w.serverID, "method", frame.Method)
+		w.notify(frame.Method)
+	case "ping":
+		if len(frame.ID) > 0 {
+			w.respondPing(ctx, frame.ID)
+		}
+	case "":
+		// a response to a request we never sent; nothing to do
+	default:
+		// other server-to-client requests (roots/list, sampling) never
+		// worked over the broker's backend session and are out of scope
+		w.logger.Debug("ignoring unsupported method on notification stream", "upstream mcp server", w.serverID, "method", frame.Method)
+	}
+}
+
+// respondPing answers a server ping delivered on the stream so keepalive
+// enabled upstreams do not conclude the broker session is dead. runs
+// inline: pings are rare and a goroutine here would be a leak surface.
+func (w *notificationWatcher) respondPing(ctx context.Context, id json.RawMessage) {
+	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": map[string]any{}})
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	w.setSessionHeaders(req)
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		w.logger.Debug("failed to answer upstream ping", "upstream mcp server", w.serverID, "error", err)
+		return
+	}
+	discardBody(resp)
+}
+
+func isEventStream(contentType string) bool {
+	mt, _, err := mime.ParseMediaType(contentType)
+	return err == nil && mt == "text/event-stream"
+}
+
+func discardBody(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4*1024))
+	_ = resp.Body.Close()
+}
+
+// sleepCtx waits for d or ctx, reporting whether the watch should continue.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/internal/broker/upstream/notification_watcher_test.go
+++ b/internal/broker/upstream/notification_watcher_test.go
@@ -1,0 +1,325 @@
+package upstream
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mcpv1alpha1 "github.com/Kuadrant/mcp-gateway/api/v1alpha1"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func watcherTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// watcherStreams reports how many healthy streams the current watcher has
+// entered; the server has bound the stream by the time it is counted, so
+// events sent afterwards cannot be lost to the attach race.
+func watcherStreams(up *MCPServer) int64 {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+	if up.watcher == nil {
+		return 0
+	}
+	return up.watcher.streamsEstablished.Load()
+}
+
+func waitForWatcherStream(t *testing.T, up *MCPServer) {
+	t.Helper()
+	require.Eventually(t, func() bool { return watcherStreams(up) >= 1 }, 10*time.Second, 10*time.Millisecond,
+		"watcher never established a notification stream")
+}
+
+func shrinkWatchBackoff(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := watchBackoff
+	watchBackoff.Duration = d
+	watchBackoff.Jitter = 0
+	t.Cleanup(func() { watchBackoff = old })
+}
+
+// regression: OnNotification used to be a no-op before Connect (nil client),
+// silently dropping list-changed deliveries. a handler registered before
+// Connect must receive notifications pushed by the upstream over the
+// broker-owned standalone stream.
+func TestNotificationWatcher_DeliversUpstreamListChanged(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "up", Version: "0.0.1"}, &mcp.ServerOptions{
+		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{ListChanged: true}},
+	})
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "up", URL: ts.URL}, "", watcherTestLogger())
+	got := make(chan string, 4)
+	up.OnNotification(func(method string) { got <- method })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	defer func() { _ = up.Disconnect() }()
+
+	// events sent while no stream is attached are not buffered by the sdk
+	// server, so wait for the watcher to bind before changing the tool set
+	waitForWatcherStream(t, up)
+
+	srv.AddTool(&mcp.Tool{Name: "late", InputSchema: map[string]any{"type": "object"}},
+		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{}, nil
+		})
+
+	select {
+	case method := <-got:
+		require.Equal(t, "notifications/tools/list_changed", method)
+	case <-time.After(10 * time.Second):
+		t.Fatal("notification never reached a handler registered before Connect")
+	}
+}
+
+// a pushed list_changed must flow through the manager's existing refresh
+// path and update the gateway registry without waiting for the ticker.
+func TestNotificationWatcher_TriggersManagerRefetch(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "push-server", Version: "0.0.1"}, &mcp.ServerOptions{
+		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{ListChanged: true}},
+	})
+	srv.AddTool(&mcp.Tool{Name: "tool1", InputSchema: map[string]any{"type": "object"}},
+		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{}, nil
+		})
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "push-server", URL: ts.URL, Prefix: "push_"}, "", watcherTestLogger())
+	gateway := NewMockGatewayServer()
+	// hour-long ticker: only the pushed notification can explain a refresh
+	manager, err := NewUpstreamMCPManager(up, gateway, nil, watcherTestLogger(), time.Hour, mcpv1alpha1.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	active := manager.Start(ctx)
+	defer active.Stop()
+
+	require.Eventually(t, func() bool { return len(gateway.ListTools()) == 1 }, 10*time.Second, 10*time.Millisecond,
+		"initial tools should be registered")
+	waitForWatcherStream(t, up)
+
+	srv.AddTool(&mcp.Tool{Name: "tool2", InputSchema: map[string]any{"type": "object"}},
+		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{}, nil
+		})
+
+	require.Eventually(t, func() bool {
+		tools := gateway.ListTools()
+		_, has := tools["push_tool2"]
+		return has
+	}, 10*time.Second, 10*time.Millisecond, "pushed list_changed should trigger a re-list")
+}
+
+// an upstream answering the standalone GET with 405 does not offer the
+// stream: the watcher must stop for good without touching the session.
+func TestNotificationWatcher_405StopsPermanently(t *testing.T) {
+	shrinkWatchBackoff(t, 10*time.Millisecond)
+
+	s := mcp.NewServer(&mcp.Implementation{Name: "no-sse", Version: "0.0.1"}, nil)
+	inner := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return s }, nil)
+	var gets atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			gets.Add(1)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "no-sse", URL: srv.URL}, "", watcherTestLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	defer func() { _ = up.Disconnect() }()
+
+	up.clientMu.RLock()
+	w := up.watcher
+	up.clientMu.RUnlock()
+	require.NotNil(t, w)
+	select {
+	case <-w.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher should stop permanently on 405")
+	}
+	require.Equal(t, int32(1), gets.Load(), "405 must not be retried")
+
+	_, err := up.ListTools(ctx)
+	require.NoError(t, err, "session must be unaffected by a 405 on the stream")
+}
+
+// transient stream failures retry forever with growing backoff and never
+// touch the session.
+func TestNotificationWatcher_RetriesNonFatally(t *testing.T) {
+	base := 20 * time.Millisecond
+	shrinkWatchBackoff(t, base)
+
+	s := mcp.NewServer(&mcp.Implementation{Name: "flaky-sse", Version: "0.0.1"}, nil)
+	inner := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return s }, nil)
+	var mu sync.Mutex
+	var getTimes []time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			mu.Lock()
+			getTimes = append(getTimes, time.Now())
+			mu.Unlock()
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "flaky-sse", URL: srv.URL}, "", watcherTestLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	defer func() { _ = up.Disconnect() }()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(getTimes) >= 4
+	}, 10*time.Second, 10*time.Millisecond, "watcher should keep retrying transient failures")
+
+	// sleeps can only stretch under load, so a lower bound on the total
+	// spacing is flake-safe: with jitter zeroed the first three gaps are
+	// base, 2*base and 4*base
+	mu.Lock()
+	elapsed := getTimes[3].Sub(getTimes[0])
+	mu.Unlock()
+	require.GreaterOrEqual(t, elapsed, 7*base-base/2, "retry gaps should grow with backoff")
+
+	_, err := up.ListTools(ctx)
+	require.NoError(t, err, "session must be unaffected by stream retries")
+}
+
+// a server ping delivered on the stream must be answered so keepalive
+// enabled upstreams do not conclude the broker session is dead.
+func TestNotificationWatcher_AnswersPing(t *testing.T) {
+	s := mcp.NewServer(&mcp.Implementation{Name: "pinger", Version: "0.0.1"}, nil)
+	inner := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return s }, nil)
+	posts := make(chan string, 16)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":\"keepalive-1\",\"method\":\"ping\"}\n\n"))
+			require.NoError(t, http.NewResponseController(w).Flush())
+			<-r.Context().Done()
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			posts <- string(body)
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			inner.ServeHTTP(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "pinger", URL: srv.URL}, "", watcherTestLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	defer func() { _ = up.Disconnect() }()
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case body := <-posts:
+			if strings.Contains(body, `"keepalive-1"`) && strings.Contains(body, `"result"`) {
+				return
+			}
+		case <-deadline:
+			t.Fatal("ping on the notification stream was never answered")
+		}
+	}
+}
+
+// disconnect must tear down the watcher goroutine and its hanging GET;
+// goleak verifies nothing started by this test survives it.
+func TestNotificationWatcher_CleanShutdown(t *testing.T) {
+	leakOpts := []goleak.Option{
+		goleak.IgnoreCurrent(),
+		// the sdk server fixture keeps a jsonrpc session reader running
+		// with no exported way to close it (closeAll is unexported); it is
+		// server-side scaffolding, not broker code under test
+		goleak.IgnoreAnyFunction("github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2.(*Connection).readIncoming"),
+	}
+	defer func() {
+		// remaining teardown (http idle connections, client readers) is
+		// asynchronous; give it a moment to quiesce before requiring a
+		// clean goroutine set
+		deadline := time.Now().Add(5 * time.Second)
+		for goleak.Find(leakOpts...) != nil && time.Now().Before(deadline) {
+			time.Sleep(50 * time.Millisecond)
+		}
+		goleak.VerifyNone(t, leakOpts...)
+	}()
+
+	s := mcp.NewServer(&mcp.Implementation{Name: "shutdown", Version: "0.0.1"}, nil)
+	inner := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return s }, nil)
+	getGone := make(chan struct{}, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if err := http.NewResponseController(w).Flush(); err != nil {
+				return
+			}
+			<-r.Context().Done() // hang the stream until torn down
+			getGone <- struct{}{}
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "shutdown", URL: srv.URL}, "", watcherTestLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	waitForWatcherStream(t, up)
+
+	up.clientMu.RLock()
+	w := up.watcher
+	up.clientMu.RUnlock()
+	require.NotNil(t, w)
+
+	require.NoError(t, up.Disconnect())
+
+	select {
+	case <-w.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher goroutine did not exit on disconnect")
+	}
+	select {
+	case <-getGone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hanging GET was not torn down on disconnect")
+	}
+
+	// disconnect is idempotent with the watcher already stopped
+	require.NoError(t, up.Disconnect())
+}

--- a/internal/broker/upstream/protocol_version_test.go
+++ b/internal/broker/upstream/protocol_version_test.go
@@ -57,7 +57,7 @@ func connectTo(t *testing.T, url string) (*MCPServer, error) {
 		URL:      url,
 		State:    string(mcpv1alpha1.ServerStateEnabled),
 		Hostname: "pinned",
-	}, "")
+	}, "", nil)
 	return up, up.Connect(t.Context(), func() {})
 }
 

--- a/internal/broker/upstream/status_test.go
+++ b/internal/broker/upstream/status_test.go
@@ -68,7 +68,7 @@ func TestExpectedVersionMatchesSDKProposal(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	up := NewUpstreamMCP(&config.MCPServer{Name: "probe", URL: ts.URL}, "")
+	up := NewUpstreamMCP(&config.MCPServer{Name: "probe", URL: ts.URL}, "", nil)
 	require.NoError(t, up.Connect(ctx, func() {}))
 	defer func() { _ = up.Disconnect() }()
 
@@ -98,7 +98,7 @@ func TestUpstreamClientCapabilities(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	up := NewUpstreamMCP(&config.MCPServer{Name: "probe", URL: ts.URL}, "")
+	up := NewUpstreamMCP(&config.MCPServer{Name: "probe", URL: ts.URL}, "", nil)
 	require.NoError(t, up.Connect(ctx, func() {}))
 	defer func() { _ = up.Disconnect() }()
 

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -226,6 +226,12 @@ func (broker *mcpBrokerImpl) getOrCreateUserSession(ctx context.Context, srv use
 	t := &mcp.StreamableClientTransport{
 		Endpoint:   srv.url,
 		HTTPClient: httpClient,
+		// these sessions only serve per-user tools/list; nothing consumes
+		// server pushes, and the sdk opens the standalone SSE GET
+		// synchronously inside Connect and treats its failure as
+		// session-fatal. skip it: saves a round trip per session and keeps
+		// a mishandled GET from failing the user's request.
+		DisableStandaloneSSE: true,
 	}
 
 	mcpClient := mcp.NewClient(&mcp.Implementation{

--- a/project-words.txt
+++ b/project-words.txt
@@ -190,6 +190,7 @@ jsonreference
 jsonschema
 jwtmgr
 Kagenti
+keepalive
 keyout
 kgateway
 Kiali


### PR DESCRIPTION
## Summary

- Since the go-sdk migration (#1218), the SDK opens a standalone GET SSE stream synchronously inside `client.Connect` and treats its failure as fatal for the whole session. A slow upstream GET costs ~4 x 30s `ResponseHeaderTimeout` (~125s, on a detached context) before killing the session; the broker then drops all the server's tools and retries on the 1m ticker with no backoff. At 60+ registered servers this becomes a permanent connection storm and upstreams never become ready.
- Fix: the SDK's standalone SSE stream stays disabled on broker upstream connections; a broker-owned notification watcher replaces it - a supervised GET per upstream session (same HTTP client, auth and TLS trust), never session-fatal, infinite capped backoff, 405/404 means a permanent stop with the session unaffected, `list_changed` triggers an immediate re-list, with `Last-Event-ID` resumption. Same semantics as mcp-go's continuous listening, with failure handling under our control.
- Connection failures now apply backoff and retain cached tools/prompts until 3 consecutive failures. The ticker re-list remains as a poll backstop, bounding staleness where a watcher is permanently stopped (upstreams without GET support).

## Behaviour changes

- Federated tools survive up to 3 consecutive failed reconnects instead of disappearing on the first failure.
- Push freshness is preserved - no `list_changed` latency change versus pre-migration.

## Test evidence

- `make lint` (CI-pinned golangci-lint v2.4.0): 0 issues
- `make test-unit` (`-race`): 467 pass, including the notification watcher suite (event-triggered re-list, 405 permanent stop, non-fatal retry with backoff, goleak-verified shutdown)
- Live A/B on a kind cluster, identical scenario both runs - 41 registered upstreams: 21 healthy, 20 behind a proxy that stalls GET /mcp response headers:

| | pre-fix (fb148dc3) | this branch |
|-|-|-|
| fatal connection failures | 80, ~127s perpetual cycles | 0 (13 min window, zero ERROR/WARN) |
| broker upstreams ready | 21/41, stalled never converge | 41/41 in 64s |
| stalled servers' tools federated | 0/20 | 20/20 (576 tools total) |
| `list_changed` push to gateway tools/list | n/a | 0.15-0.18s, well inside the 60s tick |
| cost of a stalled GET | session death, tools dropped | watcher GET held with backoff (31s to 90s+), zero session/tool impact |

- Failure path: with stalled upstreams taken fully down, tools retained through 2 consecutive failures, dropped at the 3rd; retry intervals backed off to the 60s cap; healthy upstreams unaffected; full recovery 69s after restore. Poll backstop cadence verified intact alongside push.
- 405 permanent-stop path covered by unit test (both in-cluster upstream implementations accept GET).

Closes #1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved freshness for tools and prompts updates, with faster refreshes when changes are detected.
  * Added more resilient background watching so upstream updates are picked up without interrupting active sessions.

* **Bug Fixes**
  * Prevented transient upstream connection issues from breaking existing tool and prompt availability too early.
  * Reduced the chance of stale data by adding periodic refresh backstops and better reconnect handling.

* **Documentation**
  * Updated design docs to reflect the new notification and refresh flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->