### PR TITLE
ci: bump contributor-governance pin to include #7 fix

### DIFF
--- a/.github/workflows/contributor-governance.yml
+++ b/.github/workflows/contributor-governance.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   governance:
-    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@dfca825e8d83b5409099103b1bfcd9036867412d # ratchet:Kuadrant/.github/.github/workflows/contributor-governance.yml@main
+    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@d1617682a51d84a48fbab0db932f380824284b48 # ratchet:Kuadrant/.github/.github/workflows/contributor-governance.yml@main
     secrets: inherit


### PR DESCRIPTION
The contributor-governance workflow pins the reusable workflow to a frozen SHA (`dfca825`, from Kuadrant/.github#6) that predates Kuadrant/.github#7. #7 removed the "PR author must be assigned to the linked issue" check, but this repo never re-ratcheted the pin, so it still runs the old logic and auto-closes external-contributor PRs (e.g. #1370) on reopen.

Bumps the pin `dfca825` -> `d161768` (current Kuadrant/.github `main` HEAD, includes #7).

Since `pull_request_target` uses the workflow from the base branch, this only takes effect once merged. After merge, #1370 can be reopened without re-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the contributor governance workflow to use a newer version of the shared governance process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->