### PR TITLE
ci: add ppc64le to image build platforms

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -129,7 +129,7 @@ jobs:
         with:
           context: .
           file: ./${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           provenance: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -197,7 +197,7 @@ jobs:
         with:
           context: .
           file: ./bundle.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
           provenance: false
           tags: |
@@ -251,7 +251,7 @@ jobs:
         with:
           context: ./catalog
           file: ./catalog/mcp-gateway-catalog.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
           provenance: false
           tags: |


### PR DESCRIPTION
## Summary

Adds `linux/ppc64le` to the list of platforms built in the `Build Images` workflow, covering the operator image, bundle image, and catalog image.

The downstream Red Hat Connectivity Link (RHCL) Konflux build pipeline already builds and ships `linux/ppc64le` images successfully for all RHCL components including mcp-gateway. This PR aligns the upstream CI with what downstream already validates and ships, so the upstream images on ghcr.io match the full set of architectures available to RHCL users.

## Platforms after this change

| Image | Before | After |
|---|---|---|
| mcp-gateway / mcp-controller | amd64, arm64, s390x | amd64, arm64, s390x, **ppc64le** |
| mcp-controller-bundle | amd64, arm64, s390x | amd64, arm64, s390x, **ppc64le** |
| mcp-controller-catalog | amd64, arm64, s390x | amd64, arm64, s390x, **ppc64le** |

## Testing

Downstream Konflux already builds and passes FIPS checks for ppc64le on every push, providing confidence the binary works correctly on this architecture.