### PR TITLE
fix: derive protocol-2026 server hostnames from E2E_DOMAIN

### DIFF
--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -146,6 +146,11 @@ func protocol2026PublicHostDefault() string {
 	return "mcp.protocol-2026." + e2eDomain
 }
 
+// protocol2026ServerHost returns a server hostname for the protocol-2026 listener.
+func protocol2026ServerHost(subdomain string) string {
+	return subdomain + ".protocol-2026." + e2eDomain
+}
+
 // public hosts - derived from E2E_DOMAIN
 var (
 	gatewayPublicHost        = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())

--- a/tests/e2e/dual_protocol_test.go
+++ b/tests/e2e/dual_protocol_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 			InNamespace(dualProtoNamespace).
 			WithBackendTarget("mcp-test-server1", 9090).
 			WithBackendNamespace(TestServerNameSpace).
-			WithHostname("stateful.protocol-2026.127-0-0-1.sslip.io").
+			WithHostname(protocol2026ServerHost("stateful")).
 			WithPrefix("sf_").
 			WithSectionName(Protocol2026ListenerName).
 			WithParentGateway(GatewayName, GatewayNamespace).
@@ -85,7 +85,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 			InNamespace(dualProtoNamespace).
 			WithBackendTarget("mcp-test-stateless-server", 9090).
 			WithBackendNamespace(TestServerNameSpace).
-			WithHostname("stateless.protocol-2026.127-0-0-1.sslip.io").
+			WithHostname(protocol2026ServerHost("stateless")).
 			WithPrefix("sl_").
 			WithSectionName(Protocol2026ListenerName).
 			WithParentGateway(GatewayName, GatewayNamespace).
@@ -274,7 +274,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 				InNamespace(dualProtoNamespace).
 				WithBackendTarget("mcp-test-stateless-server", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("uspec-sl.protocol-2026.127-0-0-1.sslip.io").
+				WithHostname(protocol2026ServerHost("uspec-sl")).
 				WithPrefix("usl_").
 				WithUserSpecificList().
 				WithSectionName(Protocol2026ListenerName).
@@ -315,7 +315,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 				InNamespace(dualProtoNamespace).
 				WithBackendTarget("mcp-test-stateless-server", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("uspec-cross.protocol-2026.127-0-0-1.sslip.io").
+				WithHostname(protocol2026ServerHost("uspec-cross")).
 				WithPrefix("ucross_").
 				WithUserSpecificList().
 				WithSectionName(Protocol2026ListenerName).
@@ -364,7 +364,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 				InNamespace(dualProtoNamespace).
 				WithBackendTarget("mcp-test-stateless-server", 9090).
 				WithBackendNamespace(TestServerNameSpace).
-				WithHostname("noprefix.protocol-2026.127-0-0-1.sslip.io").
+				WithHostname(protocol2026ServerHost("noprefix")).
 				WithSectionName(Protocol2026ListenerName).
 				WithParentGateway(GatewayName, GatewayNamespace).
 				Build()


### PR DESCRIPTION
## What does this PR do?

The dual-protocol e2e tests hardcoded `*.protocol-2026.127-0-0-1.sslip.io` hostnames, making them fail on non-Kind clusters where `E2E_DOMAIN` is set to a real domain.

## Changes
- Add `protocol2026ServerHost(subdomain)` helper to `tests/e2e/commons.go` that derives server hostnames from `e2eDomain` instead of hardcoding `127-0-0-1.sslip.io`
- Replace 5 hardcoded hostnames in `dual_protocol_test.go` with calls to the new helper

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [ ] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [ ] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [ ] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [ ] All CI checks pass, or failures have been investigated and explained below
- [ ] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by generating protocol-specific server hostnames from the configured test environment.
  * Updated dual-protocol and protocol-2026 test scenarios to use consistent hostname construction instead of fixed local addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->