### PR TITLE
refactor(api): consolidate HTTPS scheme handling in InternalHost()

### DIFF
--- a/api/v1/mcpgatewayextension_types.go
+++ b/api/v1/mcpgatewayextension_types.go
@@ -328,7 +328,10 @@ func (m *MCPGatewayExtension) SetReadyCondition(status metav1.ConditionStatus, r
 // InternalHost returns the internal/private host computed from the targetRef.
 // gatewayClassName is used to derive the Service name created by the Gateway controller,
 // which follows the convention <gateway-name>-<gatewayClassName>.<namespace>.svc.cluster.local.
-func (m *MCPGatewayExtension) InternalHost(port uint32, gatewayClassName string) string {
+// useHTTPS controls whether an "https://" scheme prefix is added to the computed
+// default host. It has no effect when PrivateHost is explicitly set, since that
+// value is honoured verbatim (the operator may already include their own scheme).
+func (m *MCPGatewayExtension) InternalHost(port uint32, gatewayClassName string, useHTTPS bool) string {
 	if m.Spec.PrivateHost != "" {
 		return m.Spec.PrivateHost
 	}
@@ -336,7 +339,11 @@ func (m *MCPGatewayExtension) InternalHost(port uint32, gatewayClassName string)
 	if gatewayNamespace == "" {
 		gatewayNamespace = m.Namespace
 	}
-	return fmt.Sprintf("%s-%s.%s.svc.cluster.local:%v", m.Spec.TargetRef.Name, gatewayClassName, gatewayNamespace, port)
+	host := fmt.Sprintf("%s-%s.%s.svc.cluster.local:%v", m.Spec.TargetRef.Name, gatewayClassName, gatewayNamespace, port)
+	if useHTTPS {
+		return "https://" + host
+	}
+	return host
 }
 
 // HTTPRouteDisabled returns true if HTTPRouteManagement is set to Disabled

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -341,19 +341,14 @@ func derivePublicHost(listenerConfig *ListenerConfig, annotationOverride string)
 // which the broker uses when hairpinning the internal initialize request back
 // through the gateway. When the user explicitly sets spec.privateHost, that
 // value is honoured verbatim (so an operator can override scheme, host, and
-// port). Otherwise the host is computed from the targetRef and listener port,
-// and an https:// scheme prefix is added when the listener is HTTPS so the
-// broker hairpin doesn't send plain HTTP to a TLS-only port (issue #917).
+// port) — InternalHost handles that case directly. Otherwise InternalHost
+// computes the host from the targetRef and listener port, adding an https://
+// scheme prefix when the listener is HTTPS so the broker hairpin doesn't send
+// plain HTTP to a TLS-only port (issue #917).
 func derivePrivateHost(mcpExt *mcpv1.MCPGatewayExtension, listenerConfig *ListenerConfig, gatewayClassName string) string {
-	if mcpExt.Spec.PrivateHost != "" {
-		return mcpExt.Spec.PrivateHost
-	}
-	host := mcpExt.InternalHost(listenerConfig.Port, gatewayClassName)
 	// listener.Protocol is the Gateway API protocol string, e.g. "HTTPS".
-	if strings.EqualFold(listenerConfig.Protocol, "HTTPS") {
-		return "https://" + host
-	}
-	return host
+	useHTTPS := strings.EqualFold(listenerConfig.Protocol, "HTTPS")
+	return mcpExt.InternalHost(listenerConfig.Port, gatewayClassName, useHTTPS)
 }
 
 func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension, listenerConfig *ListenerConfig, gatewayClassName string) (bool, error) {

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -483,7 +483,9 @@ func TestBuildBrokerRouterDeployment_InternalHost(t *testing.T) {
 				},
 			}
 
-			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, tt.gatewayClassName))
+			// useHTTPS=false: this test exercises host/namespace derivation only;
+			// HTTPS scheme-prefix behavior is covered separately by TestDerivePrivateHost.
+			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, tt.gatewayClassName, false))
 			command := deployment.Spec.Template.Spec.Containers[0].Command
 
 			wantFlag := "--mcp-gateway-private-host=" + tt.wantInternalHost
@@ -539,7 +541,7 @@ func TestBuildBrokerRouterDeployment_PollInterval(t *testing.T) {
 				},
 			}
 
-			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 			command := deployment.Spec.Template.Spec.Containers[0].Command
 
 			if tt.wantAbsent {
@@ -587,7 +589,7 @@ func TestBuildBrokerRouterDeployment_NoRouterKeyFlag(t *testing.T) {
 		},
 	}
 
-	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 	command := deployment.Spec.Template.Spec.Containers[0].Command
 
 	for _, arg := range command {
@@ -670,7 +672,7 @@ func TestBuildBrokerRouterDeployment_LogLevel(t *testing.T) {
 				},
 			}
 
-			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 			command := deployment.Spec.Template.Spec.Containers[0].Command
 
 			var got string
@@ -751,7 +753,7 @@ func TestBuildBrokerRouterDeployment_SpecLogLevel(t *testing.T) {
 					LogLevel: tt.specLogLevel,
 				},
 			}
-			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 			command := deployment.Spec.Template.Spec.Containers[0].Command
 			var got string
 			for _, arg := range command {
@@ -807,7 +809,7 @@ func TestBuildBrokerRouterDeployment_TrustedHeadersKey(t *testing.T) {
 				},
 			}
 
-			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+			deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 			container := deployment.Spec.Template.Spec.Containers[0]
 
 			// JWT_SESSION_SIGNING_KEY should always be present
@@ -974,7 +976,7 @@ func TestBuildBrokerRouterDeployment_ServiceAccount(t *testing.T) {
 		},
 	}
 
-	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 
 	if deployment.Spec.Template.Spec.ServiceAccountName != brokerRouterName {
 		t.Errorf("expected ServiceAccountName %q, got %q", brokerRouterName, deployment.Spec.Template.Spec.ServiceAccountName)
@@ -2140,7 +2142,7 @@ func TestBuildBrokerRouterDeployment_ReadinessProbe(t *testing.T) {
 		},
 	}
 
-	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio"))
+	deployment := r.buildBrokerRouterDeployment(mcpExt, "mcp.example.com", mcpExt.InternalHost(8080, "istio", false))
 	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
 
 	if probe == nil {


### PR DESCRIPTION
## What does this PR do?

Consolidates the HTTPS scheme handling for `InternalHost()` by moving the
scheme-prefix logic into the method itself and removing the duplicated
logic from `derivePrivateHost()`. Updates the remaining test call sites
to use the new `InternalHost()` signature.

Fixes #1336

## Pre-review checklist

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [ ] All CI checks pass, or failures have been investigated and explained below
- [ ] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway host generation for HTTPS listeners by applying the correct secure protocol to computed internal hosts.
  * Preserved explicitly configured private hosts without modification.
  * Maintained existing behavior for non-HTTPS deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->