### PR TITLE
feat: metrics phase 3 — broker Prometheus metrics and dedicated scrape endpoint

### DIFF
--- a/cmd/mcp-broker-router/broker.go
+++ b/cmd/mcp-broker-router/broker.go
@@ -114,6 +114,8 @@ func (a *app) setUpMetricsServer() {
 		Addr:              a.brokerCfg.metricsAddr,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		IdleTimeout:       30 * time.Second,
 	}
 }
 

--- a/cmd/mcp-broker-router/broker.go
+++ b/cmd/mcp-broker-router/broker.go
@@ -47,6 +47,7 @@ func (a *app) createBroker() {
 		Config:         a.mcpConfig,
 	}
 	a.setUpHTTPServer()
+	a.setUpMetricsServer()
 }
 
 func (a *app) setUpHTTPServer() {
@@ -98,6 +99,16 @@ func (a *app) setUpHTTPServer() {
 	mux.Handle("/mcp", traceContextMiddleware(a.mcpBroker.MCPHandler()))
 
 	a.brokerServer = httpSrv
+}
+
+func (a *app) setUpMetricsServer() {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", a.metricsHandler)
+	a.metricsServer = &http.Server{
+		Addr:              a.brokerCfg.metricsAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 }
 
 func traceContextMiddleware(next http.Handler) http.Handler {

--- a/cmd/mcp-broker-router/broker.go
+++ b/cmd/mcp-broker-router/broker.go
@@ -103,7 +103,13 @@ func (a *app) setUpHTTPServer() {
 
 func (a *app) setUpMetricsServer() {
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", a.metricsHandler)
+	if a.metricsHandler != nil {
+		mux.Handle("/metrics", a.metricsHandler)
+	} else {
+		mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "metrics unavailable", http.StatusServiceUnavailable)
+		})
+	}
 	a.metricsServer = &http.Server{
 		Addr:              a.brokerCfg.metricsAddr,
 		Handler:           mux,

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -66,6 +66,7 @@ type brokerConfig struct {
 	discoveryToolsEnabled      bool
 	discoveryToolThreshold     int
 	enablePprof                bool
+	metricsAddr                string
 }
 
 type app struct {
@@ -86,6 +87,7 @@ type app struct {
 	elicitHandler  http.Handler
 	metricsHandler http.Handler
 	brokerServer   *http.Server
+	metricsServer  *http.Server
 	grpcServer     *grpc.Server
 	server         *mcpRouter.ExtProcServer
 }
@@ -152,6 +154,7 @@ func parseFlags() *app {
 	flag.IntVar(&bc.discoveryToolThreshold, "discovery-tool-threshold", 0,
 		"tool count above which real tools are hidden and only meta-tools are shown. 0 means never hide.")
 	flag.BoolVar(&bc.enablePprof, "enable-pprof", false, "enable pprof profiling server on localhost:6060")
+	flag.StringVar(&bc.metricsAddr, "metrics-addr", "0.0.0.0:9090", "address for the internal Prometheus metrics endpoint")
 
 	// router-specific flags
 	flag.StringVar(&rc.addr, "mcp-router-address", "0.0.0.0:50051", "The address for MCP router")
@@ -323,6 +326,14 @@ func (a *app) run(ctx context.Context) {
 		}
 	}()
 
+	go func() {
+		a.logger.Info("[http] starting metrics server (internal)", "listening", a.metricsServer.Addr)
+		if err := a.metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			a.logger.Error("metrics server error", "error", err)
+			stop <- os.Interrupt
+		}
+	}()
+
 	<-stop
 
 	a.logger.Info("shutting down MCP Broker and MCP Router")
@@ -337,6 +348,9 @@ func (a *app) run(ctx context.Context) {
 
 	if err := a.brokerServer.Shutdown(shutdownCtx); err != nil {
 		a.logger.Error("HTTP shutdown error", "error", err)
+	}
+	if err := a.metricsServer.Shutdown(shutdownCtx); err != nil {
+		a.logger.Error("metrics server shutdown error", "error", err)
 	}
 	if err := a.mcpBroker.Shutdown(shutdownCtx); err != nil {
 		a.logger.Error("broker shutdown error", "error", err)

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -84,6 +84,7 @@ type app struct {
 	mcpBroker      broker.MCPBroker
 	tokenHandler   http.Handler
 	elicitHandler  http.Handler
+	metricsHandler http.Handler
 	brokerServer   *http.Server
 	grpcServer     *grpc.Server
 	server         *mcpRouter.ExtProcServer
@@ -179,11 +180,12 @@ func (a *app) setupLogger() (*slog.HandlerOptions, bool) {
 }
 
 func (a *app) setupTelemetry(ctx context.Context, logOpts *slog.HandlerOptions, jsonFormat bool) {
-	otelShutdown, loggerProvider, err := mcpotel.SetupOTelSDK(ctx, gitSHA, dirty, version, a.logger)
+	otelShutdown, loggerProvider, metricsHandler, err := mcpotel.SetupOTelSDK(ctx, gitSHA, dirty, version, a.logger)
 	if err != nil {
 		a.logger.Error("failed to setup OpenTelemetry", "error", err)
 	}
 	a.otelShutdown = otelShutdown
+	a.metricsHandler = metricsHandler
 
 	if loggerProvider != nil {
 		a.logger = mcpotel.NewTracingLogger(os.Stdout, logOpts, jsonFormat, loggerProvider)

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -51,6 +51,9 @@ spec:
             - name: pprof
               containerPort: 6060
               protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           resources:
             requests:
               memory: '128Mi'

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -208,6 +208,26 @@ histogram_quantile(0.99, sum(rate(mcp_broker_discovery_duration_seconds_bucket[5
 sum(mcp_broker_tools_list_response_bytes)
 ```
 
+### Istio gateway metrics (built-in)
+
+Istio emits these metrics automatically for all traffic through the gateway — no configuration required:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `istio_requests_total` | Counter | Request count by response code, source, and destination |
+| `istio_request_duration_milliseconds` | Histogram | Request latency |
+
+```promql
+# 5xx error rate per destination
+sum(rate(istio_requests_total{response_code=~"5.."}[5m])) by (destination_service_name)
+
+# 4xx rate per destination (likely misconfiguration)
+sum(rate(istio_requests_total{response_code=~"4.."}[5m])) by (destination_service_name)
+
+# p99 request latency per destination
+histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (destination_service_name, le))
+```
+
 ### Istio gateway metrics (optional MCP enrichment)
 
 Istio automatically emits `istio_requests_total` and `istio_request_duration_milliseconds` for all traffic through the gateway. Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to those existing metrics:

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -167,27 +167,12 @@ The metrics port is not routed through the Envoy gateway listener. Scrape it clu
 # Port-forward for local inspection (use pod name directly — unready pods are skipped by deployment forward)
 POD=$(kubectl get pod -n mcp-system -l app.kubernetes.io/name=mcp-gateway \
   -o jsonpath='{.items[0].metadata.name}')
-kubectl port-forward -n mcp-system pod/$POD 9090:9090
+kubectl port-forward -n mcp-system pod/$POD 9090:9090 &
+sleep 1
 curl http://localhost:9090/metrics
 ```
 
 For Prometheus scraping, add the broker pod IP as a scrape target. The broker `Service` is controller-managed and does not expose port 9090, so scrape by pod IP directly or use a `PodMonitor` if you have Prometheus Operator installed.
-
-### Configuring the metrics port
-
-The metrics address can be changed with the `--metrics-addr` flag:
-
-```bash
-kubectl set env deployment/mcp-gateway -n mcp-system \
-  METRICS_ADDR="0.0.0.0:9091"
-```
-
-Or via Helm:
-
-```bash
-helm upgrade mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
-  --set broker.metricsAddr="0.0.0.0:9091"
-```
 
 ### Useful PromQL queries
 
@@ -233,7 +218,7 @@ histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m]
 Istio automatically emits `istio_requests_total` and `istio_request_duration_milliseconds` for all traffic through the gateway. Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to those existing metrics:
 
 ```bash
-kubectl apply -f examples/otel/istio-mcp-metrics.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/examples/otel/istio-mcp-metrics.yaml
 ```
 
 This promotes the `x-mcp-servername` and `x-mcp-method` headers (already set by the MCP Router) into Prometheus label dimensions without any code changes. After applying:

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -155,9 +155,9 @@ The broker exposes a Prometheus-compatible `/metrics` endpoint on a dedicated in
 | `mcp_broker_discovery_duration_seconds` | Histogram | Duration of `tools/list` calls during discovery |
 | `mcp_broker_tools_discovered` | Gauge | Current tool count per upstream server. Set to 0 when a server becomes unreachable |
 | `mcp_broker_upstream_connection_failures_total` | Counter | Connection failures per upstream server |
-| `mcp_broker_tools_list_response_bytes` | Gauge | Size of the last `tools/list` response per upstream server. Proxy for LLM context overhead |
+| `mcp_broker_tools_list_response_bytes` | Gauge | Serialized size of the validated tool list per upstream server. Proxy for LLM context overhead |
 
-All metrics use `server_name` as the only label. Values are formatted as `namespace/name`, matching the namespace and name of the `MCPServerRegistration` resource (e.g. `mcp-system/my-server`). No high-cardinality labels (session IDs, tool names, call IDs) are used.
+`mcp_broker_discovery_total` uses `server_name` and `status` labels. All other metrics use only `server_name`. Label values are formatted as `namespace/name`, matching the namespace and name of the `MCPServerRegistration` resource (e.g. `mcp-system/my-server`). No high-cardinality labels (session IDs, tool names, call IDs) are used.
 
 ### Scraping the metrics endpoint
 

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -5,7 +5,7 @@ This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distribut
 ## Prerequisites
 
 - MCP Gateway installed and configured
-- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent)
+- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent) — required only for tracing and log export. Prometheus metrics need no additional infrastructure.
 
 > **Note:** For a pre-configured local stack with OTEL Collector, Tempo, Loki, and Grafana, see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/release-0.6.0/examples/otel).
 
@@ -151,13 +151,13 @@ The broker exposes a Prometheus-compatible `/metrics` endpoint on a dedicated in
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `mcp_broker_discovery_total` | Counter | Discovery attempts per upstream server, labelled `status=success\|failure` |
+| `mcp_broker_discovery_total` | Counter | Discovery attempts per upstream server, labelled `status=success` or `status=failure` |
 | `mcp_broker_discovery_duration_seconds` | Histogram | Duration of `tools/list` calls during discovery |
 | `mcp_broker_tools_discovered` | Gauge | Current tool count per upstream server. Set to 0 when a server becomes unreachable |
 | `mcp_broker_upstream_connection_failures_total` | Counter | Connection failures per upstream server |
 | `mcp_broker_tools_list_response_bytes` | Gauge | Size of the last `tools/list` response per upstream server. Proxy for LLM context overhead |
 
-All metrics use `server_name` as the only label, sourced from the `MCPServerRegistration` name. No high-cardinality labels (session IDs, tool names, call IDs) are used.
+All metrics use `server_name` as the only label. Values are formatted as `namespace/name`, matching the namespace and name of the `MCPServerRegistration` resource (e.g. `mcp-system/my-server`). No high-cardinality labels (session IDs, tool names, call IDs) are used.
 
 ### Scraping the metrics endpoint
 
@@ -215,7 +215,7 @@ histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m]
 
 ### Istio gateway metrics (optional MCP enrichment)
 
-Istio automatically emits `istio_requests_total` and `istio_request_duration_milliseconds` for all traffic through the gateway. Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to those existing metrics:
+Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to the existing `istio_requests_total` and `istio_request_duration_milliseconds` metrics:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/examples/otel/istio-mcp-metrics.yaml

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Integration
 
-This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing and log export. When enabled, the MCP Router (ext_proc) emits trace spans for every request and can export structured logs via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
+This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing, log export, and Prometheus metrics. Tracing and log export require an OTLP endpoint to be configured. Prometheus metrics are always enabled and require no configuration.
 
 ## Prerequisites
 
@@ -142,6 +142,94 @@ curl -s -X POST http://your-gateway-host/mcp \
 
 echo "Search for trace: $TRACE_ID"
 ```
+
+## Prometheus Metrics
+
+The broker exposes a Prometheus-compatible `/metrics` endpoint on a dedicated internal port (default `:9090`). This is always enabled — no environment variables or OTLP endpoint required.
+
+### Broker metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `mcp_broker_discovery_total` | Counter | Discovery attempts per upstream server, labelled `status=success\|failure` |
+| `mcp_broker_discovery_duration_seconds` | Histogram | Duration of `tools/list` calls during discovery |
+| `mcp_broker_tools_discovered` | Gauge | Current tool count per upstream server. Set to 0 when a server becomes unreachable |
+| `mcp_broker_upstream_connection_failures_total` | Counter | Connection failures per upstream server |
+| `mcp_broker_tools_list_response_bytes` | Gauge | Size of the last `tools/list` response per upstream server. Proxy for LLM context overhead |
+
+All metrics use `server_name` as the only label, sourced from the `MCPServerRegistration` name. No high-cardinality labels (session IDs, tool names, call IDs) are used.
+
+### Scraping the metrics endpoint
+
+The metrics port is not routed through the Envoy gateway listener. Scrape it cluster-internally:
+
+```bash
+# Port-forward for local inspection (use pod name directly — unready pods are skipped by deployment forward)
+POD=$(kubectl get pod -n mcp-system -l app.kubernetes.io/name=mcp-gateway \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward -n mcp-system pod/$POD 9090:9090
+curl http://localhost:9090/metrics
+```
+
+For Prometheus scraping, add the broker pod IP as a scrape target. The broker `Service` is controller-managed and does not expose port 9090, so scrape by pod IP directly or use a `PodMonitor` if you have Prometheus Operator installed.
+
+### Configuring the metrics port
+
+The metrics address can be changed with the `--metrics-addr` flag:
+
+```bash
+kubectl set env deployment/mcp-gateway -n mcp-system \
+  METRICS_ADDR="0.0.0.0:9091"
+```
+
+Or via Helm:
+
+```bash
+helm upgrade mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+  --set broker.metricsAddr="0.0.0.0:9091"
+```
+
+### Useful PromQL queries
+
+```promql
+# Current tool count per upstream server
+mcp_broker_tools_discovered
+
+# Discovery failure rate per server
+sum(rate(mcp_broker_discovery_total{status="failure"}[5m])) by (server_name)
+
+# Servers with active connection failures
+sum(rate(mcp_broker_upstream_connection_failures_total[5m])) by (server_name) > 0
+
+# p99 discovery latency per server
+histogram_quantile(0.99, sum(rate(mcp_broker_discovery_duration_seconds_bucket[5m])) by (server_name, le))
+
+# Total tools/list context footprint across all servers
+sum(mcp_broker_tools_list_response_bytes)
+```
+
+### Istio gateway metrics (optional MCP enrichment)
+
+Istio automatically emits `istio_requests_total` and `istio_request_duration_milliseconds` for all traffic through the gateway. Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to those existing metrics:
+
+```bash
+kubectl apply -f examples/otel/istio-mcp-metrics.yaml
+```
+
+This promotes the `x-mcp-servername` and `x-mcp-method` headers (already set by the MCP Router) into Prometheus label dimensions without any code changes. After applying:
+
+```promql
+# Request rate per MCP server
+sum(rate(istio_requests_total[5m])) by (mcp_server_name)
+
+# p99 latency per MCP server
+histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (mcp_server_name, le))
+
+# Request breakdown by MCP method
+sum(rate(istio_requests_total[5m])) by (mcp_method)
+```
+
+> **Cardinality note:** `mcp_tool_name` is available in the reference config but commented out. Each unique tool name adds a label value — enable it only if your tool count is small and bounded.
 
 ## Next Steps
 

--- a/examples/otel/grafana-mcp-metrics-dashboard.json
+++ b/examples/otel/grafana-mcp-metrics-dashboard.json
@@ -8,6 +8,12 @@
   "templating": {
     "list": [
       {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "pluginId": "prometheus"
+      },
+      {
         "name": "server_name",
         "label": "Server",
         "type": "query",
@@ -16,12 +22,6 @@
         "multi": true,
         "includeAll": true,
         "current": { "selected": true, "text": "All", "value": "$__all" }
-      },
-      {
-        "name": "datasource",
-        "label": "Prometheus",
-        "type": "datasource",
-        "pluginId": "prometheus"
       }
     ]
   },

--- a/examples/otel/grafana-mcp-metrics-dashboard.json
+++ b/examples/otel/grafana-mcp-metrics-dashboard.json
@@ -1,0 +1,283 @@
+{
+  "title": "MCP Gateway Metrics",
+  "uid": "mcp-gateway-metrics",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-15m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "server_name",
+        "label": "Server",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(mcp_broker_tools_discovered, server_name)",
+        "multi": true,
+        "includeAll": true,
+        "current": { "selected": true, "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "pluginId": "prometheus"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Tools Discovered per Server",
+      "description": "Current number of tools the broker has fetched from each upstream. Drops to 0 when a server becomes unreachable.",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short",
+          "displayName": "${__field.labels.server_name}"
+        }
+      },
+      "targets": [
+        {
+          "expr": "mcp_broker_tools_discovered{server_name=~\"$server_name\"}",
+          "legendFormat": "{{server_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Tools List Response Size (bytes)",
+      "description": "Size of the last tools/list response per server. Proxy for LLM context overhead. 0 when server is unreachable.",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "displayName": "${__field.labels.server_name}"
+        }
+      },
+      "targets": [
+        {
+          "expr": "mcp_broker_tools_list_response_bytes{server_name=~\"$server_name\"}",
+          "legendFormat": "{{server_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Total Context Footprint",
+      "description": "Sum of tools/list response bytes across all servers — total LLM context overhead from tool metadata.",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" }
+      },
+      "targets": [
+        {
+          "expr": "sum(mcp_broker_tools_list_response_bytes)",
+          "legendFormat": "Total"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Connection Failures",
+      "description": "Total connection failures per server since startup. Increments on every failed Connect() or Ping().",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short",
+          "displayName": "${__field.labels.server_name}"
+        }
+      },
+      "targets": [
+        {
+          "expr": "mcp_broker_upstream_connection_failures_total{server_name=~\"$server_name\"}",
+          "legendFormat": "{{server_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Discovery Rate (success vs failure)",
+      "description": "Rate of discovery attempts per server, split by outcome. A rising failure rate means the broker cannot fetch tools from that upstream.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "B" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byFrameRefID", "options": "A" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(mcp_broker_discovery_total{status=\"success\",server_name=~\"$server_name\"}[1m])) by (server_name)",
+          "legendFormat": "{{server_name}} success",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(mcp_broker_discovery_total{status=\"failure\",server_name=~\"$server_name\"}[1m])) by (server_name)",
+          "legendFormat": "{{server_name}} failure",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Discovery Latency (p50 / p99)",
+      "description": "How long tools/list calls take. p99 shows worst-case discovery time — slow discovery delays tool changes reaching clients.",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(mcp_broker_discovery_duration_seconds_bucket{server_name=~\"$server_name\"}[5m])) by (server_name, le))",
+          "legendFormat": "{{server_name}} p50"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(mcp_broker_discovery_duration_seconds_bucket{server_name=~\"$server_name\"}[5m])) by (server_name, le))",
+          "legendFormat": "{{server_name}} p99"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Connection Failure Rate",
+      "description": "Rate of connection failures per server. A non-zero value means the broker cannot reach the upstream — check network/DNS/upstream health.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2 },
+          "color": { "fixedColor": "red", "mode": "fixed" }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(mcp_broker_upstream_connection_failures_total{server_name=~\"$server_name\"}[1m])) by (server_name)",
+          "legendFormat": "{{server_name}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Request Rate per MCP Server (Istio)",
+      "description": "Requests through the Envoy gateway per MCP server. Requires examples/otel/istio-mcp-metrics.yaml to be applied.",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(istio_requests_total{mcp_server_name!=\"\"}[1m])) by (mcp_server_name)",
+          "legendFormat": "{{mcp_server_name}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Request Latency per MCP Server p99 (Istio)",
+      "description": "p99 request latency through the Envoy gateway per MCP server. Requires examples/otel/istio-mcp-metrics.yaml to be applied.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": { "unit": "ms", "custom": { "lineWidth": 2 } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{mcp_server_name!=\"\"}[5m])) by (mcp_server_name, le))",
+          "legendFormat": "{{mcp_server_name}} p99"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Request Rate by MCP Method (Istio)",
+      "description": "Requests through the Envoy gateway broken down by MCP method (initialize, tools/list, tools/call etc.). Requires examples/otel/istio-mcp-metrics.yaml.",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 20, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(istio_requests_total{mcp_method!=\"\"}[1m])) by (mcp_method)",
+          "legendFormat": "{{mcp_method}}"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/otel/istio-mcp-metrics.yaml
+++ b/examples/otel/istio-mcp-metrics.yaml
@@ -1,0 +1,61 @@
+# Istio Telemetry tag overrides for MCP-aware gateway metrics.
+#
+# Promotes x-mcp-servername, x-mcp-toolname, and x-mcp-method request headers
+# (set by the MCP Router ext_proc) into Prometheus metric labels on the existing
+# istio_requests_total and istio_request_duration_milliseconds metrics.
+#
+# Apply to the namespace where the Istio Gateway is deployed:
+#   kubectl apply -f examples/otel/istio-mcp-metrics.yaml
+#
+# Note: tag overrides apply to the Prometheus reporter on the Envoy proxy
+# that handles inbound traffic. Verify labels appear with:
+#   kubectl exec -n <gateway-ns> <gateway-pod> -- curl -s localhost:15000/stats/prometheus | grep mcp_server_name
+#
+# Cardinality note: mcp_tool_name is commented out by default. Each unique tool
+# name adds a label value — with many tools this can significantly increase metric
+# cardinality. Enable only if the tool count is small and bounded.
+#
+# Example queries after applying:
+#   # request rate per MCP server
+#   sum(rate(istio_requests_total[5m])) by (mcp_server_name)
+#
+#   # p99 tool call latency per MCP server
+#   histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (mcp_server_name, le))
+#
+#   # top 10 most called tools (requires mcp_tool_name uncommented below)
+#   topk(10, sum(rate(istio_requests_total[5m])) by (mcp_tool_name))
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: mcp-metrics
+  namespace: gateway-system
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+    overrides:
+    - match:
+        metric: REQUEST_COUNT
+      tagOverrides:
+        mcp_server_name:
+          operation: UPSERT
+          value: "request.headers['x-mcp-servername']"
+        mcp_method:
+          operation: UPSERT
+          value: "request.headers['x-mcp-method']"
+        # mcp_tool_name adds a label per unique tool — watch cardinality before enabling.
+        # mcp_tool_name:
+        #   operation: UPSERT
+        #   value: "request.headers['x-mcp-toolname']"
+    - match:
+        metric: REQUEST_DURATION
+      tagOverrides:
+        mcp_server_name:
+          operation: UPSERT
+          value: "request.headers['x-mcp-servername']"
+        mcp_method:
+          operation: UPSERT
+          value: "request.headers['x-mcp-method']"
+        # mcp_tool_name:
+        #   operation: UPSERT
+        #   value: "request.headers['x-mcp-toolname']"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -25,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -86,7 +88,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
@@ -104,7 +105,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,10 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.53.0
@@ -87,7 +89,8 @@ require (
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
-	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/prometheus/otlptranslator v1.0.0 // indirect
+	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,10 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTUGI4=
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
-github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
-github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEoIwkU+A6qos=
+github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
+github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
+github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -219,10 +221,14 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJ
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0/go.mod h1:fOD2Yefuxixkx3ahVNf0O/PERb6r4OlbxfATVnYvzCo=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 h1:lgh3PiVrRUWMLOVSkQicxzZll5NjF1r+AtsX1XRIHw0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0/go.mod h1:5Cnhth3m/AgOeTgE3ex12pPmiu/gGtZit03kSzx9X7s=
+go.opentelemetry.io/otel/exporters/prometheus v0.66.0 h1:vkrK8PAznv2NKt2r+kdu252ccGzkEqLc2aSXbQIALYQ=
+go.opentelemetry.io/otel/exporters/prometheus v0.66.0/go.mod h1:V/UB6D3vMF/UBOL5igAsAYnk1nG/bzYYTzvsB16cy7o=
 go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
 go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
+go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=
+go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/log v0.20.0 h1:vM3xI7TQgKPiSghe6urZtAkyFY7SodrSpC83CffDFuY=

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -278,7 +278,7 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 	}
 
 	toolsListBytes, err := meter.Int64Gauge("mcp_broker_tools_list_response_bytes",
-		metric.WithDescription("last observed size in bytes of tools/list response per upstream server"),
+		metric.WithDescription("serialized size in bytes of the validated tool list per upstream server"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mcp_broker_tools_list_response_bytes: %w", err)
@@ -457,7 +457,6 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.status.Name = man.MCPName()
 		man.status.Ready = true
 		man.status.Message = "userSpecificList server healthy, tools fetched per-user"
-		man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "success")))
 		man.resetBackoff()
 		return
 	}

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -5,6 +5,7 @@ package upstream
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -191,6 +193,13 @@ type MCPManager struct {
 
 	logger *slog.Logger
 
+	// metrics instruments — created once at construction, recorded per manage() cycle
+	discoveryTotal     metric.Int64Counter
+	discoveryDuration  metric.Float64Histogram
+	toolsDiscovered    metric.Int64Gauge
+	connectionFailures metric.Int64Counter
+	toolsListBytes     metric.Int64Gauge
+
 	// invalidToolPolicy controls behavior when upstream tools have invalid schemas
 	invalidToolPolicy InvalidToolPolicy
 
@@ -237,25 +246,68 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 		Cap:      tickerInterval,
 	}
 
+	meter := otel.GetMeterProvider().Meter("mcp-broker")
+
+	discoveryTotal, err := meter.Int64Counter("mcp_broker_discovery_total",
+		metric.WithDescription("number of discovery attempts per upstream server"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mcp_broker_discovery_total: %w", err)
+	}
+
+	discoveryDuration, err := meter.Float64Histogram("mcp_broker_discovery_duration_seconds",
+		metric.WithDescription("time taken for tools/list calls during discovery"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mcp_broker_discovery_duration_seconds: %w", err)
+	}
+
+	toolsDiscovered, err := meter.Int64Gauge("mcp_broker_tools_discovered",
+		metric.WithDescription("current number of tools discovered per upstream server"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mcp_broker_tools_discovered: %w", err)
+	}
+
+	connectionFailures, err := meter.Int64Counter("mcp_broker_upstream_connection_failures_total",
+		metric.WithDescription("number of upstream connection failures"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mcp_broker_upstream_connection_failures_total: %w", err)
+	}
+
+	toolsListBytes, err := meter.Int64Gauge("mcp_broker_tools_list_response_bytes",
+		metric.WithDescription("last observed size in bytes of tools/list response per upstream server"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mcp_broker_tools_list_response_bytes: %w", err)
+	}
+
 	return &MCPManager{
-		mcp:               upstream,
-		gatewayServer:     gatewayServer,
-		promptsServer:     promptsServer,
-		tickerInterval:    tickerInterval,
-		ticker:            time.NewTicker(tickerInterval),
-		backoff:           bo,
-		baseBackoff:       bo,
-		logger:            logger,
-		invalidToolPolicy: policy,
-		toolEvents:        make(chan struct{}, 1),
-		promptEvents:      make(chan struct{}, 1),
-		done:              make(chan struct{}),
-		toolsMap:          map[string]*mcp.Tool{},
-		servedToolsMap:    map[string]*mcp.Tool{},
-		serverTools:       []GatewayTool{},
-		promptsMap:        map[string]*mcp.Prompt{},
-		servedPromptsMap:  map[string]*mcp.Prompt{},
-		serverPrompts:     []GatewayPrompt{},
+		mcp:                upstream,
+		gatewayServer:      gatewayServer,
+		promptsServer:      promptsServer,
+		tickerInterval:     tickerInterval,
+		ticker:             time.NewTicker(tickerInterval),
+		backoff:            bo,
+		baseBackoff:        bo,
+		logger:             logger,
+		invalidToolPolicy:  policy,
+		toolEvents:         make(chan struct{}, 1),
+		promptEvents:       make(chan struct{}, 1),
+		done:               make(chan struct{}),
+		toolsMap:           map[string]*mcp.Tool{},
+		servedToolsMap:     map[string]*mcp.Tool{},
+		serverTools:        []GatewayTool{},
+		promptsMap:         map[string]*mcp.Prompt{},
+		servedPromptsMap:   map[string]*mcp.Prompt{},
+		serverPrompts:      []GatewayPrompt{},
+		discoveryTotal:     discoveryTotal,
+		discoveryDuration:  discoveryDuration,
+		toolsDiscovered:    toolsDiscovered,
+		connectionFailures: connectionFailures,
+		toolsListBytes:     toolsListBytes,
 	}, nil
 }
 
@@ -396,6 +448,8 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	}
 	man.consecutiveFailures = 0
 
+	serverAttr := attribute.String("server_name", man.mcp.GetName())
+
 	if man.mcp.GetConfig().UserSpecificList {
 		man.logger.Debug("userSpecificList server healthy, tools fetched per-user", "upstream mcp server", man.mcp.ID())
 		man.status.ID = string(man.mcp.ID())
@@ -413,7 +467,9 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.logger.DebugContext(ctx, "not fetching tools", "event", event, "upstream mcp server", man.mcp.ID(), "waiting for notification", notificationToolsListChanged)
 	} else {
 		man.logger.DebugContext(ctx, "fetching tools", "upstream mcp server", man.mcp.ID())
+		start := time.Now()
 		current, fetched, err := man.getTools(ctx)
+		man.discoveryDuration.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(serverAttr))
 		if err != nil {
 			toolErr = fmt.Errorf("upstream mcp failed to list tools server %s : %w", man.mcp.ID(), err)
 			man.recordBackendError(span, toolErr)
@@ -459,6 +515,11 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 					})
 					man.serverTools = append(man.serverTools, toAdd...)
 					man.toolsLock.Unlock()
+
+					man.toolsDiscovered.Record(ctx, int64(len(fetched)), metric.WithAttributes(serverAttr))
+					if rawBytes := marshalledToolsSize(fetched); rawBytes >= 0 {
+						man.toolsListBytes.Record(ctx, rawBytes, metric.WithAttributes(serverAttr))
+					}
 
 					man.logger.DebugContext(ctx, "updating gateway tools", "upstream mcp server", man.mcp.ID(), "adding", len(toAdd), "removing", len(toRemove))
 					if len(toRemove) > 0 {
@@ -525,6 +586,11 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		}
 	}
 	jointErr := errors.Join(toolErr, promptErr)
+	if jointErr != nil {
+		man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "failure")))
+	} else {
+		man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "success")))
+	}
 	man.setStatus(jointErr, numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
 	if jointErr != nil {
 		man.applyBackoff()
@@ -586,6 +652,11 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 // the next attempt starts fresh.
 func (man *MCPManager) handleConnectionFailure(ctx context.Context, span trace.Span, err error, numberOfTools, numberOfPrompts int) {
 	man.consecutiveFailures++
+	man.connectionFailures.Add(ctx, 1, metric.WithAttributes(attribute.String("server_name", man.mcp.GetName())))
+	man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("server_name", man.mcp.GetName()),
+		attribute.String("status", "failure"),
+	))
 	man.recordBackendError(span, err)
 	man.logger.ErrorContext(ctx, "upstream connection failure", "upstream mcp server", man.mcp.ID(), "error", err, "consecutive failures", man.consecutiveFailures)
 	if man.consecutiveFailures >= maxConsecutiveFailures {
@@ -742,6 +813,8 @@ func (man *MCPManager) removeAllTools() {
 	man.toolsMap = map[string]*mcp.Tool{}
 	man.servedToolsMap = map[string]*mcp.Tool{}
 	man.toolsLock.Unlock()
+	man.toolsDiscovered.Record(context.Background(), 0, metric.WithAttributes(attribute.String("server_name", man.mcp.GetName())))
+	man.toolsListBytes.Record(context.Background(), 0, metric.WithAttributes(attribute.String("server_name", man.mcp.GetName())))
 	man.gatewayServer.DeleteTools(toolsToRemove...)
 	man.logger.Debug("removed all tools", "upstream mcp server", man.mcp.ID(), "count", len(toolsToRemove))
 }
@@ -928,4 +1001,14 @@ func (man *MCPManager) SetPromptsForTesting(prompts []mcp.Prompt) {
 		man.promptsMap[prompts[i].Name] = &prompts[i]
 		man.servedPromptsMap[prefixedName(man.mcp.GetPrefix(), prompts[i].Name)] = &prompts[i]
 	}
+}
+
+// marshalledToolsSize returns the JSON-serialised byte count of a tools slice,
+// used as a proxy for context contribution size. returns -1 on marshal failure.
+func marshalledToolsSize(tools []mcp.Tool) int64 {
+	b, err := json.Marshal(tools)
+	if err != nil {
+		return -1
+	}
+	return int64(len(b))
 }

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -248,11 +248,11 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 
 	meter := otel.GetMeterProvider().Meter("mcp-broker")
 
-	discoveryTotal, err := meter.Int64Counter("mcp_broker_discovery_total",
+	discoveryTotal, err := meter.Int64Counter("mcp_broker_discovery",
 		metric.WithDescription("number of discovery attempts per upstream server"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_broker_discovery_total: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_broker_discovery: %w", err)
 	}
 
 	discoveryDuration, err := meter.Float64Histogram("mcp_broker_discovery_duration_seconds",
@@ -270,11 +270,11 @@ func NewUpstreamMCPManager(upstream MCP, gatewayServer ToolsAdderDeleter, prompt
 		return nil, fmt.Errorf("failed to create mcp_broker_tools_discovered: %w", err)
 	}
 
-	connectionFailures, err := meter.Int64Counter("mcp_broker_upstream_connection_failures_total",
+	connectionFailures, err := meter.Int64Counter("mcp_broker_upstream_connection_failures",
 		metric.WithDescription("number of upstream connection failures"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_broker_upstream_connection_failures_total: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_broker_upstream_connection_failures: %w", err)
 	}
 
 	toolsListBytes, err := meter.Int64Gauge("mcp_broker_tools_list_response_bytes",
@@ -457,6 +457,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		man.status.Name = man.MCPName()
 		man.status.Ready = true
 		man.status.Message = "userSpecificList server healthy, tools fetched per-user"
+		man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "success")))
 		man.resetBackoff()
 		return
 	}
@@ -532,6 +533,11 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 				}
 			}
 		}
+		if toolErr != nil {
+			man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "failure")))
+		} else {
+			man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "success")))
+		}
 	}
 
 	var promptErr error
@@ -586,11 +592,6 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		}
 	}
 	jointErr := errors.Join(toolErr, promptErr)
-	if jointErr != nil {
-		man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "failure")))
-	} else {
-		man.discoveryTotal.Add(ctx, 1, metric.WithAttributes(serverAttr, attribute.String("status", "success")))
-	}
 	man.setStatus(jointErr, numberOfTools, numberOfPrompts, invalidTools, invalidPrompts)
 	if jointErr != nil {
 		man.applyBackoff()

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -15,7 +15,18 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
+
+func TestMain(m *testing.M) {
+	// register noop meter so instrument creation in NewUpstreamMCPManager doesn't log warnings
+	otel.SetMeterProvider(noopmetric.NewMeterProvider())
+	os.Exit(m.Run())
+}
 
 // MockMCP implements the MCP interface for testing
 type MockMCP struct {
@@ -1592,4 +1603,134 @@ func TestMCPManager_Backoff(t *testing.T) {
 	mock.listToolsErr = nil
 	manager.manage(ctx, eventTypeTimer)
 	assert.True(t, manager.GetStatus().Ready)
+}
+
+func TestMCPManager_MetricsRecorded_OnSuccess(t *testing.T) {
+	// use a real SDK MeterProvider with an in-memory reader so we can assert metric values
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	defer otel.SetMeterProvider(noopmetric.NewMeterProvider())
+
+	mock := &MockMCP{
+		name:   "test-server",
+		id:     "test-server",
+		prefix: "",
+		cfg:    &config.MCPServer{Name: "test-server"},
+		tools: []mcp.Tool{
+			validTool("tool-a"),
+			validTool("tool-b"),
+		},
+		hasToolsCap: true,
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, time.Second*5, InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	manager.manage(ctx, eventTypeTimer)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	// find mcp_broker_discovery_total{status="success"}
+	discoveryTotal := findCounterValue(t, rm, "mcp_broker_discovery_total", map[string]string{
+		"server_name": "test-server",
+		"status":      "success",
+	})
+	require.Equal(t, int64(1), discoveryTotal)
+
+	// find mcp_broker_tools_discovered
+	toolsDiscovered := findGaugeValue(t, rm, "mcp_broker_tools_discovered", map[string]string{
+		"server_name": "test-server",
+	})
+	require.Equal(t, int64(2), toolsDiscovered)
+}
+
+func TestMCPManager_MetricsRecorded_OnConnectionFailure(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	defer otel.SetMeterProvider(noopmetric.NewMeterProvider())
+
+	mock := &MockMCP{
+		name:        "failing-server",
+		id:          "failing-server",
+		prefix:      "",
+		cfg:         &config.MCPServer{Name: "failing-server"},
+		connectErr:  fmt.Errorf("connection refused"),
+		hasToolsCap: true,
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	manager, err := NewUpstreamMCPManager(mock, newMockToolsAdderDeleter(), nil, logger, time.Second*5, InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	manager.manage(ctx, eventTypeTimer)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	failures := findCounterValue(t, rm, "mcp_broker_upstream_connection_failures_total", map[string]string{
+		"server_name": "failing-server",
+	})
+	require.Equal(t, int64(1), failures)
+
+	discoveryFailure := findCounterValue(t, rm, "mcp_broker_discovery_total", map[string]string{
+		"server_name": "failing-server",
+		"status":      "failure",
+	})
+	require.Equal(t, int64(1), discoveryFailure)
+}
+
+// findCounterValue finds a counter metric by name and label set and returns its value.
+func findCounterValue(t *testing.T, rm metricdata.ResourceMetrics, name string, labels map[string]string) int64 {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %s is not a Sum[int64]", name)
+			for _, dp := range data.DataPoints {
+				if labelsMatch(dp.Attributes, labels) {
+					return dp.Value
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+	return 0
+}
+
+// findGaugeValue finds a gauge metric by name and label set and returns its value.
+func findGaugeValue(t *testing.T, rm metricdata.ResourceMetrics, name string, labels map[string]string) int64 {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok, "metric %s is not a Gauge[int64]", name)
+			for _, dp := range data.DataPoints {
+				if labelsMatch(dp.Attributes, labels) {
+					return dp.Value
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+	return 0
+}
+
+func labelsMatch(attrs attribute.Set, want map[string]string) bool {
+	for k, v := range want {
+		val, ok := attrs.Value(attribute.Key(k))
+		if !ok || val.AsString() != v {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1633,8 +1633,8 @@ func TestMCPManager_MetricsRecorded_OnSuccess(t *testing.T) {
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
 
-	// find mcp_broker_discovery_total{status="success"}
-	discoveryTotal := findCounterValue(t, rm, "mcp_broker_discovery_total", map[string]string{
+	// find mcp_broker_discovery{status="success"}
+	discoveryTotal := findCounterValue(t, rm, "mcp_broker_discovery", map[string]string{
 		"server_name": "test-server",
 		"status":      "success",
 	})
@@ -1645,6 +1645,16 @@ func TestMCPManager_MetricsRecorded_OnSuccess(t *testing.T) {
 		"server_name": "test-server",
 	})
 	require.Equal(t, int64(2), toolsDiscovered)
+
+	histCount := findHistogramCount(t, rm, "mcp_broker_discovery_duration_seconds", map[string]string{
+		"server_name": "test-server",
+	})
+	require.Equal(t, uint64(1), histCount)
+
+	bytesVal := findGaugeValue(t, rm, "mcp_broker_tools_list_response_bytes", map[string]string{
+		"server_name": "test-server",
+	})
+	require.Greater(t, bytesVal, int64(0))
 }
 
 func TestMCPManager_MetricsRecorded_OnConnectionFailure(t *testing.T) {
@@ -1671,12 +1681,12 @@ func TestMCPManager_MetricsRecorded_OnConnectionFailure(t *testing.T) {
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
 
-	failures := findCounterValue(t, rm, "mcp_broker_upstream_connection_failures_total", map[string]string{
+	failures := findCounterValue(t, rm, "mcp_broker_upstream_connection_failures", map[string]string{
 		"server_name": "failing-server",
 	})
 	require.Equal(t, int64(1), failures)
 
-	discoveryFailure := findCounterValue(t, rm, "mcp_broker_discovery_total", map[string]string{
+	discoveryFailure := findCounterValue(t, rm, "mcp_broker_discovery", map[string]string{
 		"server_name": "failing-server",
 		"status":      "failure",
 	})
@@ -1696,6 +1706,27 @@ func findCounterValue(t *testing.T, rm metricdata.ResourceMetrics, name string, 
 			for _, dp := range data.DataPoints {
 				if labelsMatch(dp.Attributes, labels) {
 					return dp.Value
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+	return 0
+}
+
+// findHistogramCount returns the data point count for a histogram metric matching the given labels.
+func findHistogramCount(t *testing.T, rm metricdata.ResourceMetrics, name string, labels map[string]string) uint64 {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "metric %s is not a Histogram[float64]", name)
+			for _, dp := range data.DataPoints {
+				if labelsMatch(dp.Attributes, labels) {
+					return dp.Count
 				}
 			}
 		}

--- a/internal/otel/metrics.go
+++ b/internal/otel/metrics.go
@@ -1,0 +1,60 @@
+package otel
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	prometheusexporter "go.opentelemetry.io/otel/exporters/prometheus"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// MetricsProvider wraps the OTel MeterProvider backed by a Prometheus exporter.
+type MetricsProvider struct {
+	meterProvider *sdkmetric.MeterProvider
+	registry      *prometheus.Registry
+}
+
+// NewMetricsProvider creates a Prometheus-backed OTel MeterProvider.
+// The exporter serves metrics via the returned HTTPHandler — no OTLP endpoint needed.
+func NewMetricsProvider(_ context.Context, config *Config) (*MetricsProvider, error) {
+	registry := prometheus.NewRegistry()
+
+	exporter, err := prometheusexporter.New(
+		prometheusexporter.WithRegisterer(registry),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := NewResource(context.Background(), config)
+	if err != nil {
+		return nil, err
+	}
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(exporter),
+		sdkmetric.WithResource(res),
+	)
+
+	return &MetricsProvider{
+		meterProvider: mp,
+		registry:      registry,
+	}, nil
+}
+
+// MeterProvider returns the underlying MeterProvider for global registration.
+func (p *MetricsProvider) MeterProvider() *sdkmetric.MeterProvider {
+	return p.meterProvider
+}
+
+// HTTPHandler returns an http.Handler that serves Prometheus metrics.
+func (p *MetricsProvider) HTTPHandler() http.Handler {
+	return promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{})
+}
+
+// Shutdown flushes and stops the MeterProvider.
+func (p *MetricsProvider) Shutdown(ctx context.Context) error {
+	return p.meterProvider.Shutdown(ctx)
+}

--- a/internal/otel/metrics_test.go
+++ b/internal/otel/metrics_test.go
@@ -1,0 +1,31 @@
+package otel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMetricsProvider(t *testing.T) {
+	ctx := context.Background()
+	config := NewConfig("abc123", "", "v0.0.1")
+
+	mp, err := NewMetricsProvider(ctx, config)
+	require.NoError(t, err)
+	require.NotNil(t, mp)
+
+	err = mp.Shutdown(ctx)
+	require.NoError(t, err)
+}
+
+func TestMetricsProvider_HTTPHandler(t *testing.T) {
+	ctx := context.Background()
+	config := NewConfig("abc123", "", "v0.0.1")
+
+	mp, err := NewMetricsProvider(ctx, config)
+	require.NoError(t, err)
+	require.NotNil(t, mp.HTTPHandler())
+
+	_ = mp.Shutdown(ctx)
+}

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -21,8 +22,9 @@ func SpanError(span trace.Span, err error, msg string) {
 	span.SetStatus(codes.Error, msg)
 }
 
-// SetupOTelSDK initializes the OpenTelemetry SDK with tracing and logs support
-func SetupOTelSDK(ctx context.Context, gitSHA, dirty, version string, logger *slog.Logger) (shutdown func(context.Context) error, loggerProvider *sdklog.LoggerProvider, err error) {
+// SetupOTelSDK initializes the OpenTelemetry SDK with tracing, logs, and metrics support.
+// metricsHandler serves Prometheus metrics and must be mounted by the caller on a dedicated port.
+func SetupOTelSDK(ctx context.Context, gitSHA, dirty, version string, logger *slog.Logger) (shutdown func(context.Context) error, loggerProvider *sdklog.LoggerProvider, metricsHandler http.Handler, err error) {
 	var shutdownFuncs []func(context.Context) error
 
 	shutdown = func(ctx context.Context) error {
@@ -43,7 +45,7 @@ func SetupOTelSDK(ctx context.Context, gitSHA, dirty, version string, logger *sl
 	if config.TracesEnabled() {
 		traceProvider, err := NewProvider(ctx, config)
 		if err != nil {
-			return shutdown, nil, err
+			return shutdown, nil, nil, err
 		}
 		shutdownFuncs = append(shutdownFuncs, traceProvider.Shutdown)
 		otel.SetTracerProvider(traceProvider.TracerProvider())
@@ -53,12 +55,21 @@ func SetupOTelSDK(ctx context.Context, gitSHA, dirty, version string, logger *sl
 	if config.LogsEnabled() {
 		logsProvider, err := NewLogsProvider(ctx, config)
 		if err != nil {
-			return shutdown, nil, err
+			return shutdown, nil, nil, err
 		}
 		shutdownFuncs = append(shutdownFuncs, logsProvider.Shutdown)
 		loggerProvider = logsProvider.LoggerProvider()
 		logger.Info("OpenTelemetry logs enabled", "endpoint", config.LogsEndpoint())
 	}
 
-	return shutdown, loggerProvider, nil
+	metricsProvider, err := NewMetricsProvider(ctx, config)
+	if err != nil {
+		return shutdown, nil, nil, err
+	}
+	shutdownFuncs = append(shutdownFuncs, metricsProvider.Shutdown)
+	otel.SetMeterProvider(metricsProvider.MeterProvider())
+	metricsHandler = metricsProvider.HTTPHandler()
+	logger.Info("OpenTelemetry metrics enabled (Prometheus)")
+
+	return shutdown, loggerProvider, metricsHandler, nil
 }

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -110,6 +110,7 @@ func TestSetupOTelSDK_PropagatorSet(t *testing.T) {
 func TestSetupOTelSDK_RegistersMeterProvider(t *testing.T) {
 	// reset to noop so we can detect the change
 	otel.SetMeterProvider(noop.NewMeterProvider())
+	defer otel.SetMeterProvider(noop.NewMeterProvider()) // restore after test
 
 	ctx := context.Background()
 	shutdown, _, metricsHandler, err := SetupOTelSDK(ctx, "sha", "", "v0.0.1", noopLogger())

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -6,19 +6,25 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 func TestSetupOTelSDK_Disabled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	shutdown, loggerProvider, err := SetupOTelSDK(context.Background(), "", "", "v1.0.0", logger)
+	shutdown, loggerProvider, metricsHandler, err := SetupOTelSDK(context.Background(), "", "", "v1.0.0", logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if loggerProvider != nil {
 		t.Error("expected loggerProvider to be nil when disabled")
+	}
+
+	if metricsHandler == nil {
+		t.Error("expected metricsHandler to be non-nil")
 	}
 
 	if err := shutdown(context.Background()); err != nil {
@@ -32,7 +38,7 @@ func TestSetupOTelSDK_TracesEnabled(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	shutdown, _, err := SetupOTelSDK(context.Background(), "abc123", "false", "v1.0.0", logger)
+	shutdown, _, _, err := SetupOTelSDK(context.Background(), "abc123", "false", "v1.0.0", logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -67,7 +73,7 @@ func TestSetupOTelSDK_LogsEnabled(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	shutdown, loggerProvider, err := SetupOTelSDK(context.Background(), "", "", "v1.0.0", logger)
+	shutdown, loggerProvider, _, err := SetupOTelSDK(context.Background(), "", "", "v1.0.0", logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,7 +88,7 @@ func TestSetupOTelSDK_LogsEnabled(t *testing.T) {
 func TestSetupOTelSDK_PropagatorSet(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	_, _, err := SetupOTelSDK(context.Background(), "", "", "v1.0.0", logger)
+	_, _, _, err := SetupOTelSDK(context.Background(), "", "", "v1.0.0", logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,6 +105,26 @@ func TestSetupOTelSDK_PropagatorSet(t *testing.T) {
 	if ctx == nil {
 		t.Error("expected context from Extract")
 	}
+}
+
+func TestSetupOTelSDK_RegistersMeterProvider(t *testing.T) {
+	// reset to noop so we can detect the change
+	otel.SetMeterProvider(noop.NewMeterProvider())
+
+	ctx := context.Background()
+	shutdown, _, metricsHandler, err := SetupOTelSDK(ctx, "sha", "", "v0.0.1", noopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, metricsHandler)
+	defer shutdown(ctx) //nolint:errcheck
+
+	// the global meter provider must no longer be the noop one we set above
+	mp := otel.GetMeterProvider()
+	_, isNoop := mp.(noop.MeterProvider)
+	require.False(t, isNoop, "expected a real MeterProvider, got noop")
+}
+
+func noopLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
 }
 
 type testCarrier map[string]string


### PR DESCRIPTION
## Summary

Implements observability phase 3 as designed in #1281.

- Adds a Prometheus-backed OTel \`MeterProvider\` (always-on, no OTLP endpoint required)
- Instruments the broker with 5 new metrics covering discovery health, tool inventory, upstream stability, and context contribution
- Exposes metrics on a dedicated internal HTTP server (\`--metrics-addr\`, default \`:9090\`) isolated from the MCP listener
- Wires port \`9090\` into the \`NetworkPolicy\` and deployment manifest
- Adds reference Istio \`Telemetry\` config to enrich existing Istio metrics with MCP dimensions
- Updates \`docs/guides/opentelemetry.md\` with a Prometheus metrics section

Closes #161

## New broker metrics

| Metric | Type | Description |
|--------|------|-------------|
| \`mcp_broker_discovery_total\` | Counter | Discovery attempts per upstream server (\`status=success\|failure\`) |
| \`mcp_broker_discovery_duration_seconds\` | Histogram | Duration of \`tools/list\` calls during discovery |
| \`mcp_broker_tools_discovered\` | Gauge | Current tool count per server (0 when unreachable) |
| \`mcp_broker_upstream_connection_failures_total\` | Counter | Connection failures per upstream server |
| \`mcp_broker_tools_list_response_bytes\` | Gauge | Size of \`tools/list\` response payload per server |

All metrics use \`server_name\` as the only label (bounded by operator-controlled \`MCPServerRegistration\` count). No high-cardinality labels.

## Scrape endpoint

```
GET http://<pod-ip>:9090/metrics
```

Not routed through the Envoy gateway listener. Accessible cluster-internally only.

## Istio metrics enrichment (optional)

```bash
kubectl apply -f examples/otel/istio-mcp-metrics.yaml
```

Adds \`mcp_server_name\` and \`mcp_method\` labels to existing \`istio_requests_total\` and \`istio_request_duration_milliseconds\` metrics via Istio Telemetry tag overrides.

## Verification

### 1. Deploy and build from branch

```bash
git checkout feature/metrics-phase3
make local-env-setup
make build-and-load-image
```

Confirm the metrics server started:

```bash
kubectl logs -n mcp-system deployment/mcp-gateway | grep "starting metrics server"
# Expected: [http] starting metrics server (internal) listening=0.0.0.0:9090
```

### 2. Verify the metrics endpoint

```bash
kubectl port-forward -n mcp-system deployment/mcp-gateway 9090:9090 &
sleep 1
curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/metrics
# Expected: 200
```

### 3. Deploy additional upstream servers (optional)

Deploy the remaining test servers to see multiple `server_name` label values in metrics:

```bash
make deploy-test-servers
kubectl apply -f config/samples/mcpserverregistration-test-servers-base.yaml
```

Wait ~10s for discovery, then verify each server appears in metrics:

```bash
curl -s http://localhost:9090/metrics | grep mcp_broker_tools_discovered
# Expected: one line per registered server (everything-server, test-server1, test-server2)
```

### 4. Verify all 5 metric families appear

After ~10s for the first discovery cycle:

```bash
curl -s http://localhost:9090/metrics | grep -E "^# TYPE mcp_broker"
```

Expected output:
```
# TYPE mcp_broker_discovery_duration_seconds histogram
# TYPE mcp_broker_discovery_total counter
# TYPE mcp_broker_tools_discovered gauge
# TYPE mcp_broker_tools_list_response_bytes gauge
# TYPE mcp_broker_upstream_connection_failures_total counter
```

### 5. Verify no double _total suffix

```bash
curl -s http://localhost:9090/metrics | grep "_total_total"
# Expected: no output
```

### 6. Verify gauge zeroing on server failure

```bash
kubectl scale deployment everything-server -n mcp-test --replicas=0
# wait ~3 minutes for 3 consecutive failures, or speed up:
# kubectl set env deployment/mcp-gateway -n mcp-system MCP_CHECK_INTERVAL_SECS=5
# check BEFORE scaling back up:
curl -s http://localhost:9090/metrics | grep -E "mcp_broker_tools_discovered|mcp_broker_tools_list_response_bytes"
# Expected: both values = 0
# then restore:
kubectl scale deployment everything-server -n mcp-test --replicas=1
```

### 7. Verify endpoint isolation

```bash
curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/mcp
# Expected: 404
curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/healthz
# Expected: 404
```

### 8. Verify Istio Telemetry enrichment (optional)

```bash
kubectl apply -f examples/otel/istio-mcp-metrics.yaml

SESSION=$(curl -si "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  --no-buffer \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}' \
  2>/dev/null | grep -i "^mcp-session-id:" | tr -d '\r' | awk '{print $2}')

curl -s "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "Mcp-Session-Id: $SESSION" \
  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null

curl -s "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "Mcp-Session-Id: $SESSION" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"everything_echo","arguments":{"message":"hello"}}}'

GATEWAY_POD=$(kubectl get pod -n gateway-system \
  -l gateway.networking.k8s.io/gateway-name=mcp-gateway \
  -o jsonpath='{.items[0].metadata.name}')
kubectl exec -n gateway-system $GATEWAY_POD -- \
  curl -s localhost:15020/stats/prometheus | grep "mcp_server_name"
# Expected: lines containing mcp_server_name="mcp-test/everything-server"
```


### 9. View metrics in Grafana (optional)

Deploy the OTel observability stack and a minimal Prometheus:

```bash
make otel
kubectl wait --for=condition=Ready pod --all -n observability --timeout=120s
```

Get the broker pod IP and deploy Prometheus scraping it:

```bash
BROKER_POD_IP=$(kubectl get pod -n mcp-system -l app.kubernetes.io/name=mcp-gateway \
  -o jsonpath='{.items[0].status.podIP}')
GATEWAY_POD_IP=$(kubectl get pod -n gateway-system \
  -l gateway.networking.k8s.io/gateway-name=mcp-gateway \
  -o jsonpath='{.items[0].status.podIP}')

kubectl apply -f - <<YAML
apiVersion: v1
kind: ConfigMap
metadata:
  name: prometheus-config
  namespace: observability
data:
  prometheus.yml: |
    global:
      scrape_interval: 15s
    scrape_configs:
    - job_name: mcp-gateway-broker
      static_configs:
      - targets: ['${BROKER_POD_IP}:9090']
    - job_name: mcp-gateway-istio
      static_configs:
      - targets: ['${GATEWAY_POD_IP}:15020']
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: prometheus
  namespace: observability
spec:
  selector:
    matchLabels:
      app: prometheus
  template:
    metadata:
      labels:
        app: prometheus
    spec:
      containers:
      - name: prometheus
        image: prom/prometheus:latest
        args: ['--config.file=/etc/prometheus/prometheus.yml']
        ports:
        - containerPort: 9090
        volumeMounts:
        - name: config
          mountPath: /etc/prometheus
      volumes:
      - name: config
        configMap:
          name: prometheus-config
---
apiVersion: v1
kind: Service
metadata:
  name: prometheus
  namespace: observability
spec:
  selector:
    app: prometheus
  ports:
  - port: 9090
YAML
kubectl rollout restart deployment/prometheus -n observability
kubectl wait --for=condition=Ready pod -l app=prometheus -n observability --timeout=60s
```

Add Prometheus as a Grafana datasource and restart Grafana:

```bash
kubectl patch configmap grafana-datasources -n observability --type=merge -p '{
  "data": {
    "datasources.yaml": "apiVersion: 1\ndatasources:\n  - name: Tempo\n    type: tempo\n    access: proxy\n    url: http://tempo:3200\n    isDefault: true\n  - name: Loki\n    type: loki\n    access: proxy\n    url: http://loki:3100\n  - name: Prometheus\n    type: prometheus\n    access: proxy\n    url: http://prometheus:9090\n"
  }
}'
kubectl rollout restart deployment/grafana -n observability
kubectl wait --for=condition=Ready pod -l app=grafana -n observability --timeout=60s
```

Port-forward Grafana and open in browser:

```bash
kubectl port-forward -n observability svc/grafana 3000:3000 &
# Open http://localhost:3000 (no login required)
```

In Grafana → Explore → select **Prometheus** datasource, then run:

```promql
# Current tool count per server
mcp_broker_tools_discovered

# Discovery success vs failure rate
rate(mcp_broker_discovery_total[1m])

# p99 discovery latency
histogram_quantile(0.99, rate(mcp_broker_discovery_duration_seconds_bucket[1m]))
```

Generate continuous traffic to see the Istio request rate and latency panels move:

```bash
while true; do
  SESSION=$(curl -si "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
    -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    --no-buffer \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}' \
    2>/dev/null | grep -i "^mcp-session-id:" | tr -d '\r' | awk '{print $2}')
  curl -s "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
    -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    -H "Mcp-Session-Id: $SESSION" \
    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
  curl -s "http://mcp.127-0-0-1.sslip.io:8001/mcp" \
    -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    -H "Mcp-Session-Id: $SESSION" \
    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"everything_echo","arguments":{"message":"hello"}}}' > /dev/null
  sleep 1
done
```

- [ ] `mcp_broker_tools_discovered` returns a result with `server_name="mcp-test/everything-server"`
- [ ] `mcp_broker_discovery_total` shows both `status="success"` and `status="failure"` series
- [ ] `mcp_broker_discovery_duration_seconds` histogram returns a p99 value

To also see Istio metrics with MCP labels, first apply the Telemetry resource and make a tool call (see step 7), then query:

```promql
# request rate per MCP server (requires step 7 Telemetry resource applied)
sum(rate(istio_requests_total[1m])) by (mcp_server_name)

# p99 latency per MCP server
histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[1m])) by (mcp_server_name, le))
```

- [ ] `istio_requests_total` shows `mcp_server_name` label with values `mcpBroker` and `mcp-test/everything-server`

### 10. Import the sample Grafana dashboard

A sample dashboard is included at `examples/otel/grafana-mcp-metrics-dashboard.json`. Import it after step 9:

```bash
PROM_UID=$(curl -s http://localhost:3000/api/datasources | python3 -c "
import sys,json
for ds in json.load(sys.stdin):
    if ds['type'] == 'prometheus': print(ds['uid'])
")

python3 - <<PYEOF
import json
with open('examples/otel/grafana-mcp-metrics-dashboard.json') as f:
    dash = json.load(f)
def fix(obj):
    if isinstance(obj, dict):
        if obj.get('type') == 'prometheus' and obj.get('uid') == '\${datasource}':
            obj['uid'] = '$PROM_UID'
        for v in obj.values(): fix(v)
    elif isinstance(obj, list):
        [fix(i) for i in obj]
fix(dash)
for var in dash['templating']['list']:
    if var.get('name') == 'server_name':
        var['datasource'] = {'type': 'prometheus', 'uid': '$PROM_UID'}
import urllib.request, urllib.parse
payload = json.dumps({'dashboard': dash, 'overwrite': True, 'folderId': 0}).encode()
req = urllib.request.Request('http://localhost:3000/api/dashboards/import',
    data=payload, headers={'Content-Type': 'application/json'})
print(urllib.request.urlopen(req).read().decode())
PYEOF
```

Open the dashboard at http://localhost:3000/d/mcp-gateway-metrics/mcp-gateway-metrics

- [ ] All 10 panels show data
- [ ] Broker panels (tools discovered, discovery rate, latency) show values per server
- [ ] Istio panels (request rate, latency, method breakdown) show data after traffic is generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal Prometheus `/metrics` endpoint for broker and upstream MCP activity (discovery, tool counts, payload sizes, latency, connection failures).
  * Added a dedicated metrics server with `--metrics-addr` configuration/CLI support and metrics port exposure in the deployment.
  * Added monitoring assets: a Grafana MCP metrics dashboard and an Istio Telemetry example for MCP-aware labeling.
* **Documentation**
  * Expanded OpenTelemetry docs with Prometheus metrics setup, scraping guidance, and PromQL/cardinality notes.
* **Tests**
  * Added unit tests covering metrics provider startup/shutdown and upstream metric recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->