### PR TITLE
task 5 completed for 2026 protocol broker

### DIFF
--- a/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
+++ b/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
@@ -125,7 +125,7 @@ When `CacheScope` or `TTLMs` changes (detected on re-list), the broker atomicall
 
 ### Aggregated values in filteringMiddleware
 
-After protocol filtering, `FetchUserSpecificTools`, and `FilterTools` run, the middleware computes aggregated `ttlMs` and `cacheScope` from contributing upstreams and sets them on the result. The same aggregation applies to `prompts/list`.
+After protocol filtering and `FetchUserSpecificTools`, but **before** `FilterTools` (which strips `kuadrant/id` from tool Meta), the middleware computes aggregated `ttlMs` and `cacheScope` from contributing upstreams and sets them on the result. The same aggregation applies to `prompts/list` (before `FilterPrompts`).
 
 For 2025 clients, the compat handler strips these fields downstream — no change needed there. 2026 clients already bypass the compat handler via `protocolRouter` (verification task only).
 

--- a/docs/design/broker-2026-07-28/tasks/tasks.md
+++ b/docs/design/broker-2026-07-28/tasks/tasks.md
@@ -146,35 +146,37 @@ Implement the 2026 protocol handler:
 
 **Verification:** `make lint && make test-unit`
 
-## Task 5: Wire protocol handlers into broker
+## Task 5: Wire protocol handlers into broker ✅
 
-**Files:** `internal/broker/broker.go`, `internal/broker/user_specific_tools.go`, `internal/broker/protocol_filter.go`
+**Files:** `internal/broker/broker.go`, `internal/broker/user_specific_tools.go`, `internal/broker/protocol_filter.go`, `internal/broker/cache_aggregation.go` (new), `internal/broker/cache_aggregation_test.go` (new), `internal/broker/http_compat_test.go`, `internal/broker/protocol_filter_test.go`, `internal/tests/stateless-server/server.go`, `tests/e2e/dual_protocol_test.go`, `tests/e2e/test_cases.md`
 
 Integrate `ProtocolHandler` into the broker:
 
 - Add `handler2025 ProtocolHandler` and `handler2026 ProtocolHandler` fields to `mcpBrokerImpl`
-- Construct handlers in `NewMCPBroker`
-- In `OnConfigChange.startManagers`: rebuild `perRequestServers` using `ShouldFetchFresh` from the appropriate handler based on upstream protocol version. 2026 upstreams with `cacheScope:"private"` or `ttlMs:0` join the list alongside CRD-declared `userSpecificList` servers
-- When upstream cache metadata changes (detected on re-list in the manager event loop), atomically rebuild `perRequestServers` immediately — not deferred to the next `OnConfigChange`. This prevents a window where a newly-private upstream leaks as public
-- In `filteringMiddleware` `tools/list` case: after `FilterTools`, call `AggregateCache` on the 2026 handler with contributing upstreams' metadata and set `result.TTLMs` and `result.CacheScope` on the `ListToolsResult`
-- In `filteringMiddleware` `prompts/list` case: filter prompts by protocol version via `promptsForProtocol` (mirroring `toolsForProtocol`), then apply same cache aggregation
-- Add `promptsForProtocol` to `protocol_filter.go`: add `statefulPrompts`/`statelessPrompts` atomic caches to `mcpBrokerImpl`, rebuild in `rebuildProtocolToolCache` (rename to `rebuildProtocolCaches`), partition prompts by upstream server version the same way tools are partitioned
-- Refactor `FetchUserSpecificTools` to delegate to the protocol handler selected by client version header
-- Verify: 2025 client responses unchanged (compat handler strips `ttlMs`/`cacheScope`)
-- Verify: 2026 `prompts/list` excludes prompts from 2025-only upstreams
+- Construct handlers in `NewBroker`
+- In `startManagers`: rebuild `userSpecificServers` using `ShouldFetchFresh` from the 2026 handler based on upstream cache metadata. 2026 upstreams with `cacheScope:"private"` or `ttlMs:0` join the list alongside CRD-declared `userSpecificList` servers
+- In `filteringMiddleware` `tools/list` case: **before** `FilterTools` (which strips `kuadrant/id`), call `AggregateCache` on the 2026 handler with contributing upstreams' metadata and set `result.TTLMs` and `result.CacheScope`
+- In `filteringMiddleware` `prompts/list` case: filter prompts by protocol version via `promptsForProtocol` (mirroring `toolsForProtocol`), then apply cache aggregation before `FilterPrompts`
+- Renamed `rebuildProtocolToolCache` to `rebuildProtocolCaches`, added prompt partitioning alongside tools
+- Added `promptsForProtocol` and `statefulPrompts`/`statelessPrompts` atomic caches
+- Refactored `FetchUserSpecificTools` to delegate to the protocol handler selected by client version header
+- Tools and prompts without `kuadrant/id` are excluded from all protocol sets with a warn log (not silently defaulted to stateful)
+- `AggregateCache` returns `"public"` (not empty string) for empty input — the SDK serializes `cacheScope` without `omitempty`
+- Exported `upstream.GatewayServerID` constant for cross-package use
+- Added cache metadata middleware to the stateless test server (env-configurable `TTLMs`/`CacheScope`)
 
 **Acceptance criteria:**
-- [ ] Broker holds two `ProtocolHandler` instances
-- [ ] `perRequestServers` includes 2026 upstreams with `cacheScope:"private"` or `ttlMs:0`
-- [ ] 2026 `tools/list` responses include aggregated `ttlMs` and `cacheScope`
-- [ ] 2025 `tools/list` responses unchanged (compat handler strips fields)
-- [ ] `prompts/list` filtered by protocol version — 2026 clients only see prompts from 2026-capable upstreams
-- [ ] `prompts/list` responses include aggregated fields for 2026 clients
-- [ ] 2025 `prompts/list` responses unchanged
-- [ ] Existing `user_specific_tools_test.go`, `protocol_filter_test.go` tests pass
-- [ ] Unit test: 2026 `prompts/list` excludes 2025-only prompts
-- [ ] `make lint && make test-unit` passes
-- [ ] `make test-controller-integration` passes
+- [x] Broker holds two `ProtocolHandler` instances
+- [x] `userSpecificServers` includes 2026 upstreams with `cacheScope:"private"` or `ttlMs:0`
+- [x] 2026 `tools/list` responses include aggregated `ttlMs` and `cacheScope`
+- [x] 2025 `tools/list` responses unchanged (compat handler strips fields)
+- [x] `prompts/list` filtered by protocol version — 2026 clients only see prompts from 2026-capable upstreams
+- [x] `prompts/list` responses include aggregated fields for 2026 clients
+- [x] 2025 `prompts/list` responses unchanged
+- [x] Existing `user_specific_tools_test.go`, `protocol_filter_test.go` tests pass
+- [x] Unit test: 2026 `prompts/list` excludes 2025-only prompts
+- [x] `make lint && make test-unit` passes
+- [x] `make test-controller-integration` passes
 
 **Verification:** `make lint && make test-unit && make test-controller-integration`
 

--- a/docs/design/broker-2026-07-28/tasks/test_cases.md
+++ b/docs/design/broker-2026-07-28/tasks/test_cases.md
@@ -26,7 +26,7 @@ Given one upstream with `ttlMs:45000, cacheScope:"public"`, `AggregateCache` ret
 
 ### AggregateCache empty input
 
-Given no contributing upstreams, `AggregateCache` returns `(0, "")` (no cache fields to set).
+Given no contributing upstreams, `AggregateCache` returns `(0, "public")`. The SDK serializes `cacheScope` without `omitempty`, so an empty string fails spec validation.
 
 ### ShouldFetchFresh triggers on cacheScope private
 
@@ -58,7 +58,7 @@ A 2025 upstream that returns no `ttlMs`/`cacheScope` in its list response gets d
 
 ### filteringMiddleware sets ttlMs and cacheScope on 2026 tools/list
 
-When the middleware processes a `tools/list` result for a 2026 client, it calls `AggregateCache` and sets the result's `TTLMs` and `CacheScope` fields.
+When the middleware processes a `tools/list` result for a 2026 client, it calls `AggregateCache` **before** `FilterTools` (which strips `kuadrant/id` from tool Meta) and sets the result's `TTLMs` and `CacheScope` fields.
 
 ### filteringMiddleware sets ttlMs and cacheScope on 2026 prompts/list
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -153,13 +154,23 @@ type mcpBrokerImpl struct {
 	// serverVersions maps upstream server ID to supported protocol versions
 	serverVersions sync.Map // map[config.UpstreamMCPID][]string
 
-	// statefulTools and statelessTools cache pre-filtered tool sets for each protocol version
-	statefulTools  atomic.Pointer[[]*mcp.Tool]
-	statelessTools atomic.Pointer[[]*mcp.Tool]
+	// statefulTools and statelessTools cache pre-filtered tool sets and their
+	// contributing server IDs for each protocol version
+	statefulTools  atomic.Pointer[protocolCacheEntry[*mcp.Tool]]
+	statelessTools atomic.Pointer[protocolCacheEntry[*mcp.Tool]]
+
+	// statefulPrompts and statelessPrompts cache pre-filtered prompt sets and their
+	// contributing server IDs for each protocol version
+	statefulPrompts  atomic.Pointer[protocolCacheEntry[*mcp.Prompt]]
+	statelessPrompts atomic.Pointer[protocolCacheEntry[*mcp.Prompt]]
 
 	// statelessTransports caches TLS transports for stateless user-specific fetches,
 	// keyed by gatewayCACert+serverCACert. avoids rebuilding cert pools per request.
 	statelessTransports sync.Map // map[string]http.RoundTripper
+
+	// protocol handlers encapsulate version-specific broker behavior
+	handler2025 ProtocolHandler
+	handler2026 ProtocolHandler
 }
 
 // this ensures that mcpBrokerImpl implements the MCPBroker interface
@@ -267,6 +278,9 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		option(mcpBkr)
 	}
 
+	mcpBkr.handler2025 = NewProtocolHandler2025(mcpBkr)
+	mcpBkr.handler2026 = NewProtocolHandler2026(mcpBkr)
+
 	if mcpBkr.discovery.enabled {
 		mcpBkr.scopeStore = newScopeStore(defaultScopeTTL, defaultScopeMaxSize)
 	}
@@ -311,7 +325,7 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		mcpBkr.mcpLock.RLock()
 		defer mcpBkr.mcpLock.RUnlock()
 		mcpBkr.refreshRoutingTable()
-		mcpBkr.rebuildProtocolToolCache()
+		mcpBkr.rebuildProtocolCaches()
 	}
 	srv.AddSendingMiddleware(mcpBkr.gatewayServer.notifyTargetMiddleware())
 
@@ -371,7 +385,11 @@ func (m *mcpBrokerImpl) tracingMiddleware() mcp.Middleware {
 	}
 }
 
-// filteringMiddleware replaces the old AfterListTools/AfterListPrompts hooks
+// filteringMiddleware is a post-processing middleware: it calls next first
+// to let the SDK handler build the full result, then filters and enriches it
+// (protocol filtering, user-specific tools, auth, cache aggregation).
+// middleware ordered before this in AddReceivingMiddleware sees the filtered
+// result; middleware ordered after sees the raw SDK result.
 func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
@@ -407,6 +425,15 @@ func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 					sessionID = s.ID()
 				}
 				m.FetchUserSpecificTools(ctx, headers, toolsResult)
+
+				// collect cache metadata before FilterTools strips kuadrant/id
+				if headers.Get(protocolVersionHeader) == protocol.Version2026 {
+					contributing := m.collectToolsCacheMetadata()
+					ttl, scope := m.handler2026.AggregateCache(contributing)
+					toolsResult.TTLMs = ttl
+					toolsResult.CacheScope = scope
+				}
+
 				m.FilterTools(ctx, headers, sessionID, toolsResult)
 
 			case "prompts/list":
@@ -418,6 +445,17 @@ func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 				if extra := req.GetExtra(); extra != nil {
 					headers = extra.Header
 				}
+
+				// filter by protocol version before auth filtering
+				promptsResult.Prompts = m.promptsForProtocol(headers)
+
+				if headers.Get(protocolVersionHeader) == protocol.Version2026 {
+					contributing := m.collectPromptsCacheMetadata()
+					ttl, scope := m.handler2026.AggregateCache(contributing)
+					promptsResult.TTLMs = ttl
+					promptsResult.CacheScope = scope
+				}
+
 				m.FilterPrompts(ctx, headers, promptsResult)
 			}
 
@@ -524,7 +562,9 @@ func (m *mcpBrokerImpl) startManagers(ctx context.Context, servers []*config.MCP
 
 	m.syncTagsTools(ctx, servers)
 
-	// precompute userSpecificList servers for FetchUserSpecificTools
+	// precompute CRD-declared userSpecificList servers for FetchUserSpecificTools.
+	// 2026 cache-metadata-driven servers are checked at request time in
+	// FetchUserSpecificTools to avoid racing with managers still connecting.
 	m.userSpecificServers = nil
 	for _, srv := range servers {
 		if srv.UserSpecificList {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
-	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -416,9 +415,10 @@ func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 				if extra := req.GetExtra(); extra != nil {
 					headers = extra.Header
 				}
+				isStateless := isStatelessProtocol(headers)
 
 				// filter by protocol version before user-specific fetches
-				toolsResult.Tools = m.toolsForProtocol(headers)
+				toolsResult.Tools = m.toolsForProtocol(isStateless)
 
 				var sessionID string
 				if s := req.GetSession(); s != nil {
@@ -427,7 +427,7 @@ func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 				m.FetchUserSpecificTools(ctx, headers, toolsResult)
 
 				// collect cache metadata before FilterTools strips kuadrant/id
-				if headers.Get(protocolVersionHeader) == protocol.Version2026 {
+				if isStateless {
 					contributing := m.collectToolsCacheMetadata()
 					ttl, scope := m.handler2026.AggregateCache(contributing)
 					toolsResult.TTLMs = ttl
@@ -445,11 +445,12 @@ func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 				if extra := req.GetExtra(); extra != nil {
 					headers = extra.Header
 				}
+				isStateless := isStatelessProtocol(headers)
 
 				// filter by protocol version before auth filtering
-				promptsResult.Prompts = m.promptsForProtocol(headers)
+				promptsResult.Prompts = m.promptsForProtocol(isStateless)
 
-				if headers.Get(protocolVersionHeader) == protocol.Version2026 {
+				if isStateless {
 					contributing := m.collectPromptsCacheMetadata()
 					ttl, scope := m.handler2026.AggregateCache(contributing)
 					promptsResult.TTLMs = ttl

--- a/internal/broker/cache_aggregation.go
+++ b/internal/broker/cache_aggregation.go
@@ -40,7 +40,7 @@ func (m *mcpBrokerImpl) lookupCacheMetadata(serverIDs []config.UpstreamMCPID, me
 	m.mcpLock.RLock()
 	defer m.mcpLock.RUnlock()
 
-	var contributing []upstream.CacheMetadata
+	contributing := make([]upstream.CacheMetadata, 0, len(serverIDs))
 	for _, id := range serverIDs {
 		mgr, ok := m.mcpServers[id]
 		if !ok {

--- a/internal/broker/cache_aggregation.go
+++ b/internal/broker/cache_aggregation.go
@@ -1,0 +1,52 @@
+package broker
+
+import (
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+)
+
+// collectToolsCacheMetadata returns cache metadata for the upstreams that
+// contributed to the tools protocol cache. Uses the precomputed serverIDs
+// from rebuildProtocolCaches — no per-tool Meta extraction needed.
+func (m *mcpBrokerImpl) collectToolsCacheMetadata() []upstream.CacheMetadata {
+	cached := m.statelessTools.Load()
+	if cached == nil {
+		return nil
+	}
+	return m.lookupCacheMetadata(cached.serverIDs, func(mgr upstream.ActiveMCPServer) upstream.CacheMetadata {
+		return mgr.ToolsCacheMetadata()
+	})
+}
+
+// collectPromptsCacheMetadata returns cache metadata for the upstreams that
+// contributed to the prompts protocol cache.
+func (m *mcpBrokerImpl) collectPromptsCacheMetadata() []upstream.CacheMetadata {
+	cached := m.statelessPrompts.Load()
+	if cached == nil {
+		return nil
+	}
+	return m.lookupCacheMetadata(cached.serverIDs, func(mgr upstream.ActiveMCPServer) upstream.CacheMetadata {
+		return mgr.PromptsCacheMetadata()
+	})
+}
+
+// lookupCacheMetadata fetches cache metadata for each server ID from the
+// active managers.
+func (m *mcpBrokerImpl) lookupCacheMetadata(serverIDs []config.UpstreamMCPID, metaFn func(upstream.ActiveMCPServer) upstream.CacheMetadata) []upstream.CacheMetadata {
+	if len(serverIDs) == 0 {
+		return nil
+	}
+
+	m.mcpLock.RLock()
+	defer m.mcpLock.RUnlock()
+
+	var contributing []upstream.CacheMetadata
+	for _, id := range serverIDs {
+		mgr, ok := m.mcpServers[id]
+		if !ok {
+			continue
+		}
+		contributing = append(contributing, metaFn(mgr))
+	}
+	return contributing
+}

--- a/internal/broker/cache_aggregation_test.go
+++ b/internal/broker/cache_aggregation_test.go
@@ -1,0 +1,121 @@
+package broker
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+)
+
+func createMockActiveMCPServer(t *testing.T, cfg config.MCPServer, toolsCache, promptsCache upstream.CacheMetadata) upstream.ActiveMCPServer {
+	t.Helper()
+	mcpServer := upstream.NewUpstreamMCP(&cfg, "", nil)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, upstream.InvalidToolPolicyFilterOut)
+	assert.NoError(t, err)
+	manager.SetCacheMetadataForTesting(toolsCache, promptsCache)
+	return upstream.NewActiveForTesting(manager)
+}
+
+func TestCollectToolsCacheMetadata(t *testing.T) {
+	t.Run("returns one metadata entry per contributing server", func(t *testing.T) {
+		servers := map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			"server1": createMockActiveMCPServer(t,
+				config.MCPServer{Name: "server1", Prefix: "s1_"},
+				upstream.CacheMetadata{TTLMs: 1000, CacheScope: upstream.CacheScopePublic},
+				upstream.CacheMetadata{},
+			),
+			"server2": createMockActiveMCPServer(t,
+				config.MCPServer{Name: "server2", Prefix: "s2_"},
+				upstream.CacheMetadata{TTLMs: 2000, CacheScope: upstream.CacheScopePrivate},
+				upstream.CacheMetadata{},
+			),
+		}
+
+		broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+		broker.mcpServers = servers
+		entry := protocolCacheEntry[*mcp.Tool]{
+			items:     []*mcp.Tool{{Name: "s1_a"}, {Name: "s2_a"}},
+			serverIDs: []config.UpstreamMCPID{"server1", "server2"},
+		}
+		broker.statelessTools.Store(&entry)
+
+		got := broker.collectToolsCacheMetadata()
+		assert.Len(t, got, 2)
+		ttls := map[int]bool{}
+		scopes := map[string]bool{}
+		for _, m := range got {
+			ttls[m.TTLMs] = true
+			scopes[m.CacheScope] = true
+		}
+		assert.True(t, ttls[1000], "should contain server1 TTLMs 1000")
+		assert.True(t, ttls[2000], "should contain server2 TTLMs 2000")
+		assert.True(t, scopes[upstream.CacheScopePublic], "should contain public scope")
+		assert.True(t, scopes[upstream.CacheScopePrivate], "should contain private scope")
+	})
+
+	t.Run("no servers returns nil", func(t *testing.T) {
+		broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+		broker.mcpServers = map[config.UpstreamMCPID]upstream.ActiveMCPServer{}
+		entry := protocolCacheEntry[*mcp.Tool]{}
+		broker.statelessTools.Store(&entry)
+
+		got := broker.collectToolsCacheMetadata()
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil cache returns nil", func(t *testing.T) {
+		broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+		got := broker.collectToolsCacheMetadata()
+		assert.Nil(t, got)
+	})
+}
+
+func TestCollectPromptsCacheMetadata(t *testing.T) {
+	t.Run("returns one metadata entry per contributing server", func(t *testing.T) {
+		servers := map[config.UpstreamMCPID]upstream.ActiveMCPServer{
+			"server1": createMockActiveMCPServer(t,
+				config.MCPServer{Name: "server1", Prefix: "s1_"},
+				upstream.CacheMetadata{},
+				upstream.CacheMetadata{TTLMs: 500, CacheScope: upstream.CacheScopePublic, UserSpecificList: true},
+			),
+			"server2": createMockActiveMCPServer(t,
+				config.MCPServer{Name: "server2", Prefix: "s2_"},
+				upstream.CacheMetadata{},
+				upstream.CacheMetadata{TTLMs: 1500, CacheScope: upstream.CacheScopePrivate},
+			),
+		}
+
+		broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+		broker.mcpServers = servers
+		entry := protocolCacheEntry[*mcp.Prompt]{
+			items:     []*mcp.Prompt{{Name: "s1_a"}, {Name: "s2_a"}},
+			serverIDs: []config.UpstreamMCPID{"server1", "server2"},
+		}
+		broker.statelessPrompts.Store(&entry)
+
+		got := broker.collectPromptsCacheMetadata()
+		assert.Len(t, got, 2)
+		ttls := map[int]bool{}
+		userSpecific := map[bool]bool{}
+		for _, m := range got {
+			ttls[m.TTLMs] = true
+			userSpecific[m.UserSpecificList] = true
+		}
+		assert.True(t, ttls[500], "should contain server1 TTLMs 500")
+		assert.True(t, ttls[1500], "should contain server2 TTLMs 1500")
+		assert.True(t, userSpecific[true], "should contain server1 UserSpecificList=true")
+	})
+
+	t.Run("no servers returns nil", func(t *testing.T) {
+		broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+		broker.mcpServers = map[config.UpstreamMCPID]upstream.ActiveMCPServer{}
+		entry := protocolCacheEntry[*mcp.Prompt]{}
+		broker.statelessPrompts.Store(&entry)
+
+		got := broker.collectPromptsCacheMetadata()
+		assert.Nil(t, got)
+	})
+}

--- a/internal/broker/discovery.go
+++ b/internal/broker/discovery.go
@@ -330,7 +330,8 @@ func (m *mcpBrokerImpl) sendToolsListChanged(sessionID string) {
 // getVisibleToolNames returns a set of tool names visible to the current request,
 // after applying protocol version, auth and virtual server filtering.
 func (m *mcpBrokerImpl) getVisibleToolNames(headers http.Header) map[string]struct{} {
-	tools := m.toolsForProtocol(headers)
+	isStateless := isStatelessProtocol(headers)
+	tools := m.toolsForProtocol(isStateless)
 	tools = m.applyAuthorizedCapabilitiesFilter(headers, tools)
 	tools = m.applyVirtualServerFilter(headers, tools)
 

--- a/internal/broker/discovery.go
+++ b/internal/broker/discovery.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
-	"github.com/Kuadrant/mcp-gateway/internal/config"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
-	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -330,51 +328,17 @@ func (m *mcpBrokerImpl) sendToolsListChanged(sessionID string) {
 }
 
 // getVisibleToolNames returns a set of tool names visible to the current request,
-// after applying protocol version, auth and virtual server filtering. caller must hold mcpLock.
+// after applying protocol version, auth and virtual server filtering.
 func (m *mcpBrokerImpl) getVisibleToolNames(headers http.Header) map[string]struct{} {
-	allTools := m.collectAllPrefixedTools()
+	tools := m.toolsForProtocol(headers)
+	tools = m.applyAuthorizedCapabilitiesFilter(headers, tools)
+	tools = m.applyVirtualServerFilter(headers, tools)
 
-	// filter by client protocol version
-	clientVersion := protocol.Version2025
-	if headers.Get(protocolVersionHeader) == protocol.Version2026 {
-		clientVersion = protocol.Version2026
-	}
-	var protoFiltered []*mcp.Tool
-	for _, t := range allTools {
-		if idVal, ok := t.Meta["kuadrant/id"]; ok {
-			if id, ok := idVal.(string); ok && m.ServerSupportsVersion(config.UpstreamMCPID(id), clientVersion) {
-				protoFiltered = append(protoFiltered, t)
-			}
-		}
-	}
-
-	filtered := m.applyAuthorizedCapabilitiesFilter(headers, protoFiltered)
-	filtered = m.applyVirtualServerFilter(headers, filtered)
-
-	visible := make(map[string]struct{}, len(filtered))
-	for _, t := range filtered {
+	visible := make(map[string]struct{}, len(tools))
+	for _, t := range tools {
 		visible[t.Name] = struct{}{}
 	}
 	return visible
-}
-
-// collectAllPrefixedTools builds the full list of prefixed tools across all servers.
-// caller must hold mcpLock.
-func (m *mcpBrokerImpl) collectAllPrefixedTools() []*mcp.Tool {
-	var all []*mcp.Tool
-	for _, manager := range m.mcpServers {
-		cfg := manager.Config()
-		prefix := cfg.Prefix
-		serverID := string(cfg.ID())
-		for _, tool := range manager.GetManagedTools() {
-			t := &mcp.Tool{Name: prefix + tool.Name}
-			t.Meta = mcp.Meta{
-				"kuadrant/id": serverID,
-			}
-			all = append(all, t)
-		}
-	}
-	return all
 }
 
 // marshalToolResult marshals v to JSON and returns it as a tool result.

--- a/internal/broker/discovery_test.go
+++ b/internal/broker/discovery_test.go
@@ -25,7 +25,17 @@ func populateTestVersions(b *mcpBrokerImpl) {
 	for _, mgr := range b.mcpServers {
 		cfg := mgr.Config()
 		b.serverVersions.Store(cfg.ID(), []string{protocol.Version2025})
+		for _, t := range mgr.GetManagedTools() {
+			tool := t
+			tool.Name = cfg.Prefix + tool.Name
+			tool.Meta = mcp.Meta{"kuadrant/id": string(cfg.ID())}
+			if tool.InputSchema == nil {
+				tool.InputSchema = map[string]any{"type": "object"}
+			}
+			b.gatewayServer.AddTools(upstream.GatewayTool{Tool: tool, Handler: upstream.NoopToolHandler})
+		}
 	}
+	b.rebuildProtocolCaches()
 }
 
 func createTestManagerWithMeta(t *testing.T, serverName, prefix string, tools []mcp.Tool, category []string, hint string) upstream.ActiveMCPServer {

--- a/internal/broker/http_compat_test.go
+++ b/internal/broker/http_compat_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -400,6 +401,7 @@ func TestCompat_ToolsListResultRewrite(t *testing.T) {
 		"up_annotated": {Raw: json.RawMessage(`{"readOnlyHint":true,"destructiveHint":false}`)},
 	})
 	h.b.mcpServers["up1"] = upstream.NewActiveForTesting(manager)
+	h.b.serverVersions.Store(config.UpstreamMCPID("up1"), []string{"2025-11-25"})
 
 	// gateway-registered tools as the SDK client decode produced them: the
 	// annotated one has collapsed bools, the plain one none at all
@@ -409,6 +411,7 @@ func TestCompat_ToolsListResultRewrite(t *testing.T) {
 				Name:        "up_annotated",
 				InputSchema: map[string]any{"type": "object"},
 				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+				Meta:        mcp.Meta{"kuadrant/id": "up1"},
 			},
 			Handler: func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				return &mcp.CallToolResult{}, nil
@@ -418,6 +421,7 @@ func TestCompat_ToolsListResultRewrite(t *testing.T) {
 			Tool: mcp.Tool{
 				Name:        "up_plain",
 				InputSchema: map[string]any{"type": "object"},
+				Meta:        mcp.Meta{"kuadrant/id": "up1"},
 			},
 			Handler: func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				return &mcp.CallToolResult{}, nil
@@ -539,21 +543,6 @@ func TestCompat_NotificationDeliveredToSDKClient(t *testing.T) {
 func TestToolsListUnpaginated(t *testing.T) {
 	b := NewBroker(logger, WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
 
-	const total = mcp.DefaultPageSize + 1
-	tools := make([]upstream.GatewayTool, 0, total)
-	for i := range total {
-		tools = append(tools, upstream.GatewayTool{
-			Tool: mcp.Tool{
-				Name:        fmt.Sprintf("tool-%04d", i),
-				InputSchema: map[string]any{"type": "object"},
-			},
-			Handler: func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				return &mcp.CallToolResult{}, nil
-			},
-		})
-	}
-	b.gatewayServer.AddTools(tools...)
-
 	ct, st := mcp.NewInMemoryTransports()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -570,6 +559,23 @@ func TestToolsListUnpaginated(t *testing.T) {
 	cs, err := client.Connect(ctx, ct, nil)
 	require.NoError(t, err)
 	defer func() { _ = cs.Close() }()
+
+	const total = mcp.DefaultPageSize + 1
+	b.serverVersions.Store(config.UpstreamMCPID("pagination-server"), []string{"2025-11-25"})
+	tools := make([]upstream.GatewayTool, 0, total)
+	for i := range total {
+		tools = append(tools, upstream.GatewayTool{
+			Tool: mcp.Tool{
+				Name:        fmt.Sprintf("tool-%04d", i),
+				InputSchema: map[string]any{"type": "object"},
+				Meta:        mcp.Meta{"kuadrant/id": "pagination-server"},
+			},
+			Handler: func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return &mcp.CallToolResult{}, nil
+			},
+		})
+	}
+	b.gatewayServer.AddTools(tools...)
 
 	res, err := cs.ListTools(ctx, nil)
 	require.NoError(t, err)

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -2,7 +2,6 @@ package broker
 
 import (
 	"maps"
-	"net/http"
 	"slices"
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
@@ -170,9 +169,8 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 
 // promptsForProtocol returns the pre-cached prompt set for the client's protocol version.
 // Returns a shallow copy to avoid mutation by downstream filters.
-func (m *mcpBrokerImpl) promptsForProtocol(headers http.Header) []*mcp.Prompt {
-	version := headers.Get(protocolVersionHeader)
-	if version == protocol.Version2026 {
+func (m *mcpBrokerImpl) promptsForProtocol(isStateless bool) []*mcp.Prompt {
+	if isStateless {
 		if cached := m.statelessPrompts.Load(); cached != nil {
 			prompts := make([]*mcp.Prompt, len(cached.items))
 			copy(prompts, cached.items)
@@ -190,9 +188,8 @@ func (m *mcpBrokerImpl) promptsForProtocol(headers http.Header) []*mcp.Prompt {
 
 // toolsForProtocol returns the pre-cached tool set for the client's protocol version.
 // Returns a shallow copy to avoid mutation by downstream filters.
-func (m *mcpBrokerImpl) toolsForProtocol(headers http.Header) []*mcp.Tool {
-	version := headers.Get(protocolVersionHeader)
-	if version == protocol.Version2026 {
+func (m *mcpBrokerImpl) toolsForProtocol(isStateless bool) []*mcp.Tool {
+	if isStateless {
 		if cached := m.statelessTools.Load(); cached != nil {
 			tools := make([]*mcp.Tool, len(cached.items))
 			copy(tools, cached.items)
@@ -200,7 +197,6 @@ func (m *mcpBrokerImpl) toolsForProtocol(headers http.Header) []*mcp.Tool {
 		}
 	}
 
-	// default to stateful for no header or any other version
 	if cached := m.statefulTools.Load(); cached != nil {
 		tools := make([]*mcp.Tool, len(cached.items))
 		copy(tools, cached.items)

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -30,27 +30,41 @@ func (m *mcpBrokerImpl) computeGatewaySupportedVersions() []string {
 	return slices.Sorted(maps.Keys(seen))
 }
 
-// rebuildProtocolToolCache partitions the current gateway server tool list
-// into stateful (2025) and stateless (2026) sets based on each upstream
-// server's supportedVersions. Broker meta-tools (those without kuadrant/id)
-// are included only in the stateful set.
-func (m *mcpBrokerImpl) rebuildProtocolToolCache() {
-	allTools := m.gatewayServer.ListTools()
+// protocolCacheEntry holds a pre-filtered item set and the unique upstream
+// server IDs that contributed to it. serverIDs is computed once during
+// rebuildProtocolCaches so that cache aggregation can look up metadata by
+// ID directly, without re-extracting kuadrant/id from every item.
+// freshFetchServers (tools only, stateless entry) lists 2026 upstreams whose
+// cache metadata indicates per-request fetching, precomputed so
+// FetchUserSpecificTools avoids iterating all servers on every request.
+type protocolCacheEntry[T any] struct {
+	items             []T
+	serverIDs         []config.UpstreamMCPID
+	freshFetchServers []userSpecificServer
+}
 
-	var stateful, stateless []*mcp.Tool
+// rebuildProtocolCaches partitions the current gateway server tools and
+// prompts into stateful (2025) and stateless (2026) sets based on each
+// upstream server's supportedVersions. Broker meta-tools (those without
+// kuadrant/id) are included only in the stateful set.
+func (m *mcpBrokerImpl) rebuildProtocolCaches() {
+	// partition tools
+	allTools := m.gatewayServer.ListTools()
+	var statefulT, statelessT protocolCacheEntry[*mcp.Tool]
+	statefulServersSeen := make(map[config.UpstreamMCPID]bool)
+	statelessServersSeen := make(map[config.UpstreamMCPID]bool)
+
 	for _, gt := range allTools {
 		tool := &gt.Tool
 
-		// broker meta-tools (discover_tools, select_tools, etc) are
-		// session-scoped and only usable by stateful clients
 		if _, isBrokerTool := tool.Meta[brokerToolMetaKey]; isBrokerTool {
-			stateful = append(stateful, tool)
+			statefulT.items = append(statefulT.items, tool)
 			continue
 		}
 
 		serverIDVal, hasServerID := tool.Meta["kuadrant/id"]
 		if !hasServerID {
-			stateful = append(stateful, tool)
+			m.logger.Warn("tool missing kuadrant/id, excluded from protocol sets", "toolName", tool.Name)
 			continue
 		}
 
@@ -62,18 +76,116 @@ func (m *mcpBrokerImpl) rebuildProtocolToolCache() {
 		serverID := config.UpstreamMCPID(serverIDStr)
 
 		if m.ServerSupportsVersion(serverID, protocol.Version2025) {
-			stateful = append(stateful, tool)
+			statefulT.items = append(statefulT.items, tool)
+			if !statefulServersSeen[serverID] {
+				statefulServersSeen[serverID] = true
+				statefulT.serverIDs = append(statefulT.serverIDs, serverID)
+			}
 		}
 		if m.ServerSupportsVersion(serverID, protocol.Version2026) {
-			stateless = append(stateless, tool)
+			statelessT.items = append(statelessT.items, tool)
+			if !statelessServersSeen[serverID] {
+				statelessServersSeen[serverID] = true
+				statelessT.serverIDs = append(statelessT.serverIDs, serverID)
+			}
+		}
+	}
+	// precompute 2026 servers needing per-request fetching (cacheScope:"private"
+	// or ttlMs:0) so FetchUserSpecificTools avoids iterating all servers per request.
+	// iterates all connected 2026 upstreams, not just those with cached tools —
+	// a fully-private upstream may contribute zero shared tools.
+	// CRD-declared userSpecificList servers are excluded (handled in startManagers).
+	crdUserSpecific := make(map[config.UpstreamMCPID]bool, len(m.userSpecificServers))
+	for _, s := range m.userSpecificServers {
+		crdUserSpecific[s.id] = true
+	}
+	for id, mgr := range m.mcpServers {
+		if crdUserSpecific[id] {
+			continue
+		}
+		if !m.ServerSupportsVersion(id, protocol.Version2026) {
+			continue
+		}
+		meta := mgr.ToolsCacheMetadata()
+		cfg := mgr.Config()
+		srv := userSpecificServer{
+			id:     id,
+			name:   cfg.Name,
+			url:    cfg.URL,
+			prefix: cfg.Prefix,
+			caCert: cfg.CACert,
+		}
+		if m.handler2026.ShouldFetchFresh(srv, &meta) {
+			statelessT.freshFetchServers = append(statelessT.freshFetchServers, srv)
 		}
 	}
 
-	m.statefulTools.Store(&stateful)
-	m.statelessTools.Store(&stateless)
-	m.logger.Debug("rebuilt protocol tool cache",
-		"statefulCount", len(stateful),
-		"statelessCount", len(stateless))
+	m.statefulTools.Store(&statefulT)
+	m.statelessTools.Store(&statelessT)
+
+	// partition prompts
+	allPrompts := m.gatewayServer.ListPrompts()
+	var statefulP, statelessP protocolCacheEntry[*mcp.Prompt]
+	statefulServersSeen = make(map[config.UpstreamMCPID]bool)
+	statelessServersSeen = make(map[config.UpstreamMCPID]bool)
+
+	for _, gp := range allPrompts {
+		prompt := &gp.Prompt
+
+		serverIDVal, hasServerID := prompt.Meta["kuadrant/id"]
+		if !hasServerID {
+			m.logger.Warn("prompt missing kuadrant/id, excluded from protocol sets", "promptName", prompt.Name)
+			continue
+		}
+
+		serverIDStr, ok := serverIDVal.(string)
+		if !ok {
+			m.logger.Warn("prompt has non-string kuadrant/id", "promptName", prompt.Name, "id", serverIDVal)
+			continue
+		}
+		serverID := config.UpstreamMCPID(serverIDStr)
+
+		if m.ServerSupportsVersion(serverID, protocol.Version2025) {
+			statefulP.items = append(statefulP.items, prompt)
+			if !statefulServersSeen[serverID] {
+				statefulServersSeen[serverID] = true
+				statefulP.serverIDs = append(statefulP.serverIDs, serverID)
+			}
+		}
+		if m.ServerSupportsVersion(serverID, protocol.Version2026) {
+			statelessP.items = append(statelessP.items, prompt)
+			if !statelessServersSeen[serverID] {
+				statelessServersSeen[serverID] = true
+				statelessP.serverIDs = append(statelessP.serverIDs, serverID)
+			}
+		}
+	}
+	m.statefulPrompts.Store(&statefulP)
+	m.statelessPrompts.Store(&statelessP)
+
+	m.logger.Debug("rebuilt protocol caches",
+		"statefulTools", len(statefulT.items), "statelessTools", len(statelessT.items),
+		"statefulPrompts", len(statefulP.items), "statelessPrompts", len(statelessP.items))
+}
+
+// promptsForProtocol returns the pre-cached prompt set for the client's protocol version.
+// Returns a shallow copy to avoid mutation by downstream filters.
+func (m *mcpBrokerImpl) promptsForProtocol(headers http.Header) []*mcp.Prompt {
+	version := headers.Get(protocolVersionHeader)
+	if version == protocol.Version2026 {
+		if cached := m.statelessPrompts.Load(); cached != nil {
+			prompts := make([]*mcp.Prompt, len(cached.items))
+			copy(prompts, cached.items)
+			return prompts
+		}
+	}
+
+	if cached := m.statefulPrompts.Load(); cached != nil {
+		prompts := make([]*mcp.Prompt, len(cached.items))
+		copy(prompts, cached.items)
+		return prompts
+	}
+	return nil
 }
 
 // toolsForProtocol returns the pre-cached tool set for the client's protocol version.
@@ -82,16 +194,16 @@ func (m *mcpBrokerImpl) toolsForProtocol(headers http.Header) []*mcp.Tool {
 	version := headers.Get(protocolVersionHeader)
 	if version == protocol.Version2026 {
 		if cached := m.statelessTools.Load(); cached != nil {
-			tools := make([]*mcp.Tool, len(*cached))
-			copy(tools, *cached)
+			tools := make([]*mcp.Tool, len(cached.items))
+			copy(tools, cached.items)
 			return tools
 		}
 	}
 
 	// default to stateful for no header or any other version
 	if cached := m.statefulTools.Load(); cached != nil {
-		tools := make([]*mcp.Tool, len(*cached))
-		copy(tools, *cached)
+		tools := make([]*mcp.Tool, len(cached.items))
+		copy(tools, cached.items)
 		return tools
 	}
 	return nil

--- a/internal/broker/protocol_filter_test.go
+++ b/internal/broker/protocol_filter_test.go
@@ -2,7 +2,6 @@ package broker
 
 import (
 	"log/slog"
-	"net/http"
 	"testing"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
@@ -207,24 +206,19 @@ type namedPrompt struct{ *mcp.Prompt }
 
 func (n namedPrompt) getName() string { return n.Name }
 
-func testProtocolFilter[T namedItem](t *testing.T, label string, lookup func(http.Header) []T, stateful, stateless []string) {
+func testProtocolFilter[T namedItem](t *testing.T, label string, lookup func(bool) []T, stateful, stateless []string) {
 	t.Helper()
 	tests := []struct {
-		name      string
-		header    string
-		wantNames []string
+		name        string
+		isStateless bool
+		wantNames   []string
 	}{
-		{"2026 header returns stateless", "2026-07-28", stateless},
-		{"no header returns stateful", "", stateful},
-		{"2025 header returns stateful", "2025-11-25", stateful},
+		{"stateless returns 2026 set", true, stateless},
+		{"stateful returns 2025 set", false, stateful},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			headers := http.Header{}
-			if tt.header != "" {
-				headers.Set("Mcp-Protocol-Version", tt.header)
-			}
-			got := lookup(headers)
+			got := lookup(tt.isStateless)
 			if len(got) != len(tt.wantNames) {
 				t.Fatalf("got %d %s, want %d", len(got), label, len(tt.wantNames))
 			}
@@ -236,12 +230,10 @@ func testProtocolFilter[T namedItem](t *testing.T, label string, lookup func(htt
 		})
 	}
 	t.Run("returns shallow copy", func(t *testing.T) {
-		headers := http.Header{}
-		headers.Set("Mcp-Protocol-Version", "2026-07-28")
-		r1 := lookup(headers)
+		r1 := lookup(true)
 		n := len(r1)
 		_ = append(r1, r1[0])
-		r2 := lookup(headers)
+		r2 := lookup(true)
 		if len(r2) != n {
 			t.Errorf("cache was mutated: got %d %s, want %d", len(r2), label, n)
 		}
@@ -256,8 +248,8 @@ func TestToolsForProtocol(t *testing.T) {
 	b.statelessTools.Store(&sl)
 
 	testProtocolFilter(t, "tools",
-		func(h http.Header) []namedTool {
-			got := b.toolsForProtocol(h)
+		func(isStateless bool) []namedTool {
+			got := b.toolsForProtocol(isStateless)
 			out := make([]namedTool, len(got))
 			for i, tool := range got {
 				out[i] = namedTool{tool}
@@ -271,8 +263,8 @@ func TestToolsForProtocol(t *testing.T) {
 func TestRebuildProtocolCaches_Prompts(t *testing.T) {
 	t.Run("mixed servers with edge cases", func(t *testing.T) {
 		// 2025-only server, 2026-only server, dual-version server,
-		// prompt without kuadrant/id (defaults to stateful),
-		// prompt with non-string kuadrant/id (dropped from both sets)
+		// prompt without kuadrant/id (excluded from all sets),
+		// prompt with non-string kuadrant/id (excluded from all sets)
 		prompts := []upstream.GatewayPrompt{
 			{Prompt: mcp.Prompt{Name: "p25", Meta: map[string]any{"kuadrant/id": "srv25"}}, Handler: upstream.NoopPromptHandler},
 			{Prompt: mcp.Prompt{Name: "p26", Meta: map[string]any{"kuadrant/id": "srv26"}}, Handler: upstream.NoopPromptHandler},
@@ -321,8 +313,8 @@ func TestPromptsForProtocol(t *testing.T) {
 	b.statelessPrompts.Store(&sl)
 
 	testProtocolFilter(t, "prompts",
-		func(h http.Header) []namedPrompt {
-			got := b.promptsForProtocol(h)
+		func(isStateless bool) []namedPrompt {
+			got := b.promptsForProtocol(isStateless)
 			out := make([]namedPrompt, len(got))
 			for i, p := range got {
 				out[i] = namedPrompt{p}

--- a/internal/broker/protocol_filter_test.go
+++ b/internal/broker/protocol_filter_test.go
@@ -75,7 +75,7 @@ func TestComputeGatewaySupportedVersions(t *testing.T) {
 	}
 }
 
-func TestRebuildProtocolToolCache(t *testing.T) {
+func TestRebuildProtocolCaches(t *testing.T) {
 	tests := []struct {
 		name               string
 		tools              []upstream.GatewayTool
@@ -156,12 +156,12 @@ func TestRebuildProtocolToolCache(t *testing.T) {
 			wantStatelessCount: 1,
 		},
 		{
-			name: "tool without kuadrant/id",
+			name: "tool without kuadrant/id excluded from all sets",
 			tools: []upstream.GatewayTool{
 				{Tool: mcp.Tool{Name: "tool1", InputSchema: objectSchema, Meta: map[string]any{"other": "value"}}, Handler: upstream.NoopToolHandler},
 			},
 			serverVersions:     map[config.UpstreamMCPID][]string{},
-			wantStatefulCount:  1,
+			wantStatefulCount:  0,
 			wantStatelessCount: 0,
 		},
 	}
@@ -174,99 +174,161 @@ func TestRebuildProtocolToolCache(t *testing.T) {
 			}
 
 			broker.gatewayServer.AddTools(tt.tools...)
-			broker.rebuildProtocolToolCache()
+			broker.rebuildProtocolCaches()
 
 			stateful := broker.statefulTools.Load()
 			if stateful == nil {
 				t.Fatal("statefulTools is nil")
 			}
-			if len(*stateful) != tt.wantStatefulCount {
-				t.Errorf("stateful count: got %d, want %d", len(*stateful), tt.wantStatefulCount)
+			if len(stateful.items) != tt.wantStatefulCount {
+				t.Errorf("stateful count: got %d, want %d", len(stateful.items), tt.wantStatefulCount)
 			}
 
 			stateless := broker.statelessTools.Load()
 			if stateless == nil && tt.wantStatelessCount > 0 {
 				t.Fatal("statelessTools is nil but expected tools")
 			}
-			if stateless != nil && len(*stateless) != tt.wantStatelessCount {
-				t.Errorf("stateless count: got %d, want %d", len(*stateless), tt.wantStatelessCount)
+			if stateless != nil && len(stateless.items) != tt.wantStatelessCount {
+				t.Errorf("stateless count: got %d, want %d", len(stateless.items), tt.wantStatelessCount)
 			}
 		})
 	}
 }
 
-func TestToolsForProtocol(t *testing.T) {
-	broker := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+type namedItem interface {
+	getName() string
+}
 
-	statefulTools := []*mcp.Tool{
-		{Name: "tool1"},
-		{Name: "tool2"},
-	}
-	statelessTools := []*mcp.Tool{
-		{Name: "tool3"},
-	}
+type namedTool struct{ *mcp.Tool }
 
-	broker.statefulTools.Store(&statefulTools)
-	broker.statelessTools.Store(&statelessTools)
+func (n namedTool) getName() string { return n.Name }
 
+type namedPrompt struct{ *mcp.Prompt }
+
+func (n namedPrompt) getName() string { return n.Name }
+
+func testProtocolFilter[T namedItem](t *testing.T, label string, lookup func(http.Header) []T, stateful, stateless []string) {
+	t.Helper()
 	tests := []struct {
 		name      string
 		header    string
-		wantCount int
 		wantNames []string
 	}{
-		{
-			name:      "2026 header returns stateless",
-			header:    "2026-07-28",
-			wantCount: 1,
-			wantNames: []string{"tool3"},
-		},
-		{
-			name:      "no header returns stateful",
-			header:    "",
-			wantCount: 2,
-			wantNames: []string{"tool1", "tool2"},
-		},
-		{
-			name:      "2025 header returns stateful",
-			header:    "2025-11-25",
-			wantCount: 2,
-			wantNames: []string{"tool1", "tool2"},
-		},
+		{"2026 header returns stateless", "2026-07-28", stateless},
+		{"no header returns stateful", "", stateful},
+		{"2025 header returns stateful", "2025-11-25", stateful},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			headers := http.Header{}
 			if tt.header != "" {
 				headers.Set("Mcp-Protocol-Version", tt.header)
 			}
-
-			got := broker.toolsForProtocol(headers)
-			if len(got) != tt.wantCount {
-				t.Fatalf("got %d tools, want %d", len(got), tt.wantCount)
+			got := lookup(headers)
+			if len(got) != len(tt.wantNames) {
+				t.Fatalf("got %d %s, want %d", len(got), label, len(tt.wantNames))
 			}
-
 			for i, name := range tt.wantNames {
-				if got[i].Name != name {
-					t.Errorf("tool %d: got name %q, want %q", i, got[i].Name, name)
+				if got[i].getName() != name {
+					t.Errorf("%s %d: got name %q, want %q", label, i, got[i].getName(), name)
 				}
 			}
 		})
 	}
-
 	t.Run("returns shallow copy", func(t *testing.T) {
 		headers := http.Header{}
 		headers.Set("Mcp-Protocol-Version", "2026-07-28")
-
-		result1 := broker.toolsForProtocol(headers)
-		originalLen := len(result1)
-
-		_ = append(result1, &mcp.Tool{Name: "appended"})
-
-		result2 := broker.toolsForProtocol(headers)
-		if len(result2) != originalLen {
-			t.Errorf("cache was mutated: got %d tools, want %d", len(result2), originalLen)
+		r1 := lookup(headers)
+		n := len(r1)
+		_ = append(r1, r1[0])
+		r2 := lookup(headers)
+		if len(r2) != n {
+			t.Errorf("cache was mutated: got %d %s, want %d", len(r2), label, n)
 		}
 	})
+}
+
+func TestToolsForProtocol(t *testing.T) {
+	b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+	sf := protocolCacheEntry[*mcp.Tool]{items: []*mcp.Tool{{Name: "tool1"}, {Name: "tool2"}}}
+	sl := protocolCacheEntry[*mcp.Tool]{items: []*mcp.Tool{{Name: "tool3"}}}
+	b.statefulTools.Store(&sf)
+	b.statelessTools.Store(&sl)
+
+	testProtocolFilter(t, "tools",
+		func(h http.Header) []namedTool {
+			got := b.toolsForProtocol(h)
+			out := make([]namedTool, len(got))
+			for i, tool := range got {
+				out[i] = namedTool{tool}
+			}
+			return out
+		},
+		[]string{"tool1", "tool2"}, []string{"tool3"},
+	)
+}
+
+func TestRebuildProtocolCaches_Prompts(t *testing.T) {
+	t.Run("mixed servers with edge cases", func(t *testing.T) {
+		// 2025-only server, 2026-only server, dual-version server,
+		// prompt without kuadrant/id (defaults to stateful),
+		// prompt with non-string kuadrant/id (dropped from both sets)
+		prompts := []upstream.GatewayPrompt{
+			{Prompt: mcp.Prompt{Name: "p25", Meta: map[string]any{"kuadrant/id": "srv25"}}, Handler: upstream.NoopPromptHandler},
+			{Prompt: mcp.Prompt{Name: "p26", Meta: map[string]any{"kuadrant/id": "srv26"}}, Handler: upstream.NoopPromptHandler},
+			{Prompt: mcp.Prompt{Name: "pdual", Meta: map[string]any{"kuadrant/id": "srvdual"}}, Handler: upstream.NoopPromptHandler},
+			{Prompt: mcp.Prompt{Name: "no_id", Meta: map[string]any{"other": "value"}}, Handler: upstream.NoopPromptHandler},
+			{Prompt: mcp.Prompt{Name: "bad_id", Meta: map[string]any{"kuadrant/id": 123}}, Handler: upstream.NoopPromptHandler},
+		}
+		versions := map[config.UpstreamMCPID][]string{
+			"srv25":   {"2025-11-25"},
+			"srv26":   {"2026-07-28"},
+			"srvdual": {"2025-11-25", "2026-07-28"},
+		}
+
+		broker := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+		for id, v := range versions {
+			broker.serverVersions.Store(id, v)
+		}
+		broker.gatewayServer.AddPrompts(prompts...)
+		broker.rebuildProtocolCaches()
+
+		stateful := broker.statefulPrompts.Load()
+		if stateful == nil {
+			t.Fatal("statefulPrompts is nil")
+		}
+		// p25 + pdual = 2 (no_id and bad_id both excluded)
+		if len(stateful.items) != 2 {
+			t.Errorf("stateful count: got %d, want 2", len(stateful.items))
+		}
+
+		stateless := broker.statelessPrompts.Load()
+		if stateless == nil {
+			t.Fatal("statelessPrompts is nil")
+		}
+		// p26 + pdual = 2
+		if len(stateless.items) != 2 {
+			t.Errorf("stateless count: got %d, want 2", len(stateless.items))
+		}
+	})
+}
+
+func TestPromptsForProtocol(t *testing.T) {
+	b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+	sf := protocolCacheEntry[*mcp.Prompt]{items: []*mcp.Prompt{{Name: "prompt1"}, {Name: "prompt2"}}}
+	sl := protocolCacheEntry[*mcp.Prompt]{items: []*mcp.Prompt{{Name: "prompt3"}}}
+	b.statefulPrompts.Store(&sf)
+	b.statelessPrompts.Store(&sl)
+
+	testProtocolFilter(t, "prompts",
+		func(h http.Header) []namedPrompt {
+			got := b.promptsForProtocol(h)
+			out := make([]namedPrompt, len(got))
+			for i, p := range got {
+				out[i] = namedPrompt{p}
+			}
+			return out
+		},
+		[]string{"prompt1", "prompt2"}, []string{"prompt3"},
+	)
 }

--- a/internal/broker/protocol_handler_2026.go
+++ b/internal/broker/protocol_handler_2026.go
@@ -45,7 +45,7 @@ func (h *ProtocolHandler2026) ShouldFetchFresh(_ userSpecificServer, meta *upstr
 // "private" if any upstream is private, user-specific, or zero-TTL.
 func (h *ProtocolHandler2026) AggregateCache(contributing []upstream.CacheMetadata) (int, string) {
 	if len(contributing) == 0 {
-		return 0, ""
+		return 0, upstream.CacheScopePublic
 	}
 
 	minTTL := 0

--- a/internal/broker/protocol_handler_2026_test.go
+++ b/internal/broker/protocol_handler_2026_test.go
@@ -107,7 +107,7 @@ func TestProtocolHandler2026_AggregateCache_Empty(t *testing.T) {
 	h := NewProtocolHandler2026(nil)
 	ttl, scope := h.AggregateCache(nil)
 	assert.Equal(t, 0, ttl)
-	assert.Equal(t, "", scope)
+	assert.Equal(t, upstream.CacheScopePublic, scope)
 }
 
 func TestProtocolHandler2026_FetchUserSpecificTools_EmptyServers(t *testing.T) {

--- a/internal/broker/session_resurrection.go
+++ b/internal/broker/session_resurrection.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -21,6 +22,12 @@ import (
 // protocolVersionHeader is the spec's MCP-Protocol-Version header in the
 // canonical form http.Header.Get expects.
 const protocolVersionHeader = "Mcp-Protocol-Version"
+
+// isStatelessProtocol returns true when the request's protocol version
+// indicates a stateless (2026+) client.
+func isStatelessProtocol(headers http.Header) bool {
+	return headers.Get(protocolVersionHeader) == protocol.Version2026
+}
 
 // defaultProtocolVersion is assumed when the client omits the
 // MCP-Protocol-Version header, matching the SDK's default. deliberately the

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -29,7 +29,9 @@ import (
 const (
 	notificationToolsListChanged   = "notifications/tools/list_changed"
 	notificationPromptsListChanged = "notifications/prompts/list_changed"
-	gatewayServerID                = "kuadrant/id"
+	// GatewayServerID is the meta key stamped on every tool and prompt to
+	// identify which upstream server owns it.
+	GatewayServerID = "kuadrant/id"
 
 	// expectedProtocolVersion is the version the broker proposes in its
 	// legacy initialize to upstreams (the SDK client's fallback proposal),
@@ -729,7 +731,7 @@ func (man *MCPManager) findToolConflicts(mcpTools []GatewayTool) error {
 				man.logger.Debug("skipping conflict check, tool meta is nil", "upstream mcp server", man.mcp.ID(), "tool", existingToolName)
 				continue
 			}
-			existingToolID, ok := existingTool.Meta[gatewayServerID]
+			existingToolID, ok := existingTool.Meta[GatewayServerID]
 			if !ok {
 				man.logger.Debug("skipping conflict check, tool id is missing", "upstream mcp server", man.mcp.ID(), "tool", existingToolName)
 				continue
@@ -812,6 +814,13 @@ func (man *MCPManager) SetStatusForTesting(status ServerValidationStatus) {
 	man.status = status
 }
 
+// SetCacheMetadataForTesting sets cache metadata directly for testing.
+func (man *MCPManager) SetCacheMetadataForTesting(toolsMeta, promptsMeta CacheMetadata) {
+	if mcpServer, ok := man.mcp.(*MCPServer); ok {
+		mcpServer.SetCacheMetadataForTesting(toolsMeta, promptsMeta)
+	}
+}
+
 // NewActiveForTesting wraps a manager as an ActiveMCPServer without starting
 // the event loop. Stop is a no-op. Only for use in tests that need a static
 // manager with pre-seeded tools/status.
@@ -858,7 +867,7 @@ func (man *MCPManager) removeAllPrompts() {
 func (man *MCPManager) toolToServerTool(newTool mcp.Tool) GatewayTool {
 	newTool.Name = prefixedName(man.mcp.GetPrefix(), newTool.Name)
 	newTool.Meta = mcp.Meta{
-		gatewayServerID: string(man.mcp.ID()),
+		GatewayServerID: string(man.mcp.ID()),
 	}
 	return GatewayTool{
 		Tool:    newTool,
@@ -906,7 +915,7 @@ func prefixedName(prefix, tool string) string {
 func (man *MCPManager) promptToServerPrompt(newPrompt mcp.Prompt) GatewayPrompt {
 	newPrompt.Name = prefixedName(man.mcp.GetPrefix(), newPrompt.Name)
 	newPrompt.Meta = mcp.Meta{
-		gatewayServerID: string(man.mcp.ID()),
+		GatewayServerID: string(man.mcp.ID()),
 	}
 	return GatewayPrompt{
 		Prompt:  newPrompt,
@@ -974,7 +983,7 @@ func (man *MCPManager) findPromptConflicts(mcpPrompts []GatewayPrompt) error {
 				man.logger.Debug("skipping conflict check, prompt meta is nil", "upstream mcp server", man.mcp.ID(), "prompt", existingPromptName)
 				continue
 			}
-			existingPromptID, ok := existingPrompt.Meta[gatewayServerID]
+			existingPromptID, ok := existingPrompt.Meta[GatewayServerID]
 			if !ok {
 				man.logger.Debug("skipping conflict check, prompt id is missing", "upstream mcp server", man.mcp.ID(), "prompt", existingPromptName)
 				continue

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -529,7 +529,7 @@ func TestMCPManager_toolToServerTool(t *testing.T) {
 	assert.Equal(t, "A test tool", serverTool.Tool.Description)
 
 	// check that meta has id field
-	id, ok := serverTool.Tool.Meta[gatewayServerID]
+	id, ok := serverTool.Tool.Meta[GatewayServerID]
 	assert.True(t, ok)
 	assert.Equal(t, string(mock.id), id)
 
@@ -1449,7 +1449,7 @@ func TestMCPManager_promptToServerPrompt(t *testing.T) {
 			assert.Equal(t, tt.expectedName, serverPrompt.Prompt.Name)
 			assert.Equal(t, tt.promptDesc, serverPrompt.Prompt.Description)
 
-			id, ok := serverPrompt.Prompt.Meta[gatewayServerID]
+			id, ok := serverPrompt.Prompt.Meta[GatewayServerID]
 			assert.True(t, ok)
 			assert.Equal(t, string(mock.id), id)
 

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -468,6 +468,14 @@ func (up *MCPServer) PromptsCacheMetadata() CacheMetadata {
 	return up.promptsCacheMeta
 }
 
+// SetCacheMetadataForTesting sets cache metadata directly for testing.
+func (up *MCPServer) SetCacheMetadataForTesting(toolsMeta, promptsMeta CacheMetadata) {
+	up.clientMu.Lock()
+	defer up.clientMu.Unlock()
+	up.toolsCacheMeta = toolsMeta
+	up.promptsCacheMeta = promptsMeta
+}
+
 // SupportsPrompts checks if the upstream server declared prompt capabilities
 func (up *MCPServer) SupportsPrompts() bool {
 	if up.init == nil || up.init.Capabilities == nil {

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -58,7 +58,7 @@ type cachedUserSession struct {
 func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers http.Header, result *mcp.ListToolsResult) {
 	clientVersion := protocol.Version2025
 	handler := broker.handler2025
-	if headers.Get(protocolVersionHeader) == protocol.Version2026 {
+	if isStatelessProtocol(headers) {
 		clientVersion = protocol.Version2026
 		handler = broker.handler2026
 	}

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -50,31 +50,45 @@ type cachedUserSession struct {
 	headers atomic.Pointer[map[string]string]
 }
 
-// FetchUserSpecificTools fetches tools from userSpecificList servers using the
-// caller's session headers and merges them into the result before FilterTools runs.
-// Only servers supporting the client's protocol version are queried.
+// FetchUserSpecificTools fetches tools from servers that need per-request
+// fetching and merges them into the result before FilterTools runs.
+// Sources: CRD-declared userSpecificList (precomputed in startManagers) and
+// 2026 upstreams whose cache metadata indicates fresh fetching (evaluated here
+// at request time so newly-connected managers are picked up without a config change).
 func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers http.Header, result *mcp.ListToolsResult) {
-	broker.mcpLock.RLock()
-	servers := broker.userSpecificServers
-	broker.mcpLock.RUnlock()
-
-	if len(servers) == 0 {
-		return
-	}
-
 	clientVersion := protocol.Version2025
+	handler := broker.handler2025
 	if headers.Get(protocolVersionHeader) == protocol.Version2026 {
 		clientVersion = protocol.Version2026
+		handler = broker.handler2026
 	}
-	isStateless := clientVersion == protocol.Version2026
 
-	// filter to servers supporting the client's protocol
+	// collect CRD-declared userSpecificList servers
+	broker.mcpLock.RLock()
+	crdServers := broker.userSpecificServers
+	broker.mcpLock.RUnlock()
+
+	seen := make(map[config.UpstreamMCPID]bool, len(crdServers))
 	var matching []userSpecificServer
-	for _, srv := range servers {
+	for _, srv := range crdServers {
 		if broker.ServerSupportsVersion(srv.id, clientVersion) {
 			matching = append(matching, srv)
 		}
+		seen[srv.id] = true
 	}
+
+	// for 2026 clients, also include upstreams whose cache metadata indicates
+	// per-request fetching (precomputed in rebuildProtocolCaches)
+	if clientVersion == protocol.Version2026 {
+		if cached := broker.statelessTools.Load(); cached != nil {
+			for _, srv := range cached.freshFetchServers {
+				if !seen[srv.id] {
+					matching = append(matching, srv)
+				}
+			}
+		}
+	}
+
 	if len(matching) == 0 {
 		return
 	}
@@ -89,18 +103,15 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 
 	broker.logger.Debug("fetching user-specific tools", "serverCount", len(matching), "clientVersion", clientVersion)
 
-	before := len(result.Tools)
-	if isStateless {
-		broker.fetchStatelessUserTools(ctx, matching, headers, result)
-	} else {
-		if headers.Get(gatewaySessionHeader) == "" {
-			broker.logger.Error("no gateway session ID for user-specific tool fetch")
-			span.SetStatus(codes.Error, "missing gateway session ID")
-			return
-		}
-		broker.fetchStatefulUserTools(ctx, matching, headers, result)
+	// 2025 stateful fetches require a gateway session ID
+	if clientVersion == protocol.Version2025 && headers.Get(gatewaySessionHeader) == "" {
+		broker.logger.Error("no gateway session ID for user-specific tool fetch")
+		span.SetStatus(codes.Error, "missing gateway session ID")
+		return
 	}
 
+	before := len(result.Tools)
+	handler.FetchUserSpecificTools(ctx, matching, headers, result)
 	span.SetAttributes(attribute.Int("mcp.user_specific.tools_fetched", len(result.Tools)-before))
 }
 

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -139,6 +139,7 @@ func TestFetchUserSpecificTools_NoGatewaySessionID(t *testing.T) {
 		userSpecificFetchTimeout: 5 * time.Second,
 	}
 	withStatefulVersions(broker, servers)
+	withProtocolHandlers(broker)
 
 	result := &mcp.ListToolsResult{
 		Tools: []*mcp.Tool{{Name: "existing-tool"}},
@@ -161,6 +162,12 @@ func withStatefulVersions(b *mcpBrokerImpl, servers []userSpecificServer) {
 	for _, srv := range servers {
 		b.serverVersions.Store(srv.id, []string{"2025-11-25"})
 	}
+}
+
+// withProtocolHandlers initializes the protocol handlers on a test broker.
+func withProtocolHandlers(b *mcpBrokerImpl) {
+	b.handler2025 = NewProtocolHandler2025(b)
+	b.handler2026 = NewProtocolHandler2026(b)
 }
 
 // newTestMCPServer returns a test HTTP server that handles MCP initialize and
@@ -243,6 +250,7 @@ func TestFetchUserSpecificTools_FetchesAndMergesTools(t *testing.T) {
 		userSpecificFetchTimeout: 10 * time.Second,
 	}
 	withStatefulVersions(b, servers)
+	withProtocolHandlers(b)
 
 	result := &mcp.ListToolsResult{
 		Tools: []*mcp.Tool{{Name: "cached-tool"}},
@@ -288,6 +296,7 @@ func TestFetchUserSpecificTools_GracefulDegradation(t *testing.T) {
 		userSpecificFetchTimeout: 2 * time.Second,
 	}
 	withStatefulVersions(b, servers)
+	withProtocolHandlers(b)
 
 	result := &mcp.ListToolsResult{
 		Tools: []*mcp.Tool{{Name: "existing"}},
@@ -355,6 +364,7 @@ func TestFetchUserSpecificTools_SessionCaching(t *testing.T) {
 		userSpecificFetchTimeout: 10 * time.Second,
 	}
 	withStatefulVersions(b, servers)
+	withProtocolHandlers(b)
 
 	makeHeaders := func() http.Header {
 		return http.Header{
@@ -615,6 +625,7 @@ func TestFetchUserSpecificTools_StatelessFetch(t *testing.T) {
 		userSpecificFetchTimeout: 10 * time.Second,
 	}
 	b.serverVersions.Store(srv.id, []string{"2026-07-28"})
+	withProtocolHandlers(b)
 
 	result := &mcp.ListToolsResult{
 		Tools: []*mcp.Tool{{Name: "cached-tool"}},
@@ -663,6 +674,7 @@ func TestFetchUserSpecificTools_ProtocolFiltering(t *testing.T) {
 	}
 	b.serverVersions.Store(srv2025.id, []string{"2025-11-25"})
 	b.serverVersions.Store(srv2026.id, []string{"2026-07-28"})
+	withProtocolHandlers(b)
 
 	t.Run("2025 client sees only 2025 tools", func(t *testing.T) {
 		result := &mcp.ListToolsResult{}

--- a/internal/tests/stateless-server/server.go
+++ b/internal/tests/stateless-server/server.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -73,7 +75,7 @@ func RunServer(transport, port string) (StartupFunc, ShutdownFunc, error) {
 		InputSchema: map[string]any{"type": "object"},
 	}, stubToolHandler("run_pipeline"))
 
-	s.AddReceivingMiddleware(userToolFilterMiddleware())
+	s.AddReceivingMiddleware(userToolFilterMiddleware(), cacheMetadataMiddleware())
 
 	// greeting prompt
 	s.AddPrompt(&mcp.Prompt{
@@ -233,9 +235,61 @@ func userToolFilterMiddleware() mcp.Middleware {
 				}
 			}
 			toolsResult.Tools = filtered
+			if auth != "" {
+				toolsResult.CacheScope = "private"
+			}
 			return result, nil
 		}
 	}
+}
+
+// cacheMetadataMiddleware sets TTLMs and CacheScope on tools/list and
+// prompts/list responses. Values are configurable via env vars:
+// MCP_TOOLS_TTL_MS (default 60000), MCP_TOOLS_CACHE_SCOPE (default "public"),
+// MCP_PROMPTS_TTL_MS (default 60000), MCP_PROMPTS_CACHE_SCOPE (default "public").
+func cacheMetadataMiddleware() mcp.Middleware {
+	toolsTTL := envInt("MCP_TOOLS_TTL_MS", 60000)
+	toolsScope := envStr("MCP_TOOLS_CACHE_SCOPE", "public")
+	promptsTTL := envInt("MCP_PROMPTS_TTL_MS", 60000)
+	promptsScope := envStr("MCP_PROMPTS_CACHE_SCOPE", "public")
+
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			result, err := next(ctx, method, req)
+			if err != nil {
+				return result, err
+			}
+			switch method {
+			case "tools/list":
+				if tr, ok := result.(*mcp.ListToolsResult); ok && tr != nil {
+					tr.TTLMs = toolsTTL
+					tr.CacheScope = toolsScope
+				}
+			case "prompts/list":
+				if pr, ok := result.(*mcp.ListPromptsResult); ok && pr != nil {
+					pr.TTLMs = promptsTTL
+					pr.CacheScope = promptsScope
+				}
+			}
+			return result, nil
+		}
+	}
+}
+
+func envInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func envStr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }
 
 // requireStringArg parses an argument with mark3labs RequireString

--- a/internal/tests/stateless-server/server_test.go
+++ b/internal/tests/stateless-server/server_test.go
@@ -1,0 +1,47 @@
+package statelessserver
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserToolFilterMiddleware_PrivateScopeOnAuth(t *testing.T) {
+	middleware := userToolFilterMiddleware()
+
+	handler := middleware(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		r := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{
+				{Name: "hello_world", InputSchema: map[string]any{"type": "object"}},
+				{Name: "list_repos", InputSchema: map[string]any{"type": "object"}},
+				{Name: "run_pipeline", InputSchema: map[string]any{"type": "object"}},
+			},
+		}
+		r.CacheScope = "public"
+		return r, nil
+	})
+
+	t.Run("no auth returns public scope", func(t *testing.T) {
+		req := &mcp.ListToolsRequest{Extra: &mcp.RequestExtra{Header: http.Header{}}}
+		result, err := handler(context.Background(), "tools/list", req)
+		require.NoError(t, err)
+		tr := result.(*mcp.ListToolsResult)
+		assert.Equal(t, "public", tr.CacheScope)
+		assert.Len(t, tr.Tools, 1, "only hello_world visible without auth (headers tool not in input)")
+	})
+
+	t.Run("with auth returns private scope", func(t *testing.T) {
+		req := &mcp.ListToolsRequest{Extra: &mcp.RequestExtra{Header: http.Header{
+			"Authorization": []string{"Bearer user-a-token"},
+		}}}
+		result, err := handler(context.Background(), "tools/list", req)
+		require.NoError(t, err)
+		tr := result.(*mcp.ListToolsResult)
+		assert.Equal(t, "private", tr.CacheScope)
+		assert.Len(t, tr.Tools, 2, "hello_world and list_repos visible for user-a")
+	})
+}

--- a/tests/e2e/dual_protocol_test.go
+++ b/tests/e2e/dual_protocol_test.go
@@ -4,6 +4,8 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -531,6 +533,108 @@ var _ = Describe("Dual Protocol Gateway", Ordered, func() {
 			Expect(ok).To(BeTrue())
 			Expect(text.Text).To(ContainSubstring("greet"))
 			Expect(text.Text).To(ContainSubstring("e2e"))
+		})
+	})
+
+	Context("broker 2026 cache metadata", func() {
+		promptNames := func(prompts []*mcp.Prompt) []string {
+			names := make([]string, len(prompts))
+			for i, p := range prompts {
+				names[i] = p.Name
+			}
+			return names
+		}
+
+		It("[Happy,Broker2026] 2026 client tools/list returns ttlMs and cacheScope", func() {
+			c := newStatelessClient()
+			defer func() { _ = c.Close() }()
+
+			waitForToolsWithPrefix(c, "sl_")
+
+			Eventually(func(g Gomega) {
+				result, err := c.ListTools(ctx, nil)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result.TTLMs).To(BeNumerically(">", 0),
+					"2026 tools/list should include ttlMs > 0")
+				g.Expect(result.CacheScope).NotTo(BeEmpty(),
+					"2026 tools/list should include cacheScope")
+			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+		})
+
+		It("[Happy,Broker2026] 2025 client tools/list has no ttlMs or cacheScope", func() {
+			c := newStatefulClient()
+			defer func() { _ = c.Close() }()
+
+			waitForToolsWithPrefix(c, "sf_")
+
+			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"tools/list"}`, jsonRPCID.Add(1))
+
+			var respBody string
+			Eventually(func(g Gomega) {
+				status, rb, _, postErr := mcpRawPost(ctx, dpURL, c.ID(), []byte(body), nil)
+				g.Expect(postErr).NotTo(HaveOccurred())
+				g.Expect(status).To(Equal(200))
+
+				var msg struct {
+					Result json.RawMessage `json:"result"`
+				}
+				g.Expect(json.Unmarshal([]byte(rb), &msg)).To(Succeed(),
+					"response should be valid JSON-RPC")
+				g.Expect(msg.Result).NotTo(BeNil(),
+					"response should contain a result field")
+
+				var result struct {
+					Tools []json.RawMessage `json:"tools"`
+				}
+				g.Expect(json.Unmarshal(msg.Result, &result)).To(Succeed())
+				g.Expect(result.Tools).NotTo(BeEmpty(),
+					"result should contain tools")
+
+				respBody = string(msg.Result)
+			}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+			Expect(respBody).NotTo(ContainSubstring(`"ttlMs"`),
+				"2025 response should not contain ttlMs")
+			Expect(respBody).NotTo(ContainSubstring(`"cacheScope"`),
+				"2025 response should not contain cacheScope")
+		})
+
+		It("[Happy,Broker2026] 2026 client prompts/list excludes 2025-only prompts", func() {
+			c := newStatelessClient()
+			defer func() { _ = c.Close() }()
+
+			Eventually(func(g Gomega) {
+				result, err := c.ListPrompts(ctx, nil)
+				g.Expect(err).NotTo(HaveOccurred())
+				names := promptNames(result.Prompts)
+				g.Expect(slices.ContainsFunc(names, func(n string) bool {
+					return strings.HasPrefix(n, "sl_")
+				})).To(BeTrue(), "2026 client should see sl_ prompts")
+			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+			result, err := c.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			names := promptNames(result.Prompts)
+			Expect(slices.ContainsFunc(names, func(n string) bool {
+				return strings.HasPrefix(n, "sf_")
+			})).To(BeFalse(), "2026 client should NOT see sf_ (2025-only) prompts, got: %v", names)
+		})
+
+		It("[Happy,Broker2026] 2026 client prompts/list returns cache metadata", func() {
+			c := newStatelessClient()
+			defer func() { _ = c.Close() }()
+
+			Eventually(func(g Gomega) {
+				result, err := c.ListPrompts(ctx, nil)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(slices.ContainsFunc(promptNames(result.Prompts), func(n string) bool {
+					return strings.HasPrefix(n, "sl_")
+				})).To(BeTrue(), "should have prompts loaded")
+				g.Expect(result.TTLMs).To(BeNumerically(">", 0),
+					"2026 prompts/list should include ttlMs > 0")
+				g.Expect(result.CacheScope).NotTo(BeEmpty(),
+					"2026 prompts/list should include cacheScope")
+			}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 		})
 	})
 })

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -501,6 +501,22 @@ When an MCPVirtualServer is configured that includes a specific user-specific to
 
 - Client connects to `/mcp/stateless`, calls a 2026 tool. Routes through Router202607. Call succeeds.
 
+### [Happy,Broker2026] 2026 client tools/list returns ttlMs and cacheScope
+
+- A 2026 client sends `tools/list` to the gateway. The upstream 2026 test server reports `ttlMs:60000` and `cacheScope:"public"`. The response includes `ttlMs > 0` and a non-empty `cacheScope`.
+
+### [Happy,Broker2026] 2025 client tools/list has no ttlMs or cacheScope
+
+- A 2025 client sends `tools/list` via raw HTTP. The JSON response body does not contain `"ttlMs"` or `"cacheScope"` fields — the compat handler strips them.
+
+### [Happy,Broker2026] 2026 client prompts/list excludes 2025-only prompts
+
+- A gateway has both 2025 and 2026 upstreams with prompts. A 2026 client sends `prompts/list`. The response includes only prompts from the 2026 upstream (sl_ prefix). Prompts from the 2025-only upstream (sf_ prefix) are absent.
+
+### [Happy,Broker2026] 2026 client prompts/list returns cache metadata
+
+- A 2026 client sends `prompts/list`. The response includes `ttlMs > 0` and a non-empty `cacheScope` aggregated from the 2026 upstream's cache metadata.
+
 ## Common pitfalls
 
 - MCPServerRegistrations with empty prefix: `strings.HasPrefix(name, "")` matches all tools, including broker meta-tools (discover_tools, select_tools). Always use a non-empty prefix in tests.


### PR DESCRIPTION

## What does this PR do?

Initial e2e tests added. Integrate the ProtocolHandler interface (tasks 2-4) into the broker so 2026 clients get ttlMs/cacheScope on list responses, prompts are filtered by protocol version, and FetchUserSpecificTools uses handler delegation instead of inline branching.


Related #1316 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added protocol-aware routing for tools and prompts across 2025 and 2026 clients.
  - Added TTL and cache-scope metadata to 2026 tool and prompt listings.
  - Added protocol-specific prompt filtering and user-specific tool retrieval.
  - Added cache metadata aggregation from contributing servers.

- **Bug Fixes**
  - Improved handling of missing or invalid metadata.
  - Preserved 2025 compatibility by omitting 2026 cache fields.
  - Ensured 2026 listings exclude prompts intended only for 2025 clients.
  - Improved cache metadata accuracy before filtering results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->