### PR TITLE
scope out broker changes for 2026 support

### DIFF
--- a/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
+++ b/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
@@ -17,6 +17,7 @@ Isolate protocol-specific broker behavior behind a `ProtocolHandler` interface w
 - **G3:** Upstream notifications from 2026 backends use `subscriptions/listen`
 - **G4:** 2025 client responses unchanged
 - **G5:** Protocol-specific broker logic isolated behind an interface so 2025 removal is a clean delete
+- **G6:** `prompts/list` filtered by protocol version — 2026 clients only see prompts from 2026-capable upstreams
 
 ## Non-Goals
 
@@ -40,6 +41,10 @@ The gateway automatically fetches per-user tools from that upstream without requ
 ### When a 2026 upstream sends a tools list changed notification
 
 The broker receives the change via `subscriptions/listen`, updates its aggregated tool list, and notifies subscribed 2026 clients through the SDK's subscription system.
+
+### When a 2026 client lists prompts from a gateway with mixed-protocol upstreams
+
+The response must only include prompts from upstreams that support the 2026 protocol. Prompts from 2025-only upstreams must be excluded — a 2026 client cannot call `prompts/get` against a 2025-only upstream.
 
 ## Constraints
 
@@ -114,9 +119,13 @@ The spec puts `ttlMs`/`cacheScope` on every list result type (`tools/list`, `pro
 
 When `CacheScope` or `TTLMs` changes (detected on re-list), the broker atomically rebuilds `perRequestServers` immediately — not deferred to the next `OnConfigChange`. This prevents a window where a newly-private upstream is still treated as shared. 2026 upstreams with `"private"` scope or `ttlMs: 0` are added alongside CRD-declared `userSpecificList` servers.
 
+### Protocol filtering for tools and prompts
+
+`tools/list` already filters by protocol version via `toolsForProtocol` — a pre-computed cache partitioned into stateful (2025) and stateless (2026) tool sets, rebuilt on tool changes. `prompts/list` needs the same treatment: `promptsForProtocol` backed by `statefulPrompts`/`statelessPrompts` caches rebuilt alongside the tool caches. Without this, a 2026 client sees prompts from 2025-only upstreams that it cannot call via `prompts/get`.
+
 ### Aggregated values in filteringMiddleware
 
-After `FetchUserSpecificTools` and `FilterTools` run, the middleware computes aggregated `ttlMs` and `cacheScope` from contributing upstreams and sets them on the result.
+After protocol filtering, `FetchUserSpecificTools`, and `FilterTools` run, the middleware computes aggregated `ttlMs` and `cacheScope` from contributing upstreams and sets them on the result. The same aggregation applies to `prompts/list`.
 
 For 2025 clients, the compat handler strips these fields downstream — no change needed there. 2026 clients already bypass the compat handler via `protocolRouter` (verification task only).
 

--- a/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
+++ b/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
@@ -1,0 +1,188 @@
+# Broker: MCP `2026-07-28` Protocol Support
+
+## Problem
+
+The broker federates tools and prompts from multiple upstream MCP servers. The `2026-07-28` spec adds mandatory `ttlMs` and `cacheScope` fields to list results and replaces GET SSE notifications with `subscriptions/listen`. The broker currently ignores upstream cache values and uses the old notification pattern.
+
+Builds on [router-2026-07-28](../router-2026-07-28/router-2026-07-28-design.md) and [single-gateway-dual-protocol](../single-gateway-dual-protocol/single-gateway-dual-protocol-design.md).
+
+## Summary
+
+Isolate protocol-specific broker behavior behind a `ProtocolHandler` interface with `2025-11-25` and `2026-07-28` implementations. This keeps version-branching logic out of shared code paths and makes 2025 removal a clean delete. Store upstream `ttlMs` and `cacheScope` per server. Derive aggregated values on list responses: `min(ttlMs)`, `"private"` if any upstream is private. For 2026 upstreams, `cacheScope: "private"` supersedes `userSpecificList` on the CRD. Replace GET SSE `notificationWatcher` with `subscriptions/listen` for 2026 upstreams.
+
+## Goals
+
+- **G1:** List responses to 2026 clients include `ttlMs` and `cacheScope` derived from upstream values
+- **G2:** `cacheScope: "private"` from a 2026 upstream triggers per-user tool fetching, superseding `userSpecificList`
+- **G3:** Upstream notifications from 2026 backends use `subscriptions/listen`
+- **G4:** 2025 client responses unchanged
+- **G5:** Protocol-specific broker logic isolated behind an interface so 2025 removal is a clean delete
+
+## Non-Goals
+
+- MRTR / `InputRequiredResult` (router concern — `tools/call` goes directly to backend via Envoy - Future iteration)
+- Per-request `_meta` capabilities for elicitation
+- Stateless equivalents for `discover_tools`/`select_tools`
+- `userSpecificList` removal from the CRD (backward compat for 2025 backends)
+- TTL-based routing table refresh in the router (future work to allow separate deployments)
+- additional 2026 features (tasks extension, resource subscriptions)
+
+## Job Stories
+
+### When a 2026 client lists tools from a gateway with mixed cache scopes
+
+The response must be `cacheScope: "private"` so shared intermediaries do not serve one user's tool list to another.
+
+### When an upstream declares private scope via the 2026 protocol
+
+The gateway automatically fetches per-user tools from that upstream without requiring `userSpecificList: true` on the MCPServerRegistration. The upstream's own declaration is authoritative.
+
+### When a 2026 upstream sends a tools list changed notification
+
+The broker receives the change via `subscriptions/listen`, updates its aggregated tool list, and notifies subscribed 2026 clients through the SDK's subscription system.
+
+## Constraints
+
+### Aggregated ttlMs
+
+The broker computes `min()` across upstream `ttlMs` values, ignoring zeros. Upstreams with `ttlMs: 0` are always re-fetched on every client request and don't contribute to the aggregate. If every upstream reports `0`, the aggregate is `0`. `ttlMs: 0` does not affect `cacheScope` — only `cacheScope: "private"` and `userSpecificList` make the response private.
+
+### Aggregated cacheScope
+
+Any private-scoped upstream or `userSpecificList` server makes the entire response `"private"`. No partial caching — the response is one aggregated list.
+
+### userSpecificList coexistence
+
+2025 upstreams: `userSpecificList: true` on CRD remains the fresh-fetch signal (no `cacheScope` or `ttlMs` in protocol). 2026 upstreams: `cacheScope: "private"` or `ttlMs: 0` triggers fresh fetching, CRD field ignored. All three signals feed the same internal `ShouldFetchFresh` path.
+
+## Design
+
+### Prerequisites
+
+- `mcp-go` SDK `v1.7.0` (bump from `v1.7.0-pre.3`) — stable release with full `2026-07-28` support: `CacheableResult`, `SubscriptionsListenParams`, MRTR types, `server/discover`
+- Dual-protocol gateway (done)
+- Protocol version tracking per upstream (done) — `serverVersions` map
+
+### Protocol handler isolation
+
+Version-conditional logic is currently scattered across `user_specific_tools.go`, `protocol_filter.go`, `discovery.go`, and `http_compat.go` as inline `if version == protocol.Version2026` branches. Adding more (ttlMs aggregation, cacheScope-driven fetching, notification watcher selection) would deepen the entanglement.
+
+A `ProtocolHandler` interface encapsulates version-specific behavior:
+
+```go
+// internal/broker/protocol_handler.go
+type ProtocolHandler interface {
+    // FetchUserSpecificTools fetches per-user tools using the protocol's fetch strategy
+    FetchUserSpecificTools(ctx context.Context, servers []perRequestServer, headers http.Header, result *mcp.ListToolsResult)
+    // ShouldFetchFresh returns true if the server must be fetched on every client request
+    ShouldFetchFresh(srv perRequestServer, meta *cacheMetadata) bool
+    // AggregateCache computes ttlMs and cacheScope for the list response
+    AggregateCache(contributing []cacheMetadata) (ttlMs int, cacheScope string)
+    // StartNotificationWatcher starts the appropriate notification mechanism for an upstream
+    StartNotificationWatcher(ctx context.Context, server *upstream.MCPServer) 
+}
+```
+
+**`ProtocolHandler2025`**: stateful fetch via session pool, `userSpecificList` CRD field for fresh-fetch detection, no cache aggregation (compat handler strips), GET SSE `notificationWatcher`.
+
+**`ProtocolHandler2026`**: stateless connect-list-close, `ShouldFetchFresh` triggered by `cacheScope: "private"` or `ttlMs: 0`, `min(non-zero ttlMs)` / pessimistic `cacheScope` aggregation, SDK `subscriptions/listen`.
+
+The `filteringMiddleware` and `OnConfigChange` select the handler by protocol version. The `protocolRouter` already dispatches HTTP requests by version — this extends the pattern into the broker's internal logic.
+
+When 2025 is dropped: delete `ProtocolHandler2025`, the `compatHandler`, session resurrection, and all session management code.
+
+### Upstream cache metadata
+
+The upstream manager stores `ttlMs` and `cacheScope` per result type per server.
+
+```go
+// upstream/mcp.go
+type cacheMetadata struct {
+    TTLMs            int
+    CacheScope       string // "public" or "private"
+    UserSpecificList bool   // from CRD, carried through for scope aggregation
+}
+
+// MCPServer holds per-result-type metadata
+toolsCacheMeta  cacheMetadata // from ListTools
+promptsCacheMeta cacheMetadata // from ListPrompts
+```
+
+Defaults: `TTLMs: 0`, `CacheScope: "public"`, `UserSpecificList: false` (2025 backends via SDK).
+
+The spec puts `ttlMs`/`cacheScope` on every list result type (`tools/list`, `prompts/list`, `resources/list`, `resources/read`). Cache metadata is stored per result type per upstream — tools and prompts from the same server can have different TTLs and scopes.
+
+When `CacheScope` or `TTLMs` changes (detected on re-list), the broker atomically rebuilds `perRequestServers` immediately — not deferred to the next `OnConfigChange`. This prevents a window where a newly-private upstream is still treated as shared. 2026 upstreams with `"private"` scope or `ttlMs: 0` are added alongside CRD-declared `userSpecificList` servers.
+
+### Aggregated values in filteringMiddleware
+
+After `FetchUserSpecificTools` and `FilterTools` run, the middleware computes aggregated `ttlMs` and `cacheScope` from contributing upstreams and sets them on the result.
+
+For 2025 clients, the compat handler strips these fields downstream — no change needed there. 2026 clients already bypass the compat handler via `protocolRouter` (verification task only).
+
+### subscriptions/listen for 2026 upstreams
+
+The current `notificationWatcher` uses GET SSE to receive list-changed notifications. 2026 backends may not support this endpoint.
+
+For 2026 upstreams, the broker uses the SDK client's `subscriptions/listen` instead, subscribing to `toolsListChanged` and `promptsListChanged`. Selection is based on `UsesStatelessProtocol()`.
+
+On the broker-as-server side, the SDK's stateless `StreamableHTTPHandler` handles `subscriptions/listen` from 2026 clients. The broker's existing `RemoveTools`/`AddTools` calls on the gateway server trigger SDK-level notifications — no additional wiring expected.
+
+2025 upstreams continue using the existing `notificationWatcher` unchanged.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant Client26 as 2026 Client
+    participant Broker
+    participant UpA as Upstream A (public)
+    participant UpB as Upstream B (private)
+
+    Note over Broker: OnConfigChange / upstream connect
+    Broker->>UpA: ListTools
+    UpA-->>Broker: tools + ttlMs:60000, cacheScope:public
+    Broker->>UpB: ListTools
+    UpB-->>Broker: tools + ttlMs:30000, cacheScope:private
+    Note over Broker: Store metadata, rebuild perRequestServers
+
+    Client26->>Broker: tools/list
+    Broker->>Broker: toolsForProtocol(2026)
+    Broker->>UpB: ListTools (per-user, with client auth)
+    UpB-->>Broker: user-specific tools
+    Broker->>Broker: FilterTools, compute ttlMs=30000, cacheScope=private
+    Broker-->>Client26: {ttlMs:30000, cacheScope:"private", tools:[...]}
+```
+
+### Component Responsibilities
+
+| Component | Responsibility |
+|-----------|---------------|
+| **ProtocolHandler** | Version-specific: fresh-fetch strategy, `ShouldFetchFresh` detection, cache aggregation, notification mechanism |
+| **ProtocolHandler2025** | Stateful fetch, CRD-based fresh-fetch detection, GET SSE notifications, no cache aggregation |
+| **ProtocolHandler2026** | Stateless fetch, `ShouldFetchFresh` via `cacheScope: "private"` or `ttlMs: 0`, `subscriptions/listen`, ttlMs/cacheScope aggregation |
+| **Upstream manager** | Store `cacheMetadata` per upstream, notify broker on scope changes |
+| **filteringMiddleware** | Delegates to `ProtocolHandler` for cache aggregation after filtering |
+
+### API Changes
+
+None. `userSpecificList` stays for 2025 backward compat.
+
+## Security Considerations
+
+- **cacheScope correctness.** Wrong `"public"` on a response containing per-user tools leaks tool lists across users. The design is pessimistic: any private upstream makes the response private.
+- **ttlMs manipulation.** A malicious upstream returning a large `ttlMs` could cause stale lists. `min()` across upstreams bounds freshness.
+- **subscriptions/listen** uses the same `credentialRef` auth as `ListTools`.
+
+## Future Considerations
+
+- **Deprecate `userSpecificList`** once 2025 support is dropped
+- **TTL-based routing table refresh** using the broker's aggregated `ttlMs`
+- **Stateless `discover_tools`/`select_tools`** via `requiredHeaders` or `requestState`
+
+## Execution
+
+See:
+- [Implementation plan](tasks/tasks.md) — 8 tasks ordered by dependency
+- [Test cases](tasks/test_cases.md) — integration and e2e tests covering G1-G5
+- [Documentation plan](tasks/documentation.md) — security architecture and design doc updates

--- a/docs/design/broker-2026-07-28/tasks/documentation.md
+++ b/docs/design/broker-2026-07-28/tasks/documentation.md
@@ -1,0 +1,50 @@
+# Broker 2026-07-28 Documentation Plan
+
+Documentation for broker 2026-07-28 protocol support, organized by user goals.
+
+## No New User-Facing Guide Required
+
+The broker's 2026 protocol support is transparent to gateway operators. There are no new CRD fields, CLI flags, or configuration options. The broker automatically detects upstream protocol versions and applies the correct behavior:
+
+- `ttlMs` and `cacheScope` are derived from upstream responses, not configured
+- `cacheScope:"private"` from 2026 upstreams triggers per-user fetching automatically
+- `subscriptions/listen` replaces GET SSE for 2026 upstreams without operator action
+- `userSpecificList` continues to work for 2025 upstreams unchanged
+
+The existing `docs/guides/scaling.md` and `docs/guides/authentication.md` guides remain accurate.
+
+## Security Architecture Update (`docs/design/security-architecture.md`)
+
+### When I need to understand how cache scope protects per-user tool lists
+
+When a security reviewer or contributor needs to assess the trust model for `cacheScope` aggregation, they want to understand how the broker prevents tool list cross-contamination.
+
+**Cover:**
+- Cache scope aggregation: pessimistic `"private"` when any upstream is private
+- Why wrong `"public"` on a response with per-user tools is a tool list leak
+- `ttlMs` manipulation: malicious upstream returning large ttlMs bounded by `min()` across upstreams
+- `subscriptions/listen` uses the same `credentialRef` auth as `ListTools`
+
+### When I need to understand how ttlMs affects tool freshness
+
+When a contributor is working on routing table refresh or client-side caching, they want to understand what the aggregated `ttlMs` means.
+
+**Cover:**
+- Aggregated `ttlMs` reflects worst-case staleness of the cached portion
+- `ttlMs:0` upstreams are always-fetched — they don't contribute to the aggregate
+- The aggregate is `min(non-zero ttlMs)` — bounds freshness to the most volatile upstream
+
+## Design Doc Update (`docs/design/overview.md`)
+
+### When I need to understand the broker's protocol handling architecture
+
+When a contributor is working on the broker, they want to understand the `ProtocolHandler` interface and how version-specific behavior is isolated.
+
+**Cover:**
+- `ProtocolHandler` interface and its two implementations
+- How to add 2026-specific broker behavior without touching shared code
+- What deleting `ProtocolHandler2025` removes when 2025 is dropped
+
+## API Reference — No Changes
+
+`userSpecificList` stays for 2025 backward compat. No new CRD fields. No updates to `docs/reference/` required.

--- a/docs/design/broker-2026-07-28/tasks/tasks.md
+++ b/docs/design/broker-2026-07-28/tasks/tasks.md
@@ -1,0 +1,225 @@
+# Broker 2026-07-28 Implementation Plan
+
+## Existing Code Analysis
+
+**Package location:** `internal/broker/` (package `broker`), `internal/broker/upstream/` (package `upstream`)
+
+**SDK:** `github.com/modelcontextprotocol/go-sdk` — needs bump from `v1.7.0-pre.3` to `v1.7.0` stable
+
+**What exists and gets reused:**
+
+- `FetchUserSpecificTools` — already branches on protocol version (stateful vs stateless fetch). Becomes the body of `ProtocolHandler.FetchUserSpecificTools`
+- `perRequestServers` — precomputed in `OnConfigChange` from `UserSpecificList` CRD field. Extended to include `cacheScope:"private"` and `ttlMs:0` servers
+- `filteringMiddleware` — `tools/list` middleware that calls `toolsForProtocol`, `FetchUserSpecificTools`, `FilterTools`. Extended to call `AggregateCache`
+- `protocolRouter` in `http_compat.go` — dispatches 2026 to stateless handler, 2025 to compat handler. Unchanged
+- `compatHandler.rewriteToolsList` / `rewritePromptsList` — strips `ttlMs`/`cacheScope` from 2025 responses. Unchanged (verification only)
+- `notificationWatcher` — GET SSE stream watcher for upstream notifications. Stays for 2025 upstreams
+- `MCPServer.UsesStatelessProtocol()` — protocol version check. Used for notification mechanism selection
+- `serverVersions` sync.Map — tracks protocol versions per upstream. Used by `ShouldFetchFresh` for version-aware decisions
+
+**Notification flow:**
+- `MCPServer.startNotificationWatcher` creates a `notificationWatcher` that opens GET SSE to upstream
+- On `tools/list_changed` or `prompts/list_changed`, it calls `up.notify(method)` which triggers the manager's event loop
+- Manager re-lists tools/prompts and updates the gateway server via `AddTools`/`DeleteTools`
+- `gatewayServer.TriggerToolsListChanged` sends notifications to subscribed clients
+
+## Dependency Graph
+
+```text
+Task 1 (SDK bump to v1.7.0)
+  ↓
+Task 2 (cacheMetadata + upstream storage)
+  ↓
+Task 3 (ProtocolHandler interface + 2025 impl)  ← CHECKPOINT: existing behavior preserved
+  ↓
+Task 4 (ProtocolHandler2026 impl)
+  ↓
+Task 5 (Wire handlers into broker)
+  ↓
+Task 6 (subscriptions/listen for 2026)          ← CHECKPOINT: full feature functional
+  ↓
+Task 7 (E2E test cases)
+  ↓
+Task 8 (Documentation)
+```
+
+Tasks 1-3 are plumbing with no new behavior — existing tests validate correctness throughout. Task 4 adds new aggregation and fetch logic. Task 5 wires it. Task 6 replaces the notification mechanism for 2026. Tasks 7-8 are test and doc artifacts.
+
+## Task 1: SDK bump to v1.7.0
+
+**Files:** `go.mod`, `go.sum`
+
+Bump `github.com/modelcontextprotocol/go-sdk` from `v1.7.0-pre.3` to `v1.7.0` stable. This provides `CacheableResult` types with `TTLMs` and `CacheScope` fields, `SubscriptionsListenParams`, and stable `server/discover`.
+
+**Acceptance criteria:**
+- [ ] `go.mod` references `v1.7.0`
+- [ ] `CacheableResult` type accessible from the SDK
+- [ ] `make lint` passes
+- [ ] `make test-unit` passes
+
+**Verification:** `make lint && make test-unit`
+
+## Task 2: Upstream cache metadata storage
+
+**Files:** `internal/broker/upstream/mcp.go`, `internal/broker/upstream/manager.go`, `internal/broker/upstream/mcp_test.go`
+
+Add `cacheMetadata` to the upstream `MCPServer` and populate it from `ListTools`/`ListPrompts` responses.
+
+```go
+type cacheMetadata struct {
+    TTLMs            int
+    CacheScope       string // "public" or "private"
+    UserSpecificList bool   // from CRD, carried through for scope aggregation
+}
+```
+
+- Add `toolsCacheMeta` and `promptsCacheMeta` fields to `MCPServer`, guarded by `clientMu`
+- After `ListTools`, store metadata in `toolsCacheMeta`; after `ListPrompts`, store in `promptsCacheMeta`
+- Set `UserSpecificList` from the CRD config when constructing the upstream, so `AggregateCache` has all scope signals in one struct
+- Defaults: `TTLMs: 0`, `CacheScope: "public"`, `UserSpecificList: false` (2025 backends produce these via SDK defaults)
+- Add `ToolsCacheMetadata()` and `PromptsCacheMetadata()` to the `MCP` and `ActiveMCPServer` interfaces
+
+**Acceptance criteria:**
+- [ ] `cacheMetadata` struct defined
+- [ ] `MCPServer` stores metadata per result type (`toolsCacheMeta`, `promptsCacheMeta`)
+- [ ] `MCP` and `ActiveMCPServer` interfaces expose `ToolsCacheMetadata()` and `PromptsCacheMetadata()`
+- [ ] Defaults are `TTLMs:0`, `CacheScope:"public"` before first list
+- [ ] Unit test: tools and prompts metadata populated independently from their list results
+- [ ] `make lint && make test-unit` passes
+
+**Verification:** `make lint && make test-unit`
+
+## Task 3: ProtocolHandler interface and ProtocolHandler2025
+
+**Files:** `internal/broker/protocol_handler.go` (new), `internal/broker/protocol_handler_2025.go` (new), `internal/broker/protocol_handler_2025_test.go` (new)
+
+Define the `ProtocolHandler` interface:
+
+```go
+type ProtocolHandler interface {
+    FetchUserSpecificTools(ctx context.Context, servers []perRequestServer, headers http.Header, result *mcp.ListToolsResult)
+    ShouldFetchFresh(srv perRequestServer, meta *cacheMetadata) bool
+    AggregateCache(contributing []cacheMetadata) (ttlMs int, cacheScope string)
+    StartNotificationWatcher(ctx context.Context, server *upstream.MCPServer)
+}
+```
+
+`ProtocolHandler2025` wraps existing behavior:
+- `FetchUserSpecificTools`: stateful fetch via session pool (moves logic from `broker.FetchUserSpecificTools` 2025 branch)
+- `ShouldFetchFresh`: returns `srv.UserSpecificList` (CRD field only)
+- `AggregateCache`: returns `(0, "")` — compat handler strips these fields
+- `StartNotificationWatcher`: calls `MCPServer.startNotificationWatcher` (existing GET SSE)
+
+**Key constraint:** existing unit tests for `FetchUserSpecificTools` and `filteringMiddleware` must pass with minimal changes.
+
+**Acceptance criteria:**
+- [ ] `ProtocolHandler` interface defined in `protocol_handler.go`
+- [ ] `ProtocolHandler2025` implements all 4 methods
+- [ ] `ShouldFetchFresh` uses `UserSpecificList` CRD field only
+- [ ] `AggregateCache` returns zero values (no aggregation for 2025)
+- [ ] Existing `user_specific_tools_test.go` tests pass
+- [ ] `make lint && make test-unit` passes
+
+**Verification:** `make lint && make test-unit`
+
+**CHECKPOINT: all existing tests pass with the new interface extracted. No new behavior yet.**
+
+## Task 4: ProtocolHandler2026
+
+**Files:** `internal/broker/protocol_handler_2026.go` (new), `internal/broker/protocol_handler_2026_test.go` (new)
+
+Implement the 2026 protocol handler:
+
+- `FetchUserSpecificTools`: stateless connect-list-close (moves logic from `broker.FetchUserSpecificTools` 2026 branch)
+- `ShouldFetchFresh`: returns `true` when `meta.CacheScope == "private"` or `meta.TTLMs == 0`
+- `AggregateCache`: `min(non-zero TTLMs)` across contributing upstreams; `"private"` if any upstream is private or any has `userSpecificList`; `"public"` otherwise. If all TTLMs are 0, aggregate is 0
+- `StartNotificationWatcher`: placeholder (wired in Task 6)
+
+**Acceptance criteria:**
+- [ ] `ProtocolHandler2026` implements all 4 methods
+- [ ] `ShouldFetchFresh` triggers on `cacheScope:"private"` or `ttlMs:0`
+- [ ] `AggregateCache` computes correct `min(non-zero ttlMs)`
+- [ ] `AggregateCache` returns `"private"` when any upstream is private or has `userSpecificList`
+- [ ] `AggregateCache` returns `(0, "public")` when all TTLMs are 0 and none are private
+- [ ] Unit tests cover: all-public, mixed, all-private, ttlMs-zero, single server, empty input
+- [ ] `make lint && make test-unit` passes
+
+**Verification:** `make lint && make test-unit`
+
+## Task 5: Wire protocol handlers into broker
+
+**Files:** `internal/broker/broker.go`, `internal/broker/user_specific_tools.go`, `internal/broker/protocol_filter.go`
+
+Integrate `ProtocolHandler` into the broker:
+
+- Add `handler2025 ProtocolHandler` and `handler2026 ProtocolHandler` fields to `mcpBrokerImpl`
+- Construct handlers in `NewMCPBroker`
+- In `OnConfigChange.startManagers`: rebuild `perRequestServers` using `ShouldFetchFresh` from the appropriate handler based on upstream protocol version. 2026 upstreams with `cacheScope:"private"` or `ttlMs:0` join the list alongside CRD-declared `userSpecificList` servers
+- When upstream cache metadata changes (detected on re-list in the manager event loop), atomically rebuild `perRequestServers` immediately — not deferred to the next `OnConfigChange`. This prevents a window where a newly-private upstream leaks as public
+- In `filteringMiddleware` `tools/list` case: after `FilterTools`, call `AggregateCache` on the 2026 handler with contributing upstreams' metadata and set `result.TTLMs` and `result.CacheScope` on the `ListToolsResult`
+- In `filteringMiddleware` `prompts/list` case: same aggregation for prompts
+- Refactor `FetchUserSpecificTools` to delegate to the protocol handler selected by client version header
+- Verify: 2025 client responses unchanged (compat handler strips `ttlMs`/`cacheScope`)
+
+**Acceptance criteria:**
+- [ ] Broker holds two `ProtocolHandler` instances
+- [ ] `perRequestServers` includes 2026 upstreams with `cacheScope:"private"` or `ttlMs:0`
+- [ ] 2026 `tools/list` responses include aggregated `ttlMs` and `cacheScope`
+- [ ] 2025 `tools/list` responses unchanged (compat handler strips fields)
+- [ ] `prompts/list` responses include aggregated fields for 2026 clients
+- [ ] Existing `user_specific_tools_test.go`, `protocol_filter_test.go` tests pass
+- [ ] `make lint && make test-unit` passes
+- [ ] `make test-controller-integration` passes
+
+**Verification:** `make lint && make test-unit && make test-controller-integration`
+
+## Task 6: subscriptions/listen for 2026 upstreams
+
+**Files:** `internal/broker/upstream/mcp.go`, `internal/broker/upstream/subscriptions_listener.go` (new), `internal/broker/upstream/subscriptions_listener_test.go` (new), `internal/broker/protocol_handler_2026.go`
+
+Replace GET SSE `notificationWatcher` with SDK `subscriptions/listen` for 2026 upstreams:
+
+- Create `subscriptionsListener` that uses the SDK client's `SubscriptionsListen` to subscribe to `toolsListChanged` and `promptsListChanged`
+- Same backoff/retry semantics as `notificationWatcher`
+- Same `notify` callback interface so the manager's event loop is unchanged
+- In `MCPServer.Connect`: select notification mechanism based on `UsesStatelessProtocol()`
+- Wire `ProtocolHandler2026.StartNotificationWatcher` to use `subscriptionsListener`
+- 2025 upstreams continue using `notificationWatcher` unchanged
+
+**Acceptance criteria:**
+- [ ] `subscriptionsListener` subscribes to `toolsListChanged` and `promptsListChanged`
+- [ ] 2026 upstreams use `subscriptionsListener` instead of `notificationWatcher`
+- [ ] 2025 upstreams continue using `notificationWatcher`
+- [ ] Manager event loop processes notifications from both mechanisms identically
+- [ ] Unit test: subscriptions listener triggers tool refresh
+- [ ] `make lint && make test-unit` passes
+
+**Verification:** `make lint && make test-unit`
+
+**CHECKPOINT: full feature functional. Both protocol paths work with correct cache aggregation and notification mechanisms.**
+
+## Task 7: E2E test cases
+
+**Files:** `docs/design/broker-2026-07-28/tasks/test_cases.md`, `tests/e2e/test_cases.md` (update)
+
+Write integration and e2e test cases per `test_cases.md`.
+
+**Acceptance criteria:**
+- [ ] Integration test cases documented for aggregation logic, ShouldFetchFresh, and middleware behavior
+- [ ] E2E test cases documented for full-stack flows
+- [ ] E2E cases added to `tests/e2e/test_cases.md`
+- [ ] Cases cover all job stories from the design doc
+
+**Verification:** Review test cases cover goals G1-G5.
+
+## Task 8: Documentation
+
+**Files:** `docs/design/broker-2026-07-28/tasks/documentation.md`
+
+Documentation plan per `documentation.md`.
+
+**Acceptance criteria:**
+- [ ] Documentation plan covers user-facing changes
+- [ ] Security architecture updated for cache scope trust model
+
+**Verification:** Review documentation plan covers all user-facing behavior.

--- a/docs/design/broker-2026-07-28/tasks/tasks.md
+++ b/docs/design/broker-2026-07-28/tasks/tasks.md
@@ -157,17 +157,22 @@ Integrate `ProtocolHandler` into the broker:
 - In `OnConfigChange.startManagers`: rebuild `perRequestServers` using `ShouldFetchFresh` from the appropriate handler based on upstream protocol version. 2026 upstreams with `cacheScope:"private"` or `ttlMs:0` join the list alongside CRD-declared `userSpecificList` servers
 - When upstream cache metadata changes (detected on re-list in the manager event loop), atomically rebuild `perRequestServers` immediately — not deferred to the next `OnConfigChange`. This prevents a window where a newly-private upstream leaks as public
 - In `filteringMiddleware` `tools/list` case: after `FilterTools`, call `AggregateCache` on the 2026 handler with contributing upstreams' metadata and set `result.TTLMs` and `result.CacheScope` on the `ListToolsResult`
-- In `filteringMiddleware` `prompts/list` case: same aggregation for prompts
+- In `filteringMiddleware` `prompts/list` case: filter prompts by protocol version via `promptsForProtocol` (mirroring `toolsForProtocol`), then apply same cache aggregation
+- Add `promptsForProtocol` to `protocol_filter.go`: add `statefulPrompts`/`statelessPrompts` atomic caches to `mcpBrokerImpl`, rebuild in `rebuildProtocolToolCache` (rename to `rebuildProtocolCaches`), partition prompts by upstream server version the same way tools are partitioned
 - Refactor `FetchUserSpecificTools` to delegate to the protocol handler selected by client version header
 - Verify: 2025 client responses unchanged (compat handler strips `ttlMs`/`cacheScope`)
+- Verify: 2026 `prompts/list` excludes prompts from 2025-only upstreams
 
 **Acceptance criteria:**
 - [ ] Broker holds two `ProtocolHandler` instances
 - [ ] `perRequestServers` includes 2026 upstreams with `cacheScope:"private"` or `ttlMs:0`
 - [ ] 2026 `tools/list` responses include aggregated `ttlMs` and `cacheScope`
 - [ ] 2025 `tools/list` responses unchanged (compat handler strips fields)
+- [ ] `prompts/list` filtered by protocol version — 2026 clients only see prompts from 2026-capable upstreams
 - [ ] `prompts/list` responses include aggregated fields for 2026 clients
+- [ ] 2025 `prompts/list` responses unchanged
 - [ ] Existing `user_specific_tools_test.go`, `protocol_filter_test.go` tests pass
+- [ ] Unit test: 2026 `prompts/list` excludes 2025-only prompts
 - [ ] `make lint && make test-unit` passes
 - [ ] `make test-controller-integration` passes
 

--- a/docs/design/broker-2026-07-28/tasks/test_cases.md
+++ b/docs/design/broker-2026-07-28/tasks/test_cases.md
@@ -64,6 +64,14 @@ When the middleware processes a `tools/list` result for a 2026 client, it calls 
 
 Same as tools/list but for `prompts/list` — aggregated cache fields set on the prompt list result.
 
+### promptsForProtocol filters prompts by upstream version
+
+When a 2026 client sends `prompts/list`, the middleware calls `promptsForProtocol` which returns only prompts from 2026-capable upstreams. Prompts from 2025-only upstreams are excluded. A 2025 client sees only prompts from 2025-capable upstreams. Mirrors the existing `toolsForProtocol` behavior.
+
+### promptsForProtocol cache rebuilt on prompt changes
+
+When prompts are added or removed from the gateway server, the `statefulPrompts`/`statelessPrompts` caches are rebuilt alongside the tool caches. Verified by checking that a newly registered prompt from a 2026 upstream appears in the 2026 prompt set.
+
 ### compatHandler strips ttlMs and cacheScope for 2025 clients
 
 When a 2025 client receives a `tools/list` response that has `ttlMs` and `cacheScope` set by the middleware, the compat handler's `rewriteToolsList` removes them. Existing test coverage may already verify this — confirm and extend if needed.
@@ -100,6 +108,10 @@ A 2026 upstream sends `tools/list_changed`. The broker receives it via `subscrip
 ### [Broker2026] 2025 upstream GET SSE notification unaffected
 
 A 2025 upstream sends `tools/list_changed` via GET SSE. The broker processes it and refreshes tools normally. Verifies 2025 notification path is not regressed. Existing notification e2e tests may already cover this — extend if needed rather than duplicating.
+
+### [Happy,Broker2026] 2026 client prompts/list excludes 2025-only prompts
+
+A gateway has both 2025 and 2026 upstreams, each with prompts. A 2026 client sends `prompts/list`. The response includes only prompts from the 2026 upstream. Prompts from the 2025-only upstream are absent. A 2025 client sends `prompts/list` and sees only the 2025 upstream's prompts.
 
 ### [Broker2026,Security] Private scope prevents cross-user tool list leak
 

--- a/docs/design/broker-2026-07-28/tasks/test_cases.md
+++ b/docs/design/broker-2026-07-28/tasks/test_cases.md
@@ -1,0 +1,106 @@
+# Broker 2026-07-28 Test Cases
+
+## Integration Tests
+
+Tests that verify broker internals with mock upstreams. No Envoy, no real gateway — direct broker API calls with controlled upstream responses.
+
+### AggregateCache returns min of non-zero ttlMs
+
+Given two upstreams with `ttlMs:60000` and `ttlMs:30000`, both `cacheScope:"public"`, `AggregateCache` returns `(30000, "public")`.
+
+### AggregateCache returns private when any upstream is private
+
+Given two upstreams — one `cacheScope:"public"`, one `cacheScope:"private"` — `AggregateCache` returns `cacheScope:"private"`. The ttlMs is the min of non-zero values.
+
+### AggregateCache returns zero ttlMs when all upstreams are zero
+
+Given two upstreams both with `ttlMs:0` and `cacheScope:"public"`, `AggregateCache` returns `(0, "public")`. `ttlMs:0` triggers `ShouldFetchFresh` but does not force private scope.
+
+### AggregateCache ignores ttlMs zero for scope aggregation
+
+Given upstreams with `ttlMs:60000, cacheScope:"public"` and `ttlMs:0, cacheScope:"public"`, `AggregateCache` returns `(60000, "public")`. The `ttlMs:0` server is always-fetched by the broker but does not force private scope — only `cacheScope:"private"` and `userSpecificList` drive scope.
+
+### AggregateCache single upstream passthrough
+
+Given one upstream with `ttlMs:45000, cacheScope:"public"`, `AggregateCache` returns `(45000, "public")` unchanged.
+
+### AggregateCache empty input
+
+Given no contributing upstreams, `AggregateCache` returns `(0, "")` (no cache fields to set).
+
+### ShouldFetchFresh triggers on cacheScope private
+
+`ProtocolHandler2026.ShouldFetchFresh` returns `true` when upstream metadata has `cacheScope:"private"`, regardless of `ttlMs` value or CRD `userSpecificList` field.
+
+### ShouldFetchFresh triggers on ttlMs zero
+
+`ProtocolHandler2026.ShouldFetchFresh` returns `true` when upstream metadata has `ttlMs:0`, regardless of `cacheScope` value.
+
+### ShouldFetchFresh false for public non-zero
+
+`ProtocolHandler2026.ShouldFetchFresh` returns `false` when upstream metadata has `cacheScope:"public"` and `ttlMs > 0`.
+
+### ShouldFetchFresh 2025 uses CRD field only
+
+`ProtocolHandler2025.ShouldFetchFresh` returns the value of `userSpecificList` from the CRD, ignoring cache metadata entirely.
+
+### cacheScope private supersedes userSpecificList false
+
+When a 2026 upstream has `userSpecificList:false` on the CRD but reports `cacheScope:"private"`, the broker includes it in the `perRequestServers` list. Verified by checking `perRequestServers` after `OnConfigChange`.
+
+### perRequestServers rebuilt immediately on upstream metadata change
+
+When an upstream's `cacheScope` changes from `"public"` to `"private"` (detected on re-list), the broker atomically rebuilds `perRequestServers` immediately. The server appears in the fresh-fetch list on the next client request without waiting for `OnConfigChange`.
+
+### cacheMetadata defaults for 2025 upstreams
+
+A 2025 upstream that returns no `ttlMs`/`cacheScope` in its list response gets defaults: `TTLMs:0`, `CacheScope:"public"`.
+
+### filteringMiddleware sets ttlMs and cacheScope on 2026 tools/list
+
+When the middleware processes a `tools/list` result for a 2026 client, it calls `AggregateCache` and sets the result's `TTLMs` and `CacheScope` fields.
+
+### filteringMiddleware sets ttlMs and cacheScope on 2026 prompts/list
+
+Same as tools/list but for `prompts/list` — aggregated cache fields set on the prompt list result.
+
+### compatHandler strips ttlMs and cacheScope for 2025 clients
+
+When a 2025 client receives a `tools/list` response that has `ttlMs` and `cacheScope` set by the middleware, the compat handler's `rewriteToolsList` removes them. Existing test coverage may already verify this — confirm and extend if needed.
+
+## E2E Tests
+
+Tests that require the full gateway stack: client → Envoy → router → broker → upstream MCP servers.
+
+---
+test_suite: broker_2026_test.go
+tags: Happy,Broker2026,Security
+---
+
+### [Happy,Broker2026] 2026 client tools/list returns ttlMs and cacheScope
+
+A 2026 client sends `tools/list` to the gateway. The upstream 2026 test server reports `ttlMs:60000` and `cacheScope:"public"`. The response includes these fields at the top level of the list result alongside the tools.
+
+### [Happy,Broker2026] cacheScope private triggers per-user tool fetch
+
+A 2026 upstream reports `cacheScope:"private"`. A 2026 client sends `tools/list` with auth headers. The broker fetches per-user tools from that upstream using the client's credentials, without `userSpecificList:true` on the MCPServerRegistration. The response includes the user-specific tools and `cacheScope:"private"`.
+
+### [Happy,Broker2026] 2025 client response unchanged with 2026 upstreams
+
+A 2025 client sends `tools/list` to a gateway with 2026 upstreams reporting `ttlMs` and `cacheScope`. The response does not include these fields. Tool list content matches pre-2026 behavior.
+
+### [Happy,Broker2026] Mixed protocol gateway serves both client versions
+
+A gateway has both 2025 and 2026 upstreams. A 2026 client `tools/list` returns 2026-upstream tools with aggregated `ttlMs`/`cacheScope`. A 2025 client `tools/list` returns 2025-upstream tools without cache fields. Neither client sees tools from unsupported protocol upstreams.
+
+### [Broker2026] 2026 upstream notification triggers tool refresh
+
+A 2026 upstream sends `tools/list_changed`. The broker receives it via `subscriptions/listen`, re-lists tools, and notifies subscribed 2026 clients. Verifies the notification mechanism works end-to-end through the real gateway.
+
+### [Broker2026] 2025 upstream GET SSE notification unaffected
+
+A 2025 upstream sends `tools/list_changed` via GET SSE. The broker processes it and refreshes tools normally. Verifies 2025 notification path is not regressed. Existing notification e2e tests may already cover this — extend if needed rather than duplicating.
+
+### [Broker2026,Security] Private scope prevents cross-user tool list leak
+
+Two clients (different auth headers) send `tools/list` to a gateway with one `cacheScope:"private"` upstream and one `cacheScope:"public"` upstream. Both see the same public tools. The private upstream's tools reflect each client's credentials. The aggregated response has `cacheScope:"private"`.


### PR DESCRIPTION
## What does this PR do?

Adds a design doc for implementing the 2026 protocol in the broker component. 

Focuses on ttlms and cache scope. Moves us closer to being able to deploy the components separately and add `subscriptions/listen` support over the old notifications 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added broker `2026-07-28` protocol design guidance, clarifying how `cacheScope` and `ttlMs` are derived and how `ttlMs: 0` affects freshness and aggregation.
  * Updated the broker documentation to describe immediate cache-privacy behavior, including how per-request server handling refreshes when upstream cache settings change.
  * Expanded the `2026-07-28` implementation plan and added broker `2026-07-28` test-case scenarios covering freshness rules and cross-user privacy protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->