### PR TITLE
fix: delete EnvoyFilter when ReferenceGrant is removed

### DIFF
--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -327,6 +327,9 @@ func (r *MCPGatewayExtensionReconciler) validateGatewayTarget(ctx context.Contex
 			r.log.Info("no valid ReferenceGrant for cross-namespace reference",
 				"extension", mcpExt.Name, "extension-namespace", mcpExt.Namespace,
 				"gateway-namespace", mcpExt.Spec.TargetRef.Namespace)
+			if err := r.deleteEnvoyFilter(ctx, mcpExt); err != nil {
+				return nil, nil, err
+			}
 			if err := r.ConfigWriterDeleter.WriteEmptyConfig(ctx, config.NamespaceName(mcpExt.Namespace)); err != nil {
 				return nil, nil, err
 			}

--- a/internal/controller/mcpgatewayextension_controller_test.go
+++ b/internal/controller/mcpgatewayextension_controller_test.go
@@ -955,6 +955,61 @@ var _ = Describe("MCPGatewayExtension Controller", func() {
 			}, testTimeout, testRetryInterval).Should(Succeed())
 		})
 
+		It("should delete EnvoyFilter when the ReferenceGrant is deleted", func() {
+			reconciler := newTestReconciler()
+			waitForCacheSync(ctx, mcpExtNamespacedName)
+
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpExtNamespacedName})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				deployment := &appsv1.Deployment{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{
+					Name:      brokerRouterName,
+					Namespace: "default",
+				}, deployment)).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			setDeploymentStatus(ctx, "default", 1, 1)
+
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpExtNamespacedName})
+				g.Expect(err).NotTo(HaveOccurred())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			expectedEnvoyFilterName := fmt.Sprintf("mcp-ext-proc-%s-gateway", "default")
+			Eventually(func(g Gomega) {
+				envoyFilter := &istionetv1alpha3.EnvoyFilter{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{
+					Name:      expectedEnvoyFilterName,
+					Namespace: gatewayNamespace,
+				}, envoyFilter)).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			Expect(deleteTestReferenceGrant(ctx, refGrantName, gatewayNamespace)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpExtNamespacedName})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				updated := &mcpv1.MCPGatewayExtension{}
+				g.Expect(testK8sClient.Get(ctx, mcpExtNamespacedName, updated)).To(Succeed())
+				condition := meta.FindStatusCondition(updated.Status.Conditions, mcpv1.ConditionTypeReady)
+				g.Expect(condition).NotTo(BeNil())
+				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(mcpv1.ConditionReasonRefGrantRequired))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				envoyFilter := &istionetv1alpha3.EnvoyFilter{}
+				err := testK8sClient.Get(ctx, types.NamespacedName{
+					Name:      expectedEnvoyFilterName,
+					Namespace: gatewayNamespace,
+				}, envoyFilter)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+		})
+
 		It("should delete EnvoyFilter when MCPGatewayExtension is deleted", func() {
 			reconciler := newTestReconciler()
 			waitForCacheSync(ctx, mcpExtNamespacedName)


### PR DESCRIPTION
## What

- delete the controller-managed EnvoyFilter when a cross-namespace MCPGatewayExtension no longer has a valid ReferenceGrant
- preserve the existing empty broker configuration and `RefGrantRequired` status behavior
- add an integration regression test covering ReferenceGrant removal and EnvoyFilter cleanup

## Why

When the ReferenceGrant was deleted, the extension became NotReady but its EnvoyFilter remained attached to the Gateway. That allowed traffic to continue using the stale ext_proc configuration even though the cross-namespace reference was no longer authorized.

Propagating cleanup errors also ensures reconciliation retries if the EnvoyFilter cannot be removed.

Fixes #1271

## Testing

- `make test-unit`
- `make test-controller-integration`
- `make lint-go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete gateway configuration when a required cross-namespace permission is deleted.
  * MCP Gateway Extensions now report a clear not-ready status when the required permission is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->