### PR TITLE
fix ci e2e env  

### DIFF
--- a/build/ci-node.mk
+++ b/build/ci-node.mk
@@ -15,7 +15,8 @@ TEST_SERVER_IMAGE_REPO ?= ghcr.io/kuadrant/mcp-gateway
 TEST_SERVER_IMAGE_TAG ?= latest
 TEST_SERVER_IMAGES = test-server1 test-server2 test-server3 test-api-key-server \
 	test-broken-server test-custom-path-server test-oidc-server \
-	test-everything-server test-custom-response-server test-user-specific-server
+	test-everything-server test-custom-response-server test-user-specific-server \
+	test-stateless-server
 
 # buildx builder with the security.insecure entitlement: containerd's layer
 # extraction in the bake RUN step needs mount(2), which plain builds deny

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -27,6 +27,7 @@ wait-test-servers: ## Wait for all test server deployments to be available
 	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-custom-path-server -n mcp-test
 	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-oidc-server -n mcp-test
 	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/everything-server -n mcp-test
+	@$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-test-stateless-server -n mcp-test
 	@if $(KUBECTL) get deployment/mcp-tls-server -n mcp-test >/dev/null 2>&1; then \
 		$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-tls-server -n mcp-test; \
 	fi


### PR DESCRIPTION
Ensures the new stateless server image is persent and running for the e2e test cases


