### PR TITLE
fix(e2e): stabilize dual-protocol and version negotiation tests

### DIFF
--- a/tests/e2e/dual_protocol_test.go
+++ b/tests/e2e/dual_protocol_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 			server := reg.Register(ctx)
 
 			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationHasCondition(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
 			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 			By("user-a sees list_repos via stateless client")
@@ -307,7 +307,7 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 					"user-a should see usl_list_repos, got: %v", names)
 				g.Expect(slices.Contains(names, "usl_run_pipeline")).To(BeFalse(),
 					"user-a should NOT see usl_run_pipeline")
-			}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
+			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		})
 
 		It("[DualProtocol,UserSpecificList] 2025 client does not see tools from 2026-only UserSpecificList server", func() {
@@ -329,8 +329,13 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 			server := reg.Register(ctx)
 
 			Eventually(func(g Gomega) {
-				g.Expect(VerifyMCPServerRegistrationHasCondition(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
+				g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
 			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+			By("confirming ucross_ tools are visible via a 2026 client before testing 2025 filtering")
+			slC := newStatelessClient()
+			defer func() { _ = slC.Close() }()
+			waitForToolsWithPrefix(slC, "ucross_")
 
 			By("2025 client should not see tools from a 2026-only UserSpecificList server")
 			c := newStatefulClient()

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -1615,6 +1615,16 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 
+		By("Waiting for broker to connect to backend (tools must appear)")
+		statefulC := newTestGatewayClient()
+		defer func() { _ = statefulC.Close() }()
+		Eventually(func(g Gomega) {
+			result, err := statefulC.ListTools(ctx, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(verifyMCPServerRegistrationToolsPresent("discneg_", result)).To(BeTrue(),
+				"discneg_ tools must be present before testing version negotiation")
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
 		By("Connecting with a stateless (2026) client — should negotiate down to 2025")
 		var c *mcp.ClientSession
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
## What does this PR do?

Fixes flaky e2e test failures in dual-protocol and version negotiation tests caused by insufficient timeouts and a race between MCPServerRegistration readiness and broker tool availability.

### Verification Steps
Eye review only, passing e2e test PR check should suffice.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for service registration and backend readiness before validation.
  * Added verification that negotiated tools are available before testing protocol version negotiation.
  * Updated timeout handling for user-specific tool-listing checks.
  * Strengthened cross-protocol validation by confirming tool visibility before applying protocol-specific filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->