### PR TITLE
fix(catalog): disable opm serve pprof to unblock multi-arch build

### DIFF
--- a/build/olm.mk
+++ b/build/olm.mk
@@ -63,11 +63,14 @@ $(CATALOG_DOCKERFILE): $(OPM)
 	# opm serve binds a pprof endpoint on a fixed port (default localhost:6060). the builder
 	# stage runs 'opm serve --cache-only' to prime the cache; under multi-arch buildx every
 	# arch runs concurrently under QEMU on the same loopback and collides on that port
-	# (bind: address already in use). disable pprof for the cache-populate step. sed -i.bak is
-	# portable across GNU/BSD sed; the pattern no longer matches once patched, so it is idempotent.
+	# (bind: address already in use). disable pprof for the cache-populate step. assert the
+	# serve line exists first, then verify the full sequence landed on it, so a future opm
+	# template change fails the build loudly instead of silently reintroducing the collision.
+	# opm generate dockerfile above rewrites the file each run, so this stays idempotent.
+	grep -q '"serve".*"--cache-only"]' $(CATALOG_DOCKERFILE) || { echo "error: 'opm serve ... --cache-only' line not found in $(CATALOG_DOCKERFILE); opm template may have changed"; exit 1; }
 	sed -i.bak 's/"--cache-only"]/"--cache-only", "--pprof-addr", ""]/' $(CATALOG_DOCKERFILE)
 	rm -f $(CATALOG_DOCKERFILE).bak
-	grep -q -- '--pprof-addr' $(CATALOG_DOCKERFILE) || { echo "error: failed to inject --pprof-addr into $(CATALOG_DOCKERFILE); opm template may have changed"; exit 1; }
+	grep -q '"serve".*"--cache-only", "--pprof-addr", ""]' $(CATALOG_DOCKERFILE) || { echo "error: failed to inject --pprof-addr into the opm serve command in $(CATALOG_DOCKERFILE)"; exit 1; }
 
 .PHONY: catalog
 catalog: opm yq $(CATALOG_DOCKERFILE) ## Generate FBC catalog content

--- a/build/olm.mk
+++ b/build/olm.mk
@@ -60,6 +60,14 @@ bundle-push: ## Push the OLM bundle image
 $(CATALOG_DOCKERFILE): $(OPM)
 	-mkdir -p $(CATALOG_DIR)
 	cd catalog && $(PROJECT_PATH)/$(OPM) generate dockerfile mcp-gateway-catalog
+	# opm serve binds a pprof endpoint on a fixed port (default localhost:6060). the builder
+	# stage runs 'opm serve --cache-only' to prime the cache; under multi-arch buildx every
+	# arch runs concurrently under QEMU on the same loopback and collides on that port
+	# (bind: address already in use). disable pprof for the cache-populate step. sed -i.bak is
+	# portable across GNU/BSD sed; the pattern no longer matches once patched, so it is idempotent.
+	sed -i.bak 's/"--cache-only"]/"--cache-only", "--pprof-addr", ""]/' $(CATALOG_DOCKERFILE)
+	rm -f $(CATALOG_DOCKERFILE).bak
+	grep -q -- '--pprof-addr' $(CATALOG_DOCKERFILE) || { echo "error: failed to inject --pprof-addr into $(CATALOG_DOCKERFILE); opm template may have changed"; exit 1; }
 
 .PHONY: catalog
 catalog: opm yq $(CATALOG_DOCKERFILE) ## Generate FBC catalog content


### PR DESCRIPTION
## Problem

The `Build Catalog Image` job fails intermittently during the multi-arch buildx build:

```
[linux/ppc64le builder 3/3] RUN ["/bin/opm","serve","/configs","--cache-dir=/tmp/cache","--cache-only"]
level=fatal msg="could not start pprof endpoint: listen tcp 127.0.0.1:6060: bind: address already in use"
```

Failing CI run: https://github.com/Kuadrant/mcp-gateway/actions/runs/31590141396/job/94103793692

The catalog Dockerfile's builder stage runs `opm serve --cache-only` to prime the serve cache. `opm serve` binds a pprof endpoint on a fixed port (default `localhost:6060`). Under multi-arch buildx every arch runs concurrently under QEMU on the same host loopback, so the stages race to bind `127.0.0.1:6060` and all but the first fail fatally.

This is not new: the same error hit `s390x` before ppc64le existed. Adding ppc64le (#1361) added a fourth emulated arch, widening the race window. The bundle image build is immune because its Dockerfile has no `RUN` step.

## Fix

The Dockerfile is generated by `opm generate dockerfile` and gitignored, so the fix lives in the make recipe (`build/olm.mk`): inject `--pprof-addr ""` into the cache-populate `RUN` line, which disables the profiler entirely. The cache-populate step has no need for pprof.

The patch is idempotent (the pattern no longer matches once applied) and fails loudly if the opm template ever changes. `sed -i.bak` is portable across GNU/BSD sed.

Verified locally: `make catalog/mcp-gateway-catalog.Dockerfile` now emits:

```
RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only", "--pprof-addr", ""]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the pprof endpoint in catalog services running with cache-only mode.
  * Added validation to ensure the generated configuration is updated correctly, with clear failure handling when expected content is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
