### PR TITLE
docs: umbrella operator integration design docs, test reports, and upgrade guide

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,6 +7,8 @@
     - [Getting Started](./getting-started.md)
 - Installing the MCP Gateway
     - [Helm Install](./how-to-install-and-configure.md)
+    - [OLM Install (Kuadrant Operator)](./olm-install.md)
+    - [Upgrade from Standalone to Kuadrant Operator (OLM)](./olm-upgrade.md)
 - [Configure MCP Gateway Listener and Router](./configure-mcp-gateway-listener-and-router.md)
 - [Multi-Protocol Support](./multi-protocol-support.md)
 - Configuring MCP Servers

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,6 +7,8 @@
     - [Getting Started](./getting-started.md)
 - Installing the MCP Gateway
     - [Helm Install](./how-to-install-and-configure.md)
+    - [OLM Install (Kuadrant Operator)](./olm-install.md)
+    - [Upgrade from Standalone to Kuadrant Operator (OLM)](./olm-upgrade.md)
 - [Configure MCP Gateway Listener and Router](./configure-mcp-gateway-listener-and-router.md)
 - [Multi-Protocol Support](./multi-protocol-support.md)
 - [A2A Passthrough (Experimental)](./a2a-passthrough.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -2,11 +2,10 @@
 
 **Want to try MCP Gateway on Kubernetes and connect your first MCP servers?** Start here: **[Installation Guide](./how-to-install-and-configure.md)**
 
-<!-- do we want to update the install guide by either marking out every way to install except Helm, or by breaking into install types? we would also break config into a separate doc if we go this route -->
-
 ## Essential Setup
 
-- [Installation and Configuration](./how-to-install-and-configure.md) - Get MCP Gateway running
+- [Installation and Configuration](./how-to-install-and-configure.md) - Get MCP Gateway running with Helm
+- [OLM Install (Kuadrant Operator)](./olm-install.md) - Install on OLM/OpenShift clusters
 - [Configure Gateway Routing](./configure-mcp-gateway-listener-and-router.md) - Set up traffic routing
 - [Configure MCP Servers](./register-mcp-servers.md) - Connect internal servers
 - [External MCP Servers](./external-mcp-server.md) - Connect to external APIs

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -2,6 +2,8 @@
 
 This guide demonstrates how to install and configure the MCP Gateway to aggregate multiple Model Context Protocol (MCP) servers behind a single endpoint.
 
+> **Note:** This guide installs MCP Gateway standalone with Helm. On OLM-based clusters (including OpenShift), install via the Kuadrant Operator instead — see [OLM Install](./olm-install.md).
+
 ## Prerequisites
 
 MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You should be familiar with:

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -3,10 +3,10 @@
 This guide covers installing MCP Gateway on a cluster that uses
 [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/).
 
-MCP Gateway does not ship a standalone OLM operator. On OLM-based clusters, MCP Gateway is
-installed and managed by the **Kuadrant Operator**, which embeds the MCP Gateway controller and
-deploys it on startup. This is the consolidated (umbrella) model described in
-[RFC 0019](https://github.com/Kuadrant/architecture/pull/189).
+On OLM-based clusters, install MCP Gateway through the **Kuadrant Operator**, which embeds the
+MCP Gateway controller and deploys it on startup. This is the consolidated (umbrella) model
+described in
+[RFC 0019](https://github.com/Kuadrant/architecture/blob/main/rfcs/0019-olmv1-operator-consolidation.md).
 
 > **Note:** If you are not using OLM, install MCP Gateway standalone with Helm — see
 > [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md).
@@ -77,7 +77,7 @@ The Kuadrant Operator deploys the MCP Gateway controller on startup, without req
 `RateLimitPolicy`.)
 
 ```bash
-# The MCP CRDs are installed and owned by the Kuadrant Operator CSV
+# The MCP CRDs are installed by the Kuadrant Operator at runtime
 kubectl get crd | grep mcp.kuadrant.io
 # mcpgatewayextensions.mcp.kuadrant.io
 # mcpserverregistrations.mcp.kuadrant.io
@@ -95,9 +95,13 @@ Installing the operator deploys the controller only. To deploy the MCP Gateway d
 reconciles it and creates the broker-router `Deployment`, `Service`, `HTTPRoute`, and the
 `EnvoyFilter` on the Gateway.
 
+This example keeps the `MCPGatewayExtension` and target `Gateway` in `mcp-system`, so it does not
+require a `ReferenceGrant`. If the target Gateway is in another namespace, set
+`targetRef.namespace` and create a `ReferenceGrant` in the target namespace.
+
 ```bash
 kubectl apply -f - <<EOF
-apiVersion: mcp.kuadrant.io/v1alpha1
+apiVersion: mcp.kuadrant.io/v1
 kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway-extension
@@ -105,7 +109,7 @@ metadata:
 spec:
   targetRef:
     name: <your-gateway>
-    namespace: <your-gateway-namespace>
+    namespace: mcp-system
     sectionName: <listener-name>
 EOF
 ```
@@ -127,9 +131,9 @@ kubectl get deployment mcp-gateway -n mcp-system
 
 ## Uninstall
 
-Removing MCP Gateway means removing your `MCPGatewayExtension` resources (which the controller
-uses to clean up the broker-router data plane), then removing the operator if you no longer need
-it.
+Removing MCP Gateway means removing your `MCPGatewayExtension` resources (which the Kuadrant
+Operator uses to clean up the broker-router data plane), then removing the Kuadrant Operator if
+you no longer need it.
 
 ```bash
 # Remove the data plane (controller must still be running to clear finalizers)
@@ -142,11 +146,30 @@ kubectl delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-s
 
 > **Note:** Removing the Kuadrant `Subscription` and CSV uninstalls the entire Kuadrant control
 > plane, not just MCP Gateway. If other Kuadrant features (such as `AuthPolicy` or
-> `RateLimitPolicy`) are in use on the cluster, leave the operator installed and only remove the
-> `MCPGatewayExtension` resources.
+> `RateLimitPolicy`) are in use on the cluster, leave the Kuadrant Operator installed and only
+> remove the `MCPGatewayExtension` resources.
 
-> **Note:** OLM does not delete CRDs when a CSV is removed. Delete the MCP CRDs manually only if
-> you are sure no other operator or workload depends on them.
+> **Warning:** Deleting an MCP CRD irreversibly deletes every resource of that kind in every
+> namespace. Before deleting CRDs, back up the resources and verify that no other operator or
+> workload depends on them.
+
+Back up the MCP resources before deleting their CRDs:
+
+```bash
+kubectl get mcpgatewayextensions,mcpserverregistrations,mcpvirtualservers -A -o yaml > mcp-resources-backup.yaml
+```
+
+Delete the MCP CRDs only when you have confirmed that they are no longer needed. This command
+deletes the three MCP CRDs installed by MCP Gateway:
+
+```bash
+kubectl delete crd \
+  mcpgatewayextensions.mcp.kuadrant.io \
+  mcpserverregistrations.mcp.kuadrant.io \
+  mcpvirtualservers.mcp.kuadrant.io \
+  --wait=true \
+  --ignore-not-found=true
+```
 
 ## Next Steps
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -9,33 +9,28 @@ deploys it on startup. This is the consolidated (umbrella) model described in
 [RFC 0019](https://github.com/Kuadrant/architecture/pull/189).
 
 > **Note:** If you are not using OLM, install MCP Gateway standalone with Helm — see
-> [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md). Helm is the
-> preferred way to run MCP Gateway standalone.
+> [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md).
 >
 > If you previously installed MCP Gateway via its own OLM subscription and want to move to the
 > Kuadrant Operator, follow
-> [Upgrading from Standalone MCP Gateway to the Kuadrant Operator](./olm-upgrade.md) instead —
-> that path is zero-downtime.
+> [Upgrading from Standalone MCP Gateway to the Kuadrant Operator](./olm-upgrade.md) instead.
 
 ## Prerequisites
 
 - A cluster with OLM. OpenShift includes OLM by default; on other Kubernetes distributions,
   install OLM first.
 - Gateway API CRDs and an Istio-based Gateway API provider installed.
-- A catalog source that provides a Kuadrant Operator version which bundles MCP Gateway. Your
-  cluster administrator or the Kuadrant release notes will tell you which version and catalog to
-  use.
+- A catalog source providing a Kuadrant Operator version that bundles MCP Gateway.
 
 > **Note:** Throughout this guide, `mcp-system` is the namespace where the operator and its
 > `OperatorGroup` live. Substitute your own namespace if different.
 
 ## Step 1: Install the Kuadrant Operator
 
-Create an `OperatorGroup` and a `Subscription` for the Kuadrant Operator. Use the catalog source
-and channel provided by your administrator or the release notes.
+Create an `OperatorGroup` and a `Subscription` for the Kuadrant Operator.
 
 ```bash
-oc apply -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -51,38 +46,40 @@ spec:
   channel: <channel>
   name: kuadrant-operator
   source: <catalog-source>
-  sourceNamespace: openshift-marketplace
+  sourceNamespace: <catalog-namespace>
   installPlanApproval: Automatic
 EOF
 ```
+
+> **Note:** `<catalog-namespace>` is the namespace of your catalog source: `openshift-marketplace`
+> on OpenShift, `olm` on most other OLM installs.
 
 Wait for the operator's ClusterServiceVersion (CSV) to succeed. The CSV may take a moment to
 appear while OLM processes the subscription:
 
 ```bash
-oc get csv -n mcp-system -w
+kubectl get csv -n mcp-system -w
 # kuadrant-operator.<version>   ...   Succeeded
 ```
 
-If `oc get csv` returns nothing at first, wait a few seconds and retry — the CSV has not been
+If `kubectl get csv` returns nothing at first, wait a few seconds and retry — the CSV has not been
 created yet.
 
 ## Step 2: Verify the MCP Gateway controller is running
 
-The Kuadrant Operator deploys the MCP Gateway controller unconditionally on startup, alongside
-its other component controllers. No `Kuadrant` custom resource is required for the controller to
-run. (A `Kuadrant` CR is only needed later if you want to apply `AuthPolicy` or
+The Kuadrant Operator deploys the MCP Gateway controller on startup, without requiring a
+`Kuadrant` custom resource. (A `Kuadrant` CR is only needed later to apply `AuthPolicy` or
 `RateLimitPolicy`.)
 
 ```bash
 # The MCP CRDs are installed and owned by the Kuadrant Operator CSV
-oc get crd | grep mcp.kuadrant.io
+kubectl get crd | grep mcp.kuadrant.io
 # mcpgatewayextensions.mcp.kuadrant.io
 # mcpserverregistrations.mcp.kuadrant.io
 # mcpvirtualservers.mcp.kuadrant.io
 
 # The MCP Gateway controller is running
-oc get deployment mcp-gateway-controller -n mcp-system
+kubectl get deployment mcp-gateway-controller -n mcp-system
 # READY 1/1
 ```
 
@@ -94,7 +91,7 @@ reconciles it and creates the broker-router `Deployment`, `Service`, `HTTPRoute`
 `EnvoyFilter` on the Gateway.
 
 ```bash
-oc apply -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPGatewayExtension
 metadata:
@@ -111,14 +108,14 @@ EOF
 Verify the extension becomes Ready and the broker-router is running:
 
 ```bash
-oc get mcpgatewayextension -n mcp-system
+kubectl get mcpgatewayextension -n mcp-system
 # READY True
 
-oc get deployment mcp-gateway -n mcp-system
+kubectl get deployment mcp-gateway -n mcp-system
 # READY 1/1
 ```
 
-> **Note:** For richer deployment options — multiple isolated instances, cross-namespace Gateway
+> **Note:** For more deployment options — multiple isolated instances, cross-namespace Gateway
 > references with `ReferenceGrant`, session storage, and listener configuration — see
 > [Isolated Gateway Deployment](./isolated-gateway-deployment.md) and
 > [Configure MCP Gateway Listener and Router](./configure-mcp-gateway-listener-and-router.md).
@@ -131,11 +128,11 @@ it.
 
 ```bash
 # Remove the data plane (controller must still be running to clear finalizers)
-oc delete mcpgatewayextension --all -n mcp-system
+kubectl delete mcpgatewayextension --all -n mcp-system
 
 # Remove the operator
-oc delete subscription kuadrant-operator -n mcp-system
-oc delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-system
+kubectl delete subscription kuadrant-operator -n mcp-system
+kubectl delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-system
 ```
 
 > **Note:** OLM does not delete CRDs when a CSV is removed. Delete the MCP CRDs manually only if

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -27,10 +27,15 @@ deploys it on startup. This is the consolidated (umbrella) model described in
 
 ## Step 1: Install the Kuadrant Operator
 
-Create an `OperatorGroup` and a `Subscription` for the Kuadrant Operator.
+Create the `mcp-system` namespace, an `OperatorGroup`, and a `Subscription` for the Kuadrant Operator.
 
 ```bash
 kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-system
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -134,6 +139,11 @@ kubectl delete mcpgatewayextension --all -n mcp-system
 kubectl delete subscription kuadrant-operator -n mcp-system
 kubectl delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-system
 ```
+
+> **Note:** Removing the Kuadrant `Subscription` and CSV uninstalls the entire Kuadrant control
+> plane, not just MCP Gateway. If other Kuadrant features (such as `AuthPolicy` or
+> `RateLimitPolicy`) are in use on the cluster, leave the operator installed and only remove the
+> `MCPGatewayExtension` resources.
 
 > **Note:** OLM does not delete CRDs when a CSV is removed. Delete the MCP CRDs manually only if
 > you are sure no other operator or workload depends on them.

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -101,9 +101,10 @@ metadata:
   name: mcp-gateway-extension
   namespace: mcp-system
 spec:
-  gatewayRef:
+  targetRef:
     name: <your-gateway>
     namespace: <your-gateway-namespace>
+    sectionName: <listener-name>
 EOF
 ```
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -20,6 +20,7 @@ described in
 - A cluster with OLM. OpenShift includes OLM by default; on other Kubernetes distributions,
   install OLM first.
 - Gateway API CRDs and an Istio-based Gateway API provider installed.
+- A `Gateway` named `<your-gateway>` in `mcp-system` with a listener named `<listener-name>`.
 - A catalog source providing a Kuadrant Operator version that bundles MCP Gateway.
 
 > **Note:** Throughout this guide, `mcp-system` is the namespace where the operator and its
@@ -99,6 +100,20 @@ This example keeps the `MCPGatewayExtension` and target `Gateway` in `mcp-system
 require a `ReferenceGrant`. If the target Gateway is in another namespace, set
 `targetRef.namespace` and create a `ReferenceGrant` in the target namespace.
 
+Verify that the target Gateway and named listener exist:
+
+```bash
+GATEWAY_NAME="<your-gateway>"
+GATEWAY_NAMESPACE="mcp-system"
+LISTENER_NAME="<listener-name>"
+
+kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE"
+kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+  -o jsonpath='{range .spec.listeners[*]}{.name}{"\n"}{end}' \
+  | grep -Fx "$LISTENER_NAME"
+# <listener-name>
+```
+
 ```bash
 kubectl apply -f - <<EOF
 apiVersion: mcp.kuadrant.io/v1
@@ -148,7 +163,6 @@ kubectl delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-s
 > plane, not just MCP Gateway. If other Kuadrant features (such as `AuthPolicy` or
 > `RateLimitPolicy`) are in use on the cluster, leave the Kuadrant Operator installed and only
 > remove the `MCPGatewayExtension` resources.
-
 > **Warning:** Deleting an MCP CRD irreversibly deletes every resource of that kind in every
 > namespace. Before deleting CRDs, back up the resources and verify that no other operator or
 > workload depends on them.

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -1,71 +1,147 @@
-# Installing MCP Gateway via OLM
+# Installing MCP Gateway via OLM (Kuadrant Operator)
 
-This guide covers installing the MCP Gateway controller using [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/).
+This guide covers installing MCP Gateway on a cluster that uses
+[Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/).
+
+MCP Gateway does not ship a standalone OLM operator. On OLM-based clusters, MCP Gateway is
+installed and managed by the **Kuadrant Operator**, which embeds the MCP Gateway controller and
+deploys it on startup. This is the consolidated (umbrella) model described in
+[RFC 0019](https://github.com/Kuadrant/architecture/pull/189).
+
+> **Note:** If you are not using OLM, install MCP Gateway standalone with Helm — see
+> [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md). Helm is the
+> preferred way to run MCP Gateway standalone.
+>
+> If you previously installed MCP Gateway via its own OLM subscription and want to move to the
+> Kuadrant Operator, follow
+> [Upgrading from Standalone MCP Gateway to the Kuadrant Operator](./olm-upgrade.md) instead —
+> that path is zero-downtime.
 
 ## Prerequisites
 
-OpenShift clusters include OLM by default. For non-OpenShift Kubernetes clusters, install OLM first:
+- A cluster with OLM. OpenShift includes OLM by default; on other Kubernetes distributions,
+  install OLM first.
+- Gateway API CRDs and an Istio-based Gateway API provider installed.
+- A catalog source that provides a Kuadrant Operator version which bundles MCP Gateway. Your
+  cluster administrator or the Kuadrant release notes will tell you which version and catalog to
+  use.
+
+> **Note:** Throughout this guide, `mcp-system` is the namespace where the operator and its
+> `OperatorGroup` live. Substitute your own namespace if different.
+
+## Step 1: Install the Kuadrant Operator
+
+Create an `OperatorGroup` and a `Subscription` for the Kuadrant Operator. Use the catalog source
+and channel provided by your administrator or the release notes.
 
 ```bash
-make olm-install
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant
+  namespace: mcp-system
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  namespace: mcp-system
+spec:
+  channel: <channel>
+  name: kuadrant-operator
+  source: <catalog-source>
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
 ```
 
-## Install
-
-Deploy from a release tag using kustomize with a remote ref:
+Wait for the operator's ClusterServiceVersion (CSV) to succeed. The CSV may take a moment to
+appear while OLM processes the subscription:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.9.0
-kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
+oc get csv -n mcp-system -w
+# kuadrant-operator.<version>   ...   Succeeded
 ```
 
-Wait for the controller to be ready. The CSV may take a moment to appear while OLM processes the subscription:
+If `oc get csv` returns nothing at first, wait a few seconds and retry — the CSV has not been
+created yet.
+
+## Step 2: Verify the MCP Gateway controller is running
+
+The Kuadrant Operator deploys the MCP Gateway controller unconditionally on startup, alongside
+its other component controllers. No `Kuadrant` custom resource is required for the controller to
+run. (A `Kuadrant` CR is only needed later if you want to apply `AuthPolicy` or
+`RateLimitPolicy`.)
 
 ```bash
-kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system="" \
-  --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
+# The MCP CRDs are installed and owned by the Kuadrant Operator CSV
+oc get crd | grep mcp.kuadrant.io
+# mcpgatewayextensions.mcp.kuadrant.io
+# mcpserverregistrations.mcp.kuadrant.io
+# mcpvirtualservers.mcp.kuadrant.io
+
+# The MCP Gateway controller is running
+oc get deployment mcp-gateway-controller -n mcp-system
+# READY 1/1
 ```
 
-If the command returns "no matching resources found", wait a few seconds and retry -- the CSV has not been created yet.
+## Step 3: Deploy an MCP Gateway instance
 
-## Next Steps
+Installing the operator deploys the controller only. To deploy the MCP Gateway data plane
+(broker-router), create an `MCPGatewayExtension` that targets your Gateway. The controller
+reconciles it and creates the broker-router `Deployment`, `Service`, `HTTPRoute`, and the
+`EnvoyFilter` on the Gateway.
 
-Installing via OLM deploys the operator only. To deploy the MCP Gateway itself, create an `MCPGatewayExtension` resource. See [Manual Resource Creation](./isolated-gateway-deployment.md#manual-resource-creation) for details.
+```bash
+oc apply -f - <<EOF
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPGatewayExtension
+metadata:
+  name: mcp-gateway-extension
+  namespace: mcp-system
+spec:
+  gatewayRef:
+    name: <your-gateway>
+    namespace: <your-gateway-namespace>
+EOF
+```
+
+Verify the extension becomes Ready and the broker-router is running:
+
+```bash
+oc get mcpgatewayextension -n mcp-system
+# READY True
+
+oc get deployment mcp-gateway -n mcp-system
+# READY 1/1
+```
+
+> **Note:** For richer deployment options — multiple isolated instances, cross-namespace Gateway
+> references with `ReferenceGrant`, session storage, and listener configuration — see
+> [Isolated Gateway Deployment](./isolated-gateway-deployment.md) and
+> [Configure MCP Gateway Listener and Router](./configure-mcp-gateway-listener-and-router.md).
 
 ## Uninstall
 
-```bash
-make undeploy-olm
-```
-
-## Local Development (Kind)
-
-The default `local-env-setup` target uses kustomize:
+Removing MCP Gateway means removing your `MCPGatewayExtension` resources (which the controller
+uses to clean up the broker-router data plane), then removing the operator if you no longer need
+it.
 
 ```bash
-make local-env-setup
+# Remove the data plane (controller must still be running to clear finalizers)
+oc delete mcpgatewayextension --all -n mcp-system
+
+# Remove the operator
+oc delete subscription kuadrant-operator -n mcp-system
+oc delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-system
 ```
 
-To use the OLM-based deployment instead (installs both MCP Gateway and Kuadrant via OLM):
+> **Note:** OLM does not delete CRDs when a CSV is removed. Delete the MCP CRDs manually only if
+> you are sure no other operator or workload depends on them.
 
-```bash
-make local-env-setup-olm
-```
+## Next Steps
 
-This builds the bundle and catalog images locally, loads them into the Kind cluster, deploys the Kuadrant OLM catalog, and lets OLM resolve Kuadrant as a dependency automatically.
-
-## Available Make Targets
-
-| Target | Description |
-|--------|-------------|
-| `make bundle` | Generate OLM bundle manifests |
-| `make bundle-build` | Build the OLM bundle image |
-| `make bundle-push` | Push the OLM bundle image |
-| `make catalog-build` | Build the OLM catalog image |
-| `make catalog-push` | Push the OLM catalog image |
-| `make olm-install` | Install OLM on the cluster |
-| `make olm-uninstall` | Uninstall OLM from the cluster |
-| `make deploy-olm` | Deploy controller via OLM on local cluster |
-| `make deploy-kuadrant-catalog` | Deploy Kuadrant OLM catalog from upstream |
-| `make local-env-setup-olm` | Full local setup with MCP Gateway and Kuadrant via OLM |
-| `make undeploy-olm` | Remove OLM-deployed controller |
+- [Register MCP Servers](./register-mcp-servers.md)
+- [Authentication](./authentication.md)
+- [Authorization](./authorization.md)

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -1,71 +1,147 @@
-# Installing MCP Gateway via OLM
+# Installing MCP Gateway via OLM (Kuadrant Operator)
 
-This guide covers installing the MCP Gateway controller using [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/).
+This guide covers installing MCP Gateway on a cluster that uses
+[Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/).
+
+MCP Gateway does not ship a standalone OLM operator. On OLM-based clusters, MCP Gateway is
+installed and managed by the **Kuadrant Operator**, which embeds the MCP Gateway controller and
+deploys it on startup. This is the consolidated (umbrella) model described in
+[RFC 0019](https://github.com/Kuadrant/architecture/pull/189).
+
+> **Note:** If you are not using OLM, install MCP Gateway standalone with Helm — see
+> [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md). Helm is the
+> preferred way to run MCP Gateway standalone.
+>
+> If you previously installed MCP Gateway via its own OLM subscription and want to move to the
+> Kuadrant Operator, follow
+> [Upgrading from Standalone MCP Gateway to the Kuadrant Operator](./olm-upgrade.md) instead —
+> that path is zero-downtime.
 
 ## Prerequisites
 
-OpenShift clusters include OLM by default. For non-OpenShift Kubernetes clusters, install OLM first:
+- A cluster with OLM. OpenShift includes OLM by default; on other Kubernetes distributions,
+  install OLM first.
+- Gateway API CRDs and an Istio-based Gateway API provider installed.
+- A catalog source that provides a Kuadrant Operator version which bundles MCP Gateway. Your
+  cluster administrator or the Kuadrant release notes will tell you which version and catalog to
+  use.
+
+> **Note:** Throughout this guide, `mcp-system` is the namespace where the operator and its
+> `OperatorGroup` live. Substitute your own namespace if different.
+
+## Step 1: Install the Kuadrant Operator
+
+Create an `OperatorGroup` and a `Subscription` for the Kuadrant Operator. Use the catalog source
+and channel provided by your administrator or the release notes.
 
 ```bash
-make olm-install
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant
+  namespace: mcp-system
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  namespace: mcp-system
+spec:
+  channel: <channel>
+  name: kuadrant-operator
+  source: <catalog-source>
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
 ```
 
-## Install
-
-Deploy from a release tag using kustomize with a remote ref:
+Wait for the operator's ClusterServiceVersion (CSV) to succeed. The CSV may take a moment to
+appear while OLM processes the subscription:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.8.0
-kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
+oc get csv -n mcp-system -w
+# kuadrant-operator.<version>   ...   Succeeded
 ```
 
-Wait for the controller to be ready. The CSV may take a moment to appear while OLM processes the subscription:
+If `oc get csv` returns nothing at first, wait a few seconds and retry — the CSV has not been
+created yet.
+
+## Step 2: Verify the MCP Gateway controller is running
+
+The Kuadrant Operator deploys the MCP Gateway controller unconditionally on startup, alongside
+its other component controllers. No `Kuadrant` custom resource is required for the controller to
+run. (A `Kuadrant` CR is only needed later if you want to apply `AuthPolicy` or
+`RateLimitPolicy`.)
 
 ```bash
-kubectl wait csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system="" \
-  --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
+# The MCP CRDs are installed and owned by the Kuadrant Operator CSV
+oc get crd | grep mcp.kuadrant.io
+# mcpgatewayextensions.mcp.kuadrant.io
+# mcpserverregistrations.mcp.kuadrant.io
+# mcpvirtualservers.mcp.kuadrant.io
+
+# The MCP Gateway controller is running
+oc get deployment mcp-gateway-controller -n mcp-system
+# READY 1/1
 ```
 
-If the command returns "no matching resources found", wait a few seconds and retry -- the CSV has not been created yet.
+## Step 3: Deploy an MCP Gateway instance
 
-## Next Steps
+Installing the operator deploys the controller only. To deploy the MCP Gateway data plane
+(broker-router), create an `MCPGatewayExtension` that targets your Gateway. The controller
+reconciles it and creates the broker-router `Deployment`, `Service`, `HTTPRoute`, and the
+`EnvoyFilter` on the Gateway.
 
-Installing via OLM deploys the operator only. To deploy the MCP Gateway itself, create an `MCPGatewayExtension` resource. See [Manual Resource Creation](./isolated-gateway-deployment.md#manual-resource-creation) for details.
+```bash
+oc apply -f - <<EOF
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPGatewayExtension
+metadata:
+  name: mcp-gateway-extension
+  namespace: mcp-system
+spec:
+  gatewayRef:
+    name: <your-gateway>
+    namespace: <your-gateway-namespace>
+EOF
+```
+
+Verify the extension becomes Ready and the broker-router is running:
+
+```bash
+oc get mcpgatewayextension -n mcp-system
+# READY True
+
+oc get deployment mcp-gateway -n mcp-system
+# READY 1/1
+```
+
+> **Note:** For richer deployment options — multiple isolated instances, cross-namespace Gateway
+> references with `ReferenceGrant`, session storage, and listener configuration — see
+> [Isolated Gateway Deployment](./isolated-gateway-deployment.md) and
+> [Configure MCP Gateway Listener and Router](./configure-mcp-gateway-listener-and-router.md).
 
 ## Uninstall
 
-```bash
-make undeploy-olm
-```
-
-## Local Development (Kind)
-
-The default `local-env-setup` target uses kustomize:
+Removing MCP Gateway means removing your `MCPGatewayExtension` resources (which the controller
+uses to clean up the broker-router data plane), then removing the operator if you no longer need
+it.
 
 ```bash
-make local-env-setup
+# Remove the data plane (controller must still be running to clear finalizers)
+oc delete mcpgatewayextension --all -n mcp-system
+
+# Remove the operator
+oc delete subscription kuadrant-operator -n mcp-system
+oc delete csv -n mcp-system -l operators.coreos.com/kuadrant-operator.mcp-system
 ```
 
-To use the OLM-based deployment instead (installs both MCP Gateway and Kuadrant via OLM):
+> **Note:** OLM does not delete CRDs when a CSV is removed. Delete the MCP CRDs manually only if
+> you are sure no other operator or workload depends on them.
 
-```bash
-make local-env-setup-olm
-```
+## Next Steps
 
-This builds the bundle and catalog images locally, loads them into the Kind cluster, deploys the Kuadrant OLM catalog, and lets OLM resolve Kuadrant as a dependency automatically.
-
-## Available Make Targets
-
-| Target | Description |
-|--------|-------------|
-| `make bundle` | Generate OLM bundle manifests |
-| `make bundle-build` | Build the OLM bundle image |
-| `make bundle-push` | Push the OLM bundle image |
-| `make catalog-build` | Build the OLM catalog image |
-| `make catalog-push` | Push the OLM catalog image |
-| `make olm-install` | Install OLM on the cluster |
-| `make olm-uninstall` | Uninstall OLM from the cluster |
-| `make deploy-olm` | Deploy controller via OLM on local cluster |
-| `make deploy-kuadrant-catalog` | Deploy Kuadrant OLM catalog from upstream |
-| `make local-env-setup-olm` | Full local setup with MCP Gateway and Kuadrant via OLM |
-| `make undeploy-olm` | Remove OLM-deployed controller |
+- [Register MCP Servers](./register-mcp-servers.md)
+- [Authentication](./authentication.md)
+- [Authorization](./authorization.md)

--- a/docs/guides/olm-upgrade.md
+++ b/docs/guides/olm-upgrade.md
@@ -7,8 +7,8 @@ plane keeps serving while ownership transfers.
 
 ## Who this is for
 
-You installed MCP Gateway (version `<1.0`) via a `Subscription` named `mcp-gateway` (or
-equivalent) and now want the Kuadrant Operator to manage it instead. This is the model described
+You installed MCP Gateway (version `<1.0>`) via a standalone OLM `Subscription` and now want the
+Kuadrant Operator to manage it instead. This is the model described
 in [RFC 0019](https://github.com/Kuadrant/architecture/blob/main/rfcs/0019-olmv1-operator-consolidation.md).
 The Kuadrant Operator runs the MCP Gateway controller; no `Kuadrant` CR is required for it to
 start.
@@ -49,23 +49,37 @@ kubectl get deployment mcp-gateway -n mcp-system
 # Your extension(s) — must stay Ready
 kubectl get mcpgatewayextension -A
 
+# The standalone Subscription name, namespace, package, and installed CSV
+kubectl get subscriptions -A \
+  -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,PACKAGE:.spec.name,CSV:.status.installedCSV'
+
 # Which CSV currently owns the MCP CRDs
 kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
   -o jsonpath='{.metadata.labels}{"\n"}'
 ```
 
-The CRD labels include an `operators.coreos.com/<csv>.<namespace>` entry naming the owning CSV.
-Before migration this is the standalone `mcp-gateway` CSV.
+Record the exact standalone `Subscription` name and namespace, and its `status.installedCSV` value,
+before moving to Step 2. The latter is the CSV name that the cleanup commands must remove.
 
 ## Step 2: Remove the standalone MCP Gateway subscription
 
 OLM does not allow two operators to own the same CRDs. Removing the standalone subscription and
 its CSV relinquishes ownership of the MCP CRDs so the Kuadrant Operator can take them over.
 
+Set these variables to the exact values recorded in Step 1:
+
 ```bash
-kubectl delete subscription mcp-gateway -n mcp-system
-kubectl delete csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system
+STANDALONE_SUBSCRIPTION_NAME="<standalone-subscription-name>"
+STANDALONE_NAMESPACE="<standalone-subscription-namespace>"
+STANDALONE_CSV_NAME="<standalone-csv-name>"
+
+kubectl delete subscription "$STANDALONE_SUBSCRIPTION_NAME" \
+  -n "$STANDALONE_NAMESPACE" --wait=true
+kubectl delete csv "$STANDALONE_CSV_NAME" \
+  -n "$STANDALONE_NAMESPACE" --wait=true
 ```
+
+The CSV deletion waits for the named CSV to be fully removed before ownership transfer continues.
 
 Deleting the CSV removes the `mcp-gateway-controller` Deployment but not the broker-router. Confirm the data plane and
 your resources survived:
@@ -80,7 +94,6 @@ resources are untouched — OLM does not delete CRDs when a CSV is removed.
 
 > **Do not delete the `MCPGatewayExtension` during this step.** Its finalizer needs a running
 > controller to clear; the Kuadrant Operator's controller (Step 3) handles it once it starts.
-
 > **Note:** No MCP Gateway controller runs until the Kuadrant Operator's controller starts
 > (Step 3/4). During this window, create/update/delete operations, finalizers, and status
 > changes on `MCPGatewayExtension`, `MCPServerRegistration`, and `MCPVirtualServer` resources
@@ -94,6 +107,19 @@ happens depends on how your catalog ships it:
 - **Same channel, newer version (typical production upgrade):** if your subscription's channel
   already offers the newer version, OLM upgrades automatically (for `installPlanApproval:
   Automatic`) or presents an InstallPlan to approve.
+
+If `installPlanApproval` is `Manual`, list the InstallPlans and approve the pending plan for the
+Kuadrant Operator:
+
+```bash
+INSTALLPLAN_NAME="<installplan-name>"
+kubectl get installplan -n mcp-system
+kubectl patch installplan "$INSTALLPLAN_NAME" -n mcp-system \
+  -p '{"spec":{"approved":true}}' --type merge
+```
+
+Replace `<installplan-name>` with the InstallPlan created for this upgrade. When approval is
+`Automatic`, OLM approves the plan without this step.
 
 - **Explicit version target:** delete the existing Kuadrant subscription and CSV, then recreate
   the subscription with `startingCSV` set to the target version:
@@ -137,10 +163,12 @@ kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
   -o jsonpath='{.status.conditions[?(@.type=="Established")].status}{"\n"}'
 # True
 
-# The MCP CRDs are managed by the Kuadrant Operator at runtime
-kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
-  -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}{"\n"}'
-# kuadrant-operator
+# The active Kuadrant CSV owns the MCP CRD
+KUADRANT_CSV=$(kubectl get subscription kuadrant-operator -n mcp-system \
+  -o jsonpath='{.status.installedCSV}')
+kubectl get csv "$KUADRANT_CSV" -n mcp-system \
+  -o jsonpath='{range .spec.customresourcedefinitions.owned[?(@.name=="mcpgatewayextensions.mcp.kuadrant.io")]}{.name}{"\n"}{end}'
+# mcpgatewayextensions.mcp.kuadrant.io
 
 # The controller is running again, now deployed by the Kuadrant Operator
 kubectl get deployment mcp-gateway-controller -n mcp-system

--- a/docs/guides/olm-upgrade.md
+++ b/docs/guides/olm-upgrade.md
@@ -173,10 +173,13 @@ oc get mcpgatewayextension -A
 # READY True
 ```
 
-> **Note:** When the new controller reconciles your `MCPGatewayExtension`, it may roll the
-> broker-router pods (a rolling update behind the stable `Service`). New pods become Ready
-> before old ones are removed, so no requests are dropped — the broker-router `Deployment`,
-> `Service`, `HTTPRoute` and `EnvoyFilter` are never deleted.
+> **Note:** When the new controller reconciles your `MCPGatewayExtension`, it rolls the
+> broker-router pods whenever the Kuadrant Operator release pins a newer broker-router image
+> than the one currently running — which is normally the case on a version-advancing upgrade.
+> This is a rolling update behind the stable `Service`: new pods become Ready before old ones
+> are removed, so no requests are dropped. The pods restarting is expected; zero-downtime means
+> no request is dropped during the roll, not that the pods are never replaced. The broker-router
+> `Deployment`, `Service`, `HTTPRoute` and `EnvoyFilter` are never deleted.
 
 ## Step 6: Confirm traffic was uninterrupted
 

--- a/docs/guides/olm-upgrade.md
+++ b/docs/guides/olm-upgrade.md
@@ -9,8 +9,9 @@ plane keeps serving while ownership transfers.
 
 You installed MCP Gateway (version `<1.0`) via a `Subscription` named `mcp-gateway` (or
 equivalent) and now want the Kuadrant Operator to manage it instead. This is the model described
-in [RFC 0019](https://github.com/Kuadrant/architecture/pull/189): the Kuadrant Operator runs the
-MCP Gateway controller; no `Kuadrant` CR is required for it to start.
+in [RFC 0019](https://github.com/Kuadrant/architecture/blob/main/rfcs/0019-olmv1-operator-consolidation.md).
+The Kuadrant Operator runs the MCP Gateway controller; no `Kuadrant` CR is required for it to
+start.
 
 If you installed MCP Gateway with Helm rather than OLM, this guide does not apply — see
 [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md).
@@ -30,7 +31,7 @@ If you installed MCP Gateway with Helm rather than OLM, this guide does not appl
 ## Why this works without downtime
 
 The MCP Gateway data plane (the broker-router `Deployment`, its `Service`, the `HTTPRoute`, and
-the `EnvoyFilter`) is owned by your `MCPGatewayExtension`, not by any operator's
+the `EnvoyFilter`) is managed by your `MCPGatewayExtension`, not by any operator's
 ClusterServiceVersion (CSV). Removing or replacing an operator CSV never touches it, so the Envoy
 routing path stays up throughout the migration.
 
@@ -124,16 +125,22 @@ kubectl wait csv/kuadrant-operator.<target-version> -n mcp-system \
   --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
 ```
 
-## Step 4: Verify the Kuadrant Operator has taken over
+## Step 4: Verify the Kuadrant Operator manages MCP Gateway
 
-The Kuadrant Operator now owns the MCP CRDs and runs the controller; no `Kuadrant` CR is required
-for it to start. (A `Kuadrant` CR is only needed later for `AuthPolicy` or `RateLimitPolicy`.)
+The Kuadrant Operator now manages the MCP CRDs at runtime and runs the controller; no `Kuadrant`
+CR is required for it to start. (A `Kuadrant` CR is only needed later for `AuthPolicy` or
+`RateLimitPolicy`.)
 
 ```bash
-# CRD ownership has transferred to the Kuadrant Operator CSV
+# The MCP CRDs remain established
 kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
-  -o jsonpath='{.metadata.labels}{"\n"}'
-# The operators.coreos.com/... label now names the kuadrant-operator CSV
+  -o jsonpath='{.status.conditions[?(@.type=="Established")].status}{"\n"}'
+# True
+
+# The MCP CRDs are managed by the Kuadrant Operator at runtime
+kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
+  -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}{"\n"}'
+# kuadrant-operator
 
 # The controller is running again, now deployed by the Kuadrant Operator
 kubectl get deployment mcp-gateway-controller -n mcp-system
@@ -151,16 +158,20 @@ kubectl get mcpgatewayextension -A
 
 ## Step 5: Confirm traffic is being served
 
-Send a request through the gateway and confirm it succeeds.
+Set the endpoint values to match the Gateway listener. Use `https` with port `443` for a standard
+HTTPS listener; use `http` with the configured listener port for an HTTP listener.
 
 ```bash
-GATEWAY_HOST=<your-gateway-hostname>
+GATEWAY_SCHEME="https" # change to "http" for an HTTP listener
+GATEWAY_HOST="your-gateway-hostname"
+GATEWAY_PORT="443" # change to the Gateway listener port
+MCP_ENDPOINT="${GATEWAY_SCHEME}://${GATEWAY_HOST}:${GATEWAY_PORT}/mcp"
 
-curl -s -X POST "http://$GATEWAY_HOST:8080/mcp" \
+curl -s -X POST "$MCP_ENDPOINT" \
   -H "Content-Type: application/json" -D /tmp/hdr.txt -o /dev/null \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"post-upgrade","version":"1.0"}}}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"post-upgrade","version":"1.0"}}}'
 SID=$(grep -i mcp-session-id /tmp/hdr.txt | awk '{print $2}' | tr -d '\r\n')
-curl -s -X POST "http://$GATEWAY_HOST:8080/mcp" \
+curl -s -X POST "$MCP_ENDPOINT" \
   -H "Content-Type: application/json" -H "mcp-session-id: $SID" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<your-tool>","arguments":{}}}'
 ```

--- a/docs/guides/olm-upgrade.md
+++ b/docs/guides/olm-upgrade.md
@@ -1,134 +1,99 @@
 # Upgrading from Standalone MCP Gateway to the Kuadrant Operator (OLM)
 
-This guide covers migrating an OLM-installed MCP Gateway from the **standalone** operator
-(its own OLM subscription) to the **consolidated** deployment, where the Kuadrant Operator
-owns the MCP Gateway CRDs and runs its controller.
-
-The migration is zero-downtime: MCP traffic is not interrupted while ownership transfers.
+This guide migrates an OLM-installed MCP Gateway from the **standalone** operator (its own OLM
+subscription) to the **consolidated** deployment, where the Kuadrant Operator owns the MCP
+Gateway CRDs and runs its controller. The migration is designed to be zero-downtime: the data
+plane keeps serving while ownership transfers.
 
 ## Who this is for
 
-You installed MCP Gateway via its own OLM subscription (a `Subscription` named `mcp-gateway`,
-or equivalent, that installed the `mcp-gateway` operator) and you now want the Kuadrant
-Operator to manage MCP Gateway instead. This is the model described in
-[RFC 0019](https://github.com/Kuadrant/architecture/pull/189): the Kuadrant Operator embeds
-the MCP Gateway controller and deploys it on startup.
+You installed MCP Gateway (version `<1.0`) via a `Subscription` named `mcp-gateway` (or
+equivalent) and now want the Kuadrant Operator to manage it instead. This is the model described
+in [RFC 0019](https://github.com/Kuadrant/architecture/pull/189): the Kuadrant Operator runs the
+MCP Gateway controller; no `Kuadrant` CR is required for it to start.
 
 If you installed MCP Gateway with Helm rather than OLM, this guide does not apply — see
 [Installing and Configuring MCP Gateway](./how-to-install-and-configure.md).
 
 ## Prerequisites
 
-- An OpenShift cluster with OLM (OpenShift includes OLM by default).
+- A Kubernetes or OpenShift cluster with OLM (OpenShift includes OLM by default).
 - MCP Gateway installed via its own OLM subscription, with at least one `MCPGatewayExtension`
-  in a Ready state and traffic flowing.
+  Ready and traffic flowing.
 - The Kuadrant Operator installed via OLM in the same namespace.
-- A catalog source that provides a Kuadrant Operator version which bundles MCP Gateway. Your
-  cluster administrator or the Kuadrant release notes will tell you which version and catalog
-  to use.
+- A catalog source providing a Kuadrant Operator version that bundles MCP Gateway. Your
+  administrator or the Kuadrant release notes will tell you which version and catalog to use.
 
 > **Note:** Throughout this guide, `mcp-system` is the namespace where the operators and their
 > `OperatorGroup` live. Substitute your own namespace if different.
 
 ## Why this works without downtime
 
-The MCP Gateway data plane — the broker-router `Deployment`, its `Service`, the `HTTPRoute`,
-and the `EnvoyFilter` — is owned by your `MCPGatewayExtension` custom resource, not by the
-operator's ClusterServiceVersion (CSV). Removing or replacing an operator CSV therefore never
-deletes these resources. The Envoy routing path stays in place for the entire migration, so
-in-flight and new requests continue to be served.
+The MCP Gateway data plane (the broker-router `Deployment`, its `Service`, the `HTTPRoute`, and
+the `EnvoyFilter`) is owned by your `MCPGatewayExtension`, not by any operator's
+ClusterServiceVersion (CSV). Removing or replacing an operator CSV never touches it, so the Envoy
+routing path stays up throughout the migration.
 
 ## Step 1: Record the current state
 
-Capture what you have before changing anything, so you can confirm the migration and roll back
-if needed.
+Record current state so you can verify the migration and roll back if needed.
 
 ```bash
 # The MCP Gateway operator's controller
-oc get deployment mcp-gateway-controller -n mcp-system
+kubectl get deployment mcp-gateway-controller -n mcp-system
 
 # The broker-router (data plane) — this must keep running throughout
-oc get deployment mcp-gateway -n mcp-system
+kubectl get deployment mcp-gateway -n mcp-system
 
 # Your extension(s) — must stay Ready
-oc get mcpgatewayextension -A
+kubectl get mcpgatewayextension -A
 
 # Which CSV currently owns the MCP CRDs
-oc get crd mcpgatewayextensions.mcp.kuadrant.io \
+kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
   -o jsonpath='{.metadata.labels}{"\n"}'
 ```
 
-The CRD labels include an `operators.coreos.com/<csv>.<namespace>` entry naming the CSV that
-currently owns the CRD. Before migration this names the standalone `mcp-gateway` CSV.
+The CRD labels include an `operators.coreos.com/<csv>.<namespace>` entry naming the owning CSV.
+Before migration this is the standalone `mcp-gateway` CSV.
 
-## Step 2: Start a traffic monitor (recommended)
+## Step 2: Remove the standalone MCP Gateway subscription
 
-In a separate terminal, poll your gateway continuously so you can see for yourself that
-traffic is uninterrupted. Replace `GATEWAY_HOST`, the tool name, and the arguments with values
-that match your deployment.
+OLM does not allow two operators to own the same CRDs. Removing the standalone subscription and
+its CSV relinquishes ownership of the MCP CRDs so the Kuadrant Operator can take them over.
 
 ```bash
-GATEWAY_HOST=<your-gateway-hostname>
-
-while true; do
-  curl -s --max-time 5 -X POST "http://$GATEWAY_HOST:8080/mcp" \
-    -H "Content-Type: application/json" -D /tmp/hdr.txt -o /dev/null \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"monitor","version":"1.0"}}}'
-  SID=$(grep -i mcp-session-id /tmp/hdr.txt | awk '{print $2}' | tr -d '\r\n')
-  curl -s --max-time 5 -X POST "http://$GATEWAY_HOST:8080/mcp" \
-    -H "Content-Type: application/json" -H "mcp-session-id: $SID" \
-    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<your-tool>","arguments":{}}}'
-  echo " — $(date -u +%H:%M:%S)"
-  sleep 2
-done
+kubectl delete subscription mcp-gateway -n mcp-system
+kubectl delete csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system
 ```
 
-Leave this running until the migration is complete.
-
-## Step 3: Remove the standalone MCP Gateway subscription
-
-OLM does not allow two operators to own the same CRDs at once. Removing the standalone MCP
-Gateway subscription and its CSV relinquishes ownership of the MCP CRDs so the Kuadrant
-Operator can take them over.
+Deleting the CSV removes the `mcp-gateway-controller` Deployment but not the broker-router. Confirm the data plane and
+your resources survived:
 
 ```bash
-oc delete subscription mcp-gateway -n mcp-system
-oc delete csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system
-```
-
-> **Note:** Deleting the CSV removes the `mcp-gateway-controller` Deployment, but **not** the
-> broker-router. Confirm the data plane is still running:
-
-```bash
-oc get deployment -n mcp-system
+kubectl get deployment -n mcp-system
 # mcp-gateway-controller is gone; mcp-gateway (broker-router) is still 1/1
 ```
 
-The MCP CRDs remain on the cluster — OLM does not delete CRDs when a CSV is removed. Your
-`MCPGatewayExtension` and `MCPServerRegistration` resources are untouched, and the monitor from
-Step 2 continues to report success.
+The MCP CRDs and your `MCPGatewayExtension`, `MCPServerRegistration` and `MCPVirtualServer`
+resources are untouched — OLM does not delete CRDs when a CSV is removed.
 
-> **Do not delete the `MCPGatewayExtension` during this step.** It carries a finalizer that
-> requires a running controller to clear. The Kuadrant Operator's controller (Step 4) processes
-> it normally once it starts.
+> **Do not delete the `MCPGatewayExtension` during this step.** Its finalizer needs a running
+> controller to clear; the Kuadrant Operator's controller (Step 3) handles it once it starts.
 
-## Step 4: Move the Kuadrant Operator to the version that bundles MCP Gateway
+## Step 3: Move the Kuadrant Operator to the version that bundles MCP Gateway
 
 Upgrade the Kuadrant Operator to the version that includes the MCP Gateway controller. How this
-happens depends on how your catalog ships that version:
+happens depends on how your catalog ships it:
 
-- **Same channel, newer version (typical production upgrade):** if your existing subscription's
-  channel already offers the newer Kuadrant Operator, OLM detects it and generates the upgrade
-  automatically (for `installPlanApproval: Automatic`) or presents an InstallPlan to approve.
-  No manual subscription change is needed.
+- **Same channel, newer version (typical production upgrade):** if your subscription's channel
+  already offers the newer version, OLM upgrades automatically (for `installPlanApproval:
+  Automatic`) or presents an InstallPlan to approve.
 
-- **Explicit version target:** if you need to point at a specific version, delete the existing
-  Kuadrant subscription and CSV, then recreate the subscription with `startingCSV` set to the
-  target version. Use the catalog and channel provided by your administrator or the release
-  notes:
+- **Explicit version target:** delete the existing Kuadrant subscription and CSV, then recreate
+  the subscription with `startingCSV` set to the target version:
 
 ```bash
-oc apply -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -138,53 +103,50 @@ spec:
   channel: <channel>
   name: kuadrant-operator
   source: <catalog-source>
-  sourceNamespace: openshift-marketplace
+  sourceNamespace: <catalog-namespace>
   startingCSV: kuadrant-operator.<target-version>
   installPlanApproval: Automatic
 EOF
 ```
 
+> **Note:** `<catalog-namespace>` is the namespace of your catalog source: `openshift-marketplace`
+> on OpenShift, `olm` on most other OLM installs.
+
 Wait for the new CSV to succeed:
 
 ```bash
-oc wait csv/kuadrant-operator.<target-version> -n mcp-system \
+kubectl wait csv/kuadrant-operator.<target-version> -n mcp-system \
   --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
 ```
 
-## Step 5: Verify the Kuadrant Operator has taken over
+## Step 4: Verify the Kuadrant Operator has taken over
 
-The Kuadrant Operator now owns the MCP CRDs and runs the MCP Gateway controller. No `Kuadrant`
-custom resource is required for the controller to start — it deploys as soon as the operator
-starts. (A `Kuadrant` CR is only needed later if you want to apply `AuthPolicy` or
-`RateLimitPolicy`.)
+The Kuadrant Operator now owns the MCP CRDs and runs the controller; no `Kuadrant` CR is required
+for it to start. (A `Kuadrant` CR is only needed later for `AuthPolicy` or `RateLimitPolicy`.)
 
 ```bash
 # CRD ownership has transferred to the Kuadrant Operator CSV
-oc get crd mcpgatewayextensions.mcp.kuadrant.io \
+kubectl get crd mcpgatewayextensions.mcp.kuadrant.io \
   -o jsonpath='{.metadata.labels}{"\n"}'
 # The operators.coreos.com/... label now names the kuadrant-operator CSV
 
 # The controller is running again, now deployed by the Kuadrant Operator
-oc get deployment mcp-gateway-controller -n mcp-system
+kubectl get deployment mcp-gateway-controller -n mcp-system
 # READY 1/1
 
 # Your extension is still Ready
-oc get mcpgatewayextension -A
+kubectl get mcpgatewayextension -A
 # READY True
 ```
 
-> **Note:** When the new controller reconciles your `MCPGatewayExtension`, it rolls the
-> broker-router pods whenever the Kuadrant Operator release pins a newer broker-router image
-> than the one currently running — which is normally the case on a version-advancing upgrade.
-> This is a rolling update behind the stable `Service`: new pods become Ready before old ones
-> are removed, so no requests are dropped. The pods restarting is expected; zero-downtime means
-> no request is dropped during the roll, not that the pods are never replaced. The broker-router
-> `Deployment`, `Service`, `HTTPRoute` and `EnvoyFilter` are never deleted.
+> **Note:** If the new release pins a newer broker-router image, the controller rolls the pods
+> behind the stable `Service` as a rolling update: new pods become Ready before old ones are
+> removed, so requests continue to be served. Restarting pods is expected; the `Deployment`,
+> `Service`, `HTTPRoute` and `EnvoyFilter` are never deleted.
 
-## Step 6: Confirm traffic was uninterrupted
+## Step 5: Confirm traffic is being served
 
-Send a request and check the monitor from Step 2 — it should show no failures across the entire
-migration.
+Send a request through the gateway and confirm it succeeds.
 
 ```bash
 GATEWAY_HOST=<your-gateway-hostname>
@@ -198,16 +160,17 @@ curl -s -X POST "http://$GATEWAY_HOST:8080/mcp" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<your-tool>","arguments":{}}}'
 ```
 
-You can now stop the monitor.
+> **Note:** This bare `curl` assumes an unauthenticated listener. If you have an `AuthPolicy` on
+> the route, verify with your normal authenticated client instead. A `401`/`403` still confirms
+> the routing path is intact — the request reached the router and was rejected on auth.
 
 ## Rollback
 
-If the migration fails, restore the standalone MCP Gateway operator. Return the Kuadrant
-Operator to its previous version (via the same subscription mechanism you used in Step 4), then
-recreate the MCP Gateway subscription:
+If the migration fails, return the Kuadrant Operator to its previous version (via the same
+mechanism as Step 3), then recreate the MCP Gateway subscription:
 
 ```bash
-oc apply -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -217,16 +180,10 @@ spec:
   channel: <mcp-gateway-channel>
   name: mcp-gateway
   source: <mcp-gateway-catalog>
-  sourceNamespace: openshift-marketplace
+  sourceNamespace: <catalog-namespace>
   installPlanApproval: Automatic
 EOF
 ```
 
-The broker-router is unaffected by any rollback — it is owned by your `MCPGatewayExtension`, not
-by either operator's CSV.
-
-## Next Steps
-
-- [Register MCP Servers](./register-mcp-servers.md)
-- [Authentication](./authentication.md)
-- [Authorization](./authorization.md)
+The broker-router is unaffected by rollback — it is owned by your `MCPGatewayExtension`, not by
+either operator's CSV.

--- a/docs/guides/olm-upgrade.md
+++ b/docs/guides/olm-upgrade.md
@@ -80,6 +80,11 @@ resources are untouched — OLM does not delete CRDs when a CSV is removed.
 > **Do not delete the `MCPGatewayExtension` during this step.** Its finalizer needs a running
 > controller to clear; the Kuadrant Operator's controller (Step 3) handles it once it starts.
 
+> **Note:** No MCP Gateway controller runs until the Kuadrant Operator's controller starts
+> (Step 3/4). During this window, create/update/delete operations, finalizers, and status
+> changes on `MCPGatewayExtension`, `MCPServerRegistration`, and `MCPVirtualServer` resources
+> are not reconciled.
+
 ## Step 3: Move the Kuadrant Operator to the version that bundles MCP Gateway
 
 Upgrade the Kuadrant Operator to the version that includes the MCP Gateway controller. How this
@@ -161,8 +166,10 @@ curl -s -X POST "http://$GATEWAY_HOST:8080/mcp" \
 ```
 
 > **Note:** This bare `curl` assumes an unauthenticated listener. If you have an `AuthPolicy` on
-> the route, verify with your normal authenticated client instead. A `401`/`403` still confirms
-> the routing path is intact — the request reached the router and was rejected on auth.
+> the route, verify with your normal authenticated client instead. A `401`/`403` confirms only
+> that the gateway and authentication layer are reachable — the request was rejected before
+> broker-router. To confirm broker-router is serving traffic, use an authenticated client and
+> check for a successful response.
 
 ## Rollback
 
@@ -187,3 +194,9 @@ EOF
 
 The broker-router is unaffected by rollback — it is owned by your `MCPGatewayExtension`, not by
 either operator's CSV.
+
+## Next Steps
+
+- [Installing MCP Gateway via OLM (Kuadrant Operator)](./olm-install.md)
+- [Register MCP Servers](./register-mcp-servers.md)
+- [Authentication](./authentication.md)

--- a/docs/guides/olm-upgrade.md
+++ b/docs/guides/olm-upgrade.md
@@ -1,0 +1,229 @@
+# Upgrading from Standalone MCP Gateway to the Kuadrant Operator (OLM)
+
+This guide covers migrating an OLM-installed MCP Gateway from the **standalone** operator
+(its own OLM subscription) to the **consolidated** deployment, where the Kuadrant Operator
+owns the MCP Gateway CRDs and runs its controller.
+
+The migration is zero-downtime: MCP traffic is not interrupted while ownership transfers.
+
+## Who this is for
+
+You installed MCP Gateway via its own OLM subscription (a `Subscription` named `mcp-gateway`,
+or equivalent, that installed the `mcp-gateway` operator) and you now want the Kuadrant
+Operator to manage MCP Gateway instead. This is the model described in
+[RFC 0019](https://github.com/Kuadrant/architecture/pull/189): the Kuadrant Operator embeds
+the MCP Gateway controller and deploys it on startup.
+
+If you installed MCP Gateway with Helm rather than OLM, this guide does not apply — see
+[Installing and Configuring MCP Gateway](./how-to-install-and-configure.md).
+
+## Prerequisites
+
+- An OpenShift cluster with OLM (OpenShift includes OLM by default).
+- MCP Gateway installed via its own OLM subscription, with at least one `MCPGatewayExtension`
+  in a Ready state and traffic flowing.
+- The Kuadrant Operator installed via OLM in the same namespace.
+- A catalog source that provides a Kuadrant Operator version which bundles MCP Gateway. Your
+  cluster administrator or the Kuadrant release notes will tell you which version and catalog
+  to use.
+
+> **Note:** Throughout this guide, `mcp-system` is the namespace where the operators and their
+> `OperatorGroup` live. Substitute your own namespace if different.
+
+## Why this works without downtime
+
+The MCP Gateway data plane — the broker-router `Deployment`, its `Service`, the `HTTPRoute`,
+and the `EnvoyFilter` — is owned by your `MCPGatewayExtension` custom resource, not by the
+operator's ClusterServiceVersion (CSV). Removing or replacing an operator CSV therefore never
+deletes these resources. The Envoy routing path stays in place for the entire migration, so
+in-flight and new requests continue to be served.
+
+## Step 1: Record the current state
+
+Capture what you have before changing anything, so you can confirm the migration and roll back
+if needed.
+
+```bash
+# The MCP Gateway operator's controller
+oc get deployment mcp-gateway-controller -n mcp-system
+
+# The broker-router (data plane) — this must keep running throughout
+oc get deployment mcp-gateway -n mcp-system
+
+# Your extension(s) — must stay Ready
+oc get mcpgatewayextension -A
+
+# Which CSV currently owns the MCP CRDs
+oc get crd mcpgatewayextensions.mcp.kuadrant.io \
+  -o jsonpath='{.metadata.labels}{"\n"}'
+```
+
+The CRD labels include an `operators.coreos.com/<csv>.<namespace>` entry naming the CSV that
+currently owns the CRD. Before migration this names the standalone `mcp-gateway` CSV.
+
+## Step 2: Start a traffic monitor (recommended)
+
+In a separate terminal, poll your gateway continuously so you can see for yourself that
+traffic is uninterrupted. Replace `GATEWAY_HOST`, the tool name, and the arguments with values
+that match your deployment.
+
+```bash
+GATEWAY_HOST=<your-gateway-hostname>
+
+while true; do
+  curl -s --max-time 5 -X POST "http://$GATEWAY_HOST:8080/mcp" \
+    -H "Content-Type: application/json" -D /tmp/hdr.txt -o /dev/null \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"monitor","version":"1.0"}}}'
+  SID=$(grep -i mcp-session-id /tmp/hdr.txt | awk '{print $2}' | tr -d '\r\n')
+  curl -s --max-time 5 -X POST "http://$GATEWAY_HOST:8080/mcp" \
+    -H "Content-Type: application/json" -H "mcp-session-id: $SID" \
+    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<your-tool>","arguments":{}}}'
+  echo " — $(date -u +%H:%M:%S)"
+  sleep 2
+done
+```
+
+Leave this running until the migration is complete.
+
+## Step 3: Remove the standalone MCP Gateway subscription
+
+OLM does not allow two operators to own the same CRDs at once. Removing the standalone MCP
+Gateway subscription and its CSV relinquishes ownership of the MCP CRDs so the Kuadrant
+Operator can take them over.
+
+```bash
+oc delete subscription mcp-gateway -n mcp-system
+oc delete csv -n mcp-system -l operators.coreos.com/mcp-gateway.mcp-system
+```
+
+> **Note:** Deleting the CSV removes the `mcp-gateway-controller` Deployment, but **not** the
+> broker-router. Confirm the data plane is still running:
+
+```bash
+oc get deployment -n mcp-system
+# mcp-gateway-controller is gone; mcp-gateway (broker-router) is still 1/1
+```
+
+The MCP CRDs remain on the cluster — OLM does not delete CRDs when a CSV is removed. Your
+`MCPGatewayExtension` and `MCPServerRegistration` resources are untouched, and the monitor from
+Step 2 continues to report success.
+
+> **Do not delete the `MCPGatewayExtension` during this step.** It carries a finalizer that
+> requires a running controller to clear. The Kuadrant Operator's controller (Step 4) processes
+> it normally once it starts.
+
+## Step 4: Move the Kuadrant Operator to the version that bundles MCP Gateway
+
+Upgrade the Kuadrant Operator to the version that includes the MCP Gateway controller. How this
+happens depends on how your catalog ships that version:
+
+- **Same channel, newer version (typical production upgrade):** if your existing subscription's
+  channel already offers the newer Kuadrant Operator, OLM detects it and generates the upgrade
+  automatically (for `installPlanApproval: Automatic`) or presents an InstallPlan to approve.
+  No manual subscription change is needed.
+
+- **Explicit version target:** if you need to point at a specific version, delete the existing
+  Kuadrant subscription and CSV, then recreate the subscription with `startingCSV` set to the
+  target version. Use the catalog and channel provided by your administrator or the release
+  notes:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  namespace: mcp-system
+spec:
+  channel: <channel>
+  name: kuadrant-operator
+  source: <catalog-source>
+  sourceNamespace: openshift-marketplace
+  startingCSV: kuadrant-operator.<target-version>
+  installPlanApproval: Automatic
+EOF
+```
+
+Wait for the new CSV to succeed:
+
+```bash
+oc wait csv/kuadrant-operator.<target-version> -n mcp-system \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m
+```
+
+## Step 5: Verify the Kuadrant Operator has taken over
+
+The Kuadrant Operator now owns the MCP CRDs and runs the MCP Gateway controller. No `Kuadrant`
+custom resource is required for the controller to start — it deploys as soon as the operator
+starts. (A `Kuadrant` CR is only needed later if you want to apply `AuthPolicy` or
+`RateLimitPolicy`.)
+
+```bash
+# CRD ownership has transferred to the Kuadrant Operator CSV
+oc get crd mcpgatewayextensions.mcp.kuadrant.io \
+  -o jsonpath='{.metadata.labels}{"\n"}'
+# The operators.coreos.com/... label now names the kuadrant-operator CSV
+
+# The controller is running again, now deployed by the Kuadrant Operator
+oc get deployment mcp-gateway-controller -n mcp-system
+# READY 1/1
+
+# Your extension is still Ready
+oc get mcpgatewayextension -A
+# READY True
+```
+
+> **Note:** When the new controller reconciles your `MCPGatewayExtension`, it may roll the
+> broker-router pods (a rolling update behind the stable `Service`). New pods become Ready
+> before old ones are removed, so no requests are dropped — the broker-router `Deployment`,
+> `Service`, `HTTPRoute` and `EnvoyFilter` are never deleted.
+
+## Step 6: Confirm traffic was uninterrupted
+
+Send a request and check the monitor from Step 2 — it should show no failures across the entire
+migration.
+
+```bash
+GATEWAY_HOST=<your-gateway-hostname>
+
+curl -s -X POST "http://$GATEWAY_HOST:8080/mcp" \
+  -H "Content-Type: application/json" -D /tmp/hdr.txt -o /dev/null \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"post-upgrade","version":"1.0"}}}'
+SID=$(grep -i mcp-session-id /tmp/hdr.txt | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST "http://$GATEWAY_HOST:8080/mcp" \
+  -H "Content-Type: application/json" -H "mcp-session-id: $SID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<your-tool>","arguments":{}}}'
+```
+
+You can now stop the monitor.
+
+## Rollback
+
+If the migration fails, restore the standalone MCP Gateway operator. Return the Kuadrant
+Operator to its previous version (via the same subscription mechanism you used in Step 4), then
+recreate the MCP Gateway subscription:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mcp-gateway
+  namespace: mcp-system
+spec:
+  channel: <mcp-gateway-channel>
+  name: mcp-gateway
+  source: <mcp-gateway-catalog>
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+```
+
+The broker-router is unaffected by any rollback — it is owned by your `MCPGatewayExtension`, not
+by either operator's CSV.
+
+## Next Steps
+
+- [Register MCP Servers](./register-mcp-servers.md)
+- [Authentication](./authentication.md)
+- [Authorization](./authorization.md)


### PR DESCRIPTION
## Summary

User-facing documentation for the kuadrant-operator umbrella operator integration (RFC 0019). On OLM-based clusters, MCP Gateway no longer ships a standalone operator — it is installed and managed by the Kuadrant Operator, which embeds the MCP Gateway controller and deploys it on startup. Standalone installs continue to use Helm.

Separated from the implementation PR (#1239) so docs can land and be refined independently.

Closes #1234

## What's included

- `docs/guides/olm-install.md` — rewritten for the Kuadrant Operator install path: subscribe to the operator, then create an `MCPGatewayExtension` to deploy the broker-router data plane. No `Kuadrant` CR is required for the controller to run (it deploys unconditionally on startup). Drops the removed standalone bundle/catalog/`make`-target content (see #1343).
- `docs/guides/olm-upgrade.md` — new how-to for migrating an existing OLM-installed standalone MCP Gateway to the consolidated Kuadrant Operator deployment. Zero-downtime; procedure verified end-to-end on OpenShift 4.22.
- `docs/guides/README.md` — adds both guides to the index.

## Notes

- The Helm-based standalone deployment guide (`docs/guides/how-to-install-and-configure.md`) is already on `main`; #1235 (Helm guide) was closed separately on that basis.
- The design docs / POC reports originally in this branch were removed — the umbrella integration is canonically documented by RFC 0019 in the Kuadrant architecture repo.

## Related

- Implementation PR: #1239
- Standalone OLM packaging removal: #1343
- RFC 0019: https://github.com/Kuadrant/architecture/pull/189
- Epic: #1226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for installing MCP Gateway through the Kuadrant Operator on Kubernetes and OpenShift.
  * Clarified Helm versus OLM installation options, prerequisites, catalog namespaces, verification, and uninstall steps.
  * Updated migration guidance with validation checks, authenticated-route considerations, rollback instructions, and preservation of existing gateway configuration.
  * Updated configuration examples to the latest CRD version and clarified TLS, hairpinning, and gateway CA certificate setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->