### PR TITLE
ci: bump contributor-governance pin to include #8

### DIFF
--- a/.github/workflows/contributor-governance.yml
+++ b/.github/workflows/contributor-governance.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   governance:
-    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@d1617682a51d84a48fbab0db932f380824284b48 # ratchet:Kuadrant/.github/.github/workflows/contributor-governance.yml@main
+    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@dad3166a82c39deed215823685ffba2090a4271f # ratchet:Kuadrant/.github/.github/workflows/contributor-governance.yml@main
     secrets: inherit


### PR DESCRIPTION
Re-ratchet the reusable workflow pin to current Kuadrant/.github `main` HEAD (`d161768` -> `dad3166`), picking up Kuadrant/.github#8 (`allowlist-contributor-governance`).

Follow-up to #1373. The `# ratchet:...@main` comment is only a hint; GitHub uses the frozen SHA, so the pin needs bumping each time the shared workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contributor governance workflow to use a newer approved version.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->