### PR TITLE
Protocol handler broker (ground work)

### DIFF
--- a/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
+++ b/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
@@ -193,5 +193,5 @@ None. `userSpecificList` stays for 2025 backward compat.
 
 See:
 - [Implementation plan](tasks/tasks.md) — 8 tasks ordered by dependency
-- [Test cases](tasks/test_cases.md) — integration and e2e tests covering G1-G5
+- [Test cases](tasks/test_cases.md) — integration and e2e tests covering G1-G6
 - [Documentation plan](tasks/documentation.md) — security architecture and design doc updates

--- a/docs/design/broker-2026-07-28/tasks/tasks.md
+++ b/docs/design/broker-2026-07-28/tasks/tasks.md
@@ -80,12 +80,12 @@ type cacheMetadata struct {
 - Add `ToolsCacheMetadata()` and `PromptsCacheMetadata()` to the `MCP` and `ActiveMCPServer` interfaces
 
 **Acceptance criteria:**
-- [ ] `cacheMetadata` struct defined
-- [ ] `MCPServer` stores metadata per result type (`toolsCacheMeta`, `promptsCacheMeta`)
-- [ ] `MCP` and `ActiveMCPServer` interfaces expose `ToolsCacheMetadata()` and `PromptsCacheMetadata()`
-- [ ] Defaults are `TTLMs:0`, `CacheScope:"public"` before first list
-- [ ] Unit test: tools and prompts metadata populated independently from their list results
-- [ ] `make lint && make test-unit` passes
+- [x] `cacheMetadata` struct defined
+- [x] `MCPServer` stores metadata per result type (`toolsCacheMeta`, `promptsCacheMeta`)
+- [x] `MCP` and `ActiveMCPServer` interfaces expose `ToolsCacheMetadata()` and `PromptsCacheMetadata()`
+- [x] Defaults are `TTLMs:0`, `CacheScope:"public"` before first list
+- [x] Unit test: tools and prompts metadata populated independently from their list results
+- [x] `make lint && make test-unit` passes
 
 **Verification:** `make lint && make test-unit`
 
@@ -113,12 +113,12 @@ type ProtocolHandler interface {
 **Key constraint:** existing unit tests for `FetchUserSpecificTools` and `filteringMiddleware` must pass with minimal changes.
 
 **Acceptance criteria:**
-- [ ] `ProtocolHandler` interface defined in `protocol_handler.go`
-- [ ] `ProtocolHandler2025` implements all 4 methods
-- [ ] `ShouldFetchFresh` uses `UserSpecificList` CRD field only
-- [ ] `AggregateCache` returns zero values (no aggregation for 2025)
-- [ ] Existing `user_specific_tools_test.go` tests pass
-- [ ] `make lint && make test-unit` passes
+- [x] `ProtocolHandler` interface defined in `protocol_handler.go`
+- [x] `ProtocolHandler2025` implements all 4 methods
+- [x] `ShouldFetchFresh` uses `UserSpecificList` CRD field only
+- [x] `AggregateCache` returns zero values (no aggregation for 2025)
+- [x] Existing `user_specific_tools_test.go` tests pass
+- [x] `make lint && make test-unit` passes
 
 **Verification:** `make lint && make test-unit`
 

--- a/internal/broker/protocol_handler.go
+++ b/internal/broker/protocol_handler.go
@@ -1,0 +1,31 @@
+package broker
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ProtocolHandler encapsulates version-specific broker behavior for MCP
+// protocol versions. The broker holds one handler per supported version
+// and delegates to the appropriate one based on the upstream's or
+// client's negotiated version.
+type ProtocolHandler interface {
+	// FetchUserSpecificTools fetches tools from per-request servers using the
+	// caller's headers and merges them into result.
+	FetchUserSpecificTools(ctx context.Context, servers []userSpecificServer, headers http.Header, result *mcp.ListToolsResult)
+
+	// ShouldFetchFresh returns true if the given server's tools must be
+	// fetched per request rather than served from the broker's cache.
+	ShouldFetchFresh(srv userSpecificServer, meta *upstream.CacheMetadata) bool
+
+	// AggregateCache computes the aggregate ttlMs and cacheScope across
+	// contributing upstream servers' cache metadata.
+	AggregateCache(contributing []upstream.CacheMetadata) (ttlMs int, cacheScope string)
+
+	// StartNotificationWatcher starts the version-appropriate notification
+	// mechanism for an upstream server.
+	StartNotificationWatcher(ctx context.Context, server *upstream.MCPServer)
+}

--- a/internal/broker/protocol_handler_2025.go
+++ b/internal/broker/protocol_handler_2025.go
@@ -1,0 +1,51 @@
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var _ ProtocolHandler = (*ProtocolHandler2025)(nil)
+
+// ProtocolHandler2025 implements ProtocolHandler for MCP 2025-11-25.
+// It wraps existing stateful fetch behavior: session pool reuse,
+// gateway session ID requirement, and no cache aggregation.
+type ProtocolHandler2025 struct {
+	broker *mcpBrokerImpl
+	logger *slog.Logger
+}
+
+// NewProtocolHandler2025 creates a 2025 protocol handler backed by the broker.
+func NewProtocolHandler2025(broker *mcpBrokerImpl, logger *slog.Logger) *ProtocolHandler2025 {
+	return &ProtocolHandler2025{broker: broker, logger: logger}
+}
+
+// FetchUserSpecificTools performs stateful fetch via the session pool.
+func (h *ProtocolHandler2025) FetchUserSpecificTools(ctx context.Context, servers []userSpecificServer, headers http.Header, result *mcp.ListToolsResult) {
+	if len(servers) == 0 {
+		return
+	}
+	h.broker.fetchStatefulUserTools(ctx, servers, headers, result)
+}
+
+// ShouldFetchFresh for 2025 returns true only when the CRD declares
+// userSpecificList — no runtime cache metadata signals.
+func (h *ProtocolHandler2025) ShouldFetchFresh(srv userSpecificServer, _ *upstream.CacheMetadata) bool {
+	return h.broker.isUserSpecificByCRD(srv)
+}
+
+// AggregateCache returns zero values for 2025 — the compat handler
+// strips ttlMs and cacheScope from responses to 2025 clients.
+func (h *ProtocolHandler2025) AggregateCache(_ []upstream.CacheMetadata) (int, string) {
+	return 0, ""
+}
+
+// StartNotificationWatcher is a no-op for 2025 — notification watcher
+// startup is handled by MCPServer.Connect directly.
+func (h *ProtocolHandler2025) StartNotificationWatcher(_ context.Context, _ *upstream.MCPServer) {
+	// existing GET SSE watcher is started inside MCPServer.Connect
+}

--- a/internal/broker/protocol_handler_2025_test.go
+++ b/internal/broker/protocol_handler_2025_test.go
@@ -1,0 +1,120 @@
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/Kuadrant/mcp-gateway/internal/session"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolHandler2025_ShouldFetchFresh_UsesUserSpecificListOnly(t *testing.T) {
+	mockServer := newMockActiveMCPServer(config.MCPServer{
+		Name:             "srv",
+		URL:              "http://localhost/mcp",
+		Prefix:           "s_",
+		UserSpecificList: true,
+	})
+	b := &mcpBrokerImpl{
+		mcpServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			mockServer.cfg.ID(): mockServer,
+		},
+		logger: slog.Default(),
+	}
+	h := NewProtocolHandler2025(b, slog.Default())
+	srv := toUserSpecificServer(mockServer.cfg)
+
+	// regardless of cache metadata, ShouldFetchFresh should follow CRD field
+	require.True(t, h.ShouldFetchFresh(srv, nil))
+	require.True(t, h.ShouldFetchFresh(srv, &upstream.CacheMetadata{CacheScope: "private", TTLMs: 0}))
+	require.True(t, h.ShouldFetchFresh(srv, &upstream.CacheMetadata{CacheScope: "public", TTLMs: 5000}))
+}
+
+func TestProtocolHandler2025_ShouldFetchFresh_FalseWhenNotUserSpecific(t *testing.T) {
+	mockServer := newMockActiveMCPServer(config.MCPServer{
+		Name:             "srv",
+		URL:              "http://localhost/mcp",
+		Prefix:           "s_",
+		UserSpecificList: false,
+	})
+	b := &mcpBrokerImpl{
+		mcpServers: map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			mockServer.cfg.ID(): mockServer,
+		},
+		logger: slog.Default(),
+	}
+	h := NewProtocolHandler2025(b, slog.Default())
+	srv := toUserSpecificServer(mockServer.cfg)
+
+	require.False(t, h.ShouldFetchFresh(srv, nil))
+}
+
+func TestProtocolHandler2025_AggregateCache_ReturnsZero(t *testing.T) {
+	h := NewProtocolHandler2025(nil, slog.Default())
+
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 5000, CacheScope: "public"},
+		{TTLMs: 10000, CacheScope: "private"},
+	})
+	assert.Equal(t, 0, ttl)
+	assert.Equal(t, "", scope)
+
+	ttl, scope = h.AggregateCache(nil)
+	assert.Equal(t, 0, ttl)
+	assert.Equal(t, "", scope)
+}
+
+func TestProtocolHandler2025_FetchUserSpecificTools(t *testing.T) {
+	var initCount atomic.Int32
+	ts := newTestMCPServer(&initCount, "upstream-session-1")
+	defer ts.Close()
+
+	cfg := config.MCPServer{
+		Name:             "user-server",
+		URL:              ts.URL,
+		Prefix:           "us_",
+		State:            "Enabled",
+		UserSpecificList: true,
+	}
+	cache, _ := session.NewCache()
+	srv := toUserSpecificServer(cfg)
+	b := &mcpBrokerImpl{
+		logger:                   slog.Default(),
+		sessionCache:             cache,
+		userSpecificFetchTimeout: 10 * time.Second,
+	}
+	h := NewProtocolHandler2025(b, slog.Default())
+
+	result := &mcp.ListToolsResult{
+		Tools: []*mcp.Tool{{Name: "cached-tool"}},
+	}
+	headers := http.Header{
+		"Mcp-Session-Id": []string{"gw-session-abc"},
+		"Authorization":  []string{"Bearer user-token"},
+	}
+
+	h.FetchUserSpecificTools(context.Background(), []userSpecificServer{srv}, headers, result)
+
+	require.Len(t, result.Tools, 2)
+	assert.Equal(t, "cached-tool", result.Tools[0].Name)
+	assert.Equal(t, "us_user_tool", result.Tools[1].Name)
+}
+
+func TestProtocolHandler2025_FetchUserSpecificTools_EmptyServers(t *testing.T) {
+	h := NewProtocolHandler2025(nil, slog.Default())
+
+	result := &mcp.ListToolsResult{
+		Tools: []*mcp.Tool{{Name: "existing"}},
+	}
+
+	h.FetchUserSpecificTools(context.Background(), nil, http.Header{}, result)
+	assert.Len(t, result.Tools, 1)
+}

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -99,6 +99,10 @@ type MCP interface {
 	SupportedVersions() []string
 	// SupportsVersion returns true if this upstream supports the given protocol version.
 	SupportsVersion(v string) bool
+	// ToolsCacheMetadata returns cache metadata from the last tools/list response.
+	ToolsCacheMetadata() CacheMetadata
+	// PromptsCacheMetadata returns cache metadata from the last prompts/list response.
+	PromptsCacheMetadata() CacheMetadata
 }
 
 // ActiveMCPServer is the handle returned by Start. It exposes read-only
@@ -115,6 +119,8 @@ type ActiveMCPServer interface {
 	Config() config.MCPServer
 	SupportedVersions() []string
 	SupportsVersion(v string) bool
+	ToolsCacheMetadata() CacheMetadata
+	PromptsCacheMetadata() CacheMetadata
 }
 
 // GatewayTool pairs a tool definition with the handler the gateway
@@ -386,9 +392,11 @@ func (a *activeMCP) GetManagedPrompts() []mcp.Prompt { return a.manager.GetManag
 func (a *activeMCP) GetServedManagedPrompt(p string) *mcp.Prompt {
 	return a.manager.GetServedManagedPrompt(p)
 }
-func (a *activeMCP) Config() config.MCPServer      { return a.manager.mcp.GetConfig() }
-func (a *activeMCP) SupportedVersions() []string   { return a.manager.mcp.SupportedVersions() }
-func (a *activeMCP) SupportsVersion(v string) bool { return a.manager.mcp.SupportsVersion(v) }
+func (a *activeMCP) Config() config.MCPServer            { return a.manager.mcp.GetConfig() }
+func (a *activeMCP) SupportedVersions() []string         { return a.manager.mcp.SupportedVersions() }
+func (a *activeMCP) SupportsVersion(v string) bool       { return a.manager.mcp.SupportsVersion(v) }
+func (a *activeMCP) ToolsCacheMetadata() CacheMetadata   { return a.manager.mcp.ToolsCacheMetadata() }
+func (a *activeMCP) PromptsCacheMetadata() CacheMetadata { return a.manager.mcp.PromptsCacheMetadata() }
 
 func (man *MCPManager) registerCallbacks() func() {
 	man.logger.Debug("registering callbacks", "upstream mcp server", man.mcp.ID())

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -188,6 +188,9 @@ func (m *MockMCP) SupportsVersion(v string) bool {
 	return false
 }
 
+func (m *MockMCP) ToolsCacheMetadata() CacheMetadata   { return CacheMetadata{} }
+func (m *MockMCP) PromptsCacheMetadata() CacheMetadata { return CacheMetadata{} }
+
 // newMockMCP creates a MockMCP with sensible defaults for testing
 func newMockMCP(name, prefix string) *MockMCP {
 	id := config.UpstreamMCPID(fmt.Sprintf("%s:%s:http://mock/mcp", name, prefix))

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -28,6 +28,19 @@ var (
 	defaultExpectContinueTimeout = 1 * time.Second
 )
 
+// cache scope values for upstream list response hints
+const (
+	CacheScopePublic  = "public"
+	CacheScopePrivate = "private"
+)
+
+// CacheMetadata holds per-result-type cache hints from upstream list responses.
+type CacheMetadata struct {
+	TTLMs            int
+	CacheScope       string // CacheScopePublic or CacheScopePrivate
+	UserSpecificList bool   // from CRD, carried through for scope aggregation
+}
+
 // MCPServer represents a connection to an upstream MCP server. It wraps the
 // configuration and client, managing the connection lifecycle and storing
 // initialization state from the MCP handshake.
@@ -52,6 +65,11 @@ type MCPServer struct {
 	hintsMu   sync.RWMutex
 	toolHints map[string]ToolHints
 
+	// cache metadata from the last tools/list and prompts/list responses,
+	// guarded by clientMu
+	toolsCacheMeta   CacheMetadata
+	promptsCacheMeta CacheMetadata
+
 	// notifyHandler receives list-changed notification methods. stored on
 	// the upstream so it can be wired into each new client before its
 	// session connects, leaving no registration gap.
@@ -75,6 +93,8 @@ func NewUpstreamMCP(config *config.MCPServer, gatewayCACertPEM string, logger *s
 		MCPServer:        config,
 		gatewayCACertPEM: gatewayCACertPEM,
 		logger:           logger,
+		toolsCacheMeta:   CacheMetadata{UserSpecificList: config.UserSpecificList},
+		promptsCacheMeta: CacheMetadata{UserSpecificList: config.UserSpecificList},
 	}
 	up.headers = map[string]string{
 		"user-agent":        "mcp-broker",
@@ -434,6 +454,20 @@ func (up *MCPServer) Ping(ctx context.Context) error {
 	return session.Ping(ctx, nil)
 }
 
+// ToolsCacheMetadata returns the cache metadata from the last tools/list response.
+func (up *MCPServer) ToolsCacheMetadata() CacheMetadata {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+	return up.toolsCacheMeta
+}
+
+// PromptsCacheMetadata returns the cache metadata from the last prompts/list response.
+func (up *MCPServer) PromptsCacheMetadata() CacheMetadata {
+	up.clientMu.RLock()
+	defer up.clientMu.RUnlock()
+	return up.promptsCacheMeta
+}
+
 // SupportsPrompts checks if the upstream server declared prompt capabilities
 func (up *MCPServer) SupportsPrompts() bool {
 	if up.init == nil || up.init.Capabilities == nil {
@@ -456,7 +490,16 @@ func (up *MCPServer) ListPrompts(ctx context.Context) (*mcp.ListPromptsResult, e
 	if session == nil {
 		return nil, fmt.Errorf("client not connected")
 	}
-	return session.ListPrompts(ctx, nil)
+	result, err := session.ListPrompts(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	// partial update: preserve UserSpecificList set at construction
+	up.clientMu.Lock()
+	up.promptsCacheMeta.TTLMs = result.TTLMs
+	up.promptsCacheMeta.CacheScope = result.CacheScope
+	up.clientMu.Unlock()
+	return result, nil
 }
 
 // ListTools retrieves the list of available tools from the upstream MCP server
@@ -465,7 +508,16 @@ func (up *MCPServer) ListTools(ctx context.Context) (*mcp.ListToolsResult, error
 	if session == nil {
 		return nil, fmt.Errorf("client not connected")
 	}
-	return session.ListTools(ctx, nil)
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	// partial update: preserve UserSpecificList set at construction
+	up.clientMu.Lock()
+	up.toolsCacheMeta.TTLMs = result.TTLMs
+	up.toolsCacheMeta.CacheScope = result.CacheScope
+	up.clientMu.Unlock()
+	return result, nil
 }
 
 // SupportsResources checks if the upstream server declared resource capabilities

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"io"
 	"math/big"
@@ -652,4 +653,74 @@ func TestSupportsVersion(t *testing.T) {
 	if up.SupportsVersion("9999-01-01") {
 		t.Error("should not support unknown version")
 	}
+}
+
+func TestCacheMetadata_Defaults(t *testing.T) {
+	up := NewUpstreamMCP(&config.MCPServer{Name: "defaults"}, "", nil)
+	meta := up.ToolsCacheMetadata()
+	require.Equal(t, 0, meta.TTLMs)
+	require.Equal(t, "", meta.CacheScope)
+	require.False(t, meta.UserSpecificList)
+
+	pmeta := up.PromptsCacheMetadata()
+	require.Equal(t, 0, pmeta.TTLMs)
+	require.Equal(t, "", pmeta.CacheScope)
+	require.False(t, pmeta.UserSpecificList)
+}
+
+func TestCacheMetadata_UserSpecificListFromCRD(t *testing.T) {
+	up := NewUpstreamMCP(&config.MCPServer{
+		Name:             "user-specific",
+		UserSpecificList: true,
+	}, "", nil)
+	require.True(t, up.ToolsCacheMetadata().UserSpecificList)
+	require.True(t, up.PromptsCacheMetadata().UserSpecificList)
+}
+
+func TestCacheMetadata_PopulatedFromListTools(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "up", Version: "0.0.1"}, nil)
+	srv.AddTool(&mcp.Tool{
+		Name:        "t1",
+		Description: "test tool",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+	})
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "up", URL: ts.URL}, "", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	defer func() { _ = up.Disconnect() }()
+
+	// before listing, defaults
+	require.Equal(t, 0, up.ToolsCacheMetadata().TTLMs)
+
+	_, err := up.ListTools(ctx)
+	require.NoError(t, err)
+
+	// SDK defaults: TTLMs 0 (immediately stale), CacheScope "public"
+	meta := up.ToolsCacheMetadata()
+	require.Equal(t, 0, meta.TTLMs)
+	require.Equal(t, "public", meta.CacheScope)
+}
+
+func TestCacheMetadata_ToolsAndPromptsIndependent(t *testing.T) {
+	up := NewUpstreamMCP(&config.MCPServer{Name: "indep"}, "", nil)
+
+	// simulate storing different metadata
+	up.clientMu.Lock()
+	up.toolsCacheMeta = CacheMetadata{TTLMs: 5000, CacheScope: "public"}
+	up.promptsCacheMeta = CacheMetadata{TTLMs: 10000, CacheScope: "private"}
+	up.clientMu.Unlock()
+
+	tmeta := up.ToolsCacheMetadata()
+	pmeta := up.PromptsCacheMetadata()
+	require.Equal(t, 5000, tmeta.TTLMs)
+	require.Equal(t, "public", tmeta.CacheScope)
+	require.Equal(t, 10000, pmeta.TTLMs)
+	require.Equal(t, "private", pmeta.CacheScope)
 }

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -428,6 +428,53 @@ func gatewaySessionTTL(gatewaySessionID string) time.Duration {
 	return ttl
 }
 
+// isUserSpecificByCRD checks if the server's CRD config declares userSpecificList.
+func (broker *mcpBrokerImpl) isUserSpecificByCRD(srv userSpecificServer) bool {
+	broker.mcpLock.RLock()
+	defer broker.mcpLock.RUnlock()
+	mgr, ok := broker.mcpServers[srv.id]
+	if !ok {
+		return false
+	}
+	return mgr.Config().UserSpecificList
+}
+
+// fetchStatefulUserTools fetches tools from the given servers using the stateful
+// session pool and merges them into result. Extracted for reuse by ProtocolHandler2025.
+func (broker *mcpBrokerImpl) fetchStatefulUserTools(ctx context.Context, servers []userSpecificServer, headers http.Header, result *mcp.ListToolsResult) {
+	gatewaySessionID := headers.Get(gatewaySessionHeader)
+	if gatewaySessionID == "" {
+		broker.logger.Error("no gateway session ID for user-specific tool fetch")
+		return
+	}
+
+	userHeaders := filterUserHeaders(headers)
+
+	var mu sync.Mutex
+	var allTools []mcp.Tool
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, srv := range servers {
+		g.Go(func() error {
+			tools, err := broker.fetchToolsFromServer(gCtx, srv, userHeaders, gatewaySessionID)
+			if err != nil {
+				broker.logger.Error("failed to fetch user-specific tools", "server", srv.name, "error", err)
+				return nil
+			}
+			broker.logger.Debug("fetched user-specific tools", "server", srv.name, "toolCount", len(tools))
+			mu.Lock()
+			allTools = append(allTools, tools...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	for i := range allTools {
+		result.Tools = append(result.Tools, &allTools[i])
+	}
+}
+
 // sensitiveForwardHeaders are client headers that must never be forwarded to
 // upstream MCP servers. cookie and proxy-authorization are scoped to the
 // gateway origin/hop, not the upstream, so forwarding them would leak

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -401,6 +401,17 @@ func (m *mockActiveMCPServer) GetManagedPrompts() []mcp.Prompt             { ret
 func (m *mockActiveMCPServer) GetServedManagedPrompt(_ string) *mcp.Prompt { return nil }
 func (m *mockActiveMCPServer) Config() config.MCPServer                    { return m.cfg }
 func (m *mockActiveMCPServer) configPtr() *config.MCPServer                { return &m.cfg }
+func (m *mockActiveMCPServer) GetToolHints(_ string) (upstream.ToolHints, bool) {
+	return upstream.ToolHints{}, false
+}
+func (m *mockActiveMCPServer) SupportedVersions() []string   { return nil }
+func (m *mockActiveMCPServer) SupportsVersion(_ string) bool { return false }
+func (m *mockActiveMCPServer) ToolsCacheMetadata() upstream.CacheMetadata {
+	return upstream.CacheMetadata{}
+}
+func (m *mockActiveMCPServer) PromptsCacheMetadata() upstream.CacheMetadata {
+	return upstream.CacheMetadata{}
+}
 
 // seedUserSession dials the fake upstream and stores a pooled session for
 // the given gateway session ID.

--- a/internal/broker/version_test.go
+++ b/internal/broker/version_test.go
@@ -71,3 +71,9 @@ func (m *mockActiveServer) SupportsVersion(v string) bool {
 	}
 	return false
 }
+func (m *mockActiveServer) ToolsCacheMetadata() upstream.CacheMetadata {
+	return upstream.CacheMetadata{}
+}
+func (m *mockActiveServer) PromptsCacheMetadata() upstream.CacheMetadata {
+	return upstream.CacheMetadata{}
+}


### PR DESCRIPTION
## What does this PR do?

 - Task 2 done — CacheMetadata struct with CacheScopePublic/CacheScopePrivate constants, toolsCacheMeta/promptsCacheMeta on MCPServer, populated from
  ListTools/ListPrompts responses, exposed via MCP and ActiveMCPServer interfaces. 4 unit tests.
  - Task 3 done — ProtocolHandler interface (4 methods), ProtocolHandler2025 implementation delegating to shared fetchStatefulUserTools helper, isUserSpecificByCRD
  in user_specific_tools.go.

relates to #1316 

Remaining work:

- Task 4: ProtocolHandler2026
  - Task 5: Wire handlers into broker (includes prompt protocol filtering)
  - Task 6: subscriptions/listen for 2026
  - Task 7: E2E test cases
  - Task 8: Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP 2025-11-25 protocol handling.
  * Introduced cache metadata support for both tools and prompts (TTL, scope, and user-specific settings).
  * Enabled session-aware user-specific tool fetching when applicable.
* **Bug Fixes**
  * Improved cache freshness decisions for user-specific tool lists.
* **Tests**
  * Added coverage for the 2025 protocol handler, cache metadata behavior, and user-specific tool handling.
* **Documentation**
  * Updated the execution test plan coverage reference to goals G1–G6 and completed relevant task acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->