### PR TITLE
feat(guardrails) PART 1: validate guardrails Secret and add config types

### DIFF
--- a/api/v1/mcpgatewayextension_types.go
+++ b/api/v1/mcpgatewayextension_types.go
@@ -63,6 +63,11 @@ const (
 	LogLevelWarn LogLevel = "warn"
 	// LogLevelError sets the broker-router --log-level flag to 8
 	LogLevelError LogLevel = "error"
+
+	// GuardrailsSecretNotFound is the reason seen when the guardrails secret is not found
+	GuardrailsSecretNotFound = "GuardrailsSecretNotFound"
+	// GuardrailsNotConfigured is the reason seen when the guardrails reference annotation is missing
+	GuardrailsNotConfigured = "GuardrailsNotConfigured"
 )
 
 // MCPGatewayExtensionSpec defines the desired state of MCPGatewayExtension.

--- a/api/v1alpha1/mcpgatewayextension_types.go
+++ b/api/v1alpha1/mcpgatewayextension_types.go
@@ -63,6 +63,11 @@ const (
 	LogLevelWarn LogLevel = "warn"
 	// LogLevelError sets the broker-router --log-level flag to 8
 	LogLevelError LogLevel = "error"
+
+	// GuardrailsSecretNotFound is the reason seen when the guardrails secret is not found
+	GuardrailsSecretNotFound = "GuardrailsSecretNotFound"
+	// GuardrailsNotConfigured is the reason seen when the guardrails reference annotation is missing
+	GuardrailsNotConfigured = "GuardrailsNotConfigured"
 )
 
 // MCPGatewayExtensionSpec defines the desired state of MCPGatewayExtension.
@@ -137,6 +142,12 @@ type MCPGatewayExtensionSpec struct {
 	// The Secret must have the label mcp.kuadrant.io/secret=true.
 	// +optional
 	CACertBundleRef *CACertBundleReference `json:"caCertBundleRef,omitempty"`
+
+	// maxBodyBytes caps the size of any body the router buffers, in bytes.
+	// Applies to request/response prefix stripping and guardrails checks.
+	// +optional
+	// +kubebuilder:default=1048576
+	MaxBodyBytes *int32 `json:"maxBodyBytes,omitempty"`
 }
 
 // OAuthProtectedResource configures the OAuth protected resource metadata

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -116,6 +116,16 @@ type MCPServer struct {
 	Category            []string                   `json:"category,omitempty"            yaml:"category,omitempty"`
 	Hint                string                     `json:"hint,omitempty"                yaml:"hint,omitempty"`
 	Tags                []string                   `json:"tags,omitempty"                yaml:"tags,omitempty"`
+	GuardrailsConfigIDs []string                   `json:"guardrailsConfigIDs,omitempty" yaml:"guardrailsConfigIDs,omitempty"`
+}
+
+// GuardrailsConfig holds the resolved guardrails server config parsed from
+// the guardrails Secret referenced by the MCPGatewayExtension.
+type GuardrailsConfig struct {
+	URL       string   `json:"url"                 yaml:"url"`
+	ConfigIDs []string `json:"configIDs,omitempty" yaml:"configIDs,omitempty"`
+	Model     string   `json:"model"               yaml:"model"`
+	FailMode  string   `json:"failMode,omitempty"  yaml:"failMode,omitempty"` // "deny" | "allow"
 }
 
 // TokenURLElicitationConfig configures per-user token collection via URL elicitation.
@@ -210,9 +220,10 @@ type Observer interface {
 
 // BrokerConfig holds broker configuration
 type BrokerConfig struct {
-	Servers          []MCPServer           `json:"servers"                          yaml:"servers"`
-	VirtualServers   []VirtualServerConfig `json:"virtualServers,omitempty"         yaml:"virtualServers,omitempty"`
-	GatewayCACertPEM string                `json:"gatewayCACertPEM,omitempty"       yaml:"gatewayCACertPEM,omitempty"`
+	Servers                   []MCPServer           `json:"servers"                          yaml:"servers"`
+	VirtualServers            []VirtualServerConfig `json:"virtualServers,omitempty"         yaml:"virtualServers,omitempty"`
+	GatewayCACertPEM          string                `json:"gatewayCACertPEM,omitempty"       yaml:"gatewayCACertPEM,omitempty"`
+	GlobalGuardrailsConfigIDs []string              `json:"globalGuardrailsConfigIDs,omitempty" yaml:"globalGuardrailsConfigIDs,omitempty"`
 }
 
 // AuthConfig holds auth configuration

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -25,6 +25,7 @@ import (
 
 	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/Kuadrant/mcp-gateway/internal/guardrails"
 	"github.com/go-logr/logr"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -50,6 +51,9 @@ const (
 	labelExtensionNamespace = "mcp.kuadrant.io/extension-namespace"
 	// used to ensure a specific control plane reconciles this resource based on the gateway value
 	labelIstioRev = "istio.io/rev"
+
+	// guardrails reference labels
+	labelGuardrailsReference = "mcp.kuadrant.io/guardrails-ref"
 )
 
 func envoyFilterLabels(mcpExt *mcpv1.MCPGatewayExtension, gateway *gatewayv1.Gateway) map[string]string {
@@ -238,6 +242,14 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	}
 
 	if err := r.reconcileCACertBundle(ctx, mcpExt); err != nil {
+		var valErr *validationError
+		if errors.As(err, &valErr) {
+			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.ensureGuardrailsSecret(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
 			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
@@ -908,6 +920,38 @@ func (r *MCPGatewayExtensionReconciler) enqueueMCPGatewayExtForEnvoyFilter(_ con
 	return []reconcile.Request{{
 		NamespacedName: types.NamespacedName{Name: extName, Namespace: extNamespace},
 	}}
+}
+
+// ensureGuardrailsSecret validates the guardrails Secret referenced by the
+// labelGuardrailsReference annotation. The annotation is optional: when unset,
+// guardrails is disabled for this gateway and reconciliation proceeds normally.
+func (r *MCPGatewayExtensionReconciler) ensureGuardrailsSecret(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension) error {
+	guardrailsSecretRef := mcpExt.Annotations[labelGuardrailsReference]
+	if guardrailsSecretRef == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, client.ObjectKey{Name: guardrailsSecretRef, Namespace: mcpExt.Namespace}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return newValidationError(mcpv1.GuardrailsSecretNotFound,
+				fmt.Sprintf("guardrails secret %s not found", guardrailsSecretRef))
+		}
+		return fmt.Errorf("failed to get guardrails secret: %w", err)
+	}
+
+	// Check if the secret has the required label
+	if secret.Labels[ManagedSecretLabel] != ManagedSecretValue {
+		return newValidationError(mcpv1.ConditionReasonSecretInvalid,
+			fmt.Sprintf("guardrails secret %s missing required label %s=%s", guardrailsSecretRef, ManagedSecretLabel, ManagedSecretValue))
+	}
+
+	if _, err := guardrails.EnsureNeMoConfigData(secret.Type, secret.Data); err != nil {
+		return newValidationError(mcpv1.ConditionReasonSecretInvalid,
+			fmt.Sprintf("guardrails secret %s is invalid: %v", guardrailsSecretRef, err))
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -51,6 +51,9 @@ const (
 	conditionReasonNotReady = "NotReady"
 	// conditionReasonDisabled is the reason used when the MCPServerRegistration is disabled
 	conditionReasonDisabled = "Disabled"
+
+	// ManagedGuardrailsAnnotation is the annotation for the guardrails config IDs
+	ManagedGuardrailsAnnotation = "mcp.kuadrant.io/guardrails-config-ids"
 )
 
 // ServerInfo holds server information

--- a/internal/guardrails/secret.go
+++ b/internal/guardrails/secret.go
@@ -1,0 +1,63 @@
+package guardrails
+
+import (
+	"fmt"
+	"net/url"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+)
+
+// SecretTypeNeMo is the Secret type for NeMo Guardrails configuration.
+const SecretTypeNeMo corev1.SecretType = "guardrails/external/nemo"
+
+// Fail modes applied when the guardrails server is unreachable or errors.
+const (
+	FailModeDeny  = "deny"
+	FailModeAllow = "allow"
+)
+
+// configDataKey is the Secret data key holding the provider config YAML.
+const configDataKey = "config.yaml"
+
+// EnsureNeMoConfigData validates a guardrails Secret's type and parses its
+// config.yaml into a GuardrailsConfig, defaulting failMode to deny.
+func EnsureNeMoConfigData(secretType corev1.SecretType, data map[string][]byte) (*config.GuardrailsConfig, error) {
+	if secretType != SecretTypeNeMo {
+		return nil, fmt.Errorf("unsupported guardrails secret type %q, expected %q", secretType, SecretTypeNeMo)
+	}
+
+	raw, ok := data[configDataKey]
+	if !ok {
+		return nil, fmt.Errorf("missing required key %q", configDataKey)
+	}
+
+	cfg := &config.GuardrailsConfig{}
+	if err := yaml.Unmarshal(raw, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", configDataKey, err)
+	}
+
+	if cfg.URL == "" {
+		return nil, fmt.Errorf("%s: url is required", configDataKey)
+	}
+	parsed, err := url.Parse(cfg.URL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("%s: url %q is not a valid absolute URL", configDataKey, cfg.URL)
+	}
+
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("%s: model is required", configDataKey)
+	}
+
+	switch cfg.FailMode {
+	case "":
+		cfg.FailMode = FailModeDeny
+	case FailModeDeny, FailModeAllow:
+	default:
+		return nil, fmt.Errorf("%s: failMode must be %q or %q, got %q", configDataKey, FailModeDeny, FailModeAllow, cfg.FailMode)
+	}
+
+	return cfg, nil
+}

--- a/internal/guardrails/secret_test.go
+++ b/internal/guardrails/secret_test.go
@@ -1,0 +1,87 @@
+package guardrails
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureNeMoConfigData(t *testing.T) {
+	t.Run("rejects a secret whose type isn't the NeMo guardrails type", func(t *testing.T) {
+		_, err := EnsureNeMoConfigData("Opaque", map[string][]byte{
+			configDataKey: []byte(`
+url: https://nemo-guardrails.internal:8080
+model: meta/llama-3.1-8b-instruct
+`),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("parses a valid config and defaults failMode to deny", func(t *testing.T) {
+		cfg, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{
+			configDataKey: []byte(`
+url: https://nemo-guardrails.internal:8080
+configIDs:
+  - tool-safety-v1
+model: meta/llama-3.1-8b-instruct
+`),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "https://nemo-guardrails.internal:8080", cfg.URL)
+		require.Equal(t, []string{"tool-safety-v1"}, cfg.ConfigIDs)
+		require.Equal(t, "meta/llama-3.1-8b-instruct", cfg.Model)
+		require.Equal(t, FailModeDeny, cfg.FailMode)
+	})
+
+	t.Run("accepts an explicit failMode: allow", func(t *testing.T) {
+		cfg, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{
+			configDataKey: []byte(`
+url: https://nemo-guardrails.internal:8080
+model: meta/llama-3.1-8b-instruct
+failMode: allow
+`),
+		})
+		require.NoError(t, err)
+		require.Equal(t, FailModeAllow, cfg.FailMode)
+	})
+
+	t.Run("errors when the config.yaml key is missing", func(t *testing.T) {
+		_, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{})
+		require.Error(t, err)
+	})
+
+	t.Run("errors when url is missing", func(t *testing.T) {
+		_, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{
+			configDataKey: []byte(`model: meta/llama-3.1-8b-instruct`),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("errors when url is not absolute", func(t *testing.T) {
+		_, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{
+			configDataKey: []byte(`
+url: not-a-url
+model: meta/llama-3.1-8b-instruct
+`),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("errors when model is missing", func(t *testing.T) {
+		_, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{
+			configDataKey: []byte(`url: https://nemo-guardrails.internal:8080`),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("errors on an unrecognized failMode", func(t *testing.T) {
+		_, err := EnsureNeMoConfigData(SecretTypeNeMo, map[string][]byte{
+			configDataKey: []byte(`
+url: https://nemo-guardrails.internal:8080
+model: meta/llama-3.1-8b-instruct
+failMode: retry
+`),
+		})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What does this PR do?

<!-- One or two sentences. Link the issue if there is one. -->
Partially addresses issue #1301 
* Adds the guardrails/external/nemo Secret schema (url, configIDs, model, failMode) and EnsureNeMoConfigData to validate and parse it. 
* Wires validation into the MCPGatewayExtension reconciler via the mcp.kuadrant.io/guardrails-ref annotation.
* Adds the config propagation scaffolding (GuardrailsConfig, MCPServer.GuardrailsConfigIDs, BrokerConfig.GlobalGuardrailsConfigIDs) plus the maxBodyBytes spec field and new status condition reasons.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [ ] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [ ] All CI checks pass, or failures have been investigated and explained below
- [ ] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional NeMo Guardrails integration for gateway extensions and MCP servers.
  * Added configurable guardrails references, models, endpoints, and failure modes.
  * Added a 1 MiB default limit for buffered request and response bodies.
* **Bug Fixes**
  * Added validation and clear status reporting for missing, mislabeled, or invalid guardrails configuration.
  * Added support for allowing or denying requests when guardrails are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->