### PR TITLE
test: add payload integrity verification test (#1280)

### DIFF
--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"strings"
@@ -138,6 +139,72 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).NotTo(BeNil())
 		Expect(res.Content).NotTo(BeEmpty())
+	})
+
+	It("[Happy] Payload integrity verification", func() {
+		testResources := []client.Object{}
+		deferCleanupResources(&testResources)
+		mcpGatewayClient := newTestGatewayClient()
+
+		By("Registering test server1")
+		registration := NewTestResources("payload-integrity", k8sClient).
+			ForInternalService(sharedMCPTestServer1, 9090).
+			WithPrefix("integrity_").
+			Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Verifying tools are accessible")
+		Eventually(func(g Gomega) {
+			toolsList, err := mcpGatewayClient.ListTools(ctx, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(verifyMCPServerRegistrationToolsPresent("integrity_", toolsList)).To(BeTrue())
+		}, TestTimeoutConfigSync, TestRetryInterval).To(Succeed())
+
+		testCases := []struct {
+			name    string
+			payload string
+		}{
+			{
+				name:    "standard JSON",
+				payload: `{"key":"value","number":12345,"boolean":true,"null_val":null}`,
+			},
+			{
+				name:    "deeply nested JSON",
+				payload: `{"level1":{"level2":{"level3":{"level4":{"level5":{"data":[1,2,3,{"nested_array":["a","b","c"]}]}}}}}}`,
+			},
+			{
+				name:    "unicode content",
+				payload: `{"multilingual":"Hello 世界 🌍 🚀 🔥 💖 🎉","special_chars":"\u00e9\u00e0\u00e7\u00f1"}`,
+			},
+			{
+				name:    "binary-safe content and special characters",
+				payload: "{\x00\x01\x02\x03 line1\nline2\ttab \"quotes\" \\backslash /slash \b\f\r}",
+			},
+		}
+
+		for _, tc := range testCases {
+			By(fmt.Sprintf("Testing payload integrity for %s", tc.name))
+			expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(tc.payload)))
+
+			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{
+				Name: "integrity_checksum",
+				Arguments: map[string]string{
+					"payload": tc.payload,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).NotTo(BeNil())
+			Expect(res.Content).To(HaveLen(1))
+			textContent, ok := res.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(Equal(expectedHash), "Payload checksum mismatch for case: %s", tc.name)
+		}
 	})
 
 	It("[Happy] should register mcp server with non-default spec.path", func() {

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -427,6 +427,10 @@ When an MCPVirtualServer is configured that includes a specific user-specific to
 
 - When a client sends a tools/call request with a body approaching the default `--max-request-body-size` limit (5MB, test with ~1MB), the gateway should forward the full request to the backend without truncation. The ext_proc body phase must handle the complete payload and the backend should receive and process it successfully.
 
+### [Happy] Payload integrity verification
+
+- When a client sends tool calls containing standard JSON, deeply nested JSON, unicode content, and binary-safe strings, the gateway should deliver the exact byte payload to the backend MCP server without corruption, truncation, or re-encoding. The backend MCP server computes a SHA-256 checksum of the payload parameter and returns it to the client, which compares it against the locally calculated SHA-256 hash to verify byte-exact delivery.
+
 ## Common pitfalls
 
 - MCPServerRegistrations with empty prefix: `strings.HasPrefix(name, "")` matches all tools, including broker meta-tools (discover_tools, select_tools). Always use a non-empty prefix in tests.

--- a/tests/servers/server1/main.go
+++ b/tests/servers/server1/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"flag"
 	"fmt"
 	"log"
@@ -77,6 +78,25 @@ func headersTool(
 
 	return &mcp.CallToolResult{
 		Content: content,
+	}, nil, nil
+}
+
+type checksumArgs struct {
+	Payload string `json:"payload" jsonschema:"the raw string payload to compute SHA-256 hash for"`
+}
+
+// Computes SHA-256 hash of the received payload parameter
+func checksumTool(
+	_ context.Context,
+	_ *mcp.CallToolRequest,
+	params checksumArgs,
+) (*mcp.CallToolResult, any, error) {
+	hash := sha256.Sum256([]byte(params.Payload))
+	hashHex := fmt.Sprintf("%x", hash)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: hashHex},
+		},
 	}, nil, nil
 }
 
@@ -194,6 +214,7 @@ func main() {
 	mcp.AddTool(server, &mcp.Tool{Name: "time", Description: "get current time", Annotations: &mcp.ToolAnnotations{Title: "time"}}, timeTool)
 	mcp.AddTool(server, &mcp.Tool{Name: "slow", Description: "delay N seconds"}, slowTool)
 	mcp.AddTool(server, &mcp.Tool{Name: "headers", Description: "get headers"}, headersTool)
+	mcp.AddTool(server, &mcp.Tool{Name: "checksum", Description: "compute payload checksum"}, checksumTool)
 
 	toolManager := &dynamicToolManager{server: server}
 	mcp.AddTool(server, &mcp.Tool{Name: "add_tool", Description: "dynamically add a new tool (triggers notifications/tools/list_changed)", Annotations: &mcp.ToolAnnotations{Title: "add"}}, toolManager.addTool)

--- a/tests/servers/server1/main_test.go
+++ b/tests/servers/server1/main_test.go
@@ -44,3 +44,18 @@ func TestSlowTool(t *testing.T) {
 	require.NotNil(t, res)
 	require.Len(t, res.Content, 0)
 }
+
+func TestChecksumTool(t *testing.T) {
+	testPayload := `{"key": "value", "unicode": "🚀", "nested": {"a": [1, 2, 3]}}`
+	res, _, err := checksumTool(context.Background(), &mcp.CallToolRequest{}, checksumArgs{Payload: testPayload})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.NotNil(t, res)
+	require.Len(t, res.Content, 1)
+	require.IsType(t, &mcp.TextContent{}, res.Content[0])
+
+	// sha256 of testPayload
+	// calculated expected sha256 hash
+	expectedHash := "8e72a3f8233be49e5422c9b03e92491fd67b371a121c9a7a04303fccac02e73e"
+	require.Equal(t, expectedHash, res.Content[0].(*mcp.TextContent).Text)
+}


### PR DESCRIPTION
### Summary
Fixes #1280

This PR adds an end-to-end payload integrity verification test case to guard against silent corruption, truncation, or re-encoding of payloads sent through the MCP Gateway to upstream servers.

### Changes Made
1. **Test MCP Server (`tests/servers/server1`)**:
   - Added a `checksum` tool that computes and returns the SHA-256 hex digest of the raw payload received.
   - Added unit test (`TestChecksumTool`) in `tests/servers/server1/main_test.go`.

2. **E2E Test Case (`tests/e2e/happy_path_test.go`)**:
   - Added `[Happy] Payload integrity verification` spec.
   - Validates byte-exact payload delivery against the `checksum` tool using multiple edge-case payloads:
     - Standard JSON
     - Deeply nested JSON structures
     - Multilingual & Unicode content 
     - Binary-safe strings & special characters (`\x00\x01\x02`, quotes, backslashes, escape sequences)

3. **Test Documentation (`tests/e2e/test_cases.md`)**:
   - Documented the new test case requirement and verification criteria.

### Verification
- `go test ./tests/servers/server1/...` passes cleanly.
- Code formatted with `gofmt` and checked with `go vet`.
