### PR TITLE
fix: propagate upstream 4xx status codes during lazy init

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -103,10 +103,16 @@ func Initialize(ctx context.Context, gatewayHost string, conf *config.MCPServer,
 		// the discover short circuit answers the SDK's server/discover
 		// probe in-process; the hairpin costs exactly the requests it did
 		// on mark3labs (initialize + notifications/initialized)
+		//
+		// StatusCapturingRoundTripper converts non-2xx responses into a
+		// typed error before the SDK sees them, preserving the HTTP status
+		// code that would otherwise be lost in the SDK's string wrapping.
 		Transport: &transport.DiscoverShortCircuit{
-			Base: &transport.HeaderRoundTripper{
-				Base:    base,
-				Headers: passThroughHeaders,
+			Base: &transport.StatusCapturingRoundTripper{
+				Base: &transport.HeaderRoundTripper{
+					Base:    base,
+					Headers: passThroughHeaders,
+				},
 			},
 		},
 	}

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -524,7 +524,7 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
 			var httpErr *transport.HTTPStatusError
 			if errors.As(err, &httpErr) && httpErr.Code >= 400 && httpErr.Code < 500 {
-				return "", NewRouterErrorf(int32(httpErr.Code), "failed to create session for mcp server: %w", err)
+				return "", NewRouterError(int32(httpErr.Code), fmt.Errorf("failed to create session for mcp server: %w", err)) //nolint:gosec,nolintlint // code bounded to [400,499] by check above
 			}
 			return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 		}

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -18,6 +18,7 @@ import (
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
 	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
+	"github.com/Kuadrant/mcp-gateway/internal/transport"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -521,6 +522,10 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
 			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
+			var httpErr *transport.HTTPStatusError
+			if errors.As(err, &httpErr) && httpErr.Code >= 400 && httpErr.Code < 500 {
+				return "", NewRouterErrorf(int32(httpErr.Code), "failed to create session for mcp server: %w", err)
+			}
 			return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 		}
 		var sessionCloser = func() {

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/elicitation"
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
+	"github.com/Kuadrant/mcp-gateway/internal/transport"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -1233,6 +1234,92 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 	require.Equal(t, "tools/call", captured["x-mcp-method"])
 	require.Equal(t, "dummy", captured["x-mcp-servername"])
 	require.Equal(t, "mcp-router", captured["user-agent"])
+}
+
+func TestInitializeMCPServerSession_UpstreamErrorPropagation(t *testing.T) {
+	testCases := []struct {
+		name           string
+		initErr        error
+		wantStatusCode int
+	}{
+		{
+			name:           "upstream 403 propagated to client",
+			initErr:        fmt.Errorf("failed to create client: %w", &transport.HTTPStatusError{Code: 403, Body: `{"message":"MCP Access denied"}`}),
+			wantStatusCode: 403,
+		},
+		{
+			name:           "upstream 401 propagated to client",
+			initErr:        fmt.Errorf("failed to create client: %w", &transport.HTTPStatusError{Code: 401, Body: "Unauthorized"}),
+			wantStatusCode: 401,
+		},
+		{
+			name:           "upstream 400 propagated to client",
+			initErr:        fmt.Errorf("failed to create client: %w", &transport.HTTPStatusError{Code: 400, Body: "Bad Request"}),
+			wantStatusCode: 400,
+		},
+		{
+			name:           "upstream 502 wrapped as 500",
+			initErr:        fmt.Errorf("failed to create client: %w", &transport.HTTPStatusError{Code: 502, Body: "Bad Gateway"}),
+			wantStatusCode: 500,
+		},
+		{
+			name:           "connection refused wrapped as 500",
+			initErr:        fmt.Errorf("failed to create client: %w", fmt.Errorf("dial tcp: connection refused")),
+			wantStatusCode: 500,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *clients.HairpinClientPool) (*mcp.ClientSession, error) {
+				return nil, tc.initErr
+			}
+
+			serverConfigs := []*config.MCPServer{
+				{
+					Name:     "dummy",
+					URL:      "http://localhost:8080/mcp",
+					Prefix:   "s_",
+					State:    "Enabled",
+					Hostname: "backend.example.com",
+				},
+			}
+			router, _ := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+			router.InitForClient = mockInitForClient
+			router.RoutingConfig.Store(&config.MCPServersConfig{
+				Servers:                    serverConfigs,
+				MCPGatewayInternalHostname: "mcp-gateway.local",
+			})
+
+			validToken := router.JWTManager.Generate()
+			table := NewTableBuilder().
+				AddTool("s_mytool", &ServerRoute{
+					Name:   "dummy",
+					Host:   "backend.example.com",
+					Prefix: "s_",
+					Path:   "/mcp",
+					URL:    "http://localhost:8080/mcp",
+				}).
+				Build()
+			router.Table = func() RoutingTable { return table }
+
+			req := &MCPRequest{
+				ID:      ptr.To(0),
+				JSONRPC: "2.0",
+				Method:  "tools/call",
+				Params:  map[string]any{"name": "s_mytool"},
+				Headers: map[string]string{
+					"mcp-session-id": validToken,
+					"authorization":  "Bearer client-token",
+				},
+			}
+
+			decision := router.RouteRequest(context.Background(), &Request{Parsed: req})
+			require.NotNil(t, decision.Error, "decision must carry an error when init fails")
+			require.Equal(t, tc.wantStatusCode, decision.Error.StatusCode,
+				"4xx should propagate, 5xx and non-HTTP errors should become 500")
+		})
+	}
 }
 
 func TestMCPRequest_PromptName(t *testing.T) {

--- a/internal/transport/roundtripper_test.go
+++ b/internal/transport/roundtripper_test.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -112,5 +113,65 @@ func TestHeaderRoundTripper_NilHeaders(t *testing.T) {
 
 	if got := base.got.Header.Get("Accept"); got != "application/json" {
 		t.Errorf("expected original headers preserved, got %q", got)
+	}
+}
+
+type statusTransport struct {
+	code int
+	body string
+}
+
+func (s *statusTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(s.code)
+	if s.body != "" {
+		_, _ = rec.WriteString(s.body)
+	}
+	return rec.Result(), nil
+}
+
+func TestStatusCapturingRoundTripper_PassesThrough2xx(t *testing.T) {
+	rt := &StatusCapturingRoundTripper{Base: &statusTransport{code: 200, body: "ok"}}
+	resp, err := rt.RoundTrip(newRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error on 200: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestStatusCapturingRoundTripper_4xxReturnsTypedError(t *testing.T) {
+	body := `{"message":"Access denied"}`
+	rt := &StatusCapturingRoundTripper{Base: &statusTransport{code: 403, body: body}}
+	_, err := rt.RoundTrip(newRequest(t)) //nolint:bodyclose // error path returns nil response
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPStatusError, got %T: %v", err, err)
+	}
+	if httpErr.Code != 403 {
+		t.Errorf("expected code 403, got %d", httpErr.Code)
+	}
+	if httpErr.Body != body {
+		t.Errorf("expected body %q, got %q", body, httpErr.Body)
+	}
+}
+
+func TestStatusCapturingRoundTripper_5xxReturnsTypedError(t *testing.T) {
+	rt := &StatusCapturingRoundTripper{Base: &statusTransport{code: 502, body: "Bad Gateway"}}
+	_, err := rt.RoundTrip(newRequest(t)) //nolint:bodyclose // error path returns nil response
+	if err == nil {
+		t.Fatal("expected error on 502")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPStatusError, got %T: %v", err, err)
+	}
+	if httpErr.Code != 502 {
+		t.Errorf("expected code 502, got %d", httpErr.Code)
 	}
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -122,6 +122,7 @@ func (s *StatusCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 	}
 	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_, _ = io.Copy(io.Discard, resp.Body) // drain remainder for connection reuse
 	return nil, &HTTPStatusError{Code: resp.StatusCode, Body: string(body)}
 }
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -4,6 +4,7 @@ package transport
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -85,6 +86,43 @@ func SSEEventData(event []byte) (data [][]byte, commentOnly bool) {
 		}
 	}
 	return data, commentOnly
+}
+
+// HTTPStatusError is returned by StatusCapturingRoundTripper when the
+// upstream responds with a non-2xx status code. It preserves the original
+// HTTP status so callers higher in the stack can propagate 4xx faithfully
+// instead of collapsing everything to 500.
+type HTTPStatusError struct {
+	Code int
+	Body string
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("upstream returned HTTP %d: %s", e.Code, e.Body)
+	}
+	return fmt.Sprintf("upstream returned HTTP %d", e.Code)
+}
+
+// StatusCapturingRoundTripper intercepts non-2xx HTTP responses and converts
+// them into a typed HTTPStatusError so the status code survives SDK error
+// wrapping. The response body is read and closed before returning the error.
+type StatusCapturingRoundTripper struct {
+	Base http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper.
+func (s *StatusCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := s.Base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return nil, &HTTPStatusError{Code: resp.StatusCode, Body: string(body)}
 }
 
 // DiscoverShortCircuit answers the SDK client's SEP-2575 server/discover

--- a/tests/e2e/custom_tls_test.go
+++ b/tests/e2e/custom_tls_test.go
@@ -245,17 +245,18 @@ var _ = Describe("Custom TLS Configuration", Ordered, func() {
 		Expect(k8sClient.Create(ctx, dr)).To(Succeed())
 		testResources = append(testResources, dr)
 
-		By("Reconnecting MCP client for fresh session after DestinationRule creation")
+		By("Closing existing client before retrying with fresh sessions")
 		_ = mcpGatewayClient.Close()
-		Eventually(func(g Gomega) {
-			var err error
-			mcpGatewayClient, err = NewStatefulClientWithNotifications(ctx, gatewayURL, nil)
-			g.Expect(err).NotTo(HaveOccurred())
-		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		mcpGatewayClient = nil
 
 		By("Calling tools/call — Envoy re-encrypts via DestinationRule TLS origination")
 		Eventually(func(g Gomega) {
-			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{
+			// recreate client each attempt; a failed lazy-init may return a
+			// non-transient status that terminates the SDK connection
+			client, err := NewStatefulClientWithNotifications(ctx, gatewayURL, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = client.Close() }()
+			res, err := client.CallTool(ctx, &mcp.CallToolParams{
 				Name:      toolName,
 				Arguments: map[string]string{"message": "tls-origination-test"},
 			})

--- a/tests/e2e/custom_tls_test.go
+++ b/tests/e2e/custom_tls_test.go
@@ -254,7 +254,10 @@ var _ = Describe("Custom TLS Configuration", Ordered, func() {
 			// recreate client each attempt; a failed lazy-init may return a
 			// non-transient status that terminates the SDK connection
 			client, err := NewStatefulClientWithNotifications(ctx, gatewayURL, nil)
-			g.Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				g.Expect(err).NotTo(HaveOccurred())
+				return
+			}
 			defer func() { _ = client.Close() }()
 			res, err := client.CallTool(ctx, &mcp.CallToolParams{
 				Name:      toolName,


### PR DESCRIPTION
## Summary

- Adds `StatusCapturingRoundTripper` to intercept non-2xx HTTP responses before the MCP SDK wraps them as untyped strings, preserving the status code in a typed `HTTPStatusError`
- Router now extracts 4xx status codes from `InitForClient` errors and propagates them to the client instead of always returning 500
- 5xx and transport-level errors (connection refused, timeouts) still become 500

## Context

When Authorino denies a hairpin initialize request (e.g. user lacks tool access), the 403 and its denial message were lost through three layers of error wrapping (SDK transport, `clients.Initialize`, router). Clients saw HTTP 500 with a generic "failed to create session" message instead of the 403 with the actual denial reason.

Fixes #1331

## Test plan

- [x] Unit tests for `StatusCapturingRoundTripper` (2xx passthrough, 4xx/5xx typed error)
- [x] Router test covering 403, 401, 400 propagation and 502/connection-refused wrapping as 500
- [x] Full unit test suite passes
- [x] Lint clean (no new issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved upstream HTTP 4xx status codes during backend session initialization, improving error accuracy.
  * Included relevant upstream response details in reported errors, with response content safely limited for reliability.
  * Continued mapping server-side and connection failures to a generic 500 status.
  * Improved retry handling for custom TLS connections by reliably recreating clients after failed initialization attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->