### PR TITLE
docs: update standalone binary install guide

### DIFF
--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -25,6 +25,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 - [Go 1.26+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
 - [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed (or Docker to run it as a container)
+- `openssl` (for generating the signing key)
 - Access to MCP servers you want to aggregate
 
 ## Step 1: Build from Source
@@ -206,8 +207,10 @@ envoy -c envoy.yaml
 The gateway requires a signing key for session management. Generate one and start the binary:
 
 ```bash
-# Generate a signing key (do this once, reuse across restarts)
+# Generate a signing key and save it for reuse across restarts
 export GATEWAY_SIGNING_KEY=$(openssl rand -hex 32)
+echo "$GATEWAY_SIGNING_KEY" > .signing-key
+# On subsequent restarts, reload with: export GATEWAY_SIGNING_KEY=$(cat .signing-key)
 
 # Start the gateway
 ./bin/mcp-broker-router \

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -10,7 +10,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 - **Envoy Required**: You must configure Envoy as a proxy (Istio is not needed)
 - **Manual Configuration**: No controller automation - all server configuration is manual
 - **Guide Compatibility**: Other guides in this documentation use Kubernetes CRDs and kubectl commands and are **not applicable** to binary installations
-- **No Dynamic Discovery**: Server changes require configuration file updates and restarts
+- **No Dynamic Discovery**: Server changes require configuration file updates (hot-reload is supported, no restart needed)
 - **Production Readiness**: Not recommended for production use without additional operational tooling
 
 ## When to Use This Method
@@ -22,9 +22,9 @@ This method runs MCP Gateway broker and router components as standalone binaries
 
 ## Prerequisites
 
-- [Go 1.25+](https://golang.org/doc/install) installed (for building from source)
+- [Go 1.26+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
-- [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed and configured
+- [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed (or Docker to run it as a container)
 - Access to MCP servers you want to aggregate
 
 ## Step 1: Build from Source
@@ -38,65 +38,42 @@ cd mcp-gateway
 go build -o bin/mcp-broker-router ./cmd/mcp-broker-router
 ```
 
-**Note**: Pre-built binaries are not currently distributed. You must build from source.
+> **Note:** Pre-built binaries are not currently distributed. You must build from source.
 
 ## Step 2: Create Configuration File
 
-Create a YAML configuration file defining your MCP servers:
+Create a YAML configuration file defining your MCP servers. This example connects to a single MCP server running on localhost:
 
 ```yaml
 servers:
-  - name: weather-service
-    url: http://weather.example.com:8080/mcp
-    hostname: weather.example.com
-    enabled: true
-    prefix: "weather_"
-
-  - name: calendar-service
-    url: http://calendar.example.com:8080/mcp
-    hostname: calendar.example.com
-    enabled: true
-    prefix: "cal_"
+  - name: my-mcp-server
+    url: http://localhost:3001/mcp
+    hostname: my-mcp-server.local
+    prefix: "myserver_"
+    state: Enabled
 ```
 
 **Configuration Fields**:
 - `name`: Unique identifier for the server
 - `url`: Full URL to the MCP server endpoint (including path)
-- `hostname`: Hostname used for routing decisions
-- `enabled`: Set to `false` to temporarily disable a server
-- `prefix`: Prefix added to all tools from this server (helps avoid naming conflicts)
+- `hostname`: Routing hostname for this server. The router uses this to direct tool calls through Envoy to the correct backend. Each server needs a unique hostname that matches a virtual host in the Envoy configuration (see Step 3).
+- `prefix`: Prefix added to all tools from this server (avoids naming conflicts when aggregating multiple servers)
+- `state`: Set to `Enabled` or omit (defaults to `Enabled`)
 
-Save this as `config/servers.yaml` or any location you prefer.
+Save this as `config.yaml`.
 
-## Step 3: Start the Gateway
+## Step 3: Configure Envoy Proxy
 
-```bash
-# Run with your configuration
-./bin/mcp-broker-router \
-  --mcp-gateway-config=config/servers.yaml \
-  --mcp-gateway-public-host=your-hostname.example.com \
-  --log-level=-4
-```
+Envoy sits in front of the broker and routes traffic through the external processor (router). The router uses Envoy's ext_proc filter to inspect requests and control routing:
 
-**Command Options**:
-- `--mcp-gateway-config`: Path to your YAML configuration file
-- `--mcp-gateway-public-host`: **Required** - Public hostname for MCP Gateway (must match your Gateway listener hostname)
-- `--mcp-router-address`: Address for gRPC router (default: `0.0.0.0:50051`)
-- `--log-level`: Logging verbosity
-  - `-4`: Debug (verbose)
-  - `0`: Info (default)
-  - `4`: Errors only
+- **Non-tool requests** (initialize, tools/list): the router sets `:authority` to the gateway's public host, so Envoy routes them to the broker.
+- **Tool calls** (tools/call): the router sets `:authority` to the upstream server's `hostname` from the config, so Envoy routes them directly to that backend.
 
-The gateway starts two components:
-- **HTTP Broker**: Listens on `0.0.0.0:8080` (MCP protocol endpoint)
-- **gRPC Router**: Listens on `0.0.0.0:50051` (internal routing, requires Envoy)
+This means the Envoy config needs a virtual host for the gateway and one for each upstream server.
 
-## Step 4: Configure Envoy Proxy
-
-You need Envoy to route traffic through the external processor (router). Create an Envoy configuration file:
+Create an `envoy.yaml`:
 
 ```yaml
-# envoy.yaml - Minimal example
 static_resources:
   listeners:
   - name: mcp_listener
@@ -114,28 +91,49 @@ static_resources:
           route_config:
             name: local_route
             virtual_hosts:
-            - name: mcp_backend
-              domains: ["*"]
+            # Gateway host: handles initialize, tools/list, and other broker requests
+            - name: mcp_gateway
+              domains: ["localhost", "localhost:8888"]
               routes:
               - match:
                   prefix: "/"
                 route:
                   cluster: mcp_broker
+            # Upstream server: handles tools/call routed by the ext_proc router.
+            # The domain must match the hostname in config.yaml.
+            # Add one virtual_host per upstream MCP server.
+            - name: my_mcp_server
+              domains: ["my-mcp-server.local"]
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: my_mcp_server
           http_filters:
           - name: envoy.filters.http.ext_proc
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
-              grpc_service:
-                envoy_grpc:
-                  cluster_name: mcp_router
+              failure_mode_allow: false
+              allow_mode_override: true
+              mutation_rules:
+                allow_all_routing: true
+              message_timeout: 10s
               processing_mode:
                 request_header_mode: SEND
                 response_header_mode: SEND
                 request_body_mode: BUFFERED
                 response_body_mode: NONE
+                request_trailer_mode: SKIP
+                response_trailer_mode: SKIP
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: mcp_router
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
+  # Broker: handles MCP protocol (initialize, tools/list, etc.)
   - name: mcp_broker
     connect_timeout: 5s
     type: STRICT_DNS
@@ -147,14 +145,19 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: host.docker.internal
                 port_value: 8080
 
+  # Router: ext_proc gRPC service
   - name: mcp_router
     connect_timeout: 5s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
     load_assignment:
       cluster_name: mcp_router
       endpoints:
@@ -162,90 +165,160 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: host.docker.internal
                 port_value: 50051
+
+  # Upstream MCP server: add one cluster per server in config.yaml
+  - name: my_mcp_server
+    connect_timeout: 5s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: my_mcp_server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: host.docker.internal
+                port_value: 3001
 ```
 
-Start Envoy:
+> **Note:** This example uses `host.docker.internal` for cluster addresses, which works when running Envoy in Docker while the other components run on the host. If running Envoy natively, change these to `127.0.0.1`.
+
+Start Envoy (using Docker):
+
+```bash
+docker run --rm -p 8888:8888 \
+  -v $(pwd)/envoy.yaml:/etc/envoy/envoy.yaml:ro \
+  envoyproxy/envoy:v1.32-latest \
+  -c /etc/envoy/envoy.yaml
+```
+
+Or if Envoy is installed locally:
+
 ```bash
 envoy -c envoy.yaml
 ```
 
+## Step 4: Start the Gateway
+
+The gateway requires a signing key for session management. Generate one and start the binary:
+
+```bash
+# Generate a signing key (do this once, reuse across restarts)
+export GATEWAY_SIGNING_KEY=$(openssl rand -hex 32)
+
+# Start the gateway
+./bin/mcp-broker-router \
+  --mcp-gateway-config=config.yaml \
+  --mcp-gateway-public-host=localhost \
+  --mcp-gateway-private-host=localhost:8888 \
+  --log-level=-4
+```
+
+**Required flags/env vars**:
+- `GATEWAY_SIGNING_KEY` (env var): Key for JWT session signing. The binary will not start without it.
+- `--mcp-gateway-public-host`: Public hostname clients use to reach the gateway. Must match the gateway domain in the Envoy virtual host configuration.
+- `--mcp-gateway-private-host`: Address the router uses for hairpin requests (lazy backend initialization). Point this at Envoy's listener.
+- `--mcp-gateway-config`: Path to your YAML configuration file.
+
+**Optional flags**:
+- `--mcp-broker-public-address`: Broker listen address (default: `0.0.0.0:8080`)
+- `--mcp-router-address`: gRPC router listen address (default: `0.0.0.0:50051`)
+- `--log-level`: `-4` debug, `0` info (default), `4` warn, `8` error
+- `--log-format`: `txt` (default) or `json`
+- `--session-length`: Session duration in minutes (default: 1440 / 24h)
+
+The gateway starts two components:
+- **HTTP Broker** on `0.0.0.0:8080`: connects to upstream MCP servers, federates tools
+- **gRPC Router** on `0.0.0.0:50051`: Envoy ext_proc service, handles request routing and session management
+
 ## Step 5: Verify Installation
 
 ```bash
-# Check broker status (direct to broker)
-curl http://localhost:8080/status
-
-# Test through Envoy proxy
-curl http://localhost:8888/mcp \
+# Initialize a session through Envoy
+curl -s -D - http://localhost:8888/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}'
 
-# List available tools
-curl -X POST http://localhost:8888/mcp \
+# List available tools (use the mcp-session-id from the initialize response headers)
+curl -s http://localhost:8888/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
+  -H "mcp-session-id: <session-id-from-above>" \
+  -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}'
 ```
+
+Tools from your configured servers should appear with their configured prefix.
 
 ## Troubleshooting
 
-### Gateway Won't Start
+### Gateway Panics on Startup
+
+If you see `GATEWAY_SIGNING_KEY (or JWT_SESSION_SIGNING_KEY) is required but not set`:
 
 ```bash
-# Check if ports are in use
-lsof -i :8080  # Broker
-lsof -i :50051 # Router
+export GATEWAY_SIGNING_KEY=$(openssl rand -hex 32)
+```
 
-# Verify configuration syntax
-cat config/servers.yaml
+If you see `--mcp-gateway-public-host cannot be empty`:
 
-# Run with debug logging
-./bin/mcp-broker-router --mcp-gateway-config=config/servers.yaml --log-level=-4
+```bash
+# Add the required flag
+./bin/mcp-broker-router --mcp-gateway-public-host=localhost ...
 ```
 
 ### Tools Not Appearing
 
 ```bash
-# Test backend MCP server directly
-curl -X POST http://weather.example.com:8080/mcp \
+# Verify the upstream MCP server is reachable directly
+curl -s http://localhost:3001/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
 
-# Check gateway logs for errors
-# Restart gateway after configuration changes
+# Check gateway debug logs for connection errors
+# Run with --log-level=-4 for verbose output
 ```
+
+### Hairpin / Initialization Failures
+
+If tools/list returns empty or you see initialization errors in logs, the router cannot reach the broker through Envoy for lazy backend init:
+
+```bash
+# Ensure --mcp-gateway-private-host points at Envoy's listener
+--mcp-gateway-private-host=localhost:8888
+```
+
+### Tool Calls Fail with "unknown tool"
+
+The router rewrites `:authority` to the upstream server's `hostname` from the config, which Envoy uses to route the request to the correct backend cluster. Check that:
+
+1. The `hostname` in `config.yaml` matches a `domains` entry in the Envoy virtual host
+2. That virtual host routes to a cluster pointing at the upstream server
+3. The upstream cluster address and port are correct
 
 ### Envoy Connection Issues
 
 ```bash
-# Check Envoy is running
-ps aux | grep envoy
+# Verify Envoy is running and listening
+curl -s http://localhost:8888/
 
-# Verify Envoy can reach broker
-curl http://localhost:8080/status
-
-# Check Envoy logs for ext_proc errors
-# Ensure gRPC router (port 50051) is accessible from Envoy
+# Check that broker is reachable from Envoy's network
+# If Envoy runs in Docker, use host.docker.internal in cluster addresses
+# If Envoy runs natively, use 127.0.0.1
 ```
 
-### Configuration Not Reloading
+### Configuration Changes
 
-**Note**: Configuration changes require a restart:
-```bash
-# Stop the gateway (Ctrl+C)
-# Edit config/servers.yaml
-# Restart
-./bin/mcp-broker-router --config=config/servers.yaml
-```
+The gateway watches the configuration file for changes and hot-reloads automatically. No restart is needed after editing the config file.
 
 ## Limitations
 
 - **No Authentication/Authorization**: OAuth and policy enforcement require additional proxy configuration
 - **No Virtual Servers**: Virtual server filtering requires controller integration
-- **No Credential Management**: External server credentials must be handled manually in configuration or environment variables
-- **No Automatic Updates**: Server changes require manual config edits and restarts
-- **No High Availability**: Single instance only; HA requires external load balancing and session management
+- **No Credential Management**: External server credentials must be handled manually in configuration
+- **No High Availability**: Single instance only; HA requires external load balancing and Redis for session storage
+- **No Automatic Discovery**: Servers must be manually added to the configuration file
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Fix multiple issues that prevented the standalone binary install guide from working end-to-end
- Add required `GATEWAY_SIGNING_KEY`, fix config format (`state` vs `enabled`), fix Go version, add per-upstream Envoy routing, add missing ext_proc security settings
- Correct hot-reload documentation and add troubleshooting for common failure modes

## Test plan

- [x] Built `mcp-broker-router` from source
- [x] Ran everything server in Docker (`ghcr.io/kuadrant/mcp-gateway/test-everything-server:latest`)
- [x] Ran Envoy in Docker with the guide's `envoy.yaml`
- [x] Started gateway with the guide's flags and env vars
- [x] Verified `tools/list` returns 16 tools (14 prefixed + 2 meta-tools) via MCP Inspector CLI
- [x] Verified `tools/call myserver_echo` returns correct response via MCP Inspector CLI
- [x] Verified `tools/call myserver_get-sum` returns correct response via MCP Inspector CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the standalone binary installation guide with revised prerequisites, setup steps, and configuration examples.
  * Clarified that server changes support hot reload (no restart required) with config updates.
  * Expanded Envoy setup guidance, including routing behavior and required virtual hosts.
  * Added updated startup, verification, and troubleshooting steps for signing keys, gateway host settings, tool discovery, and connectivity checks.
  * Refreshed the limitations section to reflect the latest binary deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->