### PR TITLE
e2e: harden A2A test server request lifetime and task retention

### DIFF
--- a/config/test-servers/a2a-server-deployment.yaml
+++ b/config/test-servers/a2a-server-deployment.yaml
@@ -37,6 +37,10 @@ spec:
           value: "forecast,alerts"
         - name: AGENT_URL
           value: "http://a2a-test-server.mcp-test.svc.cluster.local:9090/a2a"
+        # bound retention of completed tasks (each large/image artifact holds ~1 MiB)
+        # so a burst of heavy tasks can't accumulate past the 128Mi limit
+        - name: TASK_TTL_MS
+          value: "120000"
         resources:
           limits:
             memory: "128Mi"

--- a/tests/servers/a2a-server/main.go
+++ b/tests/servers/a2a-server/main.go
@@ -509,7 +509,10 @@ func (s *server) createTask(r *http.Request, msg message) *task {
 	// spawn background completion only after the task is in the map, so the
 	// goroutine's lookup can't race ahead of the insert and drop the task.
 	if t.Status.State == stateWorking {
-		go s.completeLater(t.ID, text, r)
+		// build the artifacts here, in the request goroutine — the completion runs
+		// after ServeHTTP returns, where the *http.Request must not be read.
+		artifacts := s.buildArtifacts(t.ID, text, fileB64For(text), r)
+		go s.completeLater(t.ID, artifacts)
 	}
 	return t
 }
@@ -589,8 +592,10 @@ func fileArtifact(b64 string) artifact {
 	}
 }
 
-func (s *server) completeLater(taskID, text string, r *http.Request) {
-	artifacts := s.buildArtifacts(taskID, text, fileB64For(text), r)
+// completeLater finishes a "slow" task after a delay. The artifacts are built by
+// the caller in the request goroutine and passed in, so this goroutine never
+// touches the *http.Request after ServeHTTP has returned.
+func (s *server) completeLater(taskID string, artifacts []artifact) {
 	time.Sleep(s.taskDelay)
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Follow-up to #1200, addressing the two review points raised there.

Build the task artifacts in the request goroutine and pass them to the background completion, so the deferred goroutine never reads the `*http.Request` after `ServeHTTP` has returned (net/http forbids using the Request past the handler's return) ; behaviour is unchanged — the completed task carries the same artifacts, now built from headers snapshotted at request time.

Also set `TASK_TTL_MS` on the test-server Deployment so completed tasks — each "large"/"image" task retains a ~1 MiB base64 artifact — are swept well within the 128Mi memory limit rather than lingering for the 10-minute default, which a burst of heavy tasks could otherwise grow past.

Test-fixture only, no gateway code. Refs #766.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Completed tasks on the A2A test server are retained for 120 seconds.

- **Bug Fixes**
  - Improved slow-task handling to ensure task results remain available reliably after request processing completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->