### PR TITLE
fix(e2e): improve reliability for multi-gateway and notification tests

### DIFF
--- a/tests/e2e/multi_gateway_test.go
+++ b/tests/e2e/multi_gateway_test.go
@@ -237,13 +237,14 @@ var _ = Describe("MCP Gateway Multi-Gateway", func() {
 			WithSectionName(E2E1ListenerName).
 			WithPublicHost(E2E1PublicHost).
 			Build()
-		newSetup.Register(ctx)
+		// clean first: reuses the same name/namespace, so old resources (finalizers) must be fully gone
+		newSetup.Clean(ctx).Register(ctx)
 
 		By("Verifying MCPGatewayExtension becomes ready again")
 		Eventually(func(g Gomega) {
 			err := VerifyMCPGatewayExtensionReady(ctx, k8sClient, e2e1ExtName, e2e1ExtNamespace)
 			g.Expect(err).NotTo(HaveOccurred())
-		}, TestTimeoutMedium, TestRetryInterval).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
 		By("Verifying the broker/router deployment is recreated and ready")
 		Eventually(func(g Gomega) {

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -532,7 +532,7 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 				Arguments: map[string]any{"tools": []any{"notifsel_hello_world"}},
 			})
 			Expect(selectErr).NotTo(HaveOccurred())
-			Expect(res.IsError).To(BeFalse())
+			Expect(res.IsError).To(BeFalse(), "select_tools failed: %v", res.Content)
 
 			By("verifying notification was received")
 			Eventually(notifCh, TestTimeoutShort, TestRetryInterval).Should(Receive(),

--- a/tests/e2e/tool_discovery_test.go
+++ b/tests/e2e/tool_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -525,10 +526,13 @@ var _ = Describe("Tool Discovery", Ordered, func() {
 
 			WaitForToolsWithPrefix(ctx, client, "notifsel_")
 
-			sessionID := client.ID()
-			status, _, selectErr := mcpCallSelectTools(ctx, toolDiscURL, sessionID, []string{"notifsel_hello_world"}, nil)
+			// use the SDK client (not raw HTTP) so inline POST notifications reach the handler
+			res, selectErr := client.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "select_tools",
+				Arguments: map[string]any{"tools": []any{"notifsel_hello_world"}},
+			})
 			Expect(selectErr).NotTo(HaveOccurred())
-			Expect(status).To(Equal(200))
+			Expect(res.IsError).To(BeFalse())
 
 			By("verifying notification was received")
 			Eventually(notifCh, TestTimeoutShort, TestRetryInterval).Should(Receive(),


### PR DESCRIPTION
## What does this PR do?

These tests seem to be flaky on OpenShift. This should make them more stable hopefully.

1) Clean up resources before re-registration to avoid finalizer race in the multi-gateway deletion-recreation test. Bump timeout for post-recreation readiness check.

2) Replace raw HTTP `mcpCallSelectTools` with the SDK `client.CallTool` in the notification test so that inline POST notifications are routed through the SDK's `ToolListChangedHandler`. Previously, if the notification dispatch happened while the raw POST response was still open, the server could include the notification inline in that POST response body - bypassing the the SDK's notification handling.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway recreation reliability by ensuring cleanup is performed before redeployment.
  * Increased the readiness wait time after recreating gateways.
  * Improved tool-selection notification validation by switching to typed SDK tool calls and more direct success assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->