### PR TITLE
Design for integrating guard rails into the MCP Gateway

### DIFF
--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -1,0 +1,424 @@
+# Guardrails Integration
+
+## Problem
+
+> **Note:** examples reference NeMo Guardrails as the initial target.
+
+Guardrails systems don't support MCP natively. Their endpoints (`v1/chat/completions`, `v1/guardrail/checks`) are incompatible with MCP JSON-RPC. Integrating at the router level provides centralized enforcement and consistent protection across all clients.
+
+## Summary
+
+Translation layer in the router that intercepts `tools/call` requests, translates them to a guardrails check, and either proceeds or rejects. Configuration via Kubernetes Secret referenced from `MCPGatewayExtension` (global) and/or `MCPServerRegistration` (per-server). TLS reuses the gateway's existing CA bundle.
+
+## Goals
+
+- Translate MCP `tools/call` and elicitation responses to guardrails checks
+- Support global and per-server guardrails
+- Fail closed by default, configurable to allow
+- Reuse gateway CA trust pool
+- Target NeMo Guardrails initially
+
+## Non-Goals
+
+- Response guardrailing (deferred)
+- Adding MCP awareness to NeMo itself
+
+## Job Stories
+
+### When I want to enforce safety policies on tool calls
+
+When a platform engineer deploys MCP servers that interact with sensitive systems, they want tool calls checked against guardrails before execution so that dangerous calls are rejected at the gateway.
+
+### When I want guardrails on all servers by default
+
+When a platform engineer wants all tool calls checked, they want to configure guardrails once at the gateway level so every server inherits the policy.
+
+### When I need different guardrails policies per server
+
+When servers have different risk profiles, the platform engineer wants different config IDs per server so policies match capabilities.
+
+### When I want additional guardrails on a specific server
+
+When an MCP server accepts freeform input or interacts with a downstream model, the developer wants server-specific policies in addition to global ones.
+
+### When the guardrails server is down
+
+When the guardrails server is unreachable, tool calls fail closed by default. For non-critical servers, the option to fail open exists.
+
+### When the guardrails server uses a private CA
+
+When the guardrails server uses a corporate or self-signed CA, the platform engineer adds it to the gateway CA bundle.
+
+## Design
+
+### Configuration via Secret
+
+Type `guardrails/external/nemo`, following the project's Secret reference pattern (`credentialRef`, `caCertSecretRef`):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-guardrails-config
+  namespace: mcp-system
+  labels:
+    mcp.kuadrant.io/secret: "true"
+type: guardrails/external/nemo
+stringData:
+  config.yaml: |
+    url: https://nemo-guardrails.internal:8080
+    configIDs:
+      - "tool-safety-v1"
+      - "input_checking"
+    model: "meta/llama-3.1-8b-instruct"
+    failMode: deny        # deny (default) | allow
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | Guardrails server endpoint |
+| `configIDs` | no | Default config IDs applied to all servers. Empty if per-server `guardrailsConfigIDs` supply policies |
+| `model` | yes | Model identifier for the guardrails check |
+| `failMode` | no | `deny` (default): reject on failure. `allow`: proceed |
+
+> **Note:** TLS uses the gateway's existing CA bundle (`caCertBundleRef`). Add private CAs there.
+
+### API Changes
+
+#### MCPGatewayExtension
+
+```go
+type MCPGatewayExtensionSpec struct {
+    // ... existing fields ...
+
+    // guardrailsRef references a Secret of type guardrails/external/nemo.
+    // When set, all tools/call requests are checked before routing.
+    // +optional
+    GuardrailsRef *SecretReference `json:"guardrailsRef,omitempty"`
+}
+```
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPGatewayExtension
+metadata:
+  name: mcp-gateway
+spec:
+  targetRef:
+    name: mcp-gateway
+    sectionName: mcp
+  guardrailsRef:
+    name: my-guardrails-config
+```
+
+#### MCPServerRegistration
+
+```go
+type MCPServerRegistrationSpec struct {
+    // ... existing fields ...
+
+    // guardrailsConfigIDs specifies additional config IDs merged with gateway
+    // defaults into a single check request. Requires guardrailsRef on the
+    // MCPGatewayExtension — without it, the server is set to NotReady.
+    // +optional
+    GuardrailsConfigIDs []string `json:"guardrailsConfigIDs,omitempty"`
+}
+```
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: dangerous-server
+spec:
+  targetRef:
+    name: dangerous-server-route
+  prefix: dangerous_
+  guardrailsConfigIDs:
+    - "strict-input-checking"
+    - "pii-detection"
+```
+
+#### Validation
+
+If `guardrailsConfigIDs` is set but no `guardrailsRef` exists on the MCPGatewayExtension:
+
+1. MCPServerRegistration set to `NotReady` with reason `GuardrailsNotConfigured`
+2. Server removed from gateway config (no tools/list, tool calls fail)
+3. Re-reconciled when `guardrailsRef` is added
+
+#### Guardrails Secret Deletion
+
+If the guardrails Secret is deleted:
+
+1. MCPGatewayExtension gets condition `GuardrailsSecretNotFound`
+2. The controller retains the last valid guardrails config in `mcp-gateway-config` — `GlobalGuardrails` is not cleared. The router continues to attempt guardrails checks against the configured URL
+3. All MCPServerRegistrations with `guardrailsConfigIDs` are set to `NotReady` and removed from the gateway
+4. For servers without `guardrailsConfigIDs` (covered by global guardrails only), the guardrails server is now unreachable and `failMode` applies: `deny` (default) rejects tool calls, `allow` proceeds without checks
+5. To disable guardrails entirely, the platform engineer must remove `guardrailsRef` from the MCPGatewayExtension — Secret deletion alone does not disable enforcement
+
+This ensures Secret deletion does not silently fail open. The platform engineer's intent (guardrails enabled via `guardrailsRef`) is preserved until explicitly changed. Accidental Secret deletion with `failMode: deny` (the default) blocks tool calls rather than letting unverified requests through.
+
+#### Resolution Order
+
+One guardrails server per gateway. Per-server config IDs are additive.
+
+| Gateway `guardrailsRef` | Server `guardrailsConfigIDs` | Effective Behavior |
+|-------------------------|------------------------------|--------------------|
+| Not set | Not set | No guardrails |
+| Set (with default IDs) | Not set | Gateway defaults applied |
+| Set (empty default IDs) | Not set | No check — per-server-only model |
+| Set (with default IDs) | Set | Gateway defaults + server IDs merged |
+| Set (no default IDs) | Set | Server IDs only |
+| Not set | Set | **NotReady** — server removed |
+
+### Request Flow
+
+Guardrails runs in the router after backend resolution, before the Decision is returned. Applies to `tools/call` and elicitation `accept` responses. If server resolution fails, existing error handling applies — no guardrails check.
+
+**No authorization header forwarding:** The router does not forward the client's `Authorization` header to the guardrails server. NeMo Guardrails does not require client auth — it authenticates to its LLM backend via its own `OPENAI_API_KEY` env var, configured independently on the NeMo server. The guardrails server is deployed without auth enabled (the default) and accessed over in-cluster networking. This avoids exposing client bearer tokens to infrastructure services and keeps credential flows clean: client tokens are for the gateway and upstream MCP servers, not for guardrails.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Envoy
+    participant Router
+    participant Guardrails as Guardrails Server
+    participant Backend as MCP Server
+
+    Client->>Envoy: tools/call (JSON-RPC)
+    Envoy->>Router: ext_proc body phase
+    Router->>Router: parse JSON-RPC, resolve backend
+    Router->>Router: check guardrails config for server
+
+    alt guardrails enabled
+        Router->>Guardrails: POST /v1/guardrail/checks
+        Guardrails-->>Router: response
+
+        alt status: blocked
+            Router-->>Envoy: Decision.Error (403)
+            Envoy-->>Client: JSON-RPC error
+        else status: success
+            Router-->>Envoy: Decision (route to backend)
+            Envoy->>Backend: tools/call
+            Backend-->>Envoy: result
+            Envoy-->>Client: result
+        else non-2xx / timeout
+            alt failMode: deny
+                Router-->>Envoy: Decision.Error (503)
+                Envoy-->>Client: JSON-RPC error
+            else failMode: allow
+                Router-->>Envoy: Decision (route to backend)
+                Envoy->>Backend: tools/call
+            end
+        end
+    else guardrails not enabled
+        Router-->>Envoy: Decision (route to backend)
+        Envoy->>Backend: tools/call
+    end
+```
+
+### Translation Mapping (NeMo)
+
+#### MCP `tools/call` to NeMo `v1/guardrail/checks`
+
+| MCP field | NeMo field |
+|-----------|------------|
+| `params.name` | `messages[0].name` |
+| `params.arguments` (JSON-encoded) | `messages[0].content` |
+| N/A | `messages[0].role = "user"` |
+| N/A | `messages[0].config = "tool"` |
+| from config | `guardrails.config_ids` |
+| from config | `model` |
+
+Example:
+
+```json
+{
+  "model": "meta/llama-3.1-8b-instruct",
+  "messages": [
+    {
+      "role": "user",
+      "name": "execute_sql",
+      "content": "{\"query\": \"DROP TABLE users\"}",
+      "config": "tool"
+    }
+  ],
+  "guardrails": {
+    "config_ids": ["tool-safety-v1", "input_checking"]
+  }
+}
+```
+
+#### Elicitation Response to NeMo
+
+Only `accept` responses are checked (`decline`/`cancel` carry no user content).
+
+| Elicitation field | NeMo field |
+|-------------------|------------|
+| `result.action` | `messages[0].name` |
+| `result` minus `action` (JSON-encoded) | `messages[0].content` |
+| N/A | `messages[0].role = "user"` |
+| N/A | `messages[0].config = "tool"` |
+| from config | `guardrails.config_ids` |
+| from config | `model` |
+
+#### Response to Decision Mapping
+
+| Outcome | Router action |
+|---------|---------------|
+| Translation failure | Always deny with 400. `failMode` does not apply |
+| `status: "success"` | Proceed with routing |
+| `status: "blocked"` | 403 with rails message |
+| Non-2xx HTTP | Apply `failMode`: deny → 503, allow → proceed |
+| Timeout | Apply `failMode`: deny → 503, allow → proceed |
+| Malformed response body | Apply `failMode`: deny → 502, allow → proceed |
+
+Translation failures (e.g. `params.arguments` not valid JSON) are always denied — `failMode: allow` applies only to guardrails server availability, not untranslatable requests.
+
+### TLS Trust
+
+Reuses the gateway's CA trust pool (system roots + `caCertBundleRef`).
+
+### Config Propagation
+
+Controller writes resolved guardrails config into `mcp-gateway-config` Secret. Per-server `guardrailsConfigIDs` go into each server entry:
+
+```go
+type BrokerConfig struct {
+    Servers          []MCPServer           `json:"servers"          yaml:"servers"`
+    VirtualServers   []VirtualServerConfig `json:"virtualServers,omitempty" yaml:"virtualServers,omitempty"`
+    GatewayCACertPEM string                `json:"gatewayCACertPEM,omitempty" yaml:"gatewayCACertPEM,omitempty"`
+    GlobalGuardrails *GuardrailsConfig     `json:"globalGuardrails,omitempty" yaml:"globalGuardrails,omitempty"`
+}
+
+type MCPServer struct {
+    // ... existing fields ...
+    GuardrailsConfigIDs []string `json:"guardrailsConfigIDs,omitempty" yaml:"guardrailsConfigIDs,omitempty"`
+}
+
+type GuardrailsConfig struct {
+    URL       string   `json:"url"       yaml:"url"`
+    ConfigIDs []string `json:"configIDs" yaml:"configIDs"`
+    Model     string   `json:"model"     yaml:"model"`
+    FailMode  string   `json:"failMode"  yaml:"failMode"`  // "deny" | "allow"
+}
+```
+
+The router constructs a single `*http.Client` for the guardrails server, reused across requests:
+
+- **Keep-alive enabled** — persistent connections avoid TCP/TLS handshake per check
+- **`MaxIdleConnsPerHost`** tuned for expected concurrency (matches ext_proc stream count)
+- **No `http.Client.Timeout`** — end-to-end deadline is set per-request via `context.WithTimeout`, not on the client. This matches the `HairpinClientPool` pattern and allows the deadline to account for time already spent in the ext_proc body phase
+- **`http.Transport.DialContext`** timeout of 1s — bounds connection setup independently so a DNS or TCP hang fails fast rather than consuming the full request deadline
+- **Per-request `context.WithTimeout`** of 3s — covers the full round-trip: connection (if not pooled), TLS handshake (if not reused), request write, server processing, and response read. This is the guardrails budget within the 10s ext_proc `message_timeout`. The remaining ~7s covers JSON-RPC parsing, backend resolution, and hairpin init
+
+Client recreated when guardrails config changes (URL or TLS trust pool update). Idle connections from the previous client are closed.
+
+### Internal Architecture
+
+Translation behind a `GuardrailsTransformer` interface. Secret type determines implementation, resolved at config load time.
+
+```go
+// GuardrailsTransformer translates an MCP request into a provider-specific
+// check request body. configIDs is the merged gateway + per-server set.
+type GuardrailsTransformer interface {
+    Transform(req *MCPRequest, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
+}
+```
+
+Router merges config IDs (gateway defaults + per-server, deduplicated) before calling Transform. Transformer selection by Secret type:
+
+```go
+// guardrails/external/nemo  → NeMoTransformer
+// guardrails/external/other → OtherTransformer (future)
+```
+
+Transformer owns the request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
+
+### Component Responsibilities
+
+| Component | Responsibility |
+|-----------|----------------|
+| Controller | Reads/validates guardrails Secret, writes config. Sets MCPServerRegistration NotReady if gateway guardrails missing |
+| Router | Calls guardrails server before routing `tools/call` and elicitation accepts, maps response to Decision |
+| Broker | No involvement |
+| Envoy | No changes |
+
+### Observability
+
+Span attributes on `mcp-router.tool-call`:
+
+| Attribute | Value |
+|-----------|-------|
+| `guardrails.enabled` | `true` / `false` |
+| `guardrails.status` | `success` / `blocked` / `error` |
+| `guardrails.config_ids` | config IDs used |
+| `guardrails.latency_ms` | round-trip time |
+| `guardrails.fail_mode` | `deny` / `allow` |
+
+`Debug` level per check, `Info` for config changes.
+
+## Performance Impact
+
+Synchronous HTTP round-trip in the ext_proc body phase. Hot path — see `docs/design/performance.md`.
+
+- Guardrails call blocks ext_proc response. Envoy holds request body in BUFFERED mode.
+- NeMo performs LLM inference .
+- ext_proc `message_timeout` is 10s total for all body phase processing (parsing, resolution, hairpin init, guardrails).
+- Guardrails per-request deadline: 3s (`context.WithTimeout`), dial timeout: 1s. Leaves ~7s for other ext_proc processing
+- Only `tools/call` and elicitation `accept` affected. Other methods bypass guardrails entirely.
+
+## Security Considerations
+
+- **Fail closed by default** — consistent with invariant #5
+- **Secret validation** — type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`, valid `url`. `configIDs` may be empty for per-server-only policies
+- **Router-only path** — broker never interacts with guardrails
+- **No credential leak** — guardrails Secret contains no upstream MCP credentials. The router does not forward client `Authorization` headers to the guardrails server. NeMo authenticates to its LLM backend via its own `OPENAI_API_KEY`, not client tokens
+- **TLS optional in-cluster** — acceptable for in-cluster communication
+
+## Why the Router
+
+The check requires the parsed JSON-RPC body, the resolved backend server, and the guardrails config. Only the router has all three.
+
+**Alternatives considered:**
+
+- **ext_authz** — operates on headers, not body. Would need router to parse body first, copy into headers for ext_authz second pass. Two filter round-trips, fragile ordering.
+- **Lua/WASM filter** — duplicates the JSON-RPC parser. Two parsers in the same pipeline is a maintenance liability.
+
+The cost is a synchronous round-trip in the hot path. Accepted: guardrails server runs in-cluster, impact scoped to `tools/call` and elicitation `accept` only.
+
+## Future Considerations
+
+### Response Guardrailing
+
+Check `tools/call` responses before they reach the client. Requires response body buffering in ext_proc, different translation mapping, and UX for blocked responses (tool already executed). Deferred.
+
+### Guardrails for Prompts
+
+Check `prompts/get` response content. Same pattern, different translation mapping.
+
+### Circuit Breaker
+
+If the guardrails server degrades (slow but not down), every check eats the full timeout. A circuit breaker tripping after N consecutive failures would fast-fail by applying `failMode` immediately.
+
+### AI Gateway Provider Integration
+
+A provider like Praxis could offer guardrails natively. This design allows for that. The controller would translate `guardrailsRef` into provider-specific resources instead of the router performing translation. CRD field stays the same, Secret type differs per provider (example `type: guardrails/internal/praxis` ).
+
+## Open Questions
+
+### Request-side value for schema-constrained tools
+
+Most MCP tools have typed input schemas. AuthPolicy controls access, input validation handles correctness. Guardrails add clear value for freeform text or arguments passed to downstream models. For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified.
+
+### Should guardrails be on the request path, response path, or both?
+
+Response guardrails (data exfiltration, PII, harmful content) may be more valuable for many use cases. Different cost/value profile. Is request-side sufficient to validate the pattern?
+
+## Execution
+
+See:
+- [tasks/tasks.md](tasks/tasks.md) for the implementation plan (TODO)
+- [tasks/e2e_test_cases.md](tasks/test_cases.md) for E2E test cases
+- [tasks/documentation.md](tasks/documentation.md) for documentation plan

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -4,11 +4,11 @@
 
 > **Note:** examples reference NeMo Guardrails as the initial target.
 
-Guardrails systems don't support MCP natively. Their endpoints (`v1/chat/completions`, `v1/guardrail/checks`) are incompatible with MCP JSON-RPC. Integrating at the router level provides centralized enforcement and consistent protection across all clients.
+Guardrails endpoints are incompatible with MCP JSON-RPC. Guardrails are an important piece of the security landscape for agent based interactions. MCP Servers provide information to agents so it is important to be able to apply policy and govern what can be sent to those agents and their respective LLMs. 
 
 ## Summary
 
-Add a translation layer in the router that intercepts `tools/call` requests and responses, translates them to guardrails checks, and either proceeds or rejects. Request checks run in the ext_proc body phase before routing. Response checks accumulate the response body in a size-capped buffer, parse the JSON-RPC result, and send text content to the guardrails service before releasing to the client. Configuration via Kubernetes Secret referenced from `MCPGatewayExtension` (global) and/or `MCPServerRegistration` (per-server). TLS reuses the gateway's existing CA bundle configuration.
+A new translation layer in the router intercepts `tools/call` requests and responses, translates to guardrails checks, proceeds or rejects. Request checks run in ext_proc body phase before routing. Response checks accumulate the body in a size-capped buffer, parse JSON-RPC, and send text content to guardrails before releasing to the client. Configuration via Secret referenced from MCPGatewayExtension annotation (global). Allow extended policy configs per server via annotation. TLS reuses the gateway's existing CA bundle.
 
 ## Goals
 
@@ -18,6 +18,7 @@ Add a translation layer in the router that intercepts `tools/call` requests and 
 - Fail closed by default, configurable to allow
 - Reuse gateway CA trust pool
 - Target NeMo Guardrails initially
+- Keep the integration light and not part of the core API given it is likely to migrate to its own filter in the future
 
 ## Non-Goals
 
@@ -45,21 +46,15 @@ When MCP servers return data from sensitive systems, tool responses are checked 
 
 Tool calls fail closed by default. `failMode: allow` exists for non-critical servers.
 
-### When the guardrails server uses a private CA
-
-Add the CA to the gateway CA bundle (`caCertBundleRef`). No separate guardrails TLS config.
-
 ## Constraints
 
-### Deployment model
-
-The gateway does not deploy or operate a guardrails instance. A running guardrails server must exist and be reachable before configuring `guardrailsRef`.
+The gateway does not deploy or operate a guardrails instance. A running guardrails server must exist and be reachable.
 
 ## Design
 
 ### Configuration via Secret
 
-Type `guardrails/external/nemo`, following the project's Secret reference pattern (`credentialRef`, `caCertSecretRef`):
+Type `guardrails/external/nemo`, following the project's Secret reference pattern:
 
 ```yaml
 apiVersion: v1
@@ -83,113 +78,99 @@ stringData:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `url` | yes | Guardrails server endpoint |
-| `configIDs` | no | Default config IDs applied to all servers. Empty if per-server `guardrailsConfigIDs` supply policies |
+| `configIDs` | no | Default config IDs for all servers. Empty for per-server-only model |
 | `model` | yes | Model identifier for the guardrails check |
-| `failMode` | no | `deny` (default): reject on failure. `allow`: proceed |
+| `failMode` | no | `deny` (default) or `allow` |
 
-> **Note:** The body buffer size cap (`maxBodyBytes`) is configured at the gateway level on MCPGatewayExtension, not per guardrails config. See API Changes below.
+The Secret type determines which provider validates and parses the content. The controller resolves the type to a provider implementation that exposes a `ValidateConfig()` method, returning a typed config or an error.
 
-> **Note:** TLS uses the gateway's existing CA bundle (`caCertBundleRef`). Add private CAs there.
+TLS uses the gateway's existing CA bundle (`caCertBundleRef`). `maxBodyBytes` is configured on MCPGatewayExtension spec, not per guardrails config.
 
 ### API Changes
 
+Guardrails configuration is an extension to the core API, delivered via annotations rather than spec-level fields. This keeps guardrails decoupled from the CRD schema. See [Alternatives Considered](#alternatives-considered) for the rejected spec-level approach and rationale.
+
 #### MCPGatewayExtension
 
-```go
-type MCPGatewayExtensionSpec struct {
-    // ... existing fields ...
-
-    // guardrailsRef references a Secret of type guardrails/external/nemo.
-    // When set, all tools/call requests are checked before routing.
-    // +optional
-    GuardrailsRef *SecretReference `json:"guardrailsRef,omitempty"`
-
-    // maxBodyBytes is the buffer size cap in bytes for a streamed body 
-    // (request or response) accumulation. Applies to any body the router buffers (prefix
-    // stripping, guardrails inspection). Bodies exceeding this are
-    // rejected with a 413. Default 1 MiB. 
-    // For 2025 protocol the request is sent buffered from Envoy and so this setting defaults
-    // to the default body buffer in Envoy and needs to be controlled via Envoy
-    // +optional
-    MaxBodyBytes *int `json:"maxBodyBytes,omitempty"`
-}
-```
+`mcp.kuadrant.io/guardrails-ref` — Secret name in the same namespace. Validated at reconcile time, not admission.
 
 ```yaml
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway
+  annotations:
+    mcp.kuadrant.io/guardrails-ref: my-guardrails-config
 spec:
   targetRef:
     name: mcp-gateway
     sectionName: mcp
   maxBodyBytes: 1048576  # 1 MiB (default)
-  guardrailsRef:
-    name: my-guardrails-config
+```
+
+`maxBodyBytes` is a spec field — it applies to any body the router buffers (request or response) (prefix stripping, guardrails), not just guardrails.
+
+```go
+type MCPGatewayExtensionSpec struct {
+    // ... existing fields ...
+
+    // +optional
+    MaxBodyBytes *int `json:"maxBodyBytes,omitempty"`
+}
 ```
 
 #### MCPServerRegistration
 
-```go
-type MCPServerRegistrationSpec struct {
-    // ... existing fields ...
-
-    // guardrailsConfigIDs specifies additional config IDs merged with gateway
-    // defaults into a single check request. Requires guardrailsRef on the
-    // MCPGatewayExtension — without it, the server is set to NotReady.
-    // +optional
-    GuardrailsConfigIDs []string `json:"guardrailsConfigIDs,omitempty"`
-}
-```
+`mcp.kuadrant.io/guardrails-config-ids` — comma-separated config IDs merged with gateway defaults. Requires `mcp.kuadrant.io/guardrails-ref` on the MCPGatewayExtension.
 
 ```yaml
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: dangerous-server
+  annotations:
+    mcp.kuadrant.io/guardrails-config-ids: "strict-input-checking,pii-detection"
 spec:
   targetRef:
     name: dangerous-server-route
   prefix: dangerous_
-  guardrailsConfigIDs:
-    - "strict-input-checking"
-    - "pii-detection"
 ```
 
 #### Validation
 
-If `guardrailsConfigIDs` is set but no `guardrailsRef` exists on the MCPGatewayExtension:
+If `guardrails-config-ids` is set but no `guardrails-ref` exists on the MCPGatewayExtension:
 
-1. MCPServerRegistration set to `NotReady` with reason `GuardrailsNotConfigured`
-2. Server removed from gateway config (no tools/list, tool calls fail)
-3. Re-reconciled when `guardrailsRef` is added
+1. MCPServerRegistration set to `NotReady` with reason `GatewayGuardrailsNotConfigured`
+2. Server removed from gateway config
+3. Re-reconciled when the gateway annotation is added
 
 #### Guardrails Secret Deletion
 
-If the guardrails Secret is missing (deleted or never created) while `guardrailsRef` is set:
+If the referenced Secret is missing while the annotation is set:
 
 1. MCPGatewayExtension gets condition `GuardrailsSecretNotFound`
-2. `GlobalGuardrails` is cleared from `mcp-gateway-config`
-3. All MCPServerRegistrations are set to `NotReady` and removed from the gateway
-4. To restore: recreate the Secret or remove `guardrailsRef` from MCPGatewayExtension
+2. `GlobalGuardrails` cleared from `mcp-gateway-config`
+3. All MCPServerRegistrations set to `NotReady` and removed
+4. Restore by recreating the Secret or removing the annotation
 
 #### Resolution Order
 
-One guardrails server per gateway. Per-server config IDs are additive.
+One guardrails server per gateway. Per-server config IDs are additive — they cannot remove gateway defaults. This lets gateway admins enforce org-wide policies via the Secret's `configIDs` while teams add domain-specific rails for their servers.
 
-| Gateway `guardrailsRef` | Server `guardrailsConfigIDs` | Effective Behavior |
+| Gateway `guardrails-ref` | Server `guardrails-config-ids` | Effective Behavior |
 |-------------------------|------------------------------|--------------------|
 | Not set | Not set | No guardrails |
-| Set (with default IDs) | Not set | Gateway defaults applied |
-| Set (empty default IDs) | Not set | No check — per-server-only model |
-| Set (with default IDs) | Set | Gateway defaults + server IDs merged |
-| Set (no default IDs) | Set | Server IDs only |
+| Set (Secret has default IDs) | Not set | Gateway defaults applied |
+| Set (Secret has empty IDs) | Not set | No check — per-server-only model |
+| Set (Secret has default IDs) | Set | Gateway defaults + server IDs merged |
+| Set (Secret has no default IDs) | Set | Server IDs only |
 | Not set | Set | **NotReady** — server removed |
 
 ### Request Flow
 
-Guardrails runs in the router after backend resolution, before the Decision is returned. Applies to `tools/call` and elicitation `accept` responses. Client `Authorization` header is not forwarded to the guardrails server (see Security Considerations).
+Runs after backend resolution, before the Decision is returned. Applies to `tools/call` and elicitation `accept`. Client `Authorization` is not forwarded to the guardrails server.
+
+For `2026-07-28`, request bodies arrive `STREAMED` — the router accumulates chunks bounded by `maxBodyBytes`. For `2025-11-25`, request bodies are already `BUFFERED` by Envoy. Envoy's `per_connection_buffer_limit_bytes` (default 1 MiB) must be >= `maxBodyBytes` for `2025-11-25` clients.
 
 ```mermaid
 sequenceDiagram
@@ -202,7 +183,6 @@ sequenceDiagram
     Client->>Envoy: tools/call (JSON-RPC)
     Envoy->>Router: ext_proc body phase
     Router->>Router: parse JSON-RPC, resolve backend
-    Router->>Router: check guardrails config for server
 
     alt guardrails enabled
         Router->>Guardrails: POST /v1/guardrail/checks
@@ -233,23 +213,25 @@ sequenceDiagram
 
 ### Response Handling
 
-When guardrails are configured, the router sets `ResponseBodyMode` to `FULL_DUPLEX_STREAMED` via `ModeOverride`. Applies to both protocol versions. See [streamed body processing](../router-2026-07-28/streamed-body-processing.md) for the mode override mechanism.
+Response body mode depends on scope:
 
-For `2026-07-28` request bodies (`STREAMED`), the router accumulates chunks before sending to guardrails, bounded by `maxBodyBytes`. For `2025-11-25`, request bodies are already `BUFFERED` by Envoy.
+| Configuration | Response body mode | Mechanism |
+|---------------|-------------------|-----------|
+| Gateway-level (Secret has default config IDs) | `FULL_DUPLEX_STREAMED` permanently | Controller configures ext_proc filter |
+| Per-server only (empty default IDs) | `FULL_DUPLEX_STREAMED` dynamically | Router sets `ModeOverride` only for requests/responses for servers with guardrails |
 
-> **Note:** For `2025-11-25`, Envoy's `per_connection_buffer_limit_bytes` (default 1 MiB) must be >= `maxBodyBytes` — otherwise Envoy rejects before the router sees the request.
-
+See [streamed body processing](../router-2026-07-28/streamed-body-processing.md) for the mode override mechanism. This mirrors how elicitation is handled also.
 
 #### SSE responses (`text/event-stream`)
 
 > **Note:** SSE is [deprecated as of `2026-07-28`](https://blog.modelcontextprotocol.io/posts/2026-07-28/#deprecations) with a year-long offramp.
 
-For `2025-11-25` responses, each SSE event is a complete JSON-RPC message. Per-event processing reuses the `sseRewriter` pattern from `internal/mcp-router/elicitation.go`:
+Per-event processing reuses the `sseRewriter` pattern from `internal/mcp-router/elicitation.go`:
 
-1. Extract `content[].text` from tool results, send to guardrails
-2. On pass: release the event to the client
-3. On block: return error, close stream
-4. If a single event exceeds `maxBodyBytes`: reject with 413
+1. Extract `content[].text`, send to guardrails
+2. On pass: release event
+3. On block: error, close stream
+4. Event exceeds `maxBodyBytes`: 413
 
 #### JSON responses (`application/json`)
 
@@ -272,7 +254,6 @@ sequenceDiagram
         Backend-->>Envoy: SSE event 1
         Envoy->>Router: ResponseBody chunk(s)
         Router->>Router: accumulate until event boundary
-        Router->>Router: parse JSON-RPC, extract text content
         Router->>Guardrails: POST /v1/guardrail/checks
         Guardrails-->>Router: pass
         Router-->>Envoy: release event 1
@@ -290,7 +271,6 @@ sequenceDiagram
         Backend-->>Envoy: response body
         Envoy->>Router: ResponseBody chunks
         Router->>Router: accumulate full body
-        Router->>Router: parse JSON-RPC, extract text content
         Router->>Guardrails: POST /v1/guardrail/checks
         Guardrails-->>Router: verdict
         alt status: success
@@ -303,40 +283,27 @@ sequenceDiagram
     end
 ```
 
-#### Response Translation Mapping (NeMo)
-
-| MCP response field | NeMo field |
-|-------------------|------------|
-| `result.content[].text` (text items only) | `messages[0].content` |
-| tool name (from request context) | `messages[0].name` |
-| N/A | `messages[0].role = "assistant"` |
-| from config | `guardrails.config_ids` |
-| from config | `model` |
-
 #### Response to Decision Mapping
 
 | Outcome | Router action |
 |---------|---------------|
-| `status: "success"` | Release original event/body to client |
+| `status: "success"` | Release original body to client |
 | `status: "modified"` | **Unresolved** — see Open Questions |
 | `status: "blocked"` | Error response, discard buffer, close stream |
-| Event/body exceeds `maxBodyBytes` | 413 error — general resource limit, not guardrails-specific. `failMode` does not apply |
+| Exceeds `maxBodyBytes` | 413. `failMode` does not apply |
 | Non-2xx / timeout | Apply `failMode`: deny → error, allow → release |
 
 ### Translation Mapping (NeMo)
 
-#### MCP `tools/call` to NeMo `v1/guardrail/checks`
+#### Request: `tools/call` → `v1/guardrail/checks`
 
 | MCP field | NeMo field |
 |-----------|------------|
 | `params.name` | `messages[0].name` |
 | `params.arguments` (JSON-encoded) | `messages[0].content` |
 | N/A | `messages[0].role = "user"` |
-| N/A | `messages[0].config = "tool"` |
 | from config | `guardrails.config_ids` |
 | from config | `model` |
-
-Example:
 
 ```json
 {
@@ -355,7 +322,7 @@ Example:
 }
 ```
 
-#### Elicitation `accept` to NeMo
+#### Request: elicitation `accept` → `v1/guardrail/checks`
 
 `decline`/`cancel` bypass guardrails (no user content).
 
@@ -364,28 +331,29 @@ Example:
 | `result.action` | `messages[0].name` |
 | `result` minus `action` (JSON-encoded) | `messages[0].content` |
 | N/A | `messages[0].role = "user"` |
-| N/A | `messages[0].config = "tool"` |
-| from config | `guardrails.config_ids` |
-| from config | `model` |
+| from config | `guardrails.config_ids`, `model` |
 
-#### Response to Decision Mapping
+#### Response: `result` → `v1/guardrail/checks`
+
+| MCP response field | NeMo field |
+|-------------------|------------|
+| `result.content[].text` (text items only) | `messages[0].content` |
+| tool name (from request context) | `messages[0].name` |
+| N/A | `messages[0].role = "assistant"` |
+| from config | `guardrails.config_ids`, `model` |
+
+#### Decision Mapping
 
 | Outcome | Router action |
 |---------|---------------|
-| Translation failure | Always deny with 400. `failMode` does not apply |
-| `status: "success"` | Proceed with routing |
+| Translation failure | Always deny (400). `failMode` does not apply |
+| `status: "success"` | Proceed |
 | `status: "blocked"` | 403 with rails message |
-| Non-2xx HTTP | Apply `failMode`: deny → 503, allow → proceed |
-| Timeout | Apply `failMode`: deny → 503, allow → proceed |
-| Malformed response body | Apply `failMode`: deny → 502, allow → proceed |
-
-### TLS Trust
-
-Reuses the gateway's CA trust pool (system roots + `caCertBundleRef`).
+| Non-2xx / timeout / malformed | Apply `failMode` |
 
 ### Config Propagation
 
-Controller writes resolved guardrails config into `mcp-gateway-config` Secret. Per-server `guardrailsConfigIDs` go into each server entry:
+Controller writes resolved guardrails config into `mcp-gateway-config` Secret:
 
 ```go
 type BrokerConfig struct {
@@ -408,40 +376,35 @@ type GuardrailsConfig struct {
 }
 ```
 
-Single `*http.Client` per guardrails server, reused across requests. Follows the `HairpinClientPool` pattern. Recreated on config change (URL or TLS).
+Single `*http.Client` per guardrails server, following the `HairpinClientPool` pattern. Recreated on config change.
 
 | Setting | Value | Rationale |
 |---------|-------|-----------|
 | Keep-alive | enabled | avoid TCP/TLS per check |
 | `MaxIdleConnsPerHost` | ext_proc stream count | match concurrency |
-| `http.Client.Timeout` | none | per-request `context.WithTimeout` instead |
-| `DialContext` timeout | 1s | fast-fail DNS/TCP hangs |
-| Per-request deadline | 3s | guardrails budget within 10s `message_timeout` |
+| `http.Client.Timeout` | none | per-request `context.WithTimeout` |
+| `DialContext` timeout | 1s | fast-fail DNS/TCP |
+| Per-request deadline | 3s | within 10s `message_timeout` |
 
 ### Internal Architecture
 
-Translation behind a `GuardrailsTransformer` interface. Secret type determines implementation, resolved at config load time.
-
 ```go
-// GuardrailsTransformer translates MCP requests and responses into
-// provider-specific check request bodies. configIDs is the merged
-// gateway + per-server set.
 type GuardrailsTransformer interface {
     TransformRequest(req *MCPRequest, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
     TransformResponse(toolName string, content []byte, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
 }
 ```
 
-Transformer selection by Secret type (`guardrails/external/nemo` → `NeMoTransformer`). Transformer owns the request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
+Secret type determines implementation (`guardrails/external/nemo` → `NeMoTransformer`). Transformer owns request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
 
 ### Component Responsibilities
 
 | Component | Responsibility |
 |-----------|----------------|
 | Controller | Reads/validates guardrails Secret, writes config. Sets MCPServerRegistration NotReady if gateway guardrails missing |
-| Router | Calls guardrails server before routing `tools/call` and elicitation accepts, maps response to Decision |
+| Router | Calls guardrails before routing `tools/call` and elicitation accepts, maps response to Decision |
 | Broker | No involvement |
-| Envoy | `FULL_DUPLEX_STREAMED` response body mode when guardrails configured (set by router via `ModeOverride`) |
+| Envoy | `FULL_DUPLEX_STREAMED` response body mode when guardrails configured |
 
 ### Observability
 
@@ -459,19 +422,19 @@ Span attributes on `mcp-router.tool-call`:
 
 ## Performance Impact
 
-Hot path — see `docs/design/performance.md`. Synchronous HTTP round-trip per check. 3s guardrails budget within the 10s ext_proc `message_timeout`. Response-side: per-event for SSE, full-body for JSON. Bodies exceeding `maxBodyBytes` → 413 regardless of `failMode`.
+Hot path — see `docs/design/performance.md`. Synchronous HTTP round-trip per check. 3s guardrails budget within 10s `message_timeout`. Response-side: per-event for SSE, full-body for JSON. Bodies exceeding `maxBodyBytes` → 413 regardless of `failMode`.
 
 ## Security Considerations
 
 - **Fail closed by default** — consistent with invariant #5
-- **Secret validation** — type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`, valid `url`. `configIDs` may be empty for per-server-only policies
+- **Secret validation** — type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`, valid `url`
 - **Router-only path** — broker never interacts with guardrails
-- **No credential leak** — client `Authorization` not forwarded to guardrails server. NeMo uses its own `OPENAI_API_KEY` for LLM auth
-- **TLS optional in-cluster** — acceptable for in-cluster communication
+- **No credential leak** — client `Authorization` not forwarded to guardrails server
+- **TLS optional in-cluster**
 
 ## Why the Router
 
-Requires parsed JSON-RPC body, resolved backend, and guardrails config. Only the router has all three. Alternatives (`ext_authz`, Lua/WASM) either can't access the body or duplicate the JSON-RPC parser. Cost: synchronous round-trip in the hot path, scoped to `tools/call` and elicitation `accept`.
+Requires parsed JSON-RPC body, resolved backend, and guardrails config. Only the router has all three. Alternatives (`ext_authz`, Lua/WASM) either can't access the body or duplicate the JSON-RPC parser.
 
 ## Future Considerations
 
@@ -481,25 +444,51 @@ Check `prompts/get` response content. Same pattern, different translation mappin
 
 ### Circuit Breaker
 
-If the guardrails server degrades (slow but not down), every check eats the full timeout. A circuit breaker tripping after N consecutive failures would fast-fail by applying `failMode` immediately.
+If the guardrails server degrades, every check eats the full timeout. A circuit breaker tripping after N consecutive failures would fast-fail by applying `failMode` immediately.
+
+### Standalone Guardrails Filter
+
+Guardrails could move out of the router into a separate filter in the request chain with its own CRD and deployment. The annotation-based API avoids blocking this — dropping an annotation is not a breaking change.
 
 ### AI Gateway Provider Integration
 
-A provider like Praxis could offer guardrails natively. CRD field stays the same, Secret type differs per provider (`type: guardrails/internal/praxis`).
+A provider like Praxis could offer guardrails natively. Secret type differs per provider (`type: guardrails/internal/praxis`). If guardrails migrate to a standalone filter, the provider abstraction moves with it.
+
+## Alternatives Considered
+
+### Spec-level `guardrailsRef` field on MCPGatewayExtension
+
+Add `guardrailsRef *SecretReference` to `MCPGatewayExtensionSpec` and `guardrailsConfigIDs []string` to `MCPServerRegistrationSpec`.
+
+```go
+type MCPGatewayExtensionSpec struct {
+    // ... existing fields ...
+    GuardrailsRef *SecretReference `json:"guardrailsRef,omitempty"`
+}
+
+type MCPServerRegistrationSpec struct {
+    // ... existing fields ...
+    GuardrailsConfigIDs []string `json:"guardrailsConfigIDs,omitempty"`
+}
+```
+
+Benefits: schema-validated at admission, discoverable via `kubectl explain`, consistent with `caCertBundleRef`.
+
+**Rejected** — unclear whether guardrails belong permanently in the router and gateway API. The router has the parsed body, resolved backend, and config today, but that is implementation convenience, not ownership. Guardrails could migrate to a separate filter in the request chain with its own CRD. A spec field becomes dead API surface requiring backwards-compatible maintenance. The annotation avoids this.
 
 ## Open Questions
 
 ### Request-side value for schema-constrained tools
 
-Guardrails add clear value for freeform text. For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified — AuthPolicy and input validation already cover access and correctness.
+For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified — AuthPolicy and input validation already cover access and correctness.
 
 ### Modified response handling
 
-NeMo can return `status: "modified"` with altered content (e.g. PII redacted). Should the router replace the original body with the modified content, or release the original?
+NeMo can return `status: "modified"` with altered content (e.g. PII redacted). Should the router replace the original body or release the original?
 
 ### Non-text response content
 
-Only `text` content items are inspected. `image`/`audio` (base64) and `resource` (URI reference) bypass guardrails. PII in screenshots or confidential audio would not be caught. Text-only inspection leaves a gap.
+Only `text` content items are inspected. `image`/`audio` (base64) and `resource` (URI reference) bypass guardrails.
 
 ## Execution
 

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -149,15 +149,14 @@ If `guardrailsConfigIDs` is set but no `guardrailsRef` exists on the MCPGatewayE
 
 #### Guardrails Secret Deletion
 
-If the guardrails Secret is deleted:
+If the guardrails Secret is missing (deleted or never created) while `guardrailsRef` is set:
 
 1. MCPGatewayExtension gets condition `GuardrailsSecretNotFound`
-2. The controller retains the last valid guardrails config in `mcp-gateway-config` — `GlobalGuardrails` is not cleared. The router continues to attempt guardrails checks against the configured URL
-3. All MCPServerRegistrations with `guardrailsConfigIDs` are set to `NotReady` and removed from the gateway
-4. For servers without `guardrailsConfigIDs` (covered by global guardrails only), the guardrails server is now unreachable and `failMode` applies: `deny` (default) rejects tool calls, `allow` proceeds without checks
-5. To disable guardrails entirely, the platform engineer must remove `guardrailsRef` from the MCPGatewayExtension — Secret deletion alone does not disable enforcement
+2. `GlobalGuardrails` is cleared from `mcp-gateway-config`
+3. All MCPServerRegistrations are set to `NotReady` and removed from the gateway
+4. To restore: recreate the Secret or remove `guardrailsRef` from MCPGatewayExtension
 
-This ensures Secret deletion does not silently fail open. The platform engineer's intent (guardrails enabled via `guardrailsRef`) is preserved until explicitly changed. Accidental Secret deletion with `failMode: deny` (the default) blocks tool calls rather than letting unverified requests through.
+This ensures a missing Secret fails closed uniformly. No stale config is retained — there may be no prior config to retain (Secret never created), and retaining a config pointing at an unreachable URL only adds latency before the same outcome.
 
 #### Resolution Order
 

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -8,11 +8,12 @@ Guardrails systems don't support MCP natively. Their endpoints (`v1/chat/complet
 
 ## Summary
 
-Translation layer in the router that intercepts `tools/call` requests, translates them to a guardrails check, and either proceeds or rejects. Configuration via Kubernetes Secret referenced from `MCPGatewayExtension` (global) and/or `MCPServerRegistration` (per-server). TLS reuses the gateway's existing CA bundle.
+Add a translation layer in the router that intercepts `tools/call` requests and responses, translates them to guardrails checks, and either proceeds or rejects. Request checks run in the ext_proc body phase before routing. Response checks accumulate the response body in a size-capped buffer, parse the JSON-RPC result, and send text content to the guardrails service before releasing to the client. Configuration via Kubernetes Secret referenced from `MCPGatewayExtension` (global) and/or `MCPServerRegistration` (per-server). TLS reuses the gateway's existing CA bundle configuration.
 
 ## Goals
 
-- Translate MCP `tools/call` and elicitation responses to guardrails checks
+- Translate MCP `tools/call` requests and elicitation responses to guardrails checks
+- Check `tools/call` response content before it reaches the client
 - Support global and per-server guardrails
 - Fail closed by default, configurable to allow
 - Reuse gateway CA trust pool
@@ -20,7 +21,6 @@ Translation layer in the router that intercepts `tools/call` requests, translate
 
 ## Non-Goals
 
-- Response guardrailing (deferred)
 - Adding MCP awareness to NeMo itself
 
 ## Job Stories
@@ -31,23 +31,29 @@ When a platform engineer deploys MCP servers that interact with sensitive system
 
 ### When I want guardrails on all servers by default
 
-When a platform engineer wants all tool calls checked, they want to configure guardrails once at the gateway level so every server inherits the policy.
+When a platform engineer wants all tool calls checked, they configure guardrails once at the gateway level so every server inherits the policy.
 
-### When I need different guardrails policies per server
+### When I need different or additional guardrails per server
 
-When servers have different risk profiles, the platform engineer wants different config IDs per server so policies match capabilities.
+When servers have different risk profiles, the platform engineer wants per-server config IDs — either replacing or extending the global policy.
 
-### When I want additional guardrails on a specific server
+### When I want to inspect tool responses for sensitive content
 
-When an MCP server accepts freeform input or interacts with a downstream model, the developer wants server-specific policies in addition to global ones.
+When MCP servers return data from sensitive systems, tool responses are checked against guardrails before reaching the client so that PII, secrets, or harmful content in `text` results are caught at the gateway.
 
 ### When the guardrails server is down
 
-When the guardrails server is unreachable, tool calls fail closed by default. For non-critical servers, the option to fail open exists.
+Tool calls fail closed by default. `failMode: allow` exists for non-critical servers.
 
 ### When the guardrails server uses a private CA
 
-When the guardrails server uses a corporate or self-signed CA, the platform engineer adds it to the gateway CA bundle.
+Add the CA to the gateway CA bundle (`caCertBundleRef`). No separate guardrails TLS config.
+
+## Constraints
+
+### Deployment model
+
+The gateway does not deploy or operate a guardrails instance. A running guardrails server must exist and be reachable before configuring `guardrailsRef`.
 
 ## Design
 
@@ -81,6 +87,8 @@ stringData:
 | `model` | yes | Model identifier for the guardrails check |
 | `failMode` | no | `deny` (default): reject on failure. `allow`: proceed |
 
+> **Note:** The body buffer size cap (`maxBodyBytes`) is configured at the gateway level on MCPGatewayExtension, not per guardrails config. See API Changes below.
+
 > **Note:** TLS uses the gateway's existing CA bundle (`caCertBundleRef`). Add private CAs there.
 
 ### API Changes
@@ -95,6 +103,15 @@ type MCPGatewayExtensionSpec struct {
     // When set, all tools/call requests are checked before routing.
     // +optional
     GuardrailsRef *SecretReference `json:"guardrailsRef,omitempty"`
+
+    // maxBodyBytes is the buffer size cap in bytes for a streamed body 
+    // (request or response) accumulation. Applies to any body the router buffers (prefix
+    // stripping, guardrails inspection). Bodies exceeding this are
+    // rejected with a 413. Default 1 MiB. 
+    // For 2025 protocol the request is sent buffered from Envoy and so this setting defaults
+    // to the default body buffer in Envoy and needs to be controlled via Envoy
+    // +optional
+    MaxBodyBytes *int `json:"maxBodyBytes,omitempty"`
 }
 ```
 
@@ -107,6 +124,7 @@ spec:
   targetRef:
     name: mcp-gateway
     sectionName: mcp
+  maxBodyBytes: 1048576  # 1 MiB (default)
   guardrailsRef:
     name: my-guardrails-config
 ```
@@ -156,8 +174,6 @@ If the guardrails Secret is missing (deleted or never created) while `guardrails
 3. All MCPServerRegistrations are set to `NotReady` and removed from the gateway
 4. To restore: recreate the Secret or remove `guardrailsRef` from MCPGatewayExtension
 
-This ensures a missing Secret fails closed uniformly. No stale config is retained — there may be no prior config to retain (Secret never created), and retaining a config pointing at an unreachable URL only adds latency before the same outcome.
-
 #### Resolution Order
 
 One guardrails server per gateway. Per-server config IDs are additive.
@@ -173,9 +189,7 @@ One guardrails server per gateway. Per-server config IDs are additive.
 
 ### Request Flow
 
-Guardrails runs in the router after backend resolution, before the Decision is returned. Applies to `tools/call` and elicitation `accept` responses. If server resolution fails, existing error handling applies — no guardrails check.
-
-**No authorization header forwarding:** The router does not forward the client's `Authorization` header to the guardrails server. NeMo Guardrails does not require client auth — it authenticates to its LLM backend via its own `OPENAI_API_KEY` env var, configured independently on the NeMo server. The guardrails server is deployed without auth enabled (the default) and accessed over in-cluster networking. This avoids exposing client bearer tokens to infrastructure services and keeps credential flows clean: client tokens are for the gateway and upstream MCP servers, not for guardrails.
+Guardrails runs in the router after backend resolution, before the Decision is returned. Applies to `tools/call` and elicitation `accept` responses. Client `Authorization` header is not forwarded to the guardrails server (see Security Considerations).
 
 ```mermaid
 sequenceDiagram
@@ -217,6 +231,98 @@ sequenceDiagram
     end
 ```
 
+### Response Handling
+
+When guardrails are configured, the router sets `ResponseBodyMode` to `FULL_DUPLEX_STREAMED` via `ModeOverride`. Applies to both protocol versions. See [streamed body processing](../router-2026-07-28/streamed-body-processing.md) for the mode override mechanism.
+
+For `2026-07-28` request bodies (`STREAMED`), the router accumulates chunks before sending to guardrails, bounded by `maxBodyBytes`. For `2025-11-25`, request bodies are already `BUFFERED` by Envoy.
+
+> **Note:** For `2025-11-25`, Envoy's `per_connection_buffer_limit_bytes` (default 1 MiB) must be >= `maxBodyBytes` — otherwise Envoy rejects before the router sees the request.
+
+
+#### SSE responses (`text/event-stream`)
+
+> **Note:** SSE is [deprecated as of `2026-07-28`](https://blog.modelcontextprotocol.io/posts/2026-07-28/#deprecations) with a year-long offramp.
+
+For `2025-11-25` responses, each SSE event is a complete JSON-RPC message. Per-event processing reuses the `sseRewriter` pattern from `internal/mcp-router/elicitation.go`:
+
+1. Extract `content[].text` from tool results, send to guardrails
+2. On pass: release the event to the client
+3. On block: return error, close stream
+4. If a single event exceeds `maxBodyBytes`: reject with 413
+
+#### JSON responses (`application/json`)
+
+Accumulate full body (bounded by `maxBodyBytes`), extract `content[].text`, send to guardrails. Only `text` content is inspected — binary and `resource` types bypass (see Open Questions).
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Envoy
+    participant Router
+    participant Guardrails as Guardrails Server
+    participant Backend as MCP Server
+
+    Note over Router: guardrails configured → ResponseBodyMode: FULL_DUPLEX_STREAMED
+
+    Client->>Envoy: tools/call
+    Envoy->>Backend: tools/call (after request guardrails pass)
+
+    alt SSE response
+        Backend-->>Envoy: SSE event 1
+        Envoy->>Router: ResponseBody chunk(s)
+        Router->>Router: accumulate until event boundary
+        Router->>Router: parse JSON-RPC, extract text content
+        Router->>Guardrails: POST /v1/guardrail/checks
+        Guardrails-->>Router: pass
+        Router-->>Envoy: release event 1
+        Envoy-->>Client: SSE event 1
+
+        Backend-->>Envoy: SSE event 2
+        Envoy->>Router: ResponseBody chunk(s)
+        Router->>Router: accumulate until event boundary
+        Router->>Guardrails: POST /v1/guardrail/checks
+        Guardrails-->>Router: blocked
+        Router-->>Envoy: error response
+        Envoy-->>Client: error (stream closed)
+
+    else JSON response
+        Backend-->>Envoy: response body
+        Envoy->>Router: ResponseBody chunks
+        Router->>Router: accumulate full body
+        Router->>Router: parse JSON-RPC, extract text content
+        Router->>Guardrails: POST /v1/guardrail/checks
+        Guardrails-->>Router: verdict
+        alt status: success
+            Router-->>Envoy: release body
+            Envoy-->>Client: response
+        else status: blocked
+            Router-->>Envoy: error response
+            Envoy-->>Client: JSON-RPC error
+        end
+    end
+```
+
+#### Response Translation Mapping (NeMo)
+
+| MCP response field | NeMo field |
+|-------------------|------------|
+| `result.content[].text` (text items only) | `messages[0].content` |
+| tool name (from request context) | `messages[0].name` |
+| N/A | `messages[0].role = "assistant"` |
+| from config | `guardrails.config_ids` |
+| from config | `model` |
+
+#### Response to Decision Mapping
+
+| Outcome | Router action |
+|---------|---------------|
+| `status: "success"` | Release original event/body to client |
+| `status: "modified"` | **Unresolved** — see Open Questions |
+| `status: "blocked"` | Error response, discard buffer, close stream |
+| Event/body exceeds `maxBodyBytes` | 413 error — general resource limit, not guardrails-specific. `failMode` does not apply |
+| Non-2xx / timeout | Apply `failMode`: deny → error, allow → release |
+
 ### Translation Mapping (NeMo)
 
 #### MCP `tools/call` to NeMo `v1/guardrail/checks`
@@ -249,9 +355,9 @@ Example:
 }
 ```
 
-#### Elicitation Response to NeMo
+#### Elicitation `accept` to NeMo
 
-Only `accept` responses are checked (`decline`/`cancel` carry no user content).
+`decline`/`cancel` bypass guardrails (no user content).
 
 | Elicitation field | NeMo field |
 |-------------------|------------|
@@ -272,8 +378,6 @@ Only `accept` responses are checked (`decline`/`cancel` carry no user content).
 | Non-2xx HTTP | Apply `failMode`: deny → 503, allow → proceed |
 | Timeout | Apply `failMode`: deny → 503, allow → proceed |
 | Malformed response body | Apply `failMode`: deny → 502, allow → proceed |
-
-Translation failures (e.g. `params.arguments` not valid JSON) are always denied — `failMode: allow` applies only to guardrails server availability, not untranslatable requests.
 
 ### TLS Trust
 
@@ -300,40 +404,35 @@ type GuardrailsConfig struct {
     URL       string   `json:"url"       yaml:"url"`
     ConfigIDs []string `json:"configIDs" yaml:"configIDs"`
     Model     string   `json:"model"     yaml:"model"`
-    FailMode  string   `json:"failMode"  yaml:"failMode"`  // "deny" | "allow"
+    FailMode  string   `json:"failMode"  yaml:"failMode"` // "deny" | "allow"
 }
 ```
 
-The router constructs a single `*http.Client` for the guardrails server, reused across requests:
+Single `*http.Client` per guardrails server, reused across requests. Follows the `HairpinClientPool` pattern. Recreated on config change (URL or TLS).
 
-- **Keep-alive enabled** — persistent connections avoid TCP/TLS handshake per check
-- **`MaxIdleConnsPerHost`** tuned for expected concurrency (matches ext_proc stream count)
-- **No `http.Client.Timeout`** — end-to-end deadline is set per-request via `context.WithTimeout`, not on the client. This matches the `HairpinClientPool` pattern and allows the deadline to account for time already spent in the ext_proc body phase
-- **`http.Transport.DialContext`** timeout of 1s — bounds connection setup independently so a DNS or TCP hang fails fast rather than consuming the full request deadline
-- **Per-request `context.WithTimeout`** of 3s — covers the full round-trip: connection (if not pooled), TLS handshake (if not reused), request write, server processing, and response read. This is the guardrails budget within the 10s ext_proc `message_timeout`. The remaining ~7s covers JSON-RPC parsing, backend resolution, and hairpin init
-
-Client recreated when guardrails config changes (URL or TLS trust pool update). Idle connections from the previous client are closed.
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| Keep-alive | enabled | avoid TCP/TLS per check |
+| `MaxIdleConnsPerHost` | ext_proc stream count | match concurrency |
+| `http.Client.Timeout` | none | per-request `context.WithTimeout` instead |
+| `DialContext` timeout | 1s | fast-fail DNS/TCP hangs |
+| Per-request deadline | 3s | guardrails budget within 10s `message_timeout` |
 
 ### Internal Architecture
 
 Translation behind a `GuardrailsTransformer` interface. Secret type determines implementation, resolved at config load time.
 
 ```go
-// GuardrailsTransformer translates an MCP request into a provider-specific
-// check request body. configIDs is the merged gateway + per-server set.
+// GuardrailsTransformer translates MCP requests and responses into
+// provider-specific check request bodies. configIDs is the merged
+// gateway + per-server set.
 type GuardrailsTransformer interface {
-    Transform(req *MCPRequest, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
+    TransformRequest(req *MCPRequest, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
+    TransformResponse(toolName string, content []byte, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
 }
 ```
 
-Router merges config IDs (gateway defaults + per-server, deduplicated) before calling Transform. Transformer selection by Secret type:
-
-```go
-// guardrails/external/nemo  → NeMoTransformer
-// guardrails/external/other → OtherTransformer (future)
-```
-
-Transformer owns the request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
+Transformer selection by Secret type (`guardrails/external/nemo` → `NeMoTransformer`). Transformer owns the request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
 
 ### Component Responsibilities
 
@@ -342,7 +441,7 @@ Transformer owns the request body shape. Router owns HTTP call, timeout, TLS, fa
 | Controller | Reads/validates guardrails Secret, writes config. Sets MCPServerRegistration NotReady if gateway guardrails missing |
 | Router | Calls guardrails server before routing `tools/call` and elicitation accepts, maps response to Decision |
 | Broker | No involvement |
-| Envoy | No changes |
+| Envoy | `FULL_DUPLEX_STREAMED` response body mode when guardrails configured (set by router via `ModeOverride`) |
 
 ### Observability
 
@@ -360,38 +459,21 @@ Span attributes on `mcp-router.tool-call`:
 
 ## Performance Impact
 
-Synchronous HTTP round-trip in the ext_proc body phase. Hot path — see `docs/design/performance.md`.
-
-- Guardrails call blocks ext_proc response. Envoy holds request body in BUFFERED mode.
-- NeMo performs LLM inference .
-- ext_proc `message_timeout` is 10s total for all body phase processing (parsing, resolution, hairpin init, guardrails).
-- Guardrails per-request deadline: 3s (`context.WithTimeout`), dial timeout: 1s. Leaves ~7s for other ext_proc processing
-- Only `tools/call` and elicitation `accept` affected. Other methods bypass guardrails entirely.
+Hot path — see `docs/design/performance.md`. Synchronous HTTP round-trip per check. 3s guardrails budget within the 10s ext_proc `message_timeout`. Response-side: per-event for SSE, full-body for JSON. Bodies exceeding `maxBodyBytes` → 413 regardless of `failMode`.
 
 ## Security Considerations
 
 - **Fail closed by default** — consistent with invariant #5
 - **Secret validation** — type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`, valid `url`. `configIDs` may be empty for per-server-only policies
 - **Router-only path** — broker never interacts with guardrails
-- **No credential leak** — guardrails Secret contains no upstream MCP credentials. The router does not forward client `Authorization` headers to the guardrails server. NeMo authenticates to its LLM backend via its own `OPENAI_API_KEY`, not client tokens
+- **No credential leak** — client `Authorization` not forwarded to guardrails server. NeMo uses its own `OPENAI_API_KEY` for LLM auth
 - **TLS optional in-cluster** — acceptable for in-cluster communication
 
 ## Why the Router
 
-The check requires the parsed JSON-RPC body, the resolved backend server, and the guardrails config. Only the router has all three.
-
-**Alternatives considered:**
-
-- **ext_authz** — operates on headers, not body. Would need router to parse body first, copy into headers for ext_authz second pass. Two filter round-trips, fragile ordering.
-- **Lua/WASM filter** — duplicates the JSON-RPC parser. Two parsers in the same pipeline is a maintenance liability.
-
-The cost is a synchronous round-trip in the hot path. Accepted: guardrails server runs in-cluster, impact scoped to `tools/call` and elicitation `accept` only.
+Requires parsed JSON-RPC body, resolved backend, and guardrails config. Only the router has all three. Alternatives (`ext_authz`, Lua/WASM) either can't access the body or duplicate the JSON-RPC parser. Cost: synchronous round-trip in the hot path, scoped to `tools/call` and elicitation `accept`.
 
 ## Future Considerations
-
-### Response Guardrailing
-
-Check `tools/call` responses before they reach the client. Requires response body buffering in ext_proc, different translation mapping, and UX for blocked responses (tool already executed). Deferred.
 
 ### Guardrails for Prompts
 
@@ -403,21 +485,25 @@ If the guardrails server degrades (slow but not down), every check eats the full
 
 ### AI Gateway Provider Integration
 
-A provider like Praxis could offer guardrails natively. This design allows for that. The controller would translate `guardrailsRef` into provider-specific resources instead of the router performing translation. CRD field stays the same, Secret type differs per provider (example `type: guardrails/internal/praxis` ).
+A provider like Praxis could offer guardrails natively. CRD field stays the same, Secret type differs per provider (`type: guardrails/internal/praxis`).
 
 ## Open Questions
 
 ### Request-side value for schema-constrained tools
 
-Most MCP tools have typed input schemas. AuthPolicy controls access, input validation handles correctness. Guardrails add clear value for freeform text or arguments passed to downstream models. For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified.
+Guardrails add clear value for freeform text. For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified — AuthPolicy and input validation already cover access and correctness.
 
-### Should guardrails be on the request path, response path, or both?
+### Modified response handling
 
-Response guardrails (data exfiltration, PII, harmful content) may be more valuable for many use cases. Different cost/value profile. Is request-side sufficient to validate the pattern?
+NeMo can return `status: "modified"` with altered content (e.g. PII redacted). Should the router replace the original body with the modified content, or release the original?
+
+### Non-text response content
+
+Only `text` content items are inspected. `image`/`audio` (base64) and `resource` (URI reference) bypass guardrails. PII in screenshots or confidential audio would not be caught. Text-only inspection leaves a gap.
 
 ## Execution
 
 See:
 - [tasks/tasks.md](tasks/tasks.md) for the implementation plan (TODO)
-- [tasks/e2e_test_cases.md](tasks/test_cases.md) for E2E test cases
+- [tasks/test_cases.md](tasks/test_cases.md) for E2E test cases
 - [tasks/documentation.md](tasks/documentation.md) for documentation plan

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -290,7 +290,7 @@ sequenceDiagram
 | Outcome | Router action |
 |---------|---------------|
 | `status: "success"` | Release original body to client |
-| `status: "modified"` | **Unresolved** — see Open Questions |
+| `status: "modified"` | Forward modified content to client, log status at `Debug` level. Body logging is NeMo's responsibility |
 | `status: "blocked"` | Error response, discard buffer, close stream |
 | Exceeds `maxBodyBytes` | 413. `failMode` does not apply |
 | Non-2xx / timeout | Apply `failMode`: deny → error, allow → release |
@@ -390,14 +390,17 @@ Single `*http.Client` per guardrails server, following the `HairpinClientPool` p
 
 ### Internal Architecture
 
+All guardrails logic lives in `internal/guardrails/`, isolated from router internals. The router depends on a single `Checker` interface — it never imports guardrails internals. This keeps the extraction path to a standalone filter clean: one call site to rewire.
+
 ```go
-type GuardrailsTransformer interface {
-    TransformRequest(req *MCPRequest, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
-    TransformResponse(toolName string, content []byte, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
+// internal/guardrails/checker.go — the only type the router sees
+type Checker interface {
+    CheckRequest(ctx context.Context, toolName string, arguments json.RawMessage, configIDs []string) (*Decision, error)
+    CheckResponse(ctx context.Context, toolName string, content []byte, configIDs []string) (*Decision, error)
 }
 ```
 
-Secret type determines implementation (`guardrails/external/nemo` → `NeMoTransformer`). Transformer owns request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
+`Checker` owns HTTP transport, timeout, TLS, fail mode, config ID merging, and provider translation. Secret type determines the `Transformer` implementation internally (`guardrails/external/nemo` → `NeMoTransformer`).
 
 ### Component Responsibilities
 
@@ -483,10 +486,6 @@ Benefits: schema-validated at admission, discoverable via `kubectl explain`, con
 ### Request-side value for schema-constrained tools
 
 For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified — AuthPolicy and input validation already cover access and correctness.
-
-### Modified response handling
-
-NeMo can return `status: "modified"` with altered content (e.g. PII redacted). Should the router replace the original body or release the original?
 
 ### Non-text response content
 

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -494,6 +494,5 @@ Only `text` content items are inspected. `image`/`audio` (base64) and `resource`
 ## Execution
 
 See:
-- [tasks/tasks.md](tasks/tasks.md) for the implementation plan (TODO)
 - [tasks/test_cases.md](tasks/test_cases.md) for E2E test cases
 - [tasks/documentation.md](tasks/documentation.md) for documentation plan

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -78,7 +78,7 @@ stringData:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `url` | yes | Guardrails server endpoint |
-| `configIDs` | no | Default config IDs for all servers. Empty for per-server-only model |
+| `configIDs` | no | Default config IDs applied to all servers |
 | `model` | yes | Model identifier for the guardrails check |
 | `failMode` | no | `deny` (default) or `allow` |
 
@@ -155,13 +155,15 @@ If the referenced Secret is missing while the annotation is set:
 
 #### Resolution Order
 
-One guardrails server per gateway. Per-server config IDs are additive — they cannot remove gateway defaults. This lets gateway admins enforce org-wide policies via the Secret's `configIDs` while teams add domain-specific rails for their servers.
+One guardrails server per gateway. Per-server config IDs are additive — they cannot remove global guardrails policies. This lets gateway admins enforce org-wide policies via the Secret's `configIDs` while teams add domain-specific per-server guardrails policies for their servers.
 
-| Gateway `guardrails-ref` | Server `guardrails-config-ids` | Effective Behavior |
+When merging, global guardrails policy config IDs are listed first, followed by per-server guardrails policy config IDs. This ensures global policies evaluate before server-specific ones.
+
+| Global Guardrails Policy (`guardrails-ref`) | Per-Server Guardrails Policy (`guardrails-config-ids`) | Effective Behavior |
 |-------------------------|------------------------------|--------------------|
 | Not set | Not set | No guardrails |
 | Set (Secret has default IDs) | Not set | Gateway defaults applied |
-| Set (Secret has empty IDs) | Not set | No check — per-server-only model |
+| Set (Secret has empty IDs) | Not set | No check |
 | Set (Secret has default IDs) | Set | Gateway defaults + server IDs merged |
 | Set (Secret has no default IDs) | Set | Server IDs only |
 | Not set | Set | **NotReady** — server removed |

--- a/docs/design/guardrails/tasks/documentation.md
+++ b/docs/design/guardrails/tasks/documentation.md
@@ -1,0 +1,76 @@
+# Guardrails Integration — Documentation Plan
+
+Documentation for guardrails integration, organized by user goals.
+
+## User-Facing Guide (`docs/guides/guardrails.md`)
+
+### When I want to protect tool calls with guardrails
+
+When a platform engineer wants to enforce safety policies on MCP tool calls, they want to configure a guardrails server and apply it to their gateway so that all tool calls are checked before reaching backends.
+
+**Cover:**
+- Creating the guardrails Secret (type `guardrails/external/nemo`, required label)
+- Setting `guardrailsRef` on MCPGatewayExtension
+- Configuring `configIDs`, `model`, `failMode`
+- Verifying guardrails are active (test a blocked call)
+
+### When I want per-server guardrails policies
+
+When a platform engineer or MCP server developer wants different guardrails policies for specific servers, they want to add server-level config IDs alongside the global policy.
+
+**Cover:**
+- Setting `guardrailsConfigIDs` on MCPServerRegistration (not `guardrailsRef`)
+- Additive behavior: global + per-server config IDs merged into a single request
+- Per-server-only model: gateway `guardrailsRef` with empty `configIDs`, servers supply their own
+- Requirement: `guardrailsRef` must exist on MCPGatewayExtension — without it, server is NotReady
+- YAML examples showing combined configuration
+
+### When I want to understand fail modes
+
+When a platform engineer wants to decide how the gateway behaves when the guardrails server is down, they want to understand the trade-offs between fail-closed and fail-open.
+
+**Cover:**
+- `failMode: deny` (default) — tool calls rejected when guardrails unreachable
+- `failMode: allow` — tool calls proceed without guardrails check
+- Translation failures always denied regardless of `failMode`
+- Consistency with ext_proc `failure_mode_allow` invariant
+
+### When I need TLS trust for the guardrails server
+
+When a platform engineer deploys the guardrails server behind a private CA, they want to configure TLS trust.
+
+**Cover:**
+- Adding the guardrails server CA to the gateway CA bundle (`caCertBundleRef`)
+- No separate CA configuration needed
+- Non-TLS acceptable for in-cluster communication (log warning emitted)
+
+## API Reference Updates
+
+### `docs/reference/mcpgatewayextension.md`
+
+**Cover:**
+- `guardrailsRef` field (optional, SecretReference)
+- Secret requirements: type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`
+- Secret key: `config.yaml` (url, configIDs, model, failMode)
+- `configIDs` is optional — may be empty for per-server-only policies
+
+### `docs/reference/mcpserverregistration.md`
+
+**Cover:**
+- `guardrailsConfigIDs` field (optional, list of strings)
+- Additive to global guardrails config IDs, merged into single request
+- Requires `guardrailsRef` on MCPGatewayExtension — NotReady without it
+
+## Security Architecture Update (`docs/design/security-architecture.md`)
+
+### When I need to understand guardrails in the security model
+
+When a contributor needs to understand how guardrails fits into the security architecture, they want to know the trust boundaries and invariants.
+
+**Cover:**
+- Guardrails is router-only (broker not involved)
+- Router does not forward client `Authorization` headers to the guardrails server — NeMo authenticates to its LLM backend via its own `OPENAI_API_KEY`, not client tokens
+- Guardrails server deployed without auth (NeMo default), accessed over in-cluster networking
+- Fail-closed default consistent with ext_proc failure mode
+- No credential leak — guardrails Secret has no access to `credentialRef`, client tokens not exposed to guardrails infrastructure
+- One guardrails server per gateway

--- a/docs/design/guardrails/tasks/documentation.md
+++ b/docs/design/guardrails/tasks/documentation.md
@@ -35,6 +35,17 @@ When the guardrails server may become unavailable, a platform engineer configuri
 - Translation failures always denied regardless of `failMode`
 - Consistency with ext_proc `failure_mode_allow` invariant
 
+### When I need to configure body size limits
+
+When a platform engineer is configuring the gateway for large tool payloads or response bodies, they want to understand the relationship between the gateway's `maxBodyBytes` and Envoy's `per_connection_buffer_limit_bytes` so that requests are not rejected unexpectedly.
+
+**Cover:**
+- `maxBodyBytes` on MCPGatewayExtension (default 1 MiB) — controls router-side buffer for streamed body accumulation
+- For `2025-11-25` clients: Envoy's `per_connection_buffer_limit_bytes` (default 1 MiB) must be equal to or larger than `maxBodyBytes`, otherwise Envoy rejects the request before the router sees it
+- For `2026-07-28` clients: request body is streamed, `maxBodyBytes` is the only limit
+- Response bodies: `maxBodyBytes` applies per SSE event (not per stream) or per JSON body
+- How to increase: set `maxBodyBytes` on MCPGatewayExtension, and for 2025 clients also adjust the Envoy listener buffer via EnvoyFilter or Gateway API policy
+
 ### When I need TLS trust for the guardrails server
 
 When the guardrails server uses a corporate or self-signed CA, a platform engineer setting up secure communication wants to configure TLS trust so that the gateway can reach the guardrails server over HTTPS.
@@ -50,6 +61,7 @@ When the guardrails server uses a corporate or self-signed CA, a platform engine
 
 **Cover:**
 - `guardrailsRef` field (optional, SecretReference)
+- `maxBodyBytes` field (optional, default 1 MiB) — buffer size cap for streamed body accumulation
 - Secret requirements: type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`
 - Secret key: `config.yaml` (url, configIDs, model, failMode)
 - `configIDs` is optional — may be empty for per-server-only policies

--- a/docs/design/guardrails/tasks/documentation.md
+++ b/docs/design/guardrails/tasks/documentation.md
@@ -6,7 +6,7 @@ Documentation for guardrails integration, organized by user goals.
 
 ### When I want to protect tool calls with guardrails
 
-When a platform engineer wants to enforce safety policies on MCP tool calls, they want to configure a guardrails server and apply it to their gateway so that all tool calls are checked before reaching backends.
+When MCP servers interact with sensitive systems, a platform engineer deploying a gateway wants to configure a guardrails server and apply it to their gateway so that dangerous tool calls are rejected before reaching backends.
 
 **Cover:**
 - Creating the guardrails Secret (type `guardrails/external/nemo`, required label)
@@ -16,7 +16,7 @@ When a platform engineer wants to enforce safety policies on MCP tool calls, the
 
 ### When I want per-server guardrails policies
 
-When a platform engineer or MCP server developer wants different guardrails policies for specific servers, they want to add server-level config IDs alongside the global policy.
+When servers have different risk profiles, a platform engineer or MCP server developer managing multiple servers wants to add server-level config IDs alongside the global policy so that each server's guardrails match its capabilities.
 
 **Cover:**
 - Setting `guardrailsConfigIDs` on MCPServerRegistration (not `guardrailsRef`)
@@ -27,7 +27,7 @@ When a platform engineer or MCP server developer wants different guardrails poli
 
 ### When I want to understand fail modes
 
-When a platform engineer wants to decide how the gateway behaves when the guardrails server is down, they want to understand the trade-offs between fail-closed and fail-open.
+When the guardrails server may become unavailable, a platform engineer configuring gateway resilience wants to understand the trade-offs between fail-closed and fail-open so that they can choose the right policy for their risk tolerance.
 
 **Cover:**
 - `failMode: deny` (default) — tool calls rejected when guardrails unreachable
@@ -37,7 +37,7 @@ When a platform engineer wants to decide how the gateway behaves when the guardr
 
 ### When I need TLS trust for the guardrails server
 
-When a platform engineer deploys the guardrails server behind a private CA, they want to configure TLS trust.
+When the guardrails server uses a corporate or self-signed CA, a platform engineer setting up secure communication wants to configure TLS trust so that the gateway can reach the guardrails server over HTTPS.
 
 **Cover:**
 - Adding the guardrails server CA to the gateway CA bundle (`caCertBundleRef`)
@@ -65,7 +65,7 @@ When a platform engineer deploys the guardrails server behind a private CA, they
 
 ### When I need to understand guardrails in the security model
 
-When a contributor needs to understand how guardrails fits into the security architecture, they want to know the trust boundaries and invariants.
+When reviewing or extending the security architecture, a contributor working on the gateway wants to understand guardrails trust boundaries and invariants so that changes preserve the security model.
 
 **Cover:**
 - Guardrails is router-only (broker not involved)

--- a/docs/design/guardrails/tasks/documentation.md
+++ b/docs/design/guardrails/tasks/documentation.md
@@ -10,8 +10,8 @@ When MCP servers interact with sensitive systems, a platform engineer deploying 
 
 **Cover:**
 - Creating the guardrails Secret (type `guardrails/external/nemo`, required label)
-- Setting `guardrailsRef` on MCPGatewayExtension
-- Configuring `configIDs`, `model`, `failMode`
+- Setting `mcp.kuadrant.io/guardrails-ref` annotation on MCPGatewayExtension
+- Configuring `configIDs`, `model`, `failMode` in the Secret
 - Verifying guardrails are active (test a blocked call)
 
 ### When I want per-server guardrails policies
@@ -19,10 +19,10 @@ When MCP servers interact with sensitive systems, a platform engineer deploying 
 When servers have different risk profiles, a platform engineer or MCP server developer managing multiple servers wants to add server-level config IDs alongside the global policy so that each server's guardrails match its capabilities.
 
 **Cover:**
-- Setting `guardrailsConfigIDs` on MCPServerRegistration (not `guardrailsRef`)
-- Additive behavior: global + per-server config IDs merged into a single request
-- Per-server-only model: gateway `guardrailsRef` with empty `configIDs`, servers supply their own
-- Requirement: `guardrailsRef` must exist on MCPGatewayExtension — without it, server is NotReady
+- Setting `mcp.kuadrant.io/guardrails-config-ids` annotation on MCPServerRegistration
+- This annotation is an extension only — it requires `mcp.kuadrant.io/guardrails-ref` on the MCPGatewayExtension. Without a gateway-level guardrails config, the server is set to NotReady
+- Additive behavior: per-server IDs are merged with gateway defaults, they cannot remove org-wide policies
+- Per-server-only model: gateway annotation with empty `configIDs` in Secret, servers supply their own
 - YAML examples showing combined configuration
 
 ### When I want to understand fail modes
@@ -60,18 +60,19 @@ When the guardrails server uses a corporate or self-signed CA, a platform engine
 ### `docs/reference/mcpgatewayextension.md`
 
 **Cover:**
-- `guardrailsRef` field (optional, SecretReference)
-- `maxBodyBytes` field (optional, default 1 MiB) — buffer size cap for streamed body accumulation
+- `mcp.kuadrant.io/guardrails-ref` annotation (Secret name in same namespace)
+- `maxBodyBytes` spec field (optional, default 1 MiB) — buffer size cap for streamed body accumulation
 - Secret requirements: type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`
 - Secret key: `config.yaml` (url, configIDs, model, failMode)
-- `configIDs` is optional — may be empty for per-server-only policies
+- Annotation-based: not visible via `kubectl explain`, validated at reconcile time
 
 ### `docs/reference/mcpserverregistration.md`
 
 **Cover:**
-- `guardrailsConfigIDs` field (optional, list of strings)
-- Additive to global guardrails config IDs, merged into single request
-- Requires `guardrailsRef` on MCPGatewayExtension — NotReady without it
+- `mcp.kuadrant.io/guardrails-config-ids` annotation (comma-separated config IDs)
+- Extension only — not standalone. Requires `mcp.kuadrant.io/guardrails-ref` on MCPGatewayExtension
+- Additive to gateway config IDs, cannot override or remove gateway defaults
+- NotReady if gateway guardrails annotation is absent
 
 ## Security Architecture Update (`docs/design/security-architecture.md`)
 

--- a/docs/design/guardrails/tasks/documentation.md
+++ b/docs/design/guardrails/tasks/documentation.md
@@ -16,13 +16,12 @@ When MCP servers interact with sensitive systems, a platform engineer deploying 
 
 ### When I want per-server guardrails policies
 
-When servers have different risk profiles, a platform engineer or MCP server developer managing multiple servers wants to add server-level config IDs alongside the global policy so that each server's guardrails match its capabilities.
+When servers have different risk profiles, a platform engineer or MCP server developer managing multiple servers wants to add per-server guardrails policy config IDs alongside the global guardrails policy so that each server's guardrails match its capabilities.
 
 **Cover:**
 - Setting `mcp.kuadrant.io/guardrails-config-ids` annotation on MCPServerRegistration
 - This annotation is an extension only — it requires `mcp.kuadrant.io/guardrails-ref` on the MCPGatewayExtension. Without a gateway-level guardrails config, the server is set to NotReady
-- Additive behavior: per-server IDs are merged with gateway defaults, they cannot remove org-wide policies
-- Per-server-only model: gateway annotation with empty `configIDs` in Secret, servers supply their own
+- Additive behavior: per-server guardrails policy IDs are merged with global guardrails policy defaults (global first, then per-server), they cannot remove org-wide policies
 - YAML examples showing combined configuration
 
 ### When I want to understand fail modes

--- a/docs/design/guardrails/tasks/test_cases.md
+++ b/docs/design/guardrails/tasks/test_cases.md
@@ -1,0 +1,90 @@
+## Guardrails Integration Test Cases
+
+---
+test_suite: guardrails_test.go
+tags: Happy,Guardrails
+---
+
+> **Note:** E2E tests require a mock guardrails server (deployed in `tests/servers/`) implementing `v1/guardrail/checks` with configurable pass/block responses.
+
+## E2E Tests
+
+### [Happy,Guardrails] Global guardrails blocks a dangerous tool call
+
+- When an MCPGatewayExtension is configured with `guardrailsRef` and a client makes a `tools/call` with arguments that trigger a block, the gateway should return a JSON-RPC error with a 403 status. The request should never reach the backend MCP server.
+
+### [Happy,Guardrails] Global guardrails allows a safe tool call
+
+- When an MCPGatewayExtension is configured with `guardrailsRef` and a client makes a `tools/call` with arguments that pass the guardrails check, the request should be routed to the backend and the tool result returned.
+
+### [Happy,Guardrails] Per-server guardrailsConfigIDs merged with global defaults
+
+- When an MCPGatewayExtension has `guardrailsRef` with default config IDs and an MCPServerRegistration specifies additional `guardrailsConfigIDs`, tool calls to that server should be checked with all config IDs merged into a single request. Tool calls to other servers should use only gateway defaults.
+
+### [Guardrails] Per-server guardrailsConfigIDs override when global has no default IDs
+
+- When an MCPGatewayExtension has `guardrailsRef` with empty `configIDs` and an MCPServerRegistration specifies `guardrailsConfigIDs`, tool calls to that server should be checked with only the per-server config IDs. Other servers should not trigger a guardrails check.
+
+### [Guardrails] Guardrails server unreachable — failMode deny
+
+- When the guardrails server is unreachable and `failMode: deny` (default), tool calls should be rejected with a 503 JSON-RPC error.
+
+### [Guardrails] Guardrails server unreachable — failMode allow
+
+- When the guardrails server is unreachable and `failMode: allow`, tool calls should proceed to the backend as if guardrails were not configured.
+
+### [Guardrails] Server without guardrails unaffected by global config
+
+- When an MCPGatewayExtension has `guardrailsRef` set, servers whose tool calls pass the check should work identically to the non-guardrails case.
+
+### [Guardrails] Elicitation accept response checked by guardrails
+
+- When guardrails are configured and a client sends an elicitation `accept` response, the router should check it against the guardrails server. A blocked response should return a JSON-RPC error.
+
+### [Guardrails,Security] Client Authorization header not forwarded to guardrails server
+
+- When guardrails are configured and a client makes an authenticated `tools/call` with an `Authorization` header, the router should not forward the client's `Authorization` header to the guardrails server. The mock guardrails server should receive the check request without any `Authorization` header.
+
+### [Guardrails,Security] Guardrails Secret deletion fails closed for globally guarded servers
+
+- When an MCPGatewayExtension has `guardrailsRef` with `failMode: deny` and the guardrails Secret is deleted, tool calls to servers covered by global guardrails (no `guardrailsConfigIDs`) should be rejected with a 503 JSON-RPC error. The router retains the last valid config and the guardrails server is unreachable.
+
+## Controller Integration Tests (envtest)
+
+### guardrailsConfigIDs without global guardrailsRef sets NotReady
+
+- When an MCPServerRegistration specifies `guardrailsConfigIDs` but the MCPGatewayExtension has no `guardrailsRef`, the controller should set the MCPServerRegistration to NotReady with reason `GuardrailsNotConfigured`. When `guardrailsRef` is later added, the server should become Ready.
+
+### Invalid guardrails Secret — MCPGatewayExtension reports error
+
+- When `guardrailsRef` references a Secret that does not exist, lacks the required label, or has the wrong type, the MCPGatewayExtension should report a status condition with an appropriate error.
+
+### Guardrails Secret update triggers config reload
+
+- When the guardrails Secret is updated (e.g. changing `configIDs` or `url`), the controller should detect the change, re-validate, and write the updated config to `mcp-gateway-config`.
+
+### Guardrails Secret deletion retains config and sets registrations NotReady
+
+- When the guardrails Secret is deleted, the controller should retain the last valid guardrails config in `mcp-gateway-config` (not clear `GlobalGuardrails`), set MCPGatewayExtension condition to `GuardrailsSecretNotFound`, and set all MCPServerRegistrations with `guardrailsConfigIDs` to NotReady. Recreating the Secret should restore normal operation.
+
+### Guardrails Secret deletion — globally guarded servers fail closed
+
+- When the guardrails Secret is deleted and a server has no `guardrailsConfigIDs` (covered by global guardrails only with `failMode: deny`), tool calls to that server should be rejected with 503 because the guardrails server is unreachable and the retained config enforces `failMode: deny`. The server should remain in `tools/list` (it is not set to NotReady).
+
+## Unit Tests
+
+### Multiple configIDs sent in single request
+
+- When the guardrails config specifies multiple `configIDs`, the transformer should produce a single request body with all IDs in the `config_ids` array.
+
+### Translation failure returns error
+
+- When `params.arguments` is not valid JSON, Transform should return an error. The router should map this to a 400 Decision.Error regardless of `failMode`.
+
+### Elicitation decline/cancel bypass guardrails
+
+- When the router receives an elicitation `decline` or `cancel` response, it should skip the guardrails check and proceed to routing.
+
+### Config ID merging and deduplication
+
+- When gateway defaults and per-server config IDs overlap, the merged slice passed to Transform should be deduplicated.

--- a/docs/design/guardrails/tasks/test_cases.md
+++ b/docs/design/guardrails/tasks/test_cases.md
@@ -33,9 +33,9 @@ tags: Happy,Guardrails
 
 - When the guardrails server is unreachable and `failMode: allow`, tool calls should proceed to the backend as if guardrails were not configured.
 
-### [Guardrails] Server without guardrails unaffected by global config
+### [Guardrails] Global guardrails allows tool call that passes check
 
-- When an MCPGatewayExtension has `guardrailsRef` set, servers whose tool calls pass the check should work identically to the non-guardrails case.
+- When an MCPGatewayExtension has `guardrailsRef` set and a server has no per-server `guardrailsConfigIDs`, a tool call with arguments that pass the global guardrails check should be routed to the backend and the tool result returned.
 
 ### [Guardrails] Elicitation accept response checked by guardrails
 
@@ -45,9 +45,9 @@ tags: Happy,Guardrails
 
 - When guardrails are configured and a client makes an authenticated `tools/call` with an `Authorization` header, the router should not forward the client's `Authorization` header to the guardrails server. The mock guardrails server should receive the check request without any `Authorization` header.
 
-### [Guardrails,Security] Guardrails Secret deletion fails closed for globally guarded servers
+### [Guardrails,Security] Guardrails Secret deletion fails closed
 
-- When an MCPGatewayExtension has `guardrailsRef` with `failMode: deny` and the guardrails Secret is deleted, tool calls to servers covered by global guardrails (no `guardrailsConfigIDs`) should be rejected with a 503 JSON-RPC error. The router retains the last valid config and the guardrails server is unreachable.
+- When an MCPGatewayExtension has `guardrailsRef` and the guardrails Secret is deleted, `GlobalGuardrails` should be cleared from `mcp-gateway-config`, all MCPServerRegistrations should be set to NotReady and removed from the gateway config. Tool calls should fail because no tools are available.
 
 ## Controller Integration Tests (envtest)
 
@@ -63,13 +63,9 @@ tags: Happy,Guardrails
 
 - When the guardrails Secret is updated (e.g. changing `configIDs` or `url`), the controller should detect the change, re-validate, and write the updated config to `mcp-gateway-config`.
 
-### Guardrails Secret deletion retains config and sets registrations NotReady
+### Guardrails Secret deletion clears config and sets all registrations NotReady
 
-- When the guardrails Secret is deleted, the controller should retain the last valid guardrails config in `mcp-gateway-config` (not clear `GlobalGuardrails`), set MCPGatewayExtension condition to `GuardrailsSecretNotFound`, and set all MCPServerRegistrations with `guardrailsConfigIDs` to NotReady. Recreating the Secret should restore normal operation.
-
-### Guardrails Secret deletion — globally guarded servers fail closed
-
-- When the guardrails Secret is deleted and a server has no `guardrailsConfigIDs` (covered by global guardrails only with `failMode: deny`), tool calls to that server should be rejected with 503 because the guardrails server is unreachable and the retained config enforces `failMode: deny`. The server should remain in `tools/list` (it is not set to NotReady).
+- When the guardrails Secret is deleted, the controller should clear `GlobalGuardrails` from `mcp-gateway-config`, set MCPGatewayExtension condition to `GuardrailsSecretNotFound`, and set all MCPServerRegistrations to NotReady. Recreating the Secret should restore normal operation.
 
 ## Unit Tests
 

--- a/docs/design/guardrails/tasks/test_cases.md
+++ b/docs/design/guardrails/tasks/test_cases.md
@@ -45,6 +45,14 @@ tags: Happy,Guardrails
 
 - When guardrails are configured and a client makes an authenticated `tools/call` with an `Authorization` header, the router should not forward the client's `Authorization` header to the guardrails server. The mock guardrails server should receive the check request without any `Authorization` header.
 
+### [Happy,Guardrails] Tool response blocked by guardrails
+
+- When guardrails are configured and a backend MCP server returns a `tools/call` result containing text content that triggers a block, the gateway should return a JSON-RPC error to the client instead of the tool result. The original response body should not reach the client.
+
+### [Guardrails] Response body exceeding maxBodyBytes rejected with 413
+
+- When guardrails are configured and a backend MCP server returns a response body larger than the configured `maxBodyBytes`, the gateway should reject with a 413 JSON-RPC error regardless of `failMode`.
+
 ### [Guardrails,Security] Guardrails Secret deletion fails closed
 
 - When an MCPGatewayExtension has `guardrailsRef` and the guardrails Secret is deleted, `GlobalGuardrails` should be cleared from `mcp-gateway-config`, all MCPServerRegistrations should be set to NotReady and removed from the gateway config. Tool calls should fail because no tools are available.

--- a/docs/design/guardrails/tasks/test_cases.md
+++ b/docs/design/guardrails/tasks/test_cases.md
@@ -49,9 +49,41 @@ tags: Happy,Guardrails
 
 - When guardrails are configured and a backend MCP server returns a `tools/call` result containing text content that triggers a block, the gateway should return a JSON-RPC error to the client instead of the tool result. The original response body should not reach the client.
 
+### [Happy,Guardrails] Tool response modified by guardrails forwards modified content
+
+- When guardrails are configured and the guardrails server returns `status: "modified"` with altered content (e.g. PII redacted), the gateway should forward the modified content to the client, not the original response. The client should receive the redacted text in the tool result.
+
+### [Guardrails,Protocol2026] Tool response modified by guardrails forwards modified content (2026)
+
+- When guardrails are configured and a 2026-07-28 client sends a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header, and the guardrails server returns `status: "modified"` with altered content, the gateway should forward the modified content to the client, not the original response.
+
 ### [Guardrails] Response body exceeding maxBodyBytes rejected with 413
 
 - When guardrails are configured and a backend MCP server returns a response body larger than the configured `maxBodyBytes`, the gateway should reject with a 413 JSON-RPC error regardless of `failMode`.
+
+### [Guardrails,Protocol2026] Global guardrails blocks a dangerous tool call (2026)
+
+- When an MCPGatewayExtension is annotated with `mcp.kuadrant.io/guardrails-ref` and a 2026-07-28 client sends a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header and arguments that trigger a block, the gateway should return a JSON-RPC error with a 403 status. The request should never reach the backend MCP server.
+
+### [Guardrails,Protocol2026] Global guardrails allows a safe tool call (2026)
+
+- When an MCPGatewayExtension is annotated with `mcp.kuadrant.io/guardrails-ref` and a 2026-07-28 client sends a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header and arguments that pass the guardrails check, the request should be routed to the backend and the tool result returned.
+
+### [Guardrails,Protocol2026] Guardrails server unreachable — failMode deny (2026)
+
+- When the guardrails server is unreachable and `failMode: deny` (default), a 2026-07-28 client sending a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header should receive a 503 JSON-RPC error.
+
+### [Guardrails,Protocol2026] Guardrails server unreachable — failMode allow (2026)
+
+- When the guardrails server is unreachable and `failMode: allow`, a 2026-07-28 client sending a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header should have the request proceed to the backend as if guardrails were not configured.
+
+### [Happy,Guardrails,Protocol2026] Tool response blocked by guardrails (2026)
+
+- When guardrails are configured and a 2026-07-28 client sends a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header and the backend returns a result containing text content that triggers a block, the gateway should return a JSON-RPC error instead of the tool result. The original response body should not reach the client.
+
+### [Guardrails,Protocol2026] Response body exceeding maxBodyBytes rejected with 413 (2026)
+
+- When guardrails are configured and a 2026-07-28 client makes a `tools/call` with `MCP-Protocol-Version: 2026-07-28` header, and the backend returns a response body larger than the configured `maxBodyBytes`, the gateway should reject with a 413 JSON-RPC error regardless of `failMode`.
 
 ### [Guardrails,Security] Guardrails Secret deletion fails closed
 

--- a/docs/design/guardrails/tasks/test_cases.md
+++ b/docs/design/guardrails/tasks/test_cases.md
@@ -11,11 +11,11 @@ tags: Happy,Guardrails
 
 ### [Happy,Guardrails] Global guardrails blocks a dangerous tool call
 
-- When an MCPGatewayExtension is configured with `guardrailsRef` and a client makes a `tools/call` with arguments that trigger a block, the gateway should return a JSON-RPC error with a 403 status. The request should never reach the backend MCP server.
+- When an MCPGatewayExtension is annotated with `mcp.kuadrant.io/guardrails-ref` and a client makes a `tools/call` with arguments that trigger a block, the gateway should return a JSON-RPC error with a 403 status. The request should never reach the backend MCP server.
 
 ### [Happy,Guardrails] Global guardrails allows a safe tool call
 
-- When an MCPGatewayExtension is configured with `guardrailsRef` and a client makes a `tools/call` with arguments that pass the guardrails check, the request should be routed to the backend and the tool result returned.
+- When an MCPGatewayExtension is annotated with `mcp.kuadrant.io/guardrails-ref` and a client makes a `tools/call` with arguments that pass the guardrails check, the request should be routed to the backend and the tool result returned.
 
 ### [Happy,Guardrails] Per-server guardrailsConfigIDs merged with global defaults
 

--- a/docs/design/router-2026-07-28/streamed-body-processing.md
+++ b/docs/design/router-2026-07-28/streamed-body-processing.md
@@ -76,9 +76,6 @@ This is a key difference from `2025-11-25`, where `:authority` is set in the bod
 
 ## Future Considerations
 
-### FULL_DUPLEX_STREAMED for response bodies (guardrails integration)
+### Response body streaming for guardrails
 
-
-When a guardrails configuration exists, the router sets `ResponseBodyMode` to `FULL_DUPLEX_STREAMED` in the `ModeOverride` during request header processing. This applies to both `2026-07-28` and `2025-11-25` clients. Envoy sends response body chunks to ext_proc without waiting for each response, allowing the router to forward chunks to the guardrails service without stalling the upstream read. The router acts as a forwarding proxy: chunk in, send to guardrails, return the chunk or an error based on the guardrails verdict.
-
-The primary integration target is [NeMo Guardrails](https://docs.nvidia.com/nemo/guardrails/reference/guardrails-api-server/chat-completions/chat-completions), which exposes an OpenAI-compatible `POST /v1/chat/completions` endpoint. NeMo supports streaming via the `stream: true` request parameter — when enabled, the server returns partial message deltas as server-sent events. The router can forward response body chunks to this endpoint as they arrive rather than accumulating the full response.
+When guardrails are configured, the router sets `ResponseBodyMode` to `FULL_DUPLEX_STREAMED`, overriding `NONE` in the protocol-specific flow above. This applies to both `2026-07-28` and `2025-11-25` clients. For SSE responses, the router processes per-event using SSE framing. For JSON responses, the router accumulates the full body. See the [guardrails design](../guardrails/guardrails-design.md) for the buffering model and size cap behaviour.


### PR DESCRIPTION
## related to #1301 

## Adds support for Nemo based Guard Rails integrations

- allows for future expansion and changes to deployment model
- integrates nemo into the router 
- allows config and extension from gateway to mcpserverregistration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a router-level Guardrails design for inspecting MCP tool calls and elicitation requests and responses.
  * Documented gateway-wide and per-server policies, fail modes, TLS trust, Secret lifecycle behavior, size limits, and streamed response handling.
  * Added documentation plans covering configuration, security, authorization, and operational constraints.

* **Tests**
  * Added test plans for end-to-end, controller, and unit coverage, including policy evaluation, failure handling, response blocking, configuration updates, and Secret deletion or recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->