### PR TITLE
Protocol handler broker task 4

### DIFF
--- a/docs/design/broker-2026-07-28/tasks/tasks.md
+++ b/docs/design/broker-2026-07-28/tasks/tasks.md
@@ -136,13 +136,13 @@ Implement the 2026 protocol handler:
 - `StartNotificationWatcher`: placeholder (wired in Task 6)
 
 **Acceptance criteria:**
-- [ ] `ProtocolHandler2026` implements all 4 methods
-- [ ] `ShouldFetchFresh` triggers on `cacheScope:"private"` or `ttlMs:0`
-- [ ] `AggregateCache` computes correct `min(non-zero ttlMs)`
-- [ ] `AggregateCache` returns `"private"` when any upstream is private or has `userSpecificList`
-- [ ] `AggregateCache` returns `(0, "public")` when all TTLMs are 0 and none are private
-- [ ] Unit tests cover: all-public, mixed, all-private, ttlMs-zero, single server, empty input
-- [ ] `make lint && make test-unit` passes
+- [x] `ProtocolHandler2026` implements all 4 methods
+- [x] `ShouldFetchFresh` triggers on `cacheScope:"private"` or `ttlMs:0`
+- [x] `AggregateCache` computes correct `min(non-zero ttlMs)`
+- [x] `AggregateCache` returns `"private"` when any upstream is private or has `userSpecificList`
+- [x] `AggregateCache` returns `(0, "public")` when all TTLMs are 0 and none are private
+- [x] Unit tests cover: all-public, mixed, all-private, ttlMs-zero, single server, empty input
+- [x] `make lint && make test-unit` passes
 
 **Verification:** `make lint && make test-unit`
 

--- a/docs/design/broker-2026-07-28/tasks/tasks.md
+++ b/docs/design/broker-2026-07-28/tasks/tasks.md
@@ -76,14 +76,14 @@ type cacheMetadata struct {
 - Add `toolsCacheMeta` and `promptsCacheMeta` fields to `MCPServer`, guarded by `clientMu`
 - After `ListTools`, store metadata in `toolsCacheMeta`; after `ListPrompts`, store in `promptsCacheMeta`
 - Set `UserSpecificList` from the CRD config when constructing the upstream, so `AggregateCache` has all scope signals in one struct
-- Defaults: `TTLMs: 0`, `CacheScope: "public"`, `UserSpecificList: false` (2025 backends produce these via SDK defaults)
+- Defaults: `TTLMs: 0`, `CacheScope: ""`, `UserSpecificList: false` (CacheScope populated to `"public"` after first upstream list call via SDK defaults)
 - Add `ToolsCacheMetadata()` and `PromptsCacheMetadata()` to the `MCP` and `ActiveMCPServer` interfaces
 
 **Acceptance criteria:**
 - [x] `cacheMetadata` struct defined
 - [x] `MCPServer` stores metadata per result type (`toolsCacheMeta`, `promptsCacheMeta`)
 - [x] `MCP` and `ActiveMCPServer` interfaces expose `ToolsCacheMetadata()` and `PromptsCacheMetadata()`
-- [x] Defaults are `TTLMs:0`, `CacheScope:"public"` before first list
+- [x] Defaults are `TTLMs:0`, `CacheScope:""` before first list (populated to `"public"` after first upstream list call)
 - [x] Unit test: tools and prompts metadata populated independently from their list results
 - [x] `make lint && make test-unit` passes
 
@@ -132,7 +132,7 @@ Implement the 2026 protocol handler:
 
 - `FetchUserSpecificTools`: stateless connect-list-close (moves logic from `broker.FetchUserSpecificTools` 2026 branch)
 - `ShouldFetchFresh`: returns `true` when `meta.CacheScope == "private"` or `meta.TTLMs == 0`
-- `AggregateCache`: `min(non-zero TTLMs)` across contributing upstreams; `"private"` if any upstream is private or any has `userSpecificList`; `"public"` otherwise. If all TTLMs are 0, aggregate is 0
+- `AggregateCache`: `min(non-zero TTLMs)` across contributing upstreams; `"private"` if any upstream is private, has `userSpecificList`, or has `TTLMs == 0`; `"public"` otherwise
 - `StartNotificationWatcher`: placeholder (wired in Task 6)
 
 **Acceptance criteria:**
@@ -140,7 +140,7 @@ Implement the 2026 protocol handler:
 - [x] `ShouldFetchFresh` triggers on `cacheScope:"private"` or `ttlMs:0`
 - [x] `AggregateCache` computes correct `min(non-zero ttlMs)`
 - [x] `AggregateCache` returns `"private"` when any upstream is private or has `userSpecificList`
-- [x] `AggregateCache` returns `(0, "public")` when all TTLMs are 0 and none are private
+- [x] `AggregateCache` returns `(0, "private")` when any TTLMs is 0 — zero TTL forces uncacheable/private
 - [x] Unit tests cover: all-public, mixed, all-private, ttlMs-zero, single server, empty input
 - [x] `make lint && make test-unit` passes
 

--- a/internal/broker/protocol_handler_2025.go
+++ b/internal/broker/protocol_handler_2025.go
@@ -2,7 +2,6 @@ package broker
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
@@ -16,12 +15,11 @@ var _ ProtocolHandler = (*ProtocolHandler2025)(nil)
 // gateway session ID requirement, and no cache aggregation.
 type ProtocolHandler2025 struct {
 	broker *mcpBrokerImpl
-	logger *slog.Logger
 }
 
 // NewProtocolHandler2025 creates a 2025 protocol handler backed by the broker.
-func NewProtocolHandler2025(broker *mcpBrokerImpl, logger *slog.Logger) *ProtocolHandler2025 {
-	return &ProtocolHandler2025{broker: broker, logger: logger}
+func NewProtocolHandler2025(broker *mcpBrokerImpl) *ProtocolHandler2025 {
+	return &ProtocolHandler2025{broker: broker}
 }
 
 // FetchUserSpecificTools performs stateful fetch via the session pool.

--- a/internal/broker/protocol_handler_2025_test.go
+++ b/internal/broker/protocol_handler_2025_test.go
@@ -29,7 +29,7 @@ func TestProtocolHandler2025_ShouldFetchFresh_UsesUserSpecificListOnly(t *testin
 		},
 		logger: slog.Default(),
 	}
-	h := NewProtocolHandler2025(b, slog.Default())
+	h := NewProtocolHandler2025(b)
 	srv := toUserSpecificServer(mockServer.cfg)
 
 	// regardless of cache metadata, ShouldFetchFresh should follow CRD field
@@ -51,14 +51,14 @@ func TestProtocolHandler2025_ShouldFetchFresh_FalseWhenNotUserSpecific(t *testin
 		},
 		logger: slog.Default(),
 	}
-	h := NewProtocolHandler2025(b, slog.Default())
+	h := NewProtocolHandler2025(b)
 	srv := toUserSpecificServer(mockServer.cfg)
 
 	require.False(t, h.ShouldFetchFresh(srv, nil))
 }
 
 func TestProtocolHandler2025_AggregateCache_ReturnsZero(t *testing.T) {
-	h := NewProtocolHandler2025(nil, slog.Default())
+	h := NewProtocolHandler2025(nil)
 
 	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
 		{TTLMs: 5000, CacheScope: "public"},
@@ -91,7 +91,7 @@ func TestProtocolHandler2025_FetchUserSpecificTools(t *testing.T) {
 		sessionCache:             cache,
 		userSpecificFetchTimeout: 10 * time.Second,
 	}
-	h := NewProtocolHandler2025(b, slog.Default())
+	h := NewProtocolHandler2025(b)
 
 	result := &mcp.ListToolsResult{
 		Tools: []*mcp.Tool{{Name: "cached-tool"}},
@@ -109,7 +109,7 @@ func TestProtocolHandler2025_FetchUserSpecificTools(t *testing.T) {
 }
 
 func TestProtocolHandler2025_FetchUserSpecificTools_EmptyServers(t *testing.T) {
-	h := NewProtocolHandler2025(nil, slog.Default())
+	h := NewProtocolHandler2025(nil)
 
 	result := &mcp.ListToolsResult{
 		Tools: []*mcp.Tool{{Name: "existing"}},

--- a/internal/broker/protocol_handler_2025_test.go
+++ b/internal/broker/protocol_handler_2025_test.go
@@ -108,6 +108,31 @@ func TestProtocolHandler2025_FetchUserSpecificTools(t *testing.T) {
 	assert.Equal(t, "us_user_tool", result.Tools[1].Name)
 }
 
+func TestProtocolHandler2025_FetchUserSpecificTools_NoSessionID(t *testing.T) {
+	cfg := config.MCPServer{
+		Name:             "user-server",
+		URL:              "http://localhost/mcp",
+		Prefix:           "us_",
+		UserSpecificList: true,
+	}
+	srv := toUserSpecificServer(cfg)
+	b := &mcpBrokerImpl{
+		logger: slog.Default(),
+	}
+	h := NewProtocolHandler2025(b, slog.Default())
+
+	result := &mcp.ListToolsResult{
+		Tools: []*mcp.Tool{{Name: "existing"}},
+	}
+	headers := http.Header{} // no session ID
+
+	h.FetchUserSpecificTools(context.Background(), []userSpecificServer{srv}, headers, result)
+
+	// should return early, no tools added
+	assert.Len(t, result.Tools, 1)
+}
+
+
 func TestProtocolHandler2025_FetchUserSpecificTools_EmptyServers(t *testing.T) {
 	h := NewProtocolHandler2025(nil, slog.Default())
 

--- a/internal/broker/protocol_handler_2025_test.go
+++ b/internal/broker/protocol_handler_2025_test.go
@@ -108,31 +108,6 @@ func TestProtocolHandler2025_FetchUserSpecificTools(t *testing.T) {
 	assert.Equal(t, "us_user_tool", result.Tools[1].Name)
 }
 
-func TestProtocolHandler2025_FetchUserSpecificTools_NoSessionID(t *testing.T) {
-	cfg := config.MCPServer{
-		Name:             "user-server",
-		URL:              "http://localhost/mcp",
-		Prefix:           "us_",
-		UserSpecificList: true,
-	}
-	srv := toUserSpecificServer(cfg)
-	b := &mcpBrokerImpl{
-		logger: slog.Default(),
-	}
-	h := NewProtocolHandler2025(b, slog.Default())
-
-	result := &mcp.ListToolsResult{
-		Tools: []*mcp.Tool{{Name: "existing"}},
-	}
-	headers := http.Header{} // no session ID
-
-	h.FetchUserSpecificTools(context.Background(), []userSpecificServer{srv}, headers, result)
-
-	// should return early, no tools added
-	assert.Len(t, result.Tools, 1)
-}
-
-
 func TestProtocolHandler2025_FetchUserSpecificTools_EmptyServers(t *testing.T) {
 	h := NewProtocolHandler2025(nil, slog.Default())
 

--- a/internal/broker/protocol_handler_2026.go
+++ b/internal/broker/protocol_handler_2026.go
@@ -1,0 +1,72 @@
+package broker
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var _ ProtocolHandler = (*ProtocolHandler2026)(nil)
+
+// ProtocolHandler2026 implements ProtocolHandler for MCP 2026-07-28.
+// Stateless connect-list-close fetching, cache-metadata-driven fresh-fetch
+// detection, and aggregated ttlMs/cacheScope on list responses.
+type ProtocolHandler2026 struct {
+	broker *mcpBrokerImpl
+}
+
+// NewProtocolHandler2026 creates a 2026 protocol handler backed by the broker.
+func NewProtocolHandler2026(broker *mcpBrokerImpl) *ProtocolHandler2026 {
+	return &ProtocolHandler2026{broker: broker}
+}
+
+// FetchUserSpecificTools performs stateless connect-list-close for each server.
+func (h *ProtocolHandler2026) FetchUserSpecificTools(ctx context.Context, servers []userSpecificServer, headers http.Header, result *mcp.ListToolsResult) {
+	if len(servers) == 0 {
+		return
+	}
+	h.broker.fetchStatelessUserTools(ctx, servers, headers, result)
+}
+
+// ShouldFetchFresh returns true when the upstream's cache metadata indicates
+// per-request fetching: private scope or zero TTL.
+func (h *ProtocolHandler2026) ShouldFetchFresh(_ userSpecificServer, meta *upstream.CacheMetadata) bool {
+	if meta == nil {
+		return false
+	}
+	return meta.CacheScope == upstream.CacheScopePrivate || meta.TTLMs == 0
+}
+
+// AggregateCache computes the aggregate ttlMs and cacheScope across
+// contributing upstreams. ttlMs is min of non-zero values (zero means
+// always-fetched, doesn't contribute). cacheScope is "private" if any
+// upstream is private or has userSpecificList.
+func (h *ProtocolHandler2026) AggregateCache(contributing []upstream.CacheMetadata) (int, string) {
+	if len(contributing) == 0 {
+		return 0, ""
+	}
+
+	minTTL := 0
+	scope := upstream.CacheScopePublic
+
+	for i := range contributing {
+		c := &contributing[i]
+		if c.TTLMs > 0 {
+			if minTTL == 0 || c.TTLMs < minTTL {
+				minTTL = c.TTLMs
+			}
+		}
+		if c.CacheScope == upstream.CacheScopePrivate || c.UserSpecificList {
+			scope = upstream.CacheScopePrivate
+		}
+	}
+
+	return minTTL, scope
+}
+
+// StartNotificationWatcher is a placeholder — wired in Task 6 with
+// subscriptions/listen.
+func (h *ProtocolHandler2026) StartNotificationWatcher(_ context.Context, _ *upstream.MCPServer) {
+}

--- a/internal/broker/protocol_handler_2026.go
+++ b/internal/broker/protocol_handler_2026.go
@@ -40,29 +40,33 @@ func (h *ProtocolHandler2026) ShouldFetchFresh(_ userSpecificServer, meta *upstr
 }
 
 // AggregateCache computes the aggregate ttlMs and cacheScope across
-// contributing upstreams. ttlMs is min of non-zero values (zero means
-// always-fetched, doesn't contribute). cacheScope is "private" if any
-// upstream is private or has userSpecificList.
+// contributing upstreams. ttlMs is min of non-zero values; any upstream
+// with TTLMs==0 forces the aggregate to 0 (uncacheable). cacheScope is
+// "private" if any upstream is private, user-specific, or zero-TTL.
 func (h *ProtocolHandler2026) AggregateCache(contributing []upstream.CacheMetadata) (int, string) {
 	if len(contributing) == 0 {
 		return 0, ""
 	}
 
 	minTTL := 0
+	hasZero := false
 	scope := upstream.CacheScopePublic
 
 	for i := range contributing {
 		c := &contributing[i]
-		if c.TTLMs > 0 {
-			if minTTL == 0 || c.TTLMs < minTTL {
-				minTTL = c.TTLMs
-			}
+		if c.TTLMs == 0 {
+			hasZero = true
+		} else if minTTL == 0 || c.TTLMs < minTTL {
+			minTTL = c.TTLMs
 		}
 		if c.CacheScope == upstream.CacheScopePrivate || c.UserSpecificList {
 			scope = upstream.CacheScopePrivate
 		}
 	}
 
+	if hasZero {
+		return 0, upstream.CacheScopePrivate
+	}
 	return minTTL, scope
 }
 

--- a/internal/broker/protocol_handler_2026_test.go
+++ b/internal/broker/protocol_handler_2026_test.go
@@ -71,17 +71,17 @@ func TestProtocolHandler2026_AggregateCache_AllZeroTTL(t *testing.T) {
 		{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
 	})
 	assert.Equal(t, 0, ttl)
-	assert.Equal(t, upstream.CacheScopePublic, scope)
+	assert.Equal(t, upstream.CacheScopePrivate, scope)
 }
 
-func TestProtocolHandler2026_AggregateCache_ZeroTTLIgnoredForMin(t *testing.T) {
+func TestProtocolHandler2026_AggregateCache_ZeroTTLForcesUncacheable(t *testing.T) {
 	h := NewProtocolHandler2026(nil)
 	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
 		{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
 		{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
 	})
-	assert.Equal(t, 60000, ttl)
-	assert.Equal(t, upstream.CacheScopePublic, scope)
+	assert.Equal(t, 0, ttl)
+	assert.Equal(t, upstream.CacheScopePrivate, scope)
 }
 
 func TestProtocolHandler2026_AggregateCache_UserSpecificListForcesPrivate(t *testing.T) {

--- a/internal/broker/protocol_handler_2026_test.go
+++ b/internal/broker/protocol_handler_2026_test.go
@@ -1,0 +1,147 @@
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/session"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolHandler2026_ShouldFetchFresh_PrivateScope(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	assert.True(t, h.ShouldFetchFresh(userSpecificServer{}, &upstream.CacheMetadata{CacheScope: upstream.CacheScopePrivate, TTLMs: 5000}))
+}
+
+func TestProtocolHandler2026_ShouldFetchFresh_ZeroTTL(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	assert.True(t, h.ShouldFetchFresh(userSpecificServer{}, &upstream.CacheMetadata{CacheScope: upstream.CacheScopePublic, TTLMs: 0}))
+}
+
+func TestProtocolHandler2026_ShouldFetchFresh_PublicNonZero(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	assert.False(t, h.ShouldFetchFresh(userSpecificServer{}, &upstream.CacheMetadata{CacheScope: upstream.CacheScopePublic, TTLMs: 5000}))
+}
+
+func TestProtocolHandler2026_ShouldFetchFresh_NilMeta(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	assert.False(t, h.ShouldFetchFresh(userSpecificServer{}, nil))
+}
+
+func TestProtocolHandler2026_AggregateCache_AllPublic(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
+		{TTLMs: 30000, CacheScope: upstream.CacheScopePublic},
+	})
+	assert.Equal(t, 30000, ttl)
+	assert.Equal(t, upstream.CacheScopePublic, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_Mixed(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
+		{TTLMs: 30000, CacheScope: upstream.CacheScopePrivate},
+	})
+	assert.Equal(t, 30000, ttl)
+	assert.Equal(t, upstream.CacheScopePrivate, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_AllPrivate(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 10000, CacheScope: upstream.CacheScopePrivate},
+		{TTLMs: 20000, CacheScope: upstream.CacheScopePrivate},
+	})
+	assert.Equal(t, 10000, ttl)
+	assert.Equal(t, upstream.CacheScopePrivate, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_AllZeroTTL(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
+		{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
+	})
+	assert.Equal(t, 0, ttl)
+	assert.Equal(t, upstream.CacheScopePublic, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_ZeroTTLIgnoredForMin(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
+		{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
+	})
+	assert.Equal(t, 60000, ttl)
+	assert.Equal(t, upstream.CacheScopePublic, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_UserSpecificListForcesPrivate(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
+		{TTLMs: 30000, CacheScope: upstream.CacheScopePublic, UserSpecificList: true},
+	})
+	assert.Equal(t, 30000, ttl)
+	assert.Equal(t, upstream.CacheScopePrivate, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_SingleServer(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache([]upstream.CacheMetadata{
+		{TTLMs: 45000, CacheScope: upstream.CacheScopePublic},
+	})
+	assert.Equal(t, 45000, ttl)
+	assert.Equal(t, upstream.CacheScopePublic, scope)
+}
+
+func TestProtocolHandler2026_AggregateCache_Empty(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	ttl, scope := h.AggregateCache(nil)
+	assert.Equal(t, 0, ttl)
+	assert.Equal(t, "", scope)
+}
+
+func TestProtocolHandler2026_FetchUserSpecificTools_EmptyServers(t *testing.T) {
+	h := NewProtocolHandler2026(nil)
+	result := &mcp.ListToolsResult{
+		Tools: []*mcp.Tool{{Name: "existing"}},
+	}
+	h.FetchUserSpecificTools(context.Background(), nil, http.Header{}, result)
+	assert.Len(t, result.Tools, 1)
+}
+
+func TestProtocolHandler2026_FetchUserSpecificTools_Stateless(t *testing.T) {
+	ts := newStatelessTestMCPServer(t)
+	defer ts.Close()
+
+	cache, _ := session.NewCache()
+	srv := userSpecificServer{
+		id: "ns/stateless-server", name: "stateless-server",
+		url: ts.URL, prefix: "sl_",
+	}
+	b := &mcpBrokerImpl{
+		logger:                   slog.Default(),
+		sessionCache:             cache,
+		userSpecificFetchTimeout: 10 * time.Second,
+	}
+	h := NewProtocolHandler2026(b)
+
+	result := &mcp.ListToolsResult{}
+	headers := http.Header{
+		"Authorization": []string{"Bearer user-token"},
+	}
+
+	h.FetchUserSpecificTools(context.Background(), []userSpecificServer{srv}, headers, result)
+
+	require.Len(t, result.Tools, 1)
+	assert.Equal(t, "sl_tool", result.Tools[0].Name)
+}

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -89,58 +89,19 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 
 	broker.logger.Debug("fetching user-specific tools", "serverCount", len(matching), "clientVersion", clientVersion)
 
-	userHeaders := filterUserHeaders(headers)
-
-	var mu sync.Mutex
-	var allTools []mcp.Tool
-
+	before := len(result.Tools)
 	if isStateless {
-		g, gCtx := errgroup.WithContext(ctx)
-		for _, srv := range matching {
-			g.Go(func() error {
-				tools, err := broker.fetchToolsStateless(gCtx, srv, userHeaders)
-				if err != nil {
-					broker.logger.Error("failed to fetch user-specific tools (stateless)", "server", srv.name, "error", err)
-					return nil
-				}
-				broker.logger.Debug("fetched user-specific tools", "server", srv.name, "toolCount", len(tools))
-				mu.Lock()
-				allTools = append(allTools, tools...)
-				mu.Unlock()
-				return nil
-			})
-		}
-		_ = g.Wait()
+		broker.fetchStatelessUserTools(ctx, matching, headers, result)
 	} else {
-		gatewaySessionID := headers.Get(gatewaySessionHeader)
-		if gatewaySessionID == "" {
+		if headers.Get(gatewaySessionHeader) == "" {
 			broker.logger.Error("no gateway session ID for user-specific tool fetch")
 			span.SetStatus(codes.Error, "missing gateway session ID")
 			return
 		}
-		g, gCtx := errgroup.WithContext(ctx)
-		for _, srv := range matching {
-			g.Go(func() error {
-				tools, err := broker.fetchToolsStateful(gCtx, srv, userHeaders, gatewaySessionID)
-				if err != nil {
-					broker.logger.Error("failed to fetch user-specific tools", "server", srv.name, "error", err)
-					return nil
-				}
-				broker.logger.Debug("fetched user-specific tools", "server", srv.name, "toolCount", len(tools))
-				mu.Lock()
-				allTools = append(allTools, tools...)
-				mu.Unlock()
-				return nil
-			})
-		}
-		_ = g.Wait()
+		broker.fetchStatefulUserTools(ctx, matching, headers, result)
 	}
 
-	span.SetAttributes(attribute.Int("mcp.user_specific.tools_fetched", len(allTools)))
-
-	for i := range allTools {
-		result.Tools = append(result.Tools, &allTools[i])
-	}
+	span.SetAttributes(attribute.Int("mcp.user_specific.tools_fetched", len(result.Tools)-before))
 }
 
 func (broker *mcpBrokerImpl) fetchToolsStateful(ctx context.Context, srv userSpecificServer, userHeaders map[string]string, gatewaySessionID string) ([]mcp.Tool, error) {

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -98,7 +98,7 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 		g, gCtx := errgroup.WithContext(ctx)
 		for _, srv := range matching {
 			g.Go(func() error {
-				tools, err := broker.doFetchToolsStateless(gCtx, srv, userHeaders)
+				tools, err := broker.fetchToolsStateless(gCtx, srv, userHeaders)
 				if err != nil {
 					broker.logger.Error("failed to fetch user-specific tools (stateless)", "server", srv.name, "error", err)
 					return nil
@@ -121,7 +121,7 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 		g, gCtx := errgroup.WithContext(ctx)
 		for _, srv := range matching {
 			g.Go(func() error {
-				tools, err := broker.fetchToolsFromServer(gCtx, srv, userHeaders, gatewaySessionID)
+				tools, err := broker.fetchToolsStateful(gCtx, srv, userHeaders, gatewaySessionID)
 				if err != nil {
 					broker.logger.Error("failed to fetch user-specific tools", "server", srv.name, "error", err)
 					return nil
@@ -143,7 +143,7 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 	}
 }
 
-func (broker *mcpBrokerImpl) fetchToolsFromServer(ctx context.Context, srv userSpecificServer, userHeaders map[string]string, gatewaySessionID string) ([]mcp.Tool, error) {
+func (broker *mcpBrokerImpl) fetchToolsStateful(ctx context.Context, srv userSpecificServer, userHeaders map[string]string, gatewaySessionID string) ([]mcp.Tool, error) {
 	tools, err := broker.doFetchTools(ctx, srv, userHeaders, gatewaySessionID)
 	if err != nil {
 		return nil, err
@@ -239,9 +239,9 @@ func (broker *mcpBrokerImpl) doFetchTools(ctx context.Context, srv userSpecificS
 	return &fetchResult{tools: validTools, sessionID: session.ID()}, nil
 }
 
-// doFetchToolsStateless creates a fresh connection, lists tools, and closes
+// fetchToolsStateless creates a fresh connection, lists tools, and closes
 // immediately. no session pool, no caching — each call is independent.
-func (broker *mcpBrokerImpl) doFetchToolsStateless(ctx context.Context, srv userSpecificServer, userHeaders map[string]string) ([]mcp.Tool, error) {
+func (broker *mcpBrokerImpl) fetchToolsStateless(ctx context.Context, srv userSpecificServer, userHeaders map[string]string) ([]mcp.Tool, error) {
 	ctx, span := brokerTracer().Start(ctx, "broker.user-specific-tools.fetch-server-stateless",
 		trace.WithAttributes(
 			attribute.String("mcp.server.name", srv.name),
@@ -456,7 +456,7 @@ func (broker *mcpBrokerImpl) fetchStatefulUserTools(ctx context.Context, servers
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, srv := range servers {
 		g.Go(func() error {
-			tools, err := broker.fetchToolsFromServer(gCtx, srv, userHeaders, gatewaySessionID)
+			tools, err := broker.fetchToolsStateful(gCtx, srv, userHeaders, gatewaySessionID)
 			if err != nil {
 				broker.logger.Error("failed to fetch user-specific tools", "server", srv.name, "error", err)
 				return nil
@@ -486,7 +486,7 @@ func (broker *mcpBrokerImpl) fetchStatelessUserTools(ctx context.Context, server
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, srv := range servers {
 		g.Go(func() error {
-			tools, err := broker.doFetchToolsStateless(gCtx, srv, userHeaders)
+			tools, err := broker.fetchToolsStateless(gCtx, srv, userHeaders)
 			if err != nil {
 				broker.logger.Error("failed to fetch user-specific tools (stateless)", "server", srv.name, "error", err)
 				return nil

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -475,6 +475,36 @@ func (broker *mcpBrokerImpl) fetchStatefulUserTools(ctx context.Context, servers
 	}
 }
 
+// fetchStatelessUserTools fetches tools from the given servers using stateless
+// connect-list-close and merges them into result. Extracted for reuse by ProtocolHandler2026.
+func (broker *mcpBrokerImpl) fetchStatelessUserTools(ctx context.Context, servers []userSpecificServer, headers http.Header, result *mcp.ListToolsResult) {
+	userHeaders := filterUserHeaders(headers)
+
+	var mu sync.Mutex
+	var allTools []mcp.Tool
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, srv := range servers {
+		g.Go(func() error {
+			tools, err := broker.doFetchToolsStateless(gCtx, srv, userHeaders)
+			if err != nil {
+				broker.logger.Error("failed to fetch user-specific tools (stateless)", "server", srv.name, "error", err)
+				return nil
+			}
+			broker.logger.Debug("fetched user-specific tools", "server", srv.name, "toolCount", len(tools))
+			mu.Lock()
+			allTools = append(allTools, tools...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	for i := range allTools {
+		result.Tools = append(result.Tools, &allTools[i])
+	}
+}
+
 // sensitiveForwardHeaders are client headers that must never be forwarded to
 // upstream MCP servers. cookie and proxy-authorization are scoped to the
 // gateway origin/hop, not the upstream, so forwarding them would leak


### PR DESCRIPTION
## What does this PR do?

Builds on #1325 review that one first

relates to https://github.com/Kuadrant/mcp-gateway/issues/1316

  - protocol_handler_2026.go — new file, ProtocolHandler2026 implementing all 4 interface methods
  - protocol_handler_2026_test.go — new file, 14 unit tests
  - user_specific_tools.go — extracted fetchStatelessUserTools helper
  - tasks.md — ticked off Task 4 acceptance criteria



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved protocol-specific handling for MCP 2025 and 2026 clients.
  * Enhanced user-specific tool discovery across stateful and stateless connections.
  * Added cache metadata tracking for tools and prompts, including freshness decisions and cache TTL/scope aggregation.

* **Tests**
  * Expanded unit tests for protocol behavior, cache freshness/aggregation, and user-specific tool handling.
  * Added coverage for upstream cache metadata propagation and related test doubles.

* **Documentation**
  * Updated execution coverage link to reference G1–G6 instead of G1–G5.
  * Marked Tasks 2–4 acceptance-criteria checklist items as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->