### PR TITLE
chore: pin GitHub Actions to commit SHAs using ratchet

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Documentation Links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
             echo "Scanning: $paths"
           fi
 
-      - uses: JustinBeckwith/linkinator-action@v2
+      - uses: JustinBeckwith/linkinator-action@36a0bfbfecd5e237e8f8531537a693616c505faf # ratchet:JustinBeckwith/linkinator-action@v2
         if: steps.changed.outputs.paths != ''
         with:
           paths: ${{ steps.changed.outputs.paths }}

--- a/.github/workflows/ci-node-image.yaml
+++ b/.github/workflows/ci-node-image.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Compute image ref
         id: image
@@ -55,7 +55,7 @@ jobs:
           echo "baked image ref: $image"
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -2,7 +2,7 @@ name: Code Style
 
 on:
   pull_request:
-    branches: [ 'main',  ]
+    branches: ['main']
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -41,7 +41,7 @@ jobs:
           make lint-go
 
       - name: Check generated resources are synchronized
-        run: |
+        run: |-
           # Install controller-gen if not available
           go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
           make yq

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -39,15 +39,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version: "1.26"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: "24"
 

--- a/.github/workflows/contributor-governance.yml
+++ b/.github/workflows/contributor-governance.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   governance:
-    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@main
+    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@dfca825e8d83b5409099103b1bfcd9036867412d # ratchet:Kuadrant/.github/.github/workflows/contributor-governance.yml@main
     secrets: inherit

--- a/.github/workflows/controller-integration-tests.yaml
+++ b/.github/workflows/controller-integration-tests.yaml
@@ -32,9 +32,9 @@ jobs:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Run controller integration tests

--- a/.github/workflows/e2e-auth.yaml
+++ b/.github/workflows/e2e-auth.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -83,10 +83,10 @@ jobs:
         run: echo "ldflags=$(make -s print-ldflags)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
 
       - name: Build gateway image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           load: true
@@ -97,7 +97,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=gateway-image
 
       - name: Build controller image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.controller

--- a/.github/workflows/e2e-on-demand.yaml
+++ b/.github/workflows/e2e-on-demand.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check org membership
         id: check-org
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             try {
@@ -44,7 +44,7 @@ jobs:
 
       - name: React to comment
         if: steps.check-org.outputs.is-member == 'true' && steps.parse-command.outputs.suite != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             github.rest.reactions.createForIssueComment({
@@ -56,7 +56,7 @@ jobs:
 
       - name: Reject non-members
         if: steps.check-org.outputs.is-member != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             github.rest.reactions.createForIssueComment({
@@ -69,7 +69,7 @@ jobs:
 
       - name: Reject invalid suite
         if: steps.check-org.outputs.is-member == 'true' && steps.parse-command.outputs.suite == ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Get PR branch
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -104,12 +104,12 @@ jobs:
             core.setOutput('sha', pr.data.head.sha);
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -165,7 +165,7 @@ jobs:
 
       - name: Report success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -177,7 +177,7 @@ jobs:
 
       - name: Report failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -125,10 +125,10 @@ jobs:
         run: echo "ldflags=$(make -s print-ldflags)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
 
       - name: Build gateway image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           load: true
@@ -139,7 +139,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=gateway-image
 
       - name: Build controller image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.controller

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version: '1.26'
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -30,110 +30,110 @@ jobs:
       packages: write
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
-    - name: Determine versions
-      id: versions
-      run: |
-        if [ "${{ github.event_name }}" = "release" ]; then
-          # Extract version from release tag (e.g., v0.4.2 -> 0.4.2)
-          TAG="${{ github.event.release.tag_name }}"
-          CHART_VERSION="${TAG#v}"
-          APP_VERSION="${TAG}"
-        else
-          # Manual workflow dispatch
-          CHART_VERSION="${{ inputs.chart_version }}"
-          APP_VERSION="${{ inputs.app_version }}"
-          # Default app_version to v + chart_version if not specified
-          if [ -z "$APP_VERSION" ]; then
-            APP_VERSION="v${CHART_VERSION}"
+      - name: Determine versions
+        id: versions
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Extract version from release tag (e.g., v0.4.2 -> 0.4.2)
+            TAG="${{ github.event.release.tag_name }}"
+            CHART_VERSION="${TAG#v}"
+            APP_VERSION="${TAG}"
+          else
+            # Manual workflow dispatch
+            CHART_VERSION="${{ inputs.chart_version }}"
+            APP_VERSION="${{ inputs.app_version }}"
+            # Default app_version to v + chart_version if not specified
+            if [ -z "$APP_VERSION" ]; then
+              APP_VERSION="v${CHART_VERSION}"
+            fi
           fi
-        fi
 
-        # lowercase owner for OCI registry compatibility
-        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          # lowercase owner for OCI registry compatibility
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
-        echo "chart_version=${CHART_VERSION}" >> $GITHUB_OUTPUT
-        echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
-        echo "owner=${OWNER}" >> $GITHUB_OUTPUT
-        echo "Chart Version: ${CHART_VERSION}"
-        echo "App Version: ${APP_VERSION}"
-        echo "Owner: ${OWNER}"
+          echo "chart_version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
+          echo "Chart Version: ${CHART_VERSION}"
+          echo "App Version: ${APP_VERSION}"
+          echo "Owner: ${OWNER}"
 
-    - name: Validate chart version format
-      run: |
-        if [[ ! "${{ steps.versions.outputs.chart_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
-          echo "Error: Chart version must be in semver format X.Y.Z or X.Y.Z-prerelease (e.g., 0.4.2, 0.5.0-rc1)"
-          echo "Got: ${{ steps.versions.outputs.chart_version }}"
-          exit 1
-        fi
+      - name: Validate chart version format
+        run: |
+          if [[ ! "${{ steps.versions.outputs.chart_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
+            echo "Error: Chart version must be in semver format X.Y.Z or X.Y.Z-prerelease (e.g., 0.4.2, 0.5.0-rc1)"
+            echo "Got: ${{ steps.versions.outputs.chart_version }}"
+            exit 1
+          fi
 
-    - name: Install Helm
-      uses: azure/setup-helm@v4
-      with:
-        version: '3.14.0'
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # ratchet:azure/setup-helm@v4
+        with:
+          version: '3.14.0'
 
-    - name: Update Chart.yaml versions
-      run: |
-        sed -i "s/version: .*/version: ${{ steps.versions.outputs.chart_version }}/" charts/mcp-gateway/Chart.yaml
-        sed -i "s/appVersion: .*/appVersion: \"${{ steps.versions.outputs.app_version }}\"/" charts/mcp-gateway/Chart.yaml
+      - name: Update Chart.yaml versions
+        run: |
+          sed -i "s/version: .*/version: ${{ steps.versions.outputs.chart_version }}/" charts/mcp-gateway/Chart.yaml
+          sed -i "s/appVersion: .*/appVersion: \"${{ steps.versions.outputs.app_version }}\"/" charts/mcp-gateway/Chart.yaml
 
-        echo "Updated Chart.yaml:"
-        cat charts/mcp-gateway/Chart.yaml
+          echo "Updated Chart.yaml:"
+          cat charts/mcp-gateway/Chart.yaml
 
-    - name: Lint Helm chart
-      run: |
-        helm lint charts/mcp-gateway
+      - name: Lint Helm chart
+        run: |
+          helm lint charts/mcp-gateway
 
-    - name: Template Helm chart (dry run)
-      run: |
-        helm template test-release charts/mcp-gateway --debug
+      - name: Template Helm chart (dry run)
+        run: |
+          helm template test-release charts/mcp-gateway --debug
 
-    - name: Run Helm unit tests (if kubeconform is available)
-      run: |
-        # Install kubeconform for validation
-        curl -L https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
-        sudo mv kubeconform /usr/local/bin
+      - name: Run Helm unit tests (if kubeconform is available)
+        run: |
+          # Install kubeconform for validation
+          curl -L https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin
 
-        # Validate generated manifests (ignore unknown CRDs like EnvoyFilter)
-        helm template test-release charts/mcp-gateway | kubeconform -strict -summary -ignore-missing-schemas
+          # Validate generated manifests (ignore unknown CRDs like EnvoyFilter)
+          helm template test-release charts/mcp-gateway | kubeconform -strict -summary -ignore-missing-schemas
 
-    - name: Package Helm chart
-      run: |
-        helm package charts/mcp-gateway --destination ./chart-packages
-        echo "Generated packages:"
-        ls -la ./chart-packages/
+      - name: Package Helm chart
+        run: |
+          helm package charts/mcp-gateway --destination ./chart-packages
+          echo "Generated packages:"
+          ls -la ./chart-packages/
 
-    - name: Login to Container Registry
-      run: |
-        echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - name: Login to Container Registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
-    - name: Push chart to OCI registry
-      run: |
-        chart_package=$(ls ./chart-packages/mcp-gateway-*.tgz)
-        echo "Pushing chart package: $chart_package"
-        helm push "$chart_package" oci://${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts
+      - name: Push chart to OCI registry
+        run: |
+          chart_package=$(ls ./chart-packages/mcp-gateway-*.tgz)
+          echo "Pushing chart package: $chart_package"
+          helm push "$chart_package" oci://${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts
 
-    - name: Verify chart installation
-      run: |
-        # Verify the chart we just pushed works (client-only, no cluster needed)
-        echo "Testing chart template rendering from OCI registry..."
-        helm template test-install oci://${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts/mcp-gateway --version ${{ steps.versions.outputs.chart_version }} --debug
+      - name: Verify chart installation
+        run: |
+          # Verify the chart we just pushed works (client-only, no cluster needed)
+          echo "Testing chart template rendering from OCI registry..."
+          helm template test-install oci://${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts/mcp-gateway --version ${{ steps.versions.outputs.chart_version }} --debug
 
-    - name: Generate release summary
-      run: |
-        echo "## Helm Chart Release Summary" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- **Chart Name:** ${{ env.CHART_NAME }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Chart Version:** ${{ steps.versions.outputs.chart_version }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **App Version:** ${{ steps.versions.outputs.app_version }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Registry:** ${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Installation Command" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "helm install mcp-gateway oci://${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts/mcp-gateway --version ${{ steps.versions.outputs.chart_version }} --create-namespace --namespace mcp-system" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+      - name: Generate release summary
+        run: |
+          echo "## Helm Chart Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Chart Name:** ${{ env.CHART_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Chart Version:** ${{ steps.versions.outputs.chart_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **App Version:** ${{ steps.versions.outputs.app_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Registry:** ${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Installation Command" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "helm install mcp-gateway oci://${{ env.REGISTRY }}/${{ steps.versions.outputs.owner }}/charts/mcp-gateway --version ${{ steps.versions.outputs.chart_version }} --create-namespace --namespace mcp-system" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   create-git-tag:
     # Only create chart tag for manual workflow dispatch (releases already have a tag)
@@ -144,16 +144,16 @@ jobs:
       contents: write
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
-    - name: Create and push git tag
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Create and push git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        tag_name="chart-v${{ inputs.chart_version }}"
-        git tag -a "$tag_name" -m "Helm chart release v${{ inputs.chart_version }}"
-        git push origin "$tag_name"
+          tag_name="chart-v${{ inputs.chart_version }}"
+          git tag -a "$tag_name" -m "Helm chart release v${{ inputs.chart_version }}"
+          git push origin "$tag_name"
 
-        echo "Created git tag: $tag_name"
+          echo "Created git tag: $tag_name"

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -8,8 +8,8 @@ on:
         required: false
         type: string
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches: [main]
+    tags: ['v*']
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -18,7 +18,7 @@ on:
       - 'charts/**'
       - 'tests/servers/**'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -27,7 +27,7 @@ on:
       - 'charts/**'
       - 'tests/servers/**'
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -71,11 +71,11 @@ jobs:
           echo "Custom tag '$TAG' is valid"
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/${{ matrix.image }}
           labels: |
@@ -110,7 +110,7 @@ jobs:
           echo "Generated Labels: ${{ steps.meta.outputs.labels }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
 
       - name: Prepare build args
         id: build-args
@@ -125,7 +125,7 @@ jobs:
 
       - name: Build and Push Image
         id: build-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: ./${{ matrix.dockerfile }}
@@ -149,15 +149,15 @@ jobs:
       packages: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -190,10 +190,10 @@ jobs:
             IMAGE_TAG="${IMAGE_TAG}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
 
       - name: Build and push bundle image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: ./bundle.Dockerfile
@@ -213,15 +213,15 @@ jobs:
       packages: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -244,10 +244,10 @@ jobs:
             IMAGE_TAG="${IMAGE_TAG}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
 
       - name: Build and push catalog image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: ./catalog
           file: ./catalog/mcp-gateway-catalog.Dockerfile

--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -17,7 +17,7 @@ jobs:
       issues: write
     steps:
       - name: Triage issue
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ratchet:actions/github-script@v8
         with:
           script: |
             // ------------------------------------------------------

--- a/.github/workflows/linkinator-weekly.yaml
+++ b/.github/workflows/linkinator-weekly.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Full Documentation Link Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: JustinBeckwith/linkinator-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - uses: JustinBeckwith/linkinator-action@36a0bfbfecd5e237e8f8531537a693616c505faf # ratchet:JustinBeckwith/linkinator-action@v2
         with:
           paths: "**/*.md"

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version: '1.24'
 
@@ -106,14 +106,14 @@ jobs:
 
       - name: Upload performance report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: performance-report
           path: out/perf/mcp-report.html
           retention-days: 30
 
       - name: Store and compare benchmark results
-        uses: benchmark-action/github-action-benchmark@5bbce78ef18edf5b96cb2d23e8d240b485f9dc4a  # v1.16.2
+        uses: benchmark-action/github-action-benchmark@5bbce78ef18edf5b96cb2d23e8d240b485f9dc4a # ratchet:benchmark-action/github-action-benchmark@v1.16.2
         with:
           name: MCP Gateway Performance
           tool: customSmallerIsBetter

--- a/.github/workflows/ratchet-check.yaml
+++ b/.github/workflows/ratchet-check.yaml
@@ -1,0 +1,25 @@
+name: Ratchet Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    name: Check pinned actions
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make verify-ratchet

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # ratchet:reviewdog/action-setup@v1
 
       - name: Run cspell with reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          npm install -g cspell@9.4.0
-          # Run cspell and pipe to reviewdog. 
-          # The output format is 'filename:line:col - Unknown word (word)'
-          cspell --quiet . | reviewdog -efm="%f:%l:%c - %m" -name="cspell" -reporter=github-pr-review -level=warning -filter-mode=nofilter -fail-on-error=true
+        run: "set -euo pipefail\nnpm install -g cspell@9.4.0\n# Run cspell and pipe to reviewdog. \n# The output format is 'filename:line:col - Unknown word (word)'\ncspell --quiet . | reviewdog -efm=\"%f:%l:%c - %m\" -name=\"cspell\" -reporter=github-pr-review -level=warning -filter-mode=nofilter -fail-on-error=true\n"
+
+
+
+
+

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -88,11 +88,11 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image-name }}
           tags: |
@@ -110,10 +110,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
 
       - name: Build and Push Test Server Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.dockerfile }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,12 +36,12 @@ jobs:
         shell: bash
     steps:
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # ratchet:actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
         id: go
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Run make unit test
         run: |
           make test-unit

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -25,75 +25,75 @@ jobs:
   verify-crd-sync:
     runs-on: ubuntu-latest
     name: Verify CRDs are synchronized
-    
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.26'
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
+        with:
+          go-version: '1.26'
 
-    - name: Verify generated code is up-to-date
-      run: |
-        make generate
-        if ! git diff --quiet api/; then
-          echo "❌ Generated code is out of date. Run 'make generate' and commit the changes."
-          git diff api/
-          exit 1
-        fi
-        echo "✅ Generated code is up-to-date"
+      - name: Verify generated code is up-to-date
+        run: |
+          make generate
+          if ! git diff --quiet api/; then
+            echo "❌ Generated code is out of date. Run 'make generate' and commit the changes."
+            git diff api/
+            exit 1
+          fi
+          echo "✅ Generated code is up-to-date"
 
-    - name: Generate CRDs
-      run: |
-        make generate-crds
+      - name: Generate CRDs
+        run: |
+          make generate-crds
 
-    - name: Check if Helm CRDs exist
-      run: |
-        if [ ! -d "charts/mcp-gateway/crds" ]; then
-          echo "❌ Helm CRDs directory doesn't exist"
-          echo "Run 'make update-helm-crds' to create and sync CRDs"
-          exit 1
-        fi
+      - name: Check if Helm CRDs exist
+        run: |
+          if [ ! -d "charts/mcp-gateway/crds" ]; then
+            echo "❌ Helm CRDs directory doesn't exist"
+            echo "Run 'make update-helm-crds' to create and sync CRDs"
+            exit 1
+          fi
 
-    - name: Install yq
-      run: make yq
+      - name: Install yq
+        run: make yq
 
-    - name: Verify generated resources are in sync
-      run: make check
+      - name: Verify generated resources are in sync
+        run: make check
 
-    - name: Verify Helm chart can be templated
-      run: |
-        # Install Helm
-        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-        
-        # Test that the chart templates correctly with current CRDs
-        helm template test charts/mcp-gateway --debug >/dev/null
-        echo "✅ Helm chart templates successfully with current CRDs"
+      - name: Verify Helm chart can be templated
+        run: |
+          # Install Helm
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
-    - name: Generate sync instructions on failure
-      if: failure()
-      run: |
-        echo "## CRD or Generated Code Synchronization Failed" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "The generated code or CRDs are out of sync." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### To fix this issue:" >> $GITHUB_STEP_SUMMARY
-        echo "1. If you modified Go types in \`api/\`, run:" >> $GITHUB_STEP_SUMMARY
-        echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "   make generate-all" >> $GITHUB_STEP_SUMMARY
-        echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "   This regenerates deepcopy code and CRDs, then syncs to Helm charts." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "2. If you only need to sync existing CRDs to Helm:" >> $GITHUB_STEP_SUMMARY
-        echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "   make update-helm-crds" >> $GITHUB_STEP_SUMMARY
-        echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "3. If bundle manifests are out of sync, run:" >> $GITHUB_STEP_SUMMARY
-        echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "   make bundle" >> $GITHUB_STEP_SUMMARY
-        echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "4. Commit the updated files and push again" >> $GITHUB_STEP_SUMMARY
+          # Test that the chart templates correctly with current CRDs
+          helm template test charts/mcp-gateway --debug >/dev/null
+          echo "✅ Helm chart templates successfully with current CRDs"
+
+      - name: Generate sync instructions on failure
+        if: failure()
+        run: |
+          echo "## CRD or Generated Code Synchronization Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The generated code or CRDs are out of sync." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### To fix this issue:" >> $GITHUB_STEP_SUMMARY
+          echo "1. If you modified Go types in \`api/\`, run:" >> $GITHUB_STEP_SUMMARY
+          echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "   make generate-all" >> $GITHUB_STEP_SUMMARY
+          echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "   This regenerates deepcopy code and CRDs, then syncs to Helm charts." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "2. If you only need to sync existing CRDs to Helm:" >> $GITHUB_STEP_SUMMARY
+          echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "   make update-helm-crds" >> $GITHUB_STEP_SUMMARY
+          echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "3. If bundle manifests are out of sync, run:" >> $GITHUB_STEP_SUMMARY
+          echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "   make bundle" >> $GITHUB_STEP_SUMMARY
+          echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "4. Commit the updated files and push again" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -842,6 +842,26 @@ status: ## Show status of all MCP components
 	@"$(MAKE)" -s -f build/inspect.mk status-impl
 
 
+##@ Verify
+
+RATCHET ?= $(LOCALBIN)/ratchet
+RATCHET_VERSION ?= v0.11.4
+
+.PHONY: ratchet
+ratchet: $(LOCALBIN) ## Download ratchet locally if necessary.
+	@if [ ! -f $(RATCHET) ]; then \
+		echo "Installing ratchet $(RATCHET_VERSION)..."; \
+		GOBIN=$(LOCALBIN) go install github.com/sethvargo/ratchet@$(RATCHET_VERSION); \
+	fi
+
+.PHONY: ratchet-pin
+ratchet-pin: ratchet ## Pin GitHub Actions to commit SHAs.
+	$(RATCHET) pin $$(find .github/workflows \( -name '*.yaml' -o -name '*.yml' \) ! -name 'issue-triage.yaml')
+
+.PHONY: verify-ratchet
+verify-ratchet: ratchet ## Verify GitHub Actions are pinned to commit SHAs.
+	$(RATCHET) lint $$(find .github/workflows \( -name '*.yaml' -o -name '*.yml' \) ! -name 'issue-triage.yaml')
+
 ##@ Tools
 
 .PHONY: istioctl


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add a `ratchet-check` CI workflow that lints pull requests for unpinned action references

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

## Motivation
Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Pinned CI/CD automation dependencies to immutable revisions, reducing exposure to unexpected upstream changes.
  - Applied consistent action versioning across documentation, testing, image publishing, release, and governance workflows.

- **Reliability**
  - Added automated validation to detect unpinned workflow actions.
  - Standardized workflow configuration while preserving existing build, test, release, and triage behavior.

- **Chores**
  - Added Makefile commands for pinning and verifying workflow dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->