### PR TITLE
fix: reject non-CA certificates in validateCACertPEM

### DIFF
--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -762,7 +762,10 @@ func (r *MCPReconciler) findMCPServerRegistrationsForHTTPRoute(ctx context.Conte
 	return requests
 }
 
-// validateCACertPEM checks that the data contains at least one valid PEM-encoded certificate.
+// validateCACertPEM checks that the data contains at least one valid PEM-encoded
+// CA certificate. Certificates that explicitly declare BasicConstraints CA:FALSE
+// are rejected; certificates that omit BasicConstraints entirely are accepted,
+// since older root CAs and dev certs often don't set it.
 func validateCACertPEM(data []byte) error {
 	rest := data
 	found := false
@@ -775,8 +778,12 @@ func validateCACertPEM(data []byte) error {
 		if block.Type != "CERTIFICATE" {
 			return fmt.Errorf("unexpected PEM block type %q, expected CERTIFICATE", block.Type)
 		}
-		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
 			return fmt.Errorf("failed to parse certificate: %w", err)
+		}
+		if cert.BasicConstraintsValid && !cert.IsCA {
+			return fmt.Errorf("certificate for %q is not a CA certificate", cert.Subject.CommonName)
 		}
 		found = true
 	}

--- a/internal/controller/mcpserverregistration_controller_test.go
+++ b/internal/controller/mcpserverregistration_controller_test.go
@@ -93,6 +93,55 @@ func testCACertPEM(t *testing.T) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
 
+// leafCertPEM builds a cert like a server's own TLS cert: BasicConstraints is
+// present and explicitly says IsCA=false. This is what someone gets by mistakenly
+// pasting a leaf cert into ca.crt instead of the issuing CA.
+func leafCertPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "my-service.example.com"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// legacyRootCertPEM builds a cert like an old-style self-signed root CA that never
+// set the BasicConstraints extension at all. These must keep validating successfully.
+func legacyRootCertPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "Legacy Root CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: false,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
 func TestValidateCACertPEM(t *testing.T) {
 	validPEM := testCACertPEM(t)
 
@@ -128,6 +177,20 @@ func TestValidateCACertPEM(t *testing.T) {
 			name:    "corrupt certificate DER",
 			data:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not-valid-der")}),
 			wantErr: "failed to parse certificate",
+		},
+		{
+			name:    "leaf certificate explicitly not a CA",
+			data:    leafCertPEM(t),
+			wantErr: "not a CA certificate",
+		},
+		{
+			name: "legacy root CA without BasicConstraints must still be accepted",
+			data: legacyRootCertPEM(t),
+		},
+		{
+			name:    "chain with valid CA followed by a leaf cert",
+			data:    append(testCACertPEM(t), leafCertPEM(t)...),
+			wantErr: "not a CA certificate",
 		},
 	}
 


### PR DESCRIPTION
## What does this PR do?

`validateCACertPEM` now rejects certificates that explicitly declare `BasicConstraints CA:FALSE` (e.g. a server's own leaf TLS cert pasted into `ca.crt` by mistake), while still accepting certificates that omit `BasicConstraints` entirely, since older root CAs and dev certs often don't set it.

Fixes #1247

## Testing

Added 3 new subtests to `TestValidateCACertPEM`: leaf cert rejected, legacy root without `BasicConstraints` still accepted, and a chain with a valid CA followed by a leaf cert still rejected. All 9 subtests pass, including with `-race`. Full `make test-unit` suite green, no regressions.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [ ] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [ ] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [ ] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [ ] All CI checks pass, or failures have been investigated and explained below
- [ ] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CA certificate validation to reject certificates explicitly marked as non-CA.
  * Continued supporting legacy root certificates that omit CA constraints.
  * Improved validation of certificate chains containing invalid leaf certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->