### PR TITLE
fix: handle SIGTERM so graceful shutdown runs in Kubernetes

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker"
@@ -288,7 +289,10 @@ func (a *app) loadAndWatchConfig(ctx context.Context) {
 
 func (a *app) run(ctx context.Context) {
 	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt)
+	// SIGTERM is what kubelet sends on pod termination; without it the graceful
+	// shutdown below never runs in a cluster and the process dies by default
+	// signal disposition. os.Interrupt covers local runs.
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	lc := net.ListenConfig{}
 	lis, err := lc.Listen(ctx, "tcp", a.routerCfg.addr)


### PR DESCRIPTION
Kubelet sends SIGTERM on pod termination, but `run()` registered only `os.Interrupt`, so nothing below `<-stop` in `cmd/mcp-broker-router/main.go` ever ran in a cluster ; this registers SIGTERM alongside it, one line plus the import.

What was being skipped on every pod termination: pending telemetry dropped rather than flushed, in-flight HTTP requests and SSE streams cut at the socket, upstream managers never stopped, active ext_proc streams severed mid-request, Redis client never closed. Rollouts, scale-down, node drain and eviction were all effectively hard kills. It went unnoticed because Ctrl-C locally does deliver SIGINT, so the path works everywhere except the environment it was written for. The control-plane binary was never affected, `cmd/main.go` uses `ctrl.SetupSignalHandler()` which covers both, and the repo's own test servers already used the correct pattern, so the data-plane binary was the outlier.

Verified by building the binary before and after and sending a real SIGTERM to each, running as PID 1 in a container to match how the image actually executes. Unpatched at PID 1 exits 2 with no shutdown log, unpatched outside PID 1 exits 143 with no shutdown log, patched at PID 1 exits 0 and logs "shutting down MCP Broker and MCP Router". The PID 1 detail is worth flagging for anyone reproducing this, since the exit code is not the obvious one: the Go runtime does install a SIGTERM handler, so the signal is delivered and the container does not stall until the grace period, but with no `signal.Notify` registration the runtime calls `dieFromSignal`, restores `SIG_DFL` and re-raises, and at PID 1 the kernel discards that re-raise so the runtime falls through to `exit(2)`. Both paths skip the handler, so the defect is identical either way. `make lint` and `make test-unit` pass.

One thing I want to flag rather than quietly ship, because it is a real behavioural change and not obviously in scope for a one-liner. Making the path reachable means `grpcServer.GracefulStop()` now actually runs, and it takes no context, so it blocks until pending RPCs finish ; the 10s `shutdownCtx` above it does not apply to it. ext_proc streams are pending RPCs, so on a busy pod termination goes from instant to bounded only by kubelet's SIGKILL at the grace period. That is more correct than what we had, and it is the point of graceful shutdown, but it is slower, and I have confirmed the mechanism from the gRPC semantics rather than measured the magnitude under real ext_proc load. Happy to add a bounded fallback here, `Stop()` after a deadline, either in this PR or a follow-up, whichever you prefer.

No unit test: `cmd/mcp-broker-router` has no test files today and `run()` binds listeners and blocks on the signal channel, so covering this in isolation means refactoring the signal set for injection, which felt disproportionate against a one-line change. A rollout-restart e2e would cover it naturally, and that is where I would put it if the drain gap gets picked up separately, since this only makes the existing shutdown path reachable, it does not add a drain window or reclaim backend sessions whose cleanup timer died with the process.

Draft for now while the `GracefulStop` question above is settled. Fixes #1351.
