### PR TITLE
feat(e2e): support running e2e tests on OpenShift clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ tests/perf/mock-server/mock-server
 # Generated e2e config files (generated from *.template files)
 config/e2e/gateway-1.yaml
 config/e2e/gateway-2.yaml
+config/e2e/gateway-elicitation.yaml
 config/e2e/gateway-shared.yaml
 config/e2e/kustomization.yaml

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq (podman,$(CONTAINER_ENGINE))
 	CONTAINER_ENGINE_EXTRA_FLAGS ?= --load
 endif
 
-WAIT_TIME ?=120s
+WAIT_TIME ?=150s
 BROKER_ROUTER_NAME ?=mcp-gateway
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -82,6 +82,8 @@ MCP_GATEWAY_NAME ?= mcp-gateway
 E2E_DOMAIN ?= 127-0-0-1.sslip.io
 GATEWAY_CLASS_NAME ?= istio
 E2E_PLATFORM ?= kind
+GATEWAY_TLS_SECRET ?= mcp-gateway-tls-cert
+GATEWAY_TLS_LISTENER_HOSTNAME ?= *.mcp-gateway.local
 
 .PHONY: help
 help: ## Display this help
@@ -488,9 +490,10 @@ deploy-conformance-server: kind-load-conformance-server ## Deploy conformance MC
 .PHONY: generate-e2e-config
 generate-e2e-config: ## Generate e2e gateway configs from templates (E2E_DOMAIN=..., GATEWAY_CLASS_NAME=..., E2E_PLATFORM=kind|openshift)
 	@echo "Generating e2e config with E2E_DOMAIN=$(E2E_DOMAIN), GATEWAY_CLASS_NAME=$(GATEWAY_CLASS_NAME), E2E_PLATFORM=$(E2E_PLATFORM)"
-	@export E2E_DOMAIN=$(E2E_DOMAIN) GATEWAY_CLASS_NAME=$(GATEWAY_CLASS_NAME) && \
+	@export E2E_DOMAIN=$(E2E_DOMAIN) GATEWAY_CLASS_NAME=$(GATEWAY_CLASS_NAME) GATEWAY_TLS_SECRET=$(GATEWAY_TLS_SECRET) GATEWAY_TLS_LISTENER_HOSTNAME=$(GATEWAY_TLS_LISTENER_HOSTNAME) && \
 	  envsubst < config/e2e/gateway-1.yaml.template > config/e2e/gateway-1.yaml && \
 	  envsubst < config/e2e/gateway-2.yaml.template > config/e2e/gateway-2.yaml && \
+	  envsubst < config/e2e/gateway-elicitation.yaml.template > config/e2e/gateway-elicitation.yaml && \
 	  envsubst < config/e2e/gateway-shared.yaml.template > config/e2e/gateway-shared.yaml
 	@cp config/e2e/kustomization-$(E2E_PLATFORM).yaml config/e2e/kustomization.yaml
 	@echo "E2E config generated successfully"
@@ -504,9 +507,11 @@ deploy-e2e-gateways: generate-e2e-config ## Deploy two gateways for e2e multi-ga
 	@kubectl wait --for=condition=Programmed gateway/e2e-1 -n gateway-system --timeout=$(WAIT_TIME)
 	@echo "Waiting for e2e-2 to be programmed..."
 	@kubectl wait --for=condition=Programmed gateway/e2e-2 -n gateway-system --timeout=$(WAIT_TIME)
+	@echo "Waiting for e2e-elicitation to be programmed..."
+	@kubectl wait --for=condition=Programmed gateway/e2e-elicitation -n gateway-system --timeout=$(WAIT_TIME)
 	@echo "Waiting for shared gateway to be programmed..."
 	@kubectl wait --for=condition=Programmed gateway/shared-gateway -n gateway-system --timeout=$(WAIT_TIME)
-	@echo "E2E gateways ready: e2e-1, e2e-2, and shared-gateway"
+	@echo "E2E gateways ready: e2e-1, e2e-2, e2e-elicitation, and shared-gateway"
 
 # Deploy e2e gateways for OpenShift
 .PHONY: deploy-e2e-gateways-openshift

--- a/config/e2e/README.md
+++ b/config/e2e/README.md
@@ -11,7 +11,7 @@ This directory contains template files for e2e test gateways that support both K
 - `nodeport.yaml` - NodePort services for KIND local access
 
 **Generated files (gitignored):**
-- `gateway-1.yaml`, `gateway-2.yaml`, `gateway-shared.yaml` - Generated from templates
+- `gateway-1.yaml`, `gateway-2.yaml`, `gateway-elicitation.yaml`, `gateway-shared.yaml` - Generated from templates
 - `kustomization.yaml` - Copied from platform-specific kustomization file
 
 ## Usage

--- a/config/e2e/gateway-elicitation.yaml.template
+++ b/config/e2e/gateway-elicitation.yaml.template
@@ -8,10 +8,10 @@ metadata:
   name: e2e-elicitation
   namespace: gateway-system
 spec:
-  gatewayClassName: istio
+  gatewayClassName: ${GATEWAY_CLASS_NAME}
   listeners:
     - name: mcp
-      hostname: 'elicitation.127-0-0-1.sslip.io'
+      hostname: 'elicitation.${E2E_DOMAIN}'
       port: 8080
       protocol: HTTP
       allowedRoutes:
@@ -27,11 +27,11 @@ spec:
     - name: mcp-tls
       port: 8443
       protocol: HTTPS
-      hostname: '*.mcp-gateway.local'
+      hostname: '${GATEWAY_TLS_LISTENER_HOSTNAME}'
       tls:
         mode: Terminate
         certificateRefs:
-          - name: mcp-gateway-tls-cert
+          - name: '${GATEWAY_TLS_SECRET}'
       allowedRoutes:
         namespaces:
           from: All

--- a/config/test-servers/server3-deployment.yaml
+++ b/config/test-servers/server3-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         env:
         - name: LOG_LEVEL
           value: "info"
+        - name: FASTMCP_HTTP_HOST_ORIGIN_PROTECTION
+          value: "false" # gateway rewrites Host to backend address; origin check would reject
         readinessProbe:
           tcpSocket:
             port: 8000

--- a/tests/e2e/builders.go
+++ b/tests/e2e/builders.go
@@ -314,6 +314,18 @@ func (b *TestResourcesBuilder) Build() *TestResourcesBuilder {
 	return b
 }
 
+// buildHostnames constructs the hostname slice based on cluster type (KIND vs OpenShift)
+func (b *TestResourcesBuilder) buildHostnames() []gatewayapiv1.Hostname {
+	if e2eDomain == defaultE2EDomain {
+		// KIND: use .mcp-gateway.local hostname only
+		return []gatewayapiv1.Hostname{gatewayapiv1.Hostname(b.hostname)}
+	}
+	// OpenShift/real clusters: use real domain hostname only
+	return []gatewayapiv1.Hostname{
+		gatewayapiv1.Hostname(strings.Replace(b.hostname, ".mcp-gateway.local", "."+e2eDomain, 1)),
+	}
+}
+
 func (b *TestResourcesBuilder) buildInternalResources(routeName string) {
 	backendRef := gatewayapiv1.BackendObjectReference{
 		Name: gatewayapiv1.ObjectName(b.serviceName),
@@ -367,10 +379,7 @@ func (b *TestResourcesBuilder) buildInternalResources(routeName string) {
 			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
 				ParentRefs: []gatewayapiv1.ParentReference{parentRef},
 			},
-			Hostnames: []gatewayapiv1.Hostname{
-				gatewayapiv1.Hostname(b.hostname),
-				gatewayapiv1.Hostname(strings.Replace(b.hostname, ".mcp-gateway.local", "."+e2eDomain, 1)),
-			},
+			Hostnames: b.buildHostnames(),
 			Rules: []gatewayapiv1.HTTPRouteRule{
 				{
 					BackendRefs: []gatewayapiv1.HTTPBackendRef{
@@ -446,9 +455,7 @@ func (b *TestResourcesBuilder) buildExternalResources(routeName string) {
 			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
 				ParentRefs: []gatewayapiv1.ParentReference{parentRef},
 			},
-			Hostnames: []gatewayapiv1.Hostname{
-				gatewayapiv1.Hostname(b.hostname),
-			},
+			Hostnames: b.buildHostnames(),
 			Rules: []gatewayapiv1.HTTPRouteRule{
 				{
 					Matches: []gatewayapiv1.HTTPRouteMatch{
@@ -638,7 +645,6 @@ type MCPGatewayExtensionSetup struct {
 	gatewayNamespace string
 	sectionName      string
 	publicHost       string
-	listenerPort     int32
 	pollInterval     string
 	extension        *mcpv1.MCPGatewayExtension
 	referenceGrant   *gatewayv1beta1.ReferenceGrant
@@ -659,7 +665,6 @@ func NewMCPGatewayExtensionSetup(k8sClient client.Client) *MCPGatewayExtensionSe
 		k8sClient:        k8sClient,
 		gatewayName:      GatewayName,
 		gatewayNamespace: GatewayNamespace,
-		listenerPort:     8080,
 	}
 }
 
@@ -698,12 +703,6 @@ func (s *MCPGatewayExtensionSetup) WithPublicHost(host string) *MCPGatewayExtens
 // WithPollInterval sets the poll interval annotation
 func (s *MCPGatewayExtensionSetup) WithPollInterval(interval string) *MCPGatewayExtensionSetup {
 	s.pollInterval = interval
-	return s
-}
-
-// WithListenerPort sets the listener port used to compute the privateHost
-func (s *MCPGatewayExtensionSetup) WithListenerPort(port int32) *MCPGatewayExtensionSetup {
-	s.listenerPort = port
 	return s
 }
 
@@ -751,10 +750,6 @@ func (s *MCPGatewayExtensionSetup) Build() *MCPGatewayExtensionSetup {
 	}
 	if s.publicHost != "" {
 		spec.PublicHost = s.publicHost
-	}
-	if gatewayClassName != "istio" {
-		spec.PrivateHost = fmt.Sprintf("%s-%s.%s.svc.cluster.local:%d",
-			s.gatewayName, gatewayClassName, s.gatewayNamespace, s.listenerPort)
 	}
 	if s.pollInterval != "" {
 		interval, _ := strconv.Atoi(s.pollInterval)
@@ -1021,15 +1016,13 @@ type MCPGatewayExtensionBuilder struct {
 	targetGateway   string
 	targetNamespace string
 	sectionName     string
-	listenerPort    int32
 }
 
 // NewMCPGatewayExtensionBuilder creates a new MCPGatewayExtensionBuilder
 func NewMCPGatewayExtensionBuilder(name, namespace string) *MCPGatewayExtensionBuilder {
 	return &MCPGatewayExtensionBuilder{
-		name:         name,
-		namespace:    namespace,
-		listenerPort: 8080,
+		name:      name,
+		namespace: namespace,
 	}
 }
 
@@ -1048,11 +1041,6 @@ func (b *MCPGatewayExtensionBuilder) WithSectionName(sectionName string) *MCPGat
 
 // Build creates the MCPGatewayExtension resource
 func (b *MCPGatewayExtensionBuilder) Build() *mcpv1.MCPGatewayExtension {
-	var privateHost string
-	if gatewayClassName != "istio" {
-		privateHost = fmt.Sprintf("%s-%s.%s.svc.cluster.local:%d",
-			b.targetGateway, gatewayClassName, b.targetNamespace, b.listenerPort)
-	}
 	return &mcpv1.MCPGatewayExtension{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      b.name,
@@ -1067,7 +1055,6 @@ func (b *MCPGatewayExtensionBuilder) Build() *mcpv1.MCPGatewayExtension {
 				Namespace:   b.targetNamespace,
 				SectionName: b.sectionName,
 			},
-			PrivateHost: privateHost,
 		},
 	}
 }

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -69,10 +69,18 @@ const defaultE2EDomain = "127-0-0-1.sslip.io"
 
 // e2e environment configuration
 var (
-	e2eDomain        = goenv.GetDefault("E2E_DOMAIN", defaultE2EDomain)
-	e2eScheme        = goenv.GetDefault("E2E_SCHEME", "http")
-	gatewayClassName = goenv.GetDefault("GATEWAY_CLASS_NAME", "istio")
+	e2eDomain = goenv.GetDefault("E2E_DOMAIN", defaultE2EDomain)
+	e2eScheme = goenv.GetDefault("E2E_SCHEME", "http")
 )
+
+// gatewayListenerHostname returns the hostname pattern for the Gateway HTTPS listener.
+// On Kind (default domain), uses *.mcp-gateway.local. On real clusters, derives from E2E_DOMAIN.
+func gatewayListenerHostname() string {
+	if e2eDomain == defaultE2EDomain {
+		return "*.mcp-gateway.local"
+	}
+	return "*." + e2eDomain
+}
 
 // namespace configuration - configurable via environment variables
 var (
@@ -81,14 +89,53 @@ var (
 	TestServerNameSpace = goenv.GetDefault("TEST_SERVER_NAMESPACE", "mcp-test")
 )
 
+// gateway TLS configuration
+var (
+	GatewayTLSSecret         = goenv.GetDefault("GATEWAY_TLS_SECRET", "mcp-gateway-tls-cert")
+	GatewayCABundleConfigMap = goenv.GetDefault("GATEWAY_CA_BUNDLE_CONFIGMAP", "trusted-ca-bundle")
+)
+
+// gatewayPublicHostDefault returns the default public host for the gateway.
+// On Kind uses mcp.mcp-gateway.local, on real clusters uses mcp.<E2E_DOMAIN>.
+func gatewayPublicHostDefault() string {
+	if e2eDomain == defaultE2EDomain {
+		return "mcp.mcp-gateway.local"
+	}
+	return "mcp." + e2eDomain
+}
+
+func elicitationPublicHostDefault() string {
+	if e2eDomain == defaultE2EDomain {
+		return "elicit.mcp-gateway.local"
+	}
+	return "elicitation." + e2eDomain
+}
+
+// toolDiscPublicHostDefault returns the default public host for tool discovery.
+func toolDiscPublicHostDefault() string {
+	if e2eDomain == defaultE2EDomain {
+		return "mcp.tool-discovery.127-0-0-1.sslip.io"
+	}
+	return "mcp.tool-discovery." + e2eDomain
+}
+
+// toolDiscServerHostDefault returns the default server host for tool discovery.
+func toolDiscServerHostDefault() string {
+	if e2eDomain == defaultE2EDomain {
+		return "server.tool-discovery.127-0-0-1.sslip.io"
+	}
+	return "server.tool-discovery." + e2eDomain
+}
+
 // public hosts - derived from E2E_DOMAIN
 var (
-	gatewayPublicHost       = goenv.GetDefault("GATEWAY_PUBLIC_HOST", "mcp.mcp-gateway.local")
+	gatewayPublicHost       = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())
 	E2E1PublicHost          = goenv.GetDefault("E2E1_PUBLIC_HOST", "e2e-1."+e2eDomain)
 	TeamAPublicHost         = goenv.GetDefault("TEAM_A_PUBLIC_HOST", "team-a."+e2eDomain)
 	TeamBPublicHost         = goenv.GetDefault("TEAM_B_PUBLIC_HOST", "team-b."+e2eDomain)
-	ElicitationPublicHost   = goenv.GetDefault("ELICITATION_PUBLIC_HOST", "elicitation."+e2eDomain)
-	ToolDiscoveryPublicHost = goenv.GetDefault("TOOL_DISCOVERY_PUBLIC_HOST", "mcp.tool-discovery."+e2eDomain)
+	ElicitationPublicHost   = goenv.GetDefault("ELICITATION_PUBLIC_HOST", elicitationPublicHostDefault())
+	ToolDiscoveryPublicHost = goenv.GetDefault("TOOL_DISCOVERY_PUBLIC_HOST", toolDiscPublicHostDefault())
+	ToolDiscoveryServerHost = goenv.GetDefault("TOOL_DISCOVERY_SERVER_HOST", toolDiscServerHostDefault())
 )
 
 // gateway URLs - on Kind use localhost port mappings, on real clusters derive from public hosts

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -111,6 +111,13 @@ func elicitationPublicHostDefault() string {
 	return "elicitation." + e2eDomain
 }
 
+func urlElicitationPublicHostDefault() string {
+	if e2eDomain == defaultE2EDomain {
+		return "url-elicit.mcp-gateway.local"
+	}
+	return "url-elicitation." + e2eDomain
+}
+
 // toolDiscPublicHostDefault returns the default public host for tool discovery.
 func toolDiscPublicHostDefault() string {
 	if e2eDomain == defaultE2EDomain {
@@ -129,13 +136,14 @@ func toolDiscServerHostDefault() string {
 
 // public hosts - derived from E2E_DOMAIN
 var (
-	gatewayPublicHost       = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())
-	E2E1PublicHost          = goenv.GetDefault("E2E1_PUBLIC_HOST", "e2e-1."+e2eDomain)
-	TeamAPublicHost         = goenv.GetDefault("TEAM_A_PUBLIC_HOST", "team-a."+e2eDomain)
-	TeamBPublicHost         = goenv.GetDefault("TEAM_B_PUBLIC_HOST", "team-b."+e2eDomain)
-	ElicitationPublicHost   = goenv.GetDefault("ELICITATION_PUBLIC_HOST", elicitationPublicHostDefault())
-	ToolDiscoveryPublicHost = goenv.GetDefault("TOOL_DISCOVERY_PUBLIC_HOST", toolDiscPublicHostDefault())
-	ToolDiscoveryServerHost = goenv.GetDefault("TOOL_DISCOVERY_SERVER_HOST", toolDiscServerHostDefault())
+	gatewayPublicHost        = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())
+	E2E1PublicHost           = goenv.GetDefault("E2E1_PUBLIC_HOST", "e2e-1."+e2eDomain)
+	TeamAPublicHost          = goenv.GetDefault("TEAM_A_PUBLIC_HOST", "team-a."+e2eDomain)
+	TeamBPublicHost          = goenv.GetDefault("TEAM_B_PUBLIC_HOST", "team-b."+e2eDomain)
+	ElicitationPublicHost    = goenv.GetDefault("ELICITATION_PUBLIC_HOST", elicitationPublicHostDefault())
+	URLElicitationPublicHost = goenv.GetDefault("URL_ELICITATION_PUBLIC_HOST", urlElicitationPublicHostDefault())
+	ToolDiscoveryPublicHost  = goenv.GetDefault("TOOL_DISCOVERY_PUBLIC_HOST", toolDiscPublicHostDefault())
+	ToolDiscoveryServerHost  = goenv.GetDefault("TOOL_DISCOVERY_SERVER_HOST", toolDiscServerHostDefault())
 )
 
 // gateway URLs - on Kind use localhost port mappings, on real clusters derive from public hosts
@@ -145,7 +153,7 @@ var (
 	TeamAGatewayURL          = goenv.GetDefault("TEAM_A_GATEWAY_URL", gatewayURLDefault(TeamAPublicHost, "http://localhost:8005/mcp"))
 	TeamBGatewayURL          = goenv.GetDefault("TEAM_B_GATEWAY_URL", gatewayURLDefault(TeamBPublicHost, "http://localhost:8006/mcp"))
 	ElicitationGatewayURL    = goenv.GetDefault("ELICITATION_GATEWAY_URL", gatewayURLDefault(ElicitationPublicHost, "https://elicit.mcp-gateway.local:8010/mcp"))
-	URLElicitationGatewayURL = goenv.GetDefault("URL_ELICITATION_GATEWAY_URL", gatewayURLDefault(ElicitationPublicHost, "https://url-elicit.mcp-gateway.local:8010/mcp"))
+	URLElicitationGatewayURL = goenv.GetDefault("URL_ELICITATION_GATEWAY_URL", gatewayURLDefault(URLElicitationPublicHost, "https://url-elicit.mcp-gateway.local:8010/mcp"))
 	ToolDiscoveryGatewayURL  = goenv.GetDefault("TOOL_DISCOVERY_GATEWAY_URL", gatewayURLDefault(ToolDiscoveryPublicHost, "http://mcp.tool-discovery.127-0-0-1.sslip.io:8001/mcp"))
 )
 

--- a/tests/e2e/elicitation_test.go
+++ b/tests/e2e/elicitation_test.go
@@ -39,9 +39,8 @@ func declineElicitHandler() func(context.Context, *mcp.ElicitRequest) (*mcp.Elic
 }
 
 const (
-	elicitExtName    = "elicitation-ext"
-	elicitNamespace  = "mcp-elicitation"
-	elicitPublicHost = "elicit.mcp-gateway.local"
+	elicitExtName   = "elicitation-ext"
+	elicitNamespace = "mcp-elicitation"
 )
 
 var _ = Describe("Elicitation", Ordered, ContinueOnFailure, func() {
@@ -86,8 +85,7 @@ var _ = Describe("Elicitation", Ordered, ContinueOnFailure, func() {
 			InNamespace(elicitNamespace).
 			TargetingGateway(ElicitationGatewayName, GatewayNamespace).
 			WithSectionName(ElicitationListenerName).
-			WithPublicHost(elicitPublicHost).
-			WithListenerPort(8443).
+			WithPublicHost(ElicitationPublicHost).
 			WithURLElicitation().
 			Build()
 		elicitationExt.Clean(ctx).Register(ctx)
@@ -111,7 +109,6 @@ var _ = Describe("Elicitation", Ordered, ContinueOnFailure, func() {
 		registration := NewTestResources("elicitation", k8sClient).
 			InNamespace(elicitNamespace).
 			ForInternalService("everything-server", 9090).
-			WithHostname("everything-server.mcp-gateway.local").
 			WithBackendNamespace(TestServerNameSpace).
 			WithPrefix("es_").
 			WithParentGateway(ElicitationGatewayName, GatewayNamespace).

--- a/tests/e2e/kubectl_helpers.go
+++ b/tests/e2e/kubectl_helpers.go
@@ -199,28 +199,55 @@ func PatchBrokerCA(ctx context.Context, k8sClient client.Client, namespace strin
 		}
 	}
 
-	caSecret := &corev1.Secret{}
-	Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "private-ca-keypair", Namespace: "cert-manager"}, caSecret)).To(Succeed())
-	caCertPEM, ok := caSecret.Data["ca.crt"]
-	Expect(ok).To(BeTrue(), "private-ca-keypair should have ca.crt")
+	if e2eDomain == defaultE2EDomain {
+		// KIND: use cert-manager private CA
+		caSecret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "private-ca-keypair", Namespace: "cert-manager"}, caSecret)).To(Succeed())
+		caCertPEM, ok := caSecret.Data["ca.crt"]
+		Expect(ok).To(BeTrue(), "private-ca-keypair should have ca.crt")
 
-	caBundle := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gateway-ca-bundle",
-			Namespace: namespace,
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{"ca.crt": caCertPEM},
+		caBundle := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway-ca-bundle",
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{"ca.crt": caCertPEM},
+		}
+		_ = k8sClient.Delete(ctx, caBundle)
+		Expect(k8sClient.Create(ctx, caBundle)).To(Succeed())
+
+		combinedPatch := `[` +
+			`{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"gateway-ca","secret":{"secretName":"gateway-ca-bundle"}}},` +
+			`{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"gateway-ca","mountPath":"/certs/gateway-ca.crt","subPath":"ca.crt","readOnly":true}},` +
+			`{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--gateway-ca-cert=/certs/gateway-ca.crt"}` +
+			`]`
+		Expect(PatchDeploymentJSON(ctx, namespace, "mcp-gateway", combinedPatch)).To(Succeed())
+	} else {
+		// OpenShift/real clusters: copy GATEWAY_CA_BUNDLE_CONFIGMAP (defaults to trusted-ca-bundle) ConfigMap from mcp-system
+		if namespace != SystemNamespace {
+			sourceConfigMap := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: GatewayCABundleConfigMap, Namespace: SystemNamespace}, sourceConfigMap)).To(Succeed())
+
+			targetConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      GatewayCABundleConfigMap,
+					Namespace: namespace,
+					Labels:    sourceConfigMap.Labels,
+				},
+				Data: sourceConfigMap.Data,
+			}
+			_ = k8sClient.Delete(ctx, targetConfigMap)
+			Expect(k8sClient.Create(ctx, targetConfigMap)).To(Succeed())
+		}
+
+		combinedPatch := `[` +
+			`{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"gateway-ca","configMap":{"name":"` + GatewayCABundleConfigMap + `"}}},` +
+			`{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"gateway-ca","mountPath":"/certs/gateway-ca.crt","subPath":"ca-bundle.crt","readOnly":true}},` +
+			`{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--gateway-ca-cert=/certs/gateway-ca.crt"}` +
+			`]`
+		Expect(PatchDeploymentJSON(ctx, namespace, "mcp-gateway", combinedPatch)).To(Succeed())
 	}
-	_ = k8sClient.Delete(ctx, caBundle)
-	Expect(k8sClient.Create(ctx, caBundle)).To(Succeed())
-
-	combinedPatch := `[` +
-		`{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"gateway-ca","secret":{"secretName":"gateway-ca-bundle"}}},` +
-		`{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"gateway-ca","mountPath":"/certs/gateway-ca.crt","subPath":"ca.crt","readOnly":true}},` +
-		`{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--gateway-ca-cert=/certs/gateway-ca.crt"}` +
-		`]`
-	Expect(PatchDeploymentJSON(ctx, namespace, "mcp-gateway", combinedPatch)).To(Succeed())
 	Expect(WaitForDeploymentReady(ctx, namespace, "mcp-gateway")).To(Succeed())
 }
 

--- a/tests/e2e/multi_gateway_test.go
+++ b/tests/e2e/multi_gateway_test.go
@@ -420,7 +420,7 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
 	})
 
-	It("[multi-gateway] Shared Gateway with team isolation via sectionName", func() {
+	It("[multi-gateway] Shared Gateway with team isolation via sectionName", Serial, func() {
 		// This test verifies that a single Gateway with multiple listeners can be used
 		// by different teams, each with their own MCPGatewayExtension targeting their
 		// specific listener. Each team should only see tools from their own registrations.
@@ -453,7 +453,6 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 			TargetingGateway(SharedGatewayName, GatewayNamespace).
 			WithSectionName(TeamBMCPListenerName).
 			WithPublicHost(TeamBPublicHost).
-			WithListenerPort(8081).
 			Build()
 		teamBSetup.Clean(ctx).Register(ctx)
 		defer teamBSetup.TearDown(ctx)
@@ -619,7 +618,8 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 			WithTarget(SharedGatewayName, GatewayNamespace).
 			WithSectionName(TeamAMCPListenerName). // targeting Team A's listener
 			Build()
-		testResources = append(testResources, conflictExt)
+		// clean up before teamBSetup.TearDown deletes the namespace (LIFO ordering)
+		defer CleanupResource(ctx, k8sClient, conflictExt)
 		Expect(k8sClient.Create(ctx, conflictExt)).To(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -715,7 +715,7 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 		Expect(v.HTTPRouteNotFound(routeName, extNamespace)).To(Succeed())
 	})
 
-	It("[multi-gateway] Each MCPGatewayExtension gets its own HTTPRoute", func() {
+	It("[multi-gateway] Each MCPGatewayExtension gets its own HTTPRoute", Serial, func() {
 		const (
 			teamAExtName = "httproute-team-a"
 			teamBExtName = "httproute-team-b"
@@ -744,7 +744,6 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 			TargetingGateway(SharedGatewayName, GatewayNamespace).
 			WithSectionName(TeamBMCPListenerName).
 			WithPublicHost(TeamBPublicHost).
-			WithListenerPort(8081).
 			Build()
 		teamBSetup.Clean(ctx).Register(ctx)
 		defer teamBSetup.TearDown(ctx)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -6,17 +6,32 @@
 // and 127-0-0-1.sslip.io hostnames. To run against a real cluster, set:
 //
 //   E2E_DOMAIN    - base domain for all public hostnames (default: 127-0-0-1.sslip.io)
+//                   Also configures the Gateway HTTPS listener hostname as *.<domain>
 //   E2E_SCHEME    - http or https (default: http)
 //
-// Setting E2E_DOMAIN to a non-default value causes gateway URLs to be derived
-// from the public hostnames automatically (e.g. http://mcp.<domain>/mcp) instead
-// of using Kind's localhost port mappings.
+// Setting E2E_DOMAIN to a non-default value causes:
+// - Gateway URLs to be derived from public hostnames (e.g. http://mcp.<domain>/mcp)
+// - Gateway HTTPS listener hostname to use *.<domain> instead of *.mcp-gateway.local
+// - Individual server hostnames to use <name>.<domain> instead of <name>.mcp-gateway.local
 //
 // Namespace overrides (for non-standard installations):
 //
 //   MCP_GATEWAY_NAMESPACE  - MCP system namespace (default: mcp-system)
 //   GATEWAY_NAMESPACE      - Gateway namespace (default: gateway-system)
 //   TEST_SERVER_NAMESPACE  - Test server namespace (default: mcp-test)
+//
+// TLS configuration:
+//
+//   GATEWAY_TLS_SECRET           - Secret name for Gateway HTTPS listener certificate
+//                                  (default: mcp-gateway-tls-cert).
+//                                  Certificate must be valid for:
+//                                    - listener hostname (*.<domain>)
+//   GATEWAY_CA_BUNDLE_CONFIGMAP  - ConfigMap name containing CA certificates for broker to trust
+//                                  the Gateway HTTPS listener certificate (default: trusted-ca-bundle).
+//                                  Required when Gateway uses certificates signed by non-standard CAs
+//                                  (self-signed, internal CA, etc.). On Kind, uses cert-manager's
+//                                  private CA. On OpenShift/real clusters, typically uses the
+//                                  platform's trusted CA bundle.
 //
 // Individual gateway/host overrides:
 //
@@ -144,7 +159,7 @@ var _ = SynchronizedBeforeSuite(func() {
 
 	By("adding HTTPS listener to the gateway")
 	Expect(AddGatewayHTTPSListener(ctx, GatewayNamespace, GatewayName,
-		GatewayListenerName, "*.mcp-gateway.local", "mcp-gateway-tls-cert", 8443)).To(Succeed())
+		GatewayListenerName, gatewayListenerHostname(), GatewayTLSSecret, 8443)).To(Succeed())
 
 	By("waiting for gateway to be programmed")
 	Eventually(func(g Gomega) {
@@ -168,7 +183,6 @@ var _ = SynchronizedBeforeSuite(func() {
 		TargetingGateway(GatewayName, GatewayNamespace).
 		WithSectionName(GatewayListenerName).
 		WithPublicHost(gatewayPublicHost).
-		WithListenerPort(8443).
 		Build()
 
 	defaultMCPGatewayExt.

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -21,9 +21,8 @@ func isBrokerMetaTool(name string) bool {
 }
 
 const (
-	toolDiscExtName    = "tool-discovery-ext"
-	toolDiscNamespace  = "mcp-tool-discovery"
-	toolDiscPublicHost = "mcp.tool-discovery.127-0-0-1.sslip.io"
+	toolDiscExtName   = "tool-discovery-ext"
+	toolDiscNamespace = "mcp-tool-discovery"
 )
 
 var _ = Describe("Tool Discovery", Ordered, func() {
@@ -54,7 +53,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 			InNamespace(toolDiscNamespace).
 			TargetingGateway(GatewayName, GatewayNamespace).
 			WithSectionName(ToolDiscoveryListenerName).
-			WithPublicHost(toolDiscPublicHost).
+			WithPublicHost(ToolDiscoveryPublicHost).
 			Build()
 		toolDiscExt.Clean(ctx).Register(ctx)
 
@@ -113,7 +112,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("disc_meta_").
 				WithCategory("messaging").
 				WithHint("provides messaging tools").
@@ -163,7 +162,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("multicat_").
 				WithCategory("Dining", "reservations").
 				WithSectionName(ToolDiscoveryListenerName).
@@ -176,7 +175,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server1", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("catmsg_").
 				WithCategory("messaging").
 				WithSectionName(ToolDiscoveryListenerName).
@@ -241,7 +240,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("discauth_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -252,6 +251,9 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 			Eventually(func(g Gomega) {
 				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
 			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+			By("waiting for tools to appear via gateway")
+			WaitForToolsWithPrefix(ctx, mcpGatewayClient, "discauth_")
 
 			By("creating a JWT that allows only one tool")
 			allowedTools := map[string][]string{
@@ -292,7 +294,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("discvs_").
 				WithParentGateway(GatewayName, GatewayNamespace).
 				WithSectionName(ToolDiscoveryListenerName).
@@ -344,7 +346,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("selscope_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -452,7 +454,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("selpart_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -499,7 +501,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("notifsel_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -589,7 +591,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("thzero_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -632,7 +634,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("thtest_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -702,7 +704,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("iso_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -762,7 +764,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("conc_").
 				WithSectionName(ToolDiscoveryListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
@@ -843,7 +845,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				InNamespace(toolDiscNamespace).
 				WithBackendTarget("mcp-test-server2", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("server.tool-discovery.127-0-0-1.sslip.io").
+				WithHostname(ToolDiscoveryServerHost).
 				WithPrefix("reconf_").
 				WithCategory("initial-category").
 				WithHint("initial hint").


### PR DESCRIPTION
## What does this PR do?

Makes the e2e test suite portable across Kind and OpenShift by parameterizing environment-specific values (hostnames, TLS certificates, CA bundles) and adding a gateway template for the elicitation test suite.

## Changes

  - Add `buildHostnames()` to consolidate HTTPRoute hostname construction based on cluster type
  - Add `gateway-elicitation.yaml.template` with parameterized listener hostnames and TLS secret
  - Parameterize `GATEWAY_TLS_SECRET`, `GATEWAY_TLS_LISTENER_HOSTNAME`, and `GATEWAY_CA_BUNDLE_CONFIGMAP`
  - Consolidate CA patching into `PatchBrokerCA` with Kind/OCP branching
  - Add `elicitationPublicHostDefault()` to match KIND gateway URL hostname
  - Remove hardcoded `PrivateHost` and `WithListenerPort` (now handled by the operator)
  - Replace hardcoded hostnames in tool discovery tests with configurable `ToolDiscoveryServerHost`
  - Mark two multi-gateway tests `Serial` for parallel safety
  - Fix cleanup ordering for `conflictExt` in shared-gateway test
  - Add `WaitForToolsWithPrefix` before JWT-scoped tool discovery test
  - Disable `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` on server3 for cross-origin OCP routing
  - Bump `WAIT_TIME` to 150s for slower OCP gateway provisioning

## Verification

  - Run e2e tests on Kind: `make test-e2e-ci`
  - Run e2e tests on OpenShift with appropriate env vars:
    ```
    E2E_DOMAIN=<domain> E2E_SCHEME=https GATEWAY_CLASS_NAME=<class> \
    GATEWAY_TLS_SECRET=<secret> GATEWAY_TLS_LISTENER_HOSTNAME=*.<domain> \
    GATEWAY_CA_BUNDLE_CONFIGMAP=<cm> make test-e2e-ci
    ```
  - Verify that all the tests pass on both platforms

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended E2E gateway generation/deployment with gateway TLS configuration and an additional elicitation gateway manifest.
* **Bug Fixes**
  * Improved E2E readiness checks to wait for both elicitation and shared-gateway endpoints.
  * Fixed gateway-routed test traffic by disabling host-origin protection where needed.
  * Enhanced trusted CA provisioning for gateway deployments across domain modes.
* **Tests**
  * Updated E2E routing to derive gateway hostnames/TLS listener hostname from `E2E_DOMAIN`, and adjusted multi-gateway isolation/cleanup.
* **Documentation**
  * Updated E2E generated-artifact guidance and clarified TLS/hostname expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->