### PR TITLE
Fix (#1040): Replace sleep loops with explicit finalizer-wait in MCPServerRegistration controller integration tests

### DIFF
--- a/internal/controller/mcpserverregistration_controller_integration_test.go
+++ b/internal/controller/mcpserverregistration_controller_integration_test.go
@@ -236,6 +236,15 @@ func waitForMCPServerRegistrationCacheSync(ctx context.Context, nn types.Namespa
 	}, testTimeout, testRetryInterval).Should(Succeed())
 }
 
+// waitForMCPServerRegistrationFinalizer waits for cache to see the finalizer added
+func waitForMCPServerRegistrationFinalizer(ctx context.Context, nn types.NamespacedName) {
+	Eventually(func(g Gomega) {
+		cached := &mcpv1.MCPServerRegistration{}
+		g.Expect(testIndexedClient.Get(ctx, nn, cached)).To(Succeed())
+		g.Expect(controllerutil.ContainsFinalizer(cached, mcpGatewayFinalizer)).To(BeTrue())
+	}, testTimeout, testRetryInterval).Should(Succeed())
+}
+
 var _ = Describe("MCPServerRegistration Controller", func() {
 	Context("When reconciling a resource", func() {
 		const (
@@ -411,13 +420,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			// reconcile multiple times to get past finalizer addition
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1.MCPServerRegistration{}
@@ -458,13 +471,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			// reconcile multiple times to get past finalizer addition
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1.MCPServerRegistration{}
@@ -557,12 +574,18 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				g.Expect(configWriter.upsertedServers).NotTo(BeEmpty())
@@ -602,12 +625,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1.MCPServerRegistration{}
@@ -630,12 +658,18 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				g.Expect(configWriter.upsertedServers).NotTo(BeEmpty())
@@ -661,12 +695,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1.MCPServerRegistration{}
@@ -707,12 +746,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1.MCPServerRegistration{}
@@ -757,12 +801,18 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				g.Expect(configWriter.upsertedServers).NotTo(BeEmpty())
@@ -806,12 +856,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				mcpsrObj := &mcpv1.MCPServerRegistration{}
@@ -856,12 +911,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				mcpsrObj := &mcpv1.MCPServerRegistration{}
@@ -918,13 +978,17 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 			reconciler := newMCPServerReconciler(configWriter)
 			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName)
 
-			// reconcile multiple times to get past finalizer addition
-			for i := 0; i < 3; i++ {
-				_, _ = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: mcpsrNamespacedName,
-				})
-				time.Sleep(100 * time.Millisecond)
-			}
+			// reconcile to add finalizer, wait for cache sync, then reconcile again to process
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName)
+
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: mcpsrNamespacedName,
+			})
 
 			Eventually(func(g Gomega) {
 				updated := &mcpv1.MCPServerRegistration{}


### PR DESCRIPTION
### Summary

Replace sleep-based retry loops in the MCPServerRegistration controller integration tests with explicit waits for finalizer cache synchronization. This aligns these tests with the synchronization pattern already used elsewhere in the file, making them more deterministic and reducing reliance on timing-based retries.

### Notes for Reviewers

- Replaced all **11** sleep-based retry loops in this file (the issue mentions 7; I found 11 occurrences in total).
- Added `waitForMCPServerRegistrationFinalizer` because the existing `waitForMCPServerRegistrationCacheSync` helper only verifies that the object is present in the cache, not that the finalizer has been observed.
- In test cases where the second reconcile is expected to fail (as verified by the subsequent `Eventually` assertions on status conditions), the returned error is intentionally ignored to preserve the original test behavior.
- No other `time.Sleep` usages in the repository were modified, as the remaining occurrences are in unrelated unit tests and are outside the scope of this issue.

Fixes #1040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for controller finalizers before continuing reconciliation checks.
  * Expanded coverage for gateway configuration, HTTP routes, credentials, CA certificates, validation failures, and readiness status.
  * Replaced timing-dependent test steps with deterministic reconciliation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->