### PR TITLE
fix(otel): update sample Grafana dashboard and add Prometheus scrape config

### DIFF
--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -190,7 +190,22 @@ scrape_configs:
         replacement: $1:9090
 ```
 
-If you have Prometheus Operator installed, use a `PodMonitor` targeting the same label and port 9090.
+If you have Prometheus Operator installed, use a `PodMonitor`:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mcp-broker
+  namespace: mcp-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-gateway
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+```
 
 ### Useful PromQL queries
 
@@ -214,6 +229,8 @@ sum(mcp_broker_tools_list_response_bytes)
 ### Istio gateway metrics (built-in)
 
 Istio emits these metrics automatically for all traffic through the gateway. The Istio gateway pod exposes them at `:15090/stats/prometheus`. Add a scrape job for this alongside the broker scrape config:
+
+> **Note:** If you are using the Kuadrant Operator, observability configuration (including Prometheus scraping) is managed centrally via the `Kuadrant` CR. See the [Kuadrant observability guide](https://docs.kuadrant.io/latest/kuadrant-operator/doc/observability/) for details.
 
 ```yaml
   - job_name: istio-gateway

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,11 +1,11 @@
 # OpenTelemetry Integration
 
-This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing, log export, and Prometheus metrics. Tracing and log export require an OTLP endpoint to be configured. Prometheus metrics are always enabled and require no configuration.
+This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing and log export. When enabled, the MCP Router (ext_proc) emits trace spans for every request and can export structured logs via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
 
 ## Prerequisites
 
 - MCP Gateway installed and configured
-- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent) — required only for tracing and log export. Prometheus metrics need no additional infrastructure.
+- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent)
 
 > **Note:** For a pre-configured local stack with OTEL Collector, Tempo, Loki, and Grafana, see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/release-0.6.0/examples/otel).
 
@@ -142,99 +142,6 @@ curl -s -X POST http://your-gateway-host/mcp \
 
 echo "Search for trace: $TRACE_ID"
 ```
-
-## Prometheus Metrics
-
-The broker exposes a Prometheus-compatible `/metrics` endpoint on a dedicated internal port (default `:9090`). This is always enabled — no environment variables or OTLP endpoint required.
-
-### Broker metrics
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `mcp_broker_discovery_total` | Counter | Discovery attempts per upstream server, labelled `status=success` or `status=failure` |
-| `mcp_broker_discovery_duration_seconds` | Histogram | Duration of `tools/list` calls during discovery |
-| `mcp_broker_tools_discovered` | Gauge | Current tool count per upstream server. Set to 0 when a server becomes unreachable |
-| `mcp_broker_upstream_connection_failures_total` | Counter | Connection failures per upstream server |
-| `mcp_broker_tools_list_response_bytes` | Gauge | Serialized size of the validated tool list per upstream server. Proxy for LLM context overhead |
-
-`mcp_broker_discovery_total` uses `server_name` and `status` labels. All other metrics use only `server_name`. Label values are formatted as `namespace/name`, matching the namespace and name of the `MCPServerRegistration` resource (e.g. `mcp-system/my-server`). No high-cardinality labels (session IDs, tool names, call IDs) are used.
-
-### Scraping the metrics endpoint
-
-The metrics port is not routed through the Envoy gateway listener. Scrape it cluster-internally:
-
-```bash
-# Port-forward for local inspection (use pod name directly — unready pods are skipped by deployment forward)
-POD=$(kubectl get pod -n mcp-system -l app.kubernetes.io/name=mcp-gateway \
-  -o jsonpath='{.items[0].metadata.name}')
-kubectl port-forward -n mcp-system pod/$POD 9090:9090 &
-sleep 1
-curl http://localhost:9090/metrics
-```
-
-For Prometheus scraping, add the broker pod IP as a scrape target. The broker `Service` is controller-managed and does not expose port 9090, so scrape by pod IP directly or use a `PodMonitor` if you have Prometheus Operator installed.
-
-### Useful PromQL queries
-
-```promql
-# Current tool count per upstream server
-mcp_broker_tools_discovered
-
-# Discovery failure rate per server
-sum(rate(mcp_broker_discovery_total{status="failure"}[5m])) by (server_name)
-
-# Servers with active connection failures
-sum(rate(mcp_broker_upstream_connection_failures_total[5m])) by (server_name) > 0
-
-# p99 discovery latency per server
-histogram_quantile(0.99, sum(rate(mcp_broker_discovery_duration_seconds_bucket[5m])) by (server_name, le))
-
-# Total tools/list context footprint across all servers
-sum(mcp_broker_tools_list_response_bytes)
-```
-
-### Istio gateway metrics (built-in)
-
-Istio emits these metrics automatically for all traffic through the gateway — no configuration required:
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `istio_requests_total` | Counter | Request count by response code, source, and destination |
-| `istio_request_duration_milliseconds` | Histogram | Request latency |
-
-```promql
-# 5xx error rate per destination
-sum(rate(istio_requests_total{response_code=~"5.."}[5m])) by (destination_service_name)
-
-# 4xx rate per destination (likely misconfiguration)
-sum(rate(istio_requests_total{response_code=~"4.."}[5m])) by (destination_service_name)
-
-# p99 request latency per destination
-histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (destination_service_name, le))
-```
-
-### Istio gateway metrics (optional MCP enrichment)
-
-Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to the existing `istio_requests_total` and `istio_request_duration_milliseconds` metrics:
-
-```bash
-kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/examples/otel/istio-mcp-metrics.yaml
-```
-
-This promotes the `x-mcp-servername` and `x-mcp-method` headers (already set by the MCP Router) into Prometheus label dimensions without any code changes. After applying:
-
-```promql
-# Request rate per MCP server
-sum(rate(istio_requests_total[5m])) by (mcp_server_name)
-
-# p99 latency per MCP server
-histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (mcp_server_name, le))
-
-# Request breakdown by MCP method
-sum(rate(istio_requests_total[5m])) by (mcp_method)
-```
-
-> **Cardinality note:** `mcp_tool_name` is available in the reference config but commented out. Each unique tool name adds a label value — enable it only if your tool count is small and bounded.
 
 ## Next Steps
 

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,11 +1,11 @@
 # OpenTelemetry Integration
 
-This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing and log export. When enabled, the MCP Router (ext_proc) emits trace spans for every request and can export structured logs via OTLP. When no endpoint is configured, OTel is completely disabled with zero overhead.
+This guide covers enabling OpenTelemetry (OTel) on the MCP Gateway for distributed tracing, log export, and Prometheus metrics. Tracing and log export require an OTLP endpoint to be configured. Prometheus metrics are always enabled and require no configuration.
 
 ## Prerequisites
 
 - MCP Gateway installed and configured
-- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent)
+- An OTLP-compatible collector endpoint (e.g., [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Grafana Alloy, Datadog Agent) — required only for tracing and log export. Prometheus metrics need no additional infrastructure.
 
 > **Note:** For a pre-configured local stack with OTEL Collector, Tempo, Loki, and Grafana, see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/release-0.6.0/examples/otel).
 
@@ -143,7 +143,134 @@ curl -s -X POST http://your-gateway-host/mcp \
 echo "Search for trace: $TRACE_ID"
 ```
 
+## Prometheus Metrics
+
+The broker exposes a Prometheus-compatible `/metrics` endpoint on a dedicated internal port (default `:9090`). This is always enabled — no environment variables or OTLP endpoint required.
+
+### Broker metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `mcp_broker_discovery_total` | Counter | Discovery attempts per upstream server, labelled `status=success` or `status=failure` |
+| `mcp_broker_discovery_duration_seconds` | Histogram | Duration of `tools/list` calls during discovery |
+| `mcp_broker_tools_discovered` | Gauge | Current tool count per upstream server. Set to 0 when a server becomes unreachable |
+| `mcp_broker_upstream_connection_failures_total` | Counter | Connection failures per upstream server |
+| `mcp_broker_tools_list_response_bytes` | Gauge | Serialized size of the validated tool list per upstream server. Proxy for LLM context overhead |
+
+`mcp_broker_discovery_total` uses `server_name` and `status` labels. All other metrics use only `server_name`. Label values are formatted as `namespace/name`, matching the namespace and name of the `MCPServerRegistration` resource (e.g. `mcp-system/my-server`). No high-cardinality labels (session IDs, tool names, call IDs) are used.
+
+### Scraping the metrics endpoint
+
+The metrics port is not routed through the Envoy gateway listener. Scrape it cluster-internally:
+
+```bash
+# Port-forward for local inspection (use pod name directly — unready pods are skipped by deployment forward)
+POD=$(kubectl get pod -n mcp-system -l app.kubernetes.io/name=mcp-gateway \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward -n mcp-system pod/$POD 9090:9090 &
+sleep 1
+curl http://localhost:9090/metrics
+```
+
+For Prometheus scraping, the broker `Service` is controller-managed and does not expose port 9090, so scrape by pod IP directly. Use Kubernetes pod service discovery with the `app.kubernetes.io/name=mcp-gateway` label:
+
+```yaml
+scrape_configs:
+  - job_name: mcp-broker
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [mcp-system]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: mcp-gateway
+      - source_labels: [__meta_kubernetes_pod_ip]
+        target_label: __address__
+        replacement: $1:9090
+```
+
+If you have Prometheus Operator installed, use a `PodMonitor` targeting the same label and port 9090.
+
+### Useful PromQL queries
+
+```promql
+# Current tool count per upstream server
+mcp_broker_tools_discovered
+
+# Discovery failure rate per server
+sum(rate(mcp_broker_discovery_total{status="failure"}[5m])) by (server_name)
+
+# Servers with active connection failures
+sum(rate(mcp_broker_upstream_connection_failures_total[5m])) by (server_name) > 0
+
+# p99 discovery latency per server
+histogram_quantile(0.99, sum(rate(mcp_broker_discovery_duration_seconds_bucket[5m])) by (server_name, le))
+
+# Total tools/list context footprint across all servers
+sum(mcp_broker_tools_list_response_bytes)
+```
+
+### Istio gateway metrics (built-in)
+
+Istio emits these metrics automatically for all traffic through the gateway. The Istio gateway pod exposes them at `:15090/stats/prometheus`. Add a scrape job for this alongside the broker scrape config:
+
+```yaml
+  - job_name: istio-gateway
+    metrics_path: /stats/prometheus
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [gateway-system]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_gateway_istio_io_managed]
+        action: keep
+        regex: .+
+      - source_labels: [__meta_kubernetes_pod_ip]
+        target_label: __address__
+        replacement: $1:15090
+```
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `istio_requests_total` | Counter | Request count by response code, source, and destination |
+| `istio_request_duration_milliseconds` | Histogram | Request latency |
+
+```promql
+# 5xx error rate per destination
+sum(rate(istio_requests_total{response_code=~"5.."}[5m])) by (destination_service_name)
+
+# 4xx rate per destination (likely misconfiguration)
+sum(rate(istio_requests_total{response_code=~"4.."}[5m])) by (destination_service_name)
+
+# p99 request latency per destination
+histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (destination_service_name, le))
+```
+
+### Istio gateway metrics (optional MCP enrichment)
+
+Apply the reference Telemetry resource to add `mcp_server_name` and `mcp_method` labels to the existing `istio_requests_total` and `istio_request_duration_milliseconds` metrics:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/examples/otel/istio-mcp-metrics.yaml
+```
+
+This promotes the `x-mcp-servername` and `x-mcp-method` headers (already set by the MCP Router) into Prometheus label dimensions without any code changes. After applying:
+
+```promql
+# Request rate per MCP server
+sum(rate(istio_requests_total[5m])) by (mcp_server_name)
+
+# p99 latency per MCP server
+histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (mcp_server_name, le))
+
+# Request breakdown by MCP method
+sum(rate(istio_requests_total[5m])) by (mcp_method)
+```
+
+> **Cardinality note:** `mcp_tool_name` is available in the reference config but commented out. Each unique tool name adds a label value — enable it only if your tool count is small and bounded.
+
 ## Next Steps
 
-- For a pre-configured local observability stack (OTEL Collector, Tempo, Loki, Grafana), see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/release-0.6.0/examples/otel).
+- For a pre-configured local observability stack (OTEL Collector, Tempo, Loki, Grafana), see the [observability example](https://github.com/Kuadrant/mcp-gateway/tree/main/examples/otel).
 - To scale the gateway with shared session state, see the [scaling guide](./scaling.md).

--- a/examples/otel/grafana-mcp-metrics-dashboard.json
+++ b/examples/otel/grafana-mcp-metrics-dashboard.json
@@ -8,12 +8,6 @@
   "templating": {
     "list": [
       {
-        "name": "datasource",
-        "label": "Prometheus",
-        "type": "datasource",
-        "pluginId": "prometheus"
-      },
-      {
         "name": "server_name",
         "label": "Server",
         "type": "query",
@@ -22,6 +16,12 @@
         "multi": true,
         "includeAll": true,
         "current": { "selected": true, "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "pluginId": "prometheus"
       }
     ]
   },
@@ -230,8 +230,8 @@
     },
     {
       "id": 8,
-      "title": "Request Rate per MCP Server (Istio)",
-      "description": "Requests through the Envoy gateway per MCP server. Requires examples/otel/istio-mcp-metrics.yaml to be applied.",
+      "title": "Gateway Request Rate by MCP Method (Istio)",
+      "description": "Request rate through the Envoy gateway broken down by MCP method. Reliable signal for all gateway traffic. Requires examples/otel/istio-mcp-metrics.yaml.",
       "type": "timeseries",
       "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
@@ -240,25 +240,45 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(istio_requests_total{mcp_server_name!=\"\"}[1m])) by (mcp_server_name)",
-          "legendFormat": "{{mcp_server_name}}"
+          "expr": "sum(rate(istio_requests_total{mcp_method!=\"\",mcp_method!=\"unknown\"}[1m])) by (mcp_method)",
+          "legendFormat": "{{mcp_method}}"
         }
       ]
     },
     {
       "id": 9,
-      "title": "Request Latency per MCP Server p99 (Istio)",
-      "description": "p99 request latency through the Envoy gateway per MCP server. Requires examples/otel/istio-mcp-metrics.yaml to be applied.",
+      "title": "Gateway Error Rate by Response Code (Istio)",
+      "description": "4xx and 5xx error rates through the Envoy gateway. Spikes here indicate client errors or upstream failures visible at the gateway level.",
       "type": "timeseries",
       "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
-        "defaults": { "unit": "ms", "custom": { "lineWidth": 2 } }
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "B" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byFrameRefID", "options": "A" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }
+            ]
+          }
+        ]
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{mcp_server_name!=\"\"}[5m])) by (mcp_server_name, le))",
-          "legendFormat": "{{mcp_server_name}} p99"
+          "expr": "sum(rate(istio_requests_total{response_code=~\"4..\"}[1m])) by (response_code)",
+          "legendFormat": "{{response_code}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(istio_requests_total{response_code=~\"5..\"}[1m])) by (response_code)",
+          "legendFormat": "{{response_code}}",
+          "refId": "B"
         }
       ]
     },

--- a/examples/otel/grafana.yaml
+++ b/examples/otel/grafana.yaml
@@ -39,6 +39,13 @@ data:
               url: '$${__value.raw}'
               datasourceUid: tempo
               urlDisplayLabel: View Trace
+
+      - name: Prometheus
+        type: prometheus
+        uid: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: false
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -112,7 +119,8 @@ spec:
         configMap:
           name: grafana-dashboards-provider
       - name: dashboards
-        emptyDir: {}
+        configMap:
+          name: grafana-mcp-dashboard
 ---
 apiVersion: v1
 kind: Service
@@ -126,3 +134,314 @@ spec:
   - name: http
     port: 3000
     targetPort: 3000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-mcp-dashboard
+  namespace: observability
+data:
+  mcp-gateway-metrics.json: |
+    {
+      "title": "MCP Gateway Metrics",
+      "uid": "mcp-gateway-metrics",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "10s",
+      "time": { "from": "now-15m", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "server_name",
+            "label": "Server",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "query": "label_values(mcp_broker_tools_discovered, server_name)",
+            "multi": true,
+            "includeAll": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          },
+          {
+            "name": "datasource",
+            "label": "Prometheus",
+            "type": "datasource",
+            "pluginId": "prometheus"
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Tools Discovered per Server",
+          "description": "Current number of tools the broker has fetched from each upstream. Drops to 0 when a server becomes unreachable.",
+          "type": "stat",
+          "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none",
+            "textMode": "value_and_name"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": 0 },
+                  { "color": "green", "value": 1 }
+                ]
+              },
+              "unit": "short",
+              "displayName": "${__field.labels.server_name}"
+            }
+          },
+          "targets": [
+            {
+              "expr": "mcp_broker_tools_discovered{server_name=~\"$server_name\"}",
+              "legendFormat": "{{server_name}}",
+              "instant": true
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "Tools List Response Size (bytes)",
+          "description": "Size of the last tools/list response per server. Proxy for LLM context overhead. 0 when server is unreachable.",
+          "type": "stat",
+          "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "value_and_name"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "displayName": "${__field.labels.server_name}"
+            }
+          },
+          "targets": [
+            {
+              "expr": "mcp_broker_tools_list_response_bytes{server_name=~\"$server_name\"}",
+              "legendFormat": "{{server_name}}",
+              "instant": true
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "Total Context Footprint",
+          "description": "Sum of tools/list response bytes across all servers — total LLM context overhead from tool metadata.",
+          "type": "stat",
+          "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": { "unit": "bytes" }
+          },
+          "targets": [
+            {
+              "expr": "sum(mcp_broker_tools_list_response_bytes)",
+              "legendFormat": "Total"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "title": "Connection Failures",
+          "description": "Total connection failures per server since startup. Increments on every failed Connect() or Ping().",
+          "type": "stat",
+          "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none",
+            "textMode": "value_and_name"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": 0 },
+                  { "color": "orange", "value": 1 },
+                  { "color": "red", "value": 10 }
+                ]
+              },
+              "unit": "short",
+              "displayName": "${__field.labels.server_name}"
+            }
+          },
+          "targets": [
+            {
+              "expr": "mcp_broker_upstream_connection_failures_total{server_name=~\"$server_name\"}",
+              "legendFormat": "{{server_name}}",
+              "instant": true
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "title": "Discovery Rate (success vs failure)",
+          "description": "Rate of discovery attempts per server, split by outcome. A rising failure rate means the broker cannot fetch tools from that upstream.",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } },
+            "overrides": [
+              {
+                "matcher": { "id": "byFrameRefID", "options": "B" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              },
+              {
+                "matcher": { "id": "byFrameRefID", "options": "A" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(mcp_broker_discovery_total{status=\"success\",server_name=~\"$server_name\"}[1m])) by (server_name)",
+              "legendFormat": "{{server_name}} success",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(mcp_broker_discovery_total{status=\"failure\",server_name=~\"$server_name\"}[1m])) by (server_name)",
+              "legendFormat": "{{server_name}} failure",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "title": "Discovery Latency (p50 / p99)",
+          "description": "How long tools/list calls take. p99 shows worst-case discovery time — slow discovery delays tool changes reaching clients.",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": { "lineWidth": 2 }
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum(rate(mcp_broker_discovery_duration_seconds_bucket{server_name=~\"$server_name\"}[5m])) by (server_name, le))",
+              "legendFormat": "{{server_name}} p50"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(mcp_broker_discovery_duration_seconds_bucket{server_name=~\"$server_name\"}[5m])) by (server_name, le))",
+              "legendFormat": "{{server_name}} p99"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "title": "Connection Failure Rate",
+          "description": "Rate of connection failures per server. A non-zero value means the broker cannot reach the upstream — check network/DNS/upstream health.",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": { "lineWidth": 2 },
+              "color": { "fixedColor": "red", "mode": "fixed" }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(mcp_broker_upstream_connection_failures_total{server_name=~\"$server_name\"}[1m])) by (server_name)",
+              "legendFormat": "{{server_name}}"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "title": "Gateway Request Rate by MCP Method (Istio)",
+          "description": "Request rate through the Envoy gateway broken down by MCP method. Reliable signal for all gateway traffic. Requires examples/otel/istio-mcp-metrics.yaml.",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{mcp_method!=\"\",mcp_method!=\"unknown\"}[1m])) by (mcp_method)",
+              "legendFormat": "{{mcp_method}}"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "title": "Gateway Error Rate by Response Code (Istio)",
+          "description": "4xx and 5xx error rates through the Envoy gateway. Spikes here indicate client errors or upstream failures visible at the gateway level.",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } },
+            "overrides": [
+              {
+                "matcher": { "id": "byFrameRefID", "options": "B" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              },
+              {
+                "matcher": { "id": "byFrameRefID", "options": "A" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{response_code=~\"4..\"}[1m])) by (response_code)",
+              "legendFormat": "{{response_code}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(istio_requests_total{response_code=~\"5..\"}[1m])) by (response_code)",
+              "legendFormat": "{{response_code}}",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "title": "Request Rate by MCP Method (Istio)",
+          "description": "Requests through the Envoy gateway broken down by MCP method (initialize, tools/list, tools/call etc.). Requires examples/otel/istio-mcp-metrics.yaml.",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 20, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{mcp_method!=\"\"}[1m])) by (mcp_method)",
+              "legendFormat": "{{mcp_method}}"
+            }
+          ]
+        }
+      ]
+    }

--- a/examples/otel/prometheus.yaml
+++ b/examples/otel/prometheus.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: observability
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 10s
+    scrape_configs:
+      - job_name: mcp-broker
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [mcp-system]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            action: keep
+            regex: mcp-gateway
+          - source_labels: [__meta_kubernetes_pod_ip]
+            target_label: __address__
+            replacement: $1:9090
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+
+      - job_name: istio-gateway
+        metrics_path: /stats/prometheus
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [gateway-system]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_gateway_istio_io_managed]
+            action: keep
+            regex: .+
+          - source_labels: [__meta_kubernetes_pod_ip]
+            target_label: __address__
+            replacement: $1:15090
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: observability
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v2.51.0
+        args:
+          - --config.file=/etc/prometheus/prometheus.yml
+          - --storage.tsdb.path=/prometheus
+          - --web.enable-lifecycle
+        ports:
+        - containerPort: 9090
+          name: http
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: observability
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-mcp
+rules:
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-mcp
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: observability


### PR DESCRIPTION
## Summary

- Replaces two Istio panels in the sample Grafana dashboard that showed misleading/flat data due to a limitation in where `x-mcp-servername` is set on the request path
- Fixes a provisioning bug where the dashboard showed no data when loaded from a ConfigMap
- Adds a minimal Prometheus deployment manifest for the local otel stack
- Updates the OpenTelemetry guide with concrete scrape config snippets

## Changes

### Dashboard (`examples/otel/grafana-mcp-metrics-dashboard.json`)

**Panel 8** — replaced "Request Rate per MCP Server (Istio)" with **"Gateway Request Rate by MCP Method (Istio)"**

The original panel queried by `mcp_server_name`. For `tools/call`, Envoy routes the request directly to the backend — the router sets `x-mcp-servername` on the response side, not the outbound request, so the backend-bound traffic was labelled `unknown` rather than the server name. The new panel queries by `mcp_method` which is reliably set for all traffic.

**Panel 9** — replaced "Request Latency per MCP Server p99 (Istio)" with **"Gateway Error Rate by Response Code (Istio)"**

The latency panel suffered the same per-server labelling issue. The new panel shows 4xx (orange) and 5xx (red) rates from Istio — it reacts visibly during the failure demo scenario (upstream scaled to 0).

**Provisioning fix**: replaced `${datasource}` uid with the literal `prometheus` uid throughout. Grafana does not resolve template variables when provisioning dashboards from a ConfigMap, so the dashboard showed "No data sources found" for all panels.

### New file (`examples/otel/prometheus.yaml`)

Minimal Prometheus deployment for the local otel stack with two Kubernetes SD scrape jobs:
- `mcp-broker`: scrapes broker pods at `:9090/metrics` (keyed on `app.kubernetes.io/name=mcp-gateway`)
- `istio-gateway`: scrapes Istio gateway pods at `:15090/stats/prometheus` (keyed on `gateway.istio.io/managed`)

### Grafana manifest (`examples/otel/grafana.yaml`)

- Adds Prometheus datasource (uid: `prometheus`) to the datasources ConfigMap
- Mounts the dashboard JSON as a ConfigMap (`grafana-mcp-dashboard`) so it auto-provisions on stack startup — no manual import needed
- Replaces the `emptyDir` dashboards volume with the ConfigMap mount

### Guide (`docs/guides/opentelemetry.md`)

- Adds concrete `prometheus.yml` scrape config snippets for both the broker and Istio gateway (previously just said "scrape by pod IP directly")
- Notes that Istio uses `/stats/prometheus` not `/metrics` (requires `metrics_path` override)
- Fixes Next Steps link from `release-0.6.0` to `main`

## How to verify

```bash
# Start the local stack
make local-env-setup
make otel
kubectl apply -f examples/otel/prometheus.yaml
kubectl apply -f examples/otel/istio-mcp-metrics.yaml

# Port-forward
kubectl port-forward -n observability svc/grafana 3000:3000 &
```

Open http://localhost:3000/d/mcp-gateway-metrics — all panels should show data without any manual import or datasource configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that OpenTelemetry handles tracing and log export, while Prometheus metrics operate independently.
  - Added Kubernetes scraping examples for MCP Gateway and Istio gateway metrics.
  - Clarified that Prometheus metrics require no additional infrastructure beyond Prometheus configuration.

- **New Features**
  - Added a Kubernetes Prometheus deployment with service discovery and permissions.
  - Added Grafana datasource provisioning and an MCP Gateway Metrics dashboard.
  - Enhanced dashboards with server filtering, latency, discovery, connection, response, and gateway error-rate panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->