### PR TITLE
minor updates to arch docs

### DIFF
--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -58,6 +58,7 @@ The MCP Broker is a backend service configured with other MCP servers that acts 
 - Creating the aggregated tools/list call
 - Validating discovered MCP Servers meet minimum requirements (protocol version and capabilities) before including their tools in the list
 - Handle notification requests from clients and MCP Servers (proxying from the MCP server notification to registered clients)
+- Dual-protocol support: partitions tools and prompts by protocol version (2025/2026) via a `ProtocolHandler` interface, so version-specific logic (cache aggregation, per-user fetching strategy, notification mechanism) is isolated and removable. See [broker-2026-07-28 design](broker-2026-07-28/broker-2026-07-28-design.md)
 
 
 

--- a/docs/design/security-architecture.md
+++ b/docs/design/security-architecture.md
@@ -58,6 +58,7 @@ MCP Client
 | Gateway → Router (ext_proc) | Request headers, buffered body |
 | Gateway → Upstream MCP Server | All client headers, MCP JSON-RPC body |
 | Gateway → Broker | MCP JSON-RPC body, gateway session JWT, `x-mcp-authorized` signed header |
+| Broker → Upstream (per-user fetch) | Client `Authorization` header; gateway-scoped credentials (`cookie`, `proxy-authorization`) stripped |
 | Upstream MCP Server → Client | MCP JSON-RPC response body (streamed as-is), backend session IDs (rewritten to gateway session IDs) |
 
 ### Information shared with upstream MCP servers (model providers)
@@ -93,6 +94,8 @@ The gateway is NOT responsible for:
 - The controller (`internal/controller/`) scopes generated Secrets to the operator namespace and sets owner references for garbage collection. The controller's ClusterRole grants cluster-wide secrets access, but the informer cache is filtered by label (`mcp.kuadrant.io/secret: "true"`) to limit the working set
 - Routing headers set by the router (tool name, session ID, server name) are derived from parsed JSON-RPC bodies or gateway-issued JWTs, not from raw client input. Client-supplied headers are proxied through to upstream backends as-is — header filtering is the responsibility of the gateway HTTPRoute configuration and AuthPolicy
 - The router strips or rewrites gateway-internal headers (`mcp-session-id`, `mcp-init-host`, `router-key`) before traffic reaches upstream backends
+- **`cacheScope` correctness**: the broker uses pessimistic aggregation — any upstream with `cacheScope: "private"`, `ttlMs: 0`, or CRD `userSpecificList: true` makes the entire `tools/list` response `"private"`. Wrong `"public"` on a response containing per-user tools would leak tool lists across users. `cacheScope: "private"` triggers per-user fetching automatically, superseding the CRD field for 2026 upstreams
+- **User-specific fetch credential isolation**: when the broker fetches per-user tools from upstreams, `filterUserHeaders` strips gateway-scoped credentials (`cookie`, `proxy-authorization`) and transport headers (`content-type`, `mcp-session-id`, etc.) before forwarding. The client's `Authorization` header is preserved for upstream authentication
 
 ## Authentication and Authorization
 


### PR DESCRIPTION
## What does this PR do?

Adds some minor docs updates to cover some of the areas in the broker and router for 2026 protocol

Related to #1316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the broker architecture documentation to describe support for multiple protocol versions.
  * Documented version-specific handling for tools, prompts, caching, fetching, and notifications.
  * Clarified per-user authorization forwarding, credential filtering, and cache-scope behavior during tool retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->