### PR TITLE
2026 phase 2

### DIFF
--- a/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
+++ b/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
@@ -1,0 +1,182 @@
+# Broker: MCP `2026-07-28` Protocol Support
+
+## Problem
+
+The broker federates tools and prompts from multiple upstream MCP servers. The `2026-07-28` spec adds mandatory `ttlMs` and `cacheScope` fields to list results and replaces GET SSE notifications with `subscriptions/listen`. The broker currently ignores upstream cache values and uses the old notification pattern.
+
+Builds on [router-2026-07-28](../router-2026-07-28/router-2026-07-28-design.md) and [single-gateway-dual-protocol](../single-gateway-dual-protocol/single-gateway-dual-protocol-design.md).
+
+## Summary
+
+Isolate protocol-specific broker behavior behind a `ProtocolHandler` interface with `2025-11-25` and `2026-07-28` implementations. This keeps version-branching logic out of shared code paths and makes 2025 removal a clean delete. Store upstream `ttlMs` and `cacheScope` per server. Derive aggregated values on list responses: `min(ttlMs)`, `"private"` if any upstream is private. For 2026 upstreams, `cacheScope: "private"` supersedes `userSpecificList` on the CRD. Replace GET SSE `notificationWatcher` with `subscriptions/listen` for 2026 upstreams.
+
+## Goals
+
+- **G1:** List responses to 2026 clients include `ttlMs` and `cacheScope` derived from upstream values
+- **G2:** `cacheScope: "private"` from a 2026 upstream triggers per-user tool fetching, superseding `userSpecificList`
+- **G3:** Upstream notifications from 2026 backends use `subscriptions/listen`
+- **G4:** 2025 client responses unchanged (compat handler continues stripping)
+- **G5:** Protocol-specific broker logic isolated behind an interface so 2025 removal is a clean delete
+
+## Non-Goals
+
+- MRTR / `InputRequiredResult` (router concern — `tools/call` goes directly to backend via Envoy)
+- Per-request `_meta` capabilities for elicitation (tracked in `router-2026-07-28/tasks/broker-2026-scope.md` Item 5)
+- Stateless equivalents for `discover_tools`/`select_tools` (needs a scoping mechanism without sessions)
+- `userSpecificList` removal from the CRD (backward compat for 2025 backends)
+- TTL-based routing table refresh in the router
+- Other 2026 features (tasks extension, resource subscriptions)
+
+## Job Stories
+
+### When a 2026 client lists tools from a gateway with mixed cache scopes
+
+The response must be `cacheScope: "private"` so shared intermediaries do not serve one user's tool list to another.
+
+### When an upstream declares private scope via the 2026 protocol
+
+The gateway automatically fetches per-user tools from that upstream without requiring `userSpecificList: true` on the MCPServerRegistration. The upstream's own declaration is authoritative.
+
+### When a 2026 upstream sends a tools list changed notification
+
+The broker receives the change via `subscriptions/listen`, updates its aggregated tool list, and notifies subscribed 2026 clients through the SDK's subscription system.
+
+## Constraints
+
+### Aggregated ttlMs
+
+`min(upstream ttlMs values)`. If any upstream reports `0`, the aggregate is `0`.
+
+### Aggregated cacheScope
+
+Any private-scoped upstream or `userSpecificList` server makes the entire response `"private"`. No partial caching — the response is one aggregated list.
+
+### userSpecificList coexistence
+
+2025 upstreams: `userSpecificList: true` on CRD remains the per-user signal (no `cacheScope` in protocol). 2026 upstreams: `cacheScope: "private"` is authoritative, CRD field ignored. Both feed the same internal per-user fetch path.
+
+## Design
+
+### Prerequisites
+
+- `mcp-go` SDK `v1.7.0` (bump from `v1.7.0-pre.3`) — stable release with full `2026-07-28` support: `CacheableResult`, `SubscriptionsListenParams`, MRTR types, `server/discover`
+- Dual-protocol gateway (done)
+- Protocol version tracking per upstream (done) — `serverVersions` map
+
+### Protocol handler isolation
+
+Version-conditional logic is currently scattered across `user_specific_tools.go`, `protocol_filter.go`, `discovery.go`, and `http_compat.go` as inline `if version == protocol.Version2026` branches. Adding more (ttlMs aggregation, cacheScope-driven fetching, notification watcher selection) would deepen the entanglement.
+
+A `ProtocolHandler` interface encapsulates version-specific behavior:
+
+```go
+// internal/broker/protocol_handler.go
+type ProtocolHandler interface {
+    // FetchUserSpecificTools fetches per-user tools using the protocol's fetch strategy
+    FetchUserSpecificTools(ctx context.Context, servers []userSpecificServer, headers http.Header, result *mcp.ListToolsResult)
+    // IsUserSpecific returns true if the server needs per-user tool fetching
+    IsUserSpecific(srv userSpecificServer, meta *cacheMetadata) bool
+    // AggregateCache computes ttlMs and cacheScope for the list response
+    AggregateCache(contributing []cacheMetadata) (ttlMs int, cacheScope string)
+    // StartNotificationWatcher starts the appropriate notification mechanism for an upstream
+    StartNotificationWatcher(ctx context.Context, server *upstream.MCPServer) 
+}
+```
+
+**`ProtocolHandler2025`**: stateful fetch via session pool, `userSpecificList` CRD field for per-user detection, no cache aggregation (compat handler strips), GET SSE `notificationWatcher`.
+
+**`ProtocolHandler2026`**: stateless connect-list-close, `cacheScope: "private"` for per-user detection, `min(ttlMs)` / pessimistic `cacheScope` aggregation, SDK `subscriptions/listen`.
+
+The `filteringMiddleware` and `OnConfigChange` select the handler by protocol version. The `protocolRouter` already dispatches HTTP requests by version — this extends the pattern into the broker's internal logic.
+
+When 2025 is dropped: delete `ProtocolHandler2025`, the `compatHandler`, session resurrection, and all session management code.
+
+### Upstream cache metadata
+
+The upstream manager stores `ttlMs` and `cacheScope` per server from each `ListTools`/`ListPrompts` response.
+
+```go
+// upstream/mcp.go
+type cacheMetadata struct {
+    TTLMs      int
+    CacheScope string // "public" or "private"
+}
+```
+
+Defaults: `TTLMs: 0`, `CacheScope: "public"` (2025 backends via SDK).
+
+The spec puts `ttlMs`/`cacheScope` on every list result type (`tools/list`, `prompts/list`, `resources/list`, `resources/read`). The broker currently federates tools and prompts only. Cache metadata is stored per upstream, not per result type — sufficient while resources are unsupported. When resources are added, metadata should be stored per result type per upstream.
+
+When `CacheScope` changes, the broker rebuilds `userSpecificServers` to include/exclude the server. 2026 upstreams with `"private"` scope are added to the slice alongside CRD-declared `userSpecificList` servers.
+
+### Aggregated values in filteringMiddleware
+
+After `FetchUserSpecificTools` and `FilterTools` run, the middleware computes aggregated `ttlMs` and `cacheScope` from contributing upstreams and sets them on the result.
+
+For 2025 clients, the compat handler strips these fields downstream — no change needed there. 2026 clients already bypass the compat handler via `protocolRouter` (verification task only).
+
+### subscriptions/listen for 2026 upstreams
+
+The current `notificationWatcher` uses GET SSE to receive list-changed notifications. 2026 backends may not support this endpoint.
+
+For 2026 upstreams, the broker uses the SDK client's `subscriptions/listen` instead, subscribing to `toolsListChanged` and `promptsListChanged`. Selection is based on `UsesStatelessProtocol()`.
+
+On the broker-as-server side, the SDK's stateless `StreamableHTTPHandler` handles `subscriptions/listen` from 2026 clients. The broker's existing `RemoveTools`/`AddTools` calls on the gateway server trigger SDK-level notifications — no additional wiring expected.
+
+2025 upstreams continue using the existing `notificationWatcher` unchanged.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant Client26 as 2026 Client
+    participant Broker
+    participant UpA as Upstream A (public)
+    participant UpB as Upstream B (private)
+
+    Note over Broker: OnConfigChange / upstream connect
+    Broker->>UpA: ListTools
+    UpA-->>Broker: tools + ttlMs:60000, cacheScope:public
+    Broker->>UpB: ListTools
+    UpB-->>Broker: tools + ttlMs:30000, cacheScope:private
+    Note over Broker: Store metadata, rebuild userSpecificServers
+
+    Client26->>Broker: tools/list
+    Broker->>Broker: toolsForProtocol(2026)
+    Broker->>UpB: ListTools (per-user, with client auth)
+    UpB-->>Broker: user-specific tools
+    Broker->>Broker: FilterTools, compute ttlMs=30000, cacheScope=private
+    Broker-->>Client26: {ttlMs:30000, cacheScope:"private", tools:[...]}
+```
+
+### Component Responsibilities
+
+| Component | Responsibility |
+|-----------|---------------|
+| **ProtocolHandler** | Version-specific: user-specific fetch strategy, per-user detection, cache aggregation, notification mechanism |
+| **ProtocolHandler2025** | Stateful fetch, CRD-based per-user detection, GET SSE notifications, no cache aggregation |
+| **ProtocolHandler2026** | Stateless fetch, cacheScope-based per-user detection, `subscriptions/listen`, ttlMs/cacheScope aggregation |
+| **Upstream manager** | Store `cacheMetadata` per upstream, notify broker on scope changes |
+| **filteringMiddleware** | Delegates to `ProtocolHandler` for cache aggregation after filtering |
+
+### API Changes
+
+None. `userSpecificList` stays for 2025 backward compat.
+
+## Security Considerations
+
+- **cacheScope correctness.** Wrong `"public"` on a response containing per-user tools leaks tool lists across users. The design is pessimistic: any private upstream makes the response private.
+- **ttlMs manipulation.** A malicious upstream returning a large `ttlMs` could cause stale lists. `min()` across upstreams bounds freshness.
+- **subscriptions/listen** uses the same `credentialRef` auth as `ListTools`.
+
+## Future Considerations
+
+- **Deprecate `userSpecificList`** once 2025 support is dropped
+- **TTL-based routing table refresh** using the broker's aggregated `ttlMs`
+- **Stateless `discover_tools`/`select_tools`** via `requiredHeaders` or `requestState`
+
+## Execution
+
+See:
+- TODO Tasks for the implementation plan
+- TODO for test cases

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -1,0 +1,424 @@
+# Guardrails Integration
+
+## Problem
+
+> **Note:** examples reference NeMo Guardrails as the initial target.
+
+Guardrails systems don't support MCP natively. Their endpoints (`v1/chat/completions`, `v1/guardrail/checks`) are incompatible with MCP JSON-RPC. Integrating at the router level provides centralized enforcement and consistent protection across all clients.
+
+## Summary
+
+Translation layer in the router that intercepts `tools/call` requests, translates them to a guardrails check, and either proceeds or rejects. Configuration via Kubernetes Secret referenced from `MCPGatewayExtension` (global) and/or `MCPServerRegistration` (per-server). TLS reuses the gateway's existing CA bundle.
+
+## Goals
+
+- Translate MCP `tools/call` and elicitation responses to guardrails checks
+- Support global and per-server guardrails
+- Fail closed by default, configurable to allow
+- Reuse gateway CA trust pool
+- Target NeMo Guardrails initially
+
+## Non-Goals
+
+- Response guardrailing (deferred)
+- Adding MCP awareness to NeMo itself
+
+## Job Stories
+
+### When I want to enforce safety policies on tool calls
+
+When a platform engineer deploys MCP servers that interact with sensitive systems, they want tool calls checked against guardrails before execution so that dangerous calls are rejected at the gateway.
+
+### When I want guardrails on all servers by default
+
+When a platform engineer wants all tool calls checked, they want to configure guardrails once at the gateway level so every server inherits the policy.
+
+### When I need different guardrails policies per server
+
+When servers have different risk profiles, the platform engineer wants different config IDs per server so policies match capabilities.
+
+### When I want additional guardrails on a specific server
+
+When an MCP server accepts freeform input or interacts with a downstream model, the developer wants server-specific policies in addition to global ones.
+
+### When the guardrails server is down
+
+When the guardrails server is unreachable, tool calls fail closed by default. For non-critical servers, the option to fail open exists.
+
+### When the guardrails server uses a private CA
+
+When the guardrails server uses a corporate or self-signed CA, the platform engineer adds it to the gateway CA bundle.
+
+## Design
+
+### Configuration via Secret
+
+Type `guardrails/external/nemo`, following the project's Secret reference pattern (`credentialRef`, `caCertSecretRef`):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-guardrails-config
+  namespace: mcp-system
+  labels:
+    mcp.kuadrant.io/secret: "true"
+type: guardrails/external/nemo
+stringData:
+  config.yaml: |
+    url: https://nemo-guardrails.internal:8080
+    configIDs:
+      - "tool-safety-v1"
+      - "input_checking"
+    model: "meta/llama-3.1-8b-instruct"
+    failMode: deny        # deny (default) | allow
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | Guardrails server endpoint |
+| `configIDs` | no | Default config IDs applied to all servers. Empty if per-server `guardrailsConfigIDs` supply policies |
+| `model` | yes | Model identifier for the guardrails check |
+| `failMode` | no | `deny` (default): reject on failure. `allow`: proceed |
+
+> **Note:** TLS uses the gateway's existing CA bundle (`caCertBundleRef`). Add private CAs there.
+
+### API Changes
+
+#### MCPGatewayExtension
+
+```go
+type MCPGatewayExtensionSpec struct {
+    // ... existing fields ...
+
+    // guardrailsRef references a Secret of type guardrails/external/nemo.
+    // When set, all tools/call requests are checked before routing.
+    // +optional
+    GuardrailsRef *SecretReference `json:"guardrailsRef,omitempty"`
+}
+```
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPGatewayExtension
+metadata:
+  name: mcp-gateway
+spec:
+  targetRef:
+    name: mcp-gateway
+    sectionName: mcp
+  guardrailsRef:
+    name: my-guardrails-config
+```
+
+#### MCPServerRegistration
+
+```go
+type MCPServerRegistrationSpec struct {
+    // ... existing fields ...
+
+    // guardrailsConfigIDs specifies additional config IDs merged with gateway
+    // defaults into a single check request. Requires guardrailsRef on the
+    // MCPGatewayExtension — without it, the server is set to NotReady.
+    // +optional
+    GuardrailsConfigIDs []string `json:"guardrailsConfigIDs,omitempty"`
+}
+```
+
+```yaml
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: dangerous-server
+spec:
+  targetRef:
+    name: dangerous-server-route
+  prefix: dangerous_
+  guardrailsConfigIDs:
+    - "strict-input-checking"
+    - "pii-detection"
+```
+
+#### Validation
+
+If `guardrailsConfigIDs` is set but no `guardrailsRef` exists on the MCPGatewayExtension:
+
+1. MCPServerRegistration set to `NotReady` with reason `GuardrailsNotConfigured`
+2. Server removed from gateway config (no tools/list, tool calls fail)
+3. Re-reconciled when `guardrailsRef` is added
+
+#### Guardrails Secret Deletion
+
+If the guardrails Secret is deleted:
+
+1. MCPGatewayExtension gets condition `GuardrailsSecretNotFound`
+2. The controller retains the last valid guardrails config in `mcp-gateway-config` — `GlobalGuardrails` is not cleared. The router continues to attempt guardrails checks against the configured URL
+3. All MCPServerRegistrations with `guardrailsConfigIDs` are set to `NotReady` and removed from the gateway
+4. For servers without `guardrailsConfigIDs` (covered by global guardrails only), the guardrails server is now unreachable and `failMode` applies: `deny` (default) rejects tool calls, `allow` proceeds without checks
+5. To disable guardrails entirely, the platform engineer must remove `guardrailsRef` from the MCPGatewayExtension — Secret deletion alone does not disable enforcement
+
+This ensures Secret deletion does not silently fail open. The platform engineer's intent (guardrails enabled via `guardrailsRef`) is preserved until explicitly changed. Accidental Secret deletion with `failMode: deny` (the default) blocks tool calls rather than letting unverified requests through.
+
+#### Resolution Order
+
+One guardrails server per gateway. Per-server config IDs are additive.
+
+| Gateway `guardrailsRef` | Server `guardrailsConfigIDs` | Effective Behavior |
+|-------------------------|------------------------------|--------------------|
+| Not set | Not set | No guardrails |
+| Set (with default IDs) | Not set | Gateway defaults applied |
+| Set (empty default IDs) | Not set | No check — per-server-only model |
+| Set (with default IDs) | Set | Gateway defaults + server IDs merged |
+| Set (no default IDs) | Set | Server IDs only |
+| Not set | Set | **NotReady** — server removed |
+
+### Request Flow
+
+Guardrails runs in the router after backend resolution, before the Decision is returned. Applies to `tools/call` and elicitation `accept` responses. If server resolution fails, existing error handling applies — no guardrails check.
+
+**No authorization header forwarding:** The router does not forward the client's `Authorization` header to the guardrails server. NeMo Guardrails does not require client auth — it authenticates to its LLM backend via its own `OPENAI_API_KEY` env var, configured independently on the NeMo server. The guardrails server is deployed without auth enabled (the default) and accessed over in-cluster networking. This avoids exposing client bearer tokens to infrastructure services and keeps credential flows clean: client tokens are for the gateway and upstream MCP servers, not for guardrails.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Envoy
+    participant Router
+    participant Guardrails as Guardrails Server
+    participant Backend as MCP Server
+
+    Client->>Envoy: tools/call (JSON-RPC)
+    Envoy->>Router: ext_proc body phase
+    Router->>Router: parse JSON-RPC, resolve backend
+    Router->>Router: check guardrails config for server
+
+    alt guardrails enabled
+        Router->>Guardrails: POST /v1/guardrail/checks
+        Guardrails-->>Router: response
+
+        alt status: blocked
+            Router-->>Envoy: Decision.Error (403)
+            Envoy-->>Client: JSON-RPC error
+        else status: success
+            Router-->>Envoy: Decision (route to backend)
+            Envoy->>Backend: tools/call
+            Backend-->>Envoy: result
+            Envoy-->>Client: result
+        else non-2xx / timeout
+            alt failMode: deny
+                Router-->>Envoy: Decision.Error (503)
+                Envoy-->>Client: JSON-RPC error
+            else failMode: allow
+                Router-->>Envoy: Decision (route to backend)
+                Envoy->>Backend: tools/call
+            end
+        end
+    else guardrails not enabled
+        Router-->>Envoy: Decision (route to backend)
+        Envoy->>Backend: tools/call
+    end
+```
+
+### Translation Mapping (NeMo)
+
+#### MCP `tools/call` to NeMo `v1/guardrail/checks`
+
+| MCP field | NeMo field |
+|-----------|------------|
+| `params.name` | `messages[0].name` |
+| `params.arguments` (JSON-encoded) | `messages[0].content` |
+| N/A | `messages[0].role = "user"` |
+| N/A | `messages[0].config = "tool"` |
+| from config | `guardrails.config_ids` |
+| from config | `model` |
+
+Example:
+
+```json
+{
+  "model": "meta/llama-3.1-8b-instruct",
+  "messages": [
+    {
+      "role": "user",
+      "name": "execute_sql",
+      "content": "{\"query\": \"DROP TABLE users\"}",
+      "config": "tool"
+    }
+  ],
+  "guardrails": {
+    "config_ids": ["tool-safety-v1", "input_checking"]
+  }
+}
+```
+
+#### Elicitation Response to NeMo
+
+Only `accept` responses are checked (`decline`/`cancel` carry no user content).
+
+| Elicitation field | NeMo field |
+|-------------------|------------|
+| `result.action` | `messages[0].name` |
+| `result` minus `action` (JSON-encoded) | `messages[0].content` |
+| N/A | `messages[0].role = "user"` |
+| N/A | `messages[0].config = "tool"` |
+| from config | `guardrails.config_ids` |
+| from config | `model` |
+
+#### Response to Decision Mapping
+
+| Outcome | Router action |
+|---------|---------------|
+| Translation failure | Always deny with 400. `failMode` does not apply |
+| `status: "success"` | Proceed with routing |
+| `status: "blocked"` | 403 with rails message |
+| Non-2xx HTTP | Apply `failMode`: deny → 503, allow → proceed |
+| Timeout | Apply `failMode`: deny → 503, allow → proceed |
+| Malformed response body | Apply `failMode`: deny → 502, allow → proceed |
+
+Translation failures (e.g. `params.arguments` not valid JSON) are always denied — `failMode: allow` applies only to guardrails server availability, not untranslatable requests.
+
+### TLS Trust
+
+Reuses the gateway's CA trust pool (system roots + `caCertBundleRef`).
+
+### Config Propagation
+
+Controller writes resolved guardrails config into `mcp-gateway-config` Secret. Per-server `guardrailsConfigIDs` go into each server entry:
+
+```go
+type BrokerConfig struct {
+    Servers          []MCPServer           `json:"servers"          yaml:"servers"`
+    VirtualServers   []VirtualServerConfig `json:"virtualServers,omitempty" yaml:"virtualServers,omitempty"`
+    GatewayCACertPEM string                `json:"gatewayCACertPEM,omitempty" yaml:"gatewayCACertPEM,omitempty"`
+    GlobalGuardrails *GuardrailsConfig     `json:"globalGuardrails,omitempty" yaml:"globalGuardrails,omitempty"`
+}
+
+type MCPServer struct {
+    // ... existing fields ...
+    GuardrailsConfigIDs []string `json:"guardrailsConfigIDs,omitempty" yaml:"guardrailsConfigIDs,omitempty"`
+}
+
+type GuardrailsConfig struct {
+    URL       string   `json:"url"       yaml:"url"`
+    ConfigIDs []string `json:"configIDs" yaml:"configIDs"`
+    Model     string   `json:"model"     yaml:"model"`
+    FailMode  string   `json:"failMode"  yaml:"failMode"`  // "deny" | "allow"
+}
+```
+
+The router constructs a single `*http.Client` for the guardrails server, reused across requests:
+
+- **Keep-alive enabled** — persistent connections avoid TCP/TLS handshake per check
+- **`MaxIdleConnsPerHost`** tuned for expected concurrency (matches ext_proc stream count)
+- **No `http.Client.Timeout`** — end-to-end deadline is set per-request via `context.WithTimeout`, not on the client. This matches the `HairpinClientPool` pattern and allows the deadline to account for time already spent in the ext_proc body phase
+- **`http.Transport.DialContext`** timeout of 1s — bounds connection setup independently so a DNS or TCP hang fails fast rather than consuming the full request deadline
+- **Per-request `context.WithTimeout`** of 3s — covers the full round-trip: connection (if not pooled), TLS handshake (if not reused), request write, server processing, and response read. This is the guardrails budget within the 10s ext_proc `message_timeout`. The remaining ~7s covers JSON-RPC parsing, backend resolution, and hairpin init
+
+Client recreated when guardrails config changes (URL or TLS trust pool update). Idle connections from the previous client are closed.
+
+### Internal Architecture
+
+Translation behind a `GuardrailsTransformer` interface. Secret type determines implementation, resolved at config load time.
+
+```go
+// GuardrailsTransformer translates an MCP request into a provider-specific
+// check request body. configIDs is the merged gateway + per-server set.
+type GuardrailsTransformer interface {
+    Transform(req *MCPRequest, cfg *GuardrailsConfig, configIDs []string) ([]byte, error)
+}
+```
+
+Router merges config IDs (gateway defaults + per-server, deduplicated) before calling Transform. Transformer selection by Secret type:
+
+```go
+// guardrails/external/nemo  → NeMoTransformer
+// guardrails/external/other → OtherTransformer (future)
+```
+
+Transformer owns the request body shape. Router owns HTTP call, timeout, TLS, fail mode, config ID merging, and Decision mapping.
+
+### Component Responsibilities
+
+| Component | Responsibility |
+|-----------|----------------|
+| Controller | Reads/validates guardrails Secret, writes config. Sets MCPServerRegistration NotReady if gateway guardrails missing |
+| Router | Calls guardrails server before routing `tools/call` and elicitation accepts, maps response to Decision |
+| Broker | No involvement |
+| Envoy | No changes |
+
+### Observability
+
+Span attributes on `mcp-router.tool-call`:
+
+| Attribute | Value |
+|-----------|-------|
+| `guardrails.enabled` | `true` / `false` |
+| `guardrails.status` | `success` / `blocked` / `error` |
+| `guardrails.config_ids` | config IDs used |
+| `guardrails.latency_ms` | round-trip time |
+| `guardrails.fail_mode` | `deny` / `allow` |
+
+`Debug` level per check, `Info` for config changes.
+
+## Performance Impact
+
+Synchronous HTTP round-trip in the ext_proc body phase. Hot path — see `docs/design/performance.md`.
+
+- Guardrails call blocks ext_proc response. Envoy holds request body in BUFFERED mode.
+- NeMo performs LLM inference .
+- ext_proc `message_timeout` is 10s total for all body phase processing (parsing, resolution, hairpin init, guardrails).
+- Guardrails per-request deadline: 3s (`context.WithTimeout`), dial timeout: 1s. Leaves ~7s for other ext_proc processing
+- Only `tools/call` and elicitation `accept` affected. Other methods bypass guardrails entirely.
+
+## Security Considerations
+
+- **Fail closed by default** — consistent with invariant #5
+- **Secret validation** — type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`, valid `url`. `configIDs` may be empty for per-server-only policies
+- **Router-only path** — broker never interacts with guardrails
+- **No credential leak** — guardrails Secret contains no upstream MCP credentials. The router does not forward client `Authorization` headers to the guardrails server. NeMo authenticates to its LLM backend via its own `OPENAI_API_KEY`, not client tokens
+- **TLS optional in-cluster** — acceptable for in-cluster communication
+
+## Why the Router
+
+The check requires the parsed JSON-RPC body, the resolved backend server, and the guardrails config. Only the router has all three.
+
+**Alternatives considered:**
+
+- **ext_authz** — operates on headers, not body. Would need router to parse body first, copy into headers for ext_authz second pass. Two filter round-trips, fragile ordering.
+- **Lua/WASM filter** — duplicates the JSON-RPC parser. Two parsers in the same pipeline is a maintenance liability.
+
+The cost is a synchronous round-trip in the hot path. Accepted: guardrails server runs in-cluster, impact scoped to `tools/call` and elicitation `accept` only.
+
+## Future Considerations
+
+### Response Guardrailing
+
+Check `tools/call` responses before they reach the client. Requires response body buffering in ext_proc, different translation mapping, and UX for blocked responses (tool already executed). Deferred.
+
+### Guardrails for Prompts
+
+Check `prompts/get` response content. Same pattern, different translation mapping.
+
+### Circuit Breaker
+
+If the guardrails server degrades (slow but not down), every check eats the full timeout. A circuit breaker tripping after N consecutive failures would fast-fail by applying `failMode` immediately.
+
+### AI Gateway Provider Integration
+
+A provider like Praxis could offer guardrails natively. This design allows for that. The controller would translate `guardrailsRef` into provider-specific resources instead of the router performing translation. CRD field stays the same, Secret type differs per provider (example `type: guardrails/internal/praxis` ).
+
+## Open Questions
+
+### Request-side value for schema-constrained tools
+
+Most MCP tools have typed input schemas. AuthPolicy controls access, input validation handles correctness. Guardrails add clear value for freeform text or arguments passed to downstream models. For rigid schemas (`{"namespace": "prod", "replicas": 3}`), the latency cost may not be justified.
+
+### Should guardrails be on the request path, response path, or both?
+
+Response guardrails (data exfiltration, PII, harmful content) may be more valuable for many use cases. Different cost/value profile. Is request-side sufficient to validate the pattern?
+
+## Execution
+
+See:
+- [tasks/tasks.md](tasks/tasks.md) for the implementation plan (TODO)
+- [tasks/e2e_test_cases.md](tasks/test_cases.md) for E2E test cases
+- [tasks/documentation.md](tasks/documentation.md) for documentation plan

--- a/docs/design/guardrails/guardrails-design.md
+++ b/docs/design/guardrails/guardrails-design.md
@@ -149,15 +149,14 @@ If `guardrailsConfigIDs` is set but no `guardrailsRef` exists on the MCPGatewayE
 
 #### Guardrails Secret Deletion
 
-If the guardrails Secret is deleted:
+If the guardrails Secret is missing (deleted or never created) while `guardrailsRef` is set:
 
 1. MCPGatewayExtension gets condition `GuardrailsSecretNotFound`
-2. The controller retains the last valid guardrails config in `mcp-gateway-config` — `GlobalGuardrails` is not cleared. The router continues to attempt guardrails checks against the configured URL
-3. All MCPServerRegistrations with `guardrailsConfigIDs` are set to `NotReady` and removed from the gateway
-4. For servers without `guardrailsConfigIDs` (covered by global guardrails only), the guardrails server is now unreachable and `failMode` applies: `deny` (default) rejects tool calls, `allow` proceeds without checks
-5. To disable guardrails entirely, the platform engineer must remove `guardrailsRef` from the MCPGatewayExtension — Secret deletion alone does not disable enforcement
+2. `GlobalGuardrails` is cleared from `mcp-gateway-config`
+3. All MCPServerRegistrations are set to `NotReady` and removed from the gateway
+4. To restore: recreate the Secret or remove `guardrailsRef` from MCPGatewayExtension
 
-This ensures Secret deletion does not silently fail open. The platform engineer's intent (guardrails enabled via `guardrailsRef`) is preserved until explicitly changed. Accidental Secret deletion with `failMode: deny` (the default) blocks tool calls rather than letting unverified requests through.
+This ensures a missing Secret fails closed uniformly. No stale config is retained — there may be no prior config to retain (Secret never created), and retaining a config pointing at an unreachable URL only adds latency before the same outcome.
 
 #### Resolution Order
 

--- a/docs/design/guardrails/tasks/documentation.md
+++ b/docs/design/guardrails/tasks/documentation.md
@@ -1,0 +1,76 @@
+# Guardrails Integration — Documentation Plan
+
+Documentation for guardrails integration, organized by user goals.
+
+## User-Facing Guide (`docs/guides/guardrails.md`)
+
+### When I want to protect tool calls with guardrails
+
+When a platform engineer wants to enforce safety policies on MCP tool calls, they want to configure a guardrails server and apply it to their gateway so that all tool calls are checked before reaching backends.
+
+**Cover:**
+- Creating the guardrails Secret (type `guardrails/external/nemo`, required label)
+- Setting `guardrailsRef` on MCPGatewayExtension
+- Configuring `configIDs`, `model`, `failMode`
+- Verifying guardrails are active (test a blocked call)
+
+### When I want per-server guardrails policies
+
+When a platform engineer or MCP server developer wants different guardrails policies for specific servers, they want to add server-level config IDs alongside the global policy.
+
+**Cover:**
+- Setting `guardrailsConfigIDs` on MCPServerRegistration (not `guardrailsRef`)
+- Additive behavior: global + per-server config IDs merged into a single request
+- Per-server-only model: gateway `guardrailsRef` with empty `configIDs`, servers supply their own
+- Requirement: `guardrailsRef` must exist on MCPGatewayExtension — without it, server is NotReady
+- YAML examples showing combined configuration
+
+### When I want to understand fail modes
+
+When a platform engineer wants to decide how the gateway behaves when the guardrails server is down, they want to understand the trade-offs between fail-closed and fail-open.
+
+**Cover:**
+- `failMode: deny` (default) — tool calls rejected when guardrails unreachable
+- `failMode: allow` — tool calls proceed without guardrails check
+- Translation failures always denied regardless of `failMode`
+- Consistency with ext_proc `failure_mode_allow` invariant
+
+### When I need TLS trust for the guardrails server
+
+When a platform engineer deploys the guardrails server behind a private CA, they want to configure TLS trust.
+
+**Cover:**
+- Adding the guardrails server CA to the gateway CA bundle (`caCertBundleRef`)
+- No separate CA configuration needed
+- Non-TLS acceptable for in-cluster communication (log warning emitted)
+
+## API Reference Updates
+
+### `docs/reference/mcpgatewayextension.md`
+
+**Cover:**
+- `guardrailsRef` field (optional, SecretReference)
+- Secret requirements: type `guardrails/external/nemo`, label `mcp.kuadrant.io/secret=true`
+- Secret key: `config.yaml` (url, configIDs, model, failMode)
+- `configIDs` is optional — may be empty for per-server-only policies
+
+### `docs/reference/mcpserverregistration.md`
+
+**Cover:**
+- `guardrailsConfigIDs` field (optional, list of strings)
+- Additive to global guardrails config IDs, merged into single request
+- Requires `guardrailsRef` on MCPGatewayExtension — NotReady without it
+
+## Security Architecture Update (`docs/design/security-architecture.md`)
+
+### When I need to understand guardrails in the security model
+
+When a contributor needs to understand how guardrails fits into the security architecture, they want to know the trust boundaries and invariants.
+
+**Cover:**
+- Guardrails is router-only (broker not involved)
+- Router does not forward client `Authorization` headers to the guardrails server — NeMo authenticates to its LLM backend via its own `OPENAI_API_KEY`, not client tokens
+- Guardrails server deployed without auth (NeMo default), accessed over in-cluster networking
+- Fail-closed default consistent with ext_proc failure mode
+- No credential leak — guardrails Secret has no access to `credentialRef`, client tokens not exposed to guardrails infrastructure
+- One guardrails server per gateway

--- a/docs/design/guardrails/tasks/test_cases.md
+++ b/docs/design/guardrails/tasks/test_cases.md
@@ -1,0 +1,90 @@
+## Guardrails Integration Test Cases
+
+---
+test_suite: guardrails_test.go
+tags: Happy,Guardrails
+---
+
+> **Note:** E2E tests require a mock guardrails server (deployed in `tests/servers/`) implementing `v1/guardrail/checks` with configurable pass/block responses.
+
+## E2E Tests
+
+### [Happy,Guardrails] Global guardrails blocks a dangerous tool call
+
+- When an MCPGatewayExtension is configured with `guardrailsRef` and a client makes a `tools/call` with arguments that trigger a block, the gateway should return a JSON-RPC error with a 403 status. The request should never reach the backend MCP server.
+
+### [Happy,Guardrails] Global guardrails allows a safe tool call
+
+- When an MCPGatewayExtension is configured with `guardrailsRef` and a client makes a `tools/call` with arguments that pass the guardrails check, the request should be routed to the backend and the tool result returned.
+
+### [Happy,Guardrails] Per-server guardrailsConfigIDs merged with global defaults
+
+- When an MCPGatewayExtension has `guardrailsRef` with default config IDs and an MCPServerRegistration specifies additional `guardrailsConfigIDs`, tool calls to that server should be checked with all config IDs merged into a single request. Tool calls to other servers should use only gateway defaults.
+
+### [Guardrails] Per-server guardrailsConfigIDs override when global has no default IDs
+
+- When an MCPGatewayExtension has `guardrailsRef` with empty `configIDs` and an MCPServerRegistration specifies `guardrailsConfigIDs`, tool calls to that server should be checked with only the per-server config IDs. Other servers should not trigger a guardrails check.
+
+### [Guardrails] Guardrails server unreachable — failMode deny
+
+- When the guardrails server is unreachable and `failMode: deny` (default), tool calls should be rejected with a 503 JSON-RPC error.
+
+### [Guardrails] Guardrails server unreachable — failMode allow
+
+- When the guardrails server is unreachable and `failMode: allow`, tool calls should proceed to the backend as if guardrails were not configured.
+
+### [Guardrails] Server without guardrails unaffected by global config
+
+- When an MCPGatewayExtension has `guardrailsRef` set, servers whose tool calls pass the check should work identically to the non-guardrails case.
+
+### [Guardrails] Elicitation accept response checked by guardrails
+
+- When guardrails are configured and a client sends an elicitation `accept` response, the router should check it against the guardrails server. A blocked response should return a JSON-RPC error.
+
+### [Guardrails,Security] Client Authorization header not forwarded to guardrails server
+
+- When guardrails are configured and a client makes an authenticated `tools/call` with an `Authorization` header, the router should not forward the client's `Authorization` header to the guardrails server. The mock guardrails server should receive the check request without any `Authorization` header.
+
+### [Guardrails,Security] Guardrails Secret deletion fails closed for globally guarded servers
+
+- When an MCPGatewayExtension has `guardrailsRef` with `failMode: deny` and the guardrails Secret is deleted, tool calls to servers covered by global guardrails (no `guardrailsConfigIDs`) should be rejected with a 503 JSON-RPC error. The router retains the last valid config and the guardrails server is unreachable.
+
+## Controller Integration Tests (envtest)
+
+### guardrailsConfigIDs without global guardrailsRef sets NotReady
+
+- When an MCPServerRegistration specifies `guardrailsConfigIDs` but the MCPGatewayExtension has no `guardrailsRef`, the controller should set the MCPServerRegistration to NotReady with reason `GuardrailsNotConfigured`. When `guardrailsRef` is later added, the server should become Ready.
+
+### Invalid guardrails Secret — MCPGatewayExtension reports error
+
+- When `guardrailsRef` references a Secret that does not exist, lacks the required label, or has the wrong type, the MCPGatewayExtension should report a status condition with an appropriate error.
+
+### Guardrails Secret update triggers config reload
+
+- When the guardrails Secret is updated (e.g. changing `configIDs` or `url`), the controller should detect the change, re-validate, and write the updated config to `mcp-gateway-config`.
+
+### Guardrails Secret deletion retains config and sets registrations NotReady
+
+- When the guardrails Secret is deleted, the controller should retain the last valid guardrails config in `mcp-gateway-config` (not clear `GlobalGuardrails`), set MCPGatewayExtension condition to `GuardrailsSecretNotFound`, and set all MCPServerRegistrations with `guardrailsConfigIDs` to NotReady. Recreating the Secret should restore normal operation.
+
+### Guardrails Secret deletion — globally guarded servers fail closed
+
+- When the guardrails Secret is deleted and a server has no `guardrailsConfigIDs` (covered by global guardrails only with `failMode: deny`), tool calls to that server should be rejected with 503 because the guardrails server is unreachable and the retained config enforces `failMode: deny`. The server should remain in `tools/list` (it is not set to NotReady).
+
+## Unit Tests
+
+### Multiple configIDs sent in single request
+
+- When the guardrails config specifies multiple `configIDs`, the transformer should produce a single request body with all IDs in the `config_ids` array.
+
+### Translation failure returns error
+
+- When `params.arguments` is not valid JSON, Transform should return an error. The router should map this to a 400 Decision.Error regardless of `failMode`.
+
+### Elicitation decline/cancel bypass guardrails
+
+- When the router receives an elicitation `decline` or `cancel` response, it should skip the guardrails check and proceed to routing.
+
+### Config ID merging and deduplication
+
+- When gateway defaults and per-server config IDs overlap, the merged slice passed to Transform should be deduplicated.

--- a/tests/e2e/dual_protocol_test.go
+++ b/tests/e2e/dual_protocol_test.go
@@ -99,7 +99,12 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		// leave resources for post-failure debugging; BeforeAll Clean() handles cleanup on next run
+		for i := len(testResources) - 1; i >= 0; i-- {
+			CleanupResource(ctx, k8sClient, testResources[i])
+		}
+		if dpExt != nil {
+			dpExt.TearDown(ctx)
+		}
 	})
 
 	JustAfterEach(func() {


### PR DESCRIPTION
## What does this PR do?

Design for broker changes to support 2026 protocol

Fixes #

Adds debugging to consistently CI only failing test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an MCP `2026-07-28` broker design document, including upstream cache/TTL aggregation rules and updated list/notification behavior expectations.
  * Published NeMo Guardrails integration design guidance for enforcing MCP tool calls with configurable fail-closed behavior and security/configuration constraints.
  * Added a guardrails documentation plan and a detailed guardrails test-suite specification.
* **Tests**
  * Improved end-to-end test cleanup by deterministically tearing down accumulated Kubernetes resources and dual-protocol extension state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->