### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -167,10 +167,22 @@ Docs on main are published to docs.kuadrant.io, so version references must point
 git checkout main && git pull upstream main
 git checkout -b bump-version-{VERSION}
 ./scripts/set-release-version.sh {VERSION}
-make bundle
+make bundle VERSION={VERSION}
 ```
 
-Note: `make bundle` runs without `VERSION` so the bundle CSV keeps the default `latest` image tags and `0.0.0` version. CI regenerates the bundle the same way, so the CRD sync check will pass. The versioned image refs in docs, scripts, and deployment manifests come from `set-release-version.sh`.
+Note: main tracks the last **released** version, not `latest`/dev placeholders. Run `make bundle` with `VERSION={VERSION}` set (matching the release branch step), otherwise the CSV (`config/manifests/bases/mcp-gateway.clusterserviceversion.yaml`) and `config/mcp-gateway/components/controller/deployment-controller.yaml` get stamped with `latest`/`0.0.0` placeholders instead of `v{VERSION}` — this breaks the OLM upgrade graph.
+
+`set-release-version.sh` does not update `charts/mcp-gateway/Chart.yaml`. Bump it manually:
+```bash
+# charts/mcp-gateway/Chart.yaml: set both to {VERSION}
+version: {VERSION}
+appVersion: "{VERSION}"
+```
+
+Before committing, verify no stale version references remain:
+```bash
+grep -rn "{PREVIOUS_VERSION}" --include="*.yaml" --include="*.yml" --include="*.md" --include="*.sh" config/ charts/ docs/guides/
+```
 
 Show the diff and ask the user to confirm, then commit:
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -760,7 +760,7 @@ local-env-setup: setup-cluster-base ## Setup complete local demo environment wit
 	@echo "Setting up Local Demo Environment"
 	@echo "========================================="
 	"$(MAKE)" deploy-gateway
-	"$(MAKE)" deploy
+	"$(MAKE)" deploy-local
 	"${MAKE}" add-jwt-key
 	# Deploy everything server (2025) and stateless server (2026) for dual-protocol demo
 	"$(MAKE)" deploy-everything-server

--- a/build/deploy.mk
+++ b/build/deploy.mk
@@ -13,4 +13,18 @@ undeploy-gateway: $(KUSTOMIZE) ## Remove the MCP gateway
 .PHONY: deploy-namespaces
 deploy-namespaces: # Create MCP namespaces
 	kubectl apply -f config/mcp-system/namespace.yaml
-	kubectl apply -f config/istio/gateway/namespace.yaml	
+	kubectl apply -f config/istio/gateway/namespace.yaml
+
+# Deploy only the controller, using the images built and kind-loaded by
+# build-and-load-image (tagged 'latest') instead of the pinned release version
+.PHONY: deploy-controller-local
+deploy-controller-local: install-crd ## Deploy only the controller, using locally-built images
+	kubectl apply -k config/mcp-gateway/overlays/mcp-system-local/
+	@echo "Waiting for controller to be ready..."
+	@kubectl wait --for=condition=Available deployment/mcp-gateway-controller -n mcp-system --timeout=$(WAIT_TIME)
+	@echo "Waiting for MCPGatewayExtension to be ready..."
+	@kubectl wait --for=condition=Ready mcpgatewayextension/mcp-gateway-extension -n mcp-system --timeout=$(WAIT_TIME)
+	@echo "Controller and broker-router are ready"
+
+.PHONY: deploy-local
+deploy-local: install-crd deploy-namespaces deploy-controller-local ## Deploy controller to mcp-system namespace using locally-built images

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"prefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.9.0
-    createdAt: "2026-08-14T14:44:20Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:latest
+    createdAt: "2026-08-14T15:16:44Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.9.0
+  name: mcp-gateway.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -190,8 +190,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:v0.9.0
-                    image: ghcr.io/kuadrant/mcp-controller:v0.9.0
+                        value: ghcr.io/kuadrant/mcp-gateway:latest
+                    image: ghcr.io/kuadrant/mcp-controller:latest
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -251,6 +251,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:v0.9.0
+    - image: ghcr.io/kuadrant/mcp-gateway:latest
       name: router-broker
-  version: 0.9.0
+  version: 0.0.0

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -5,14 +5,14 @@ metadata:
     alm-examples: "[\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1\",\n    \"kind\": \"MCPGatewayExtension\",\n    \"metadata\": {\n      \"name\": \"mcp-gateway-extension\",\n      \"namespace\": \"mcp-system\"\n    },\n    \"spec\": {\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"Gateway\",\n        \"name\": \"mcp-gateway\",\n        \"namespace\": \"gateway-system\",\n        \"sectionName\": \"mcp\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1\",\n    \"kind\": \"MCPServerRegistration\",\n    \"metadata\": {\n      \"name\": \"example-server\",\n      \"namespace\": \"mcp-test\"\n    },\n    \"spec\": {\n      \"prefix\": \"example_\",\n      \"targetRef\": {\n        \"group\": \"gateway.networking.k8s.io\",\n        \"kind\": \"HTTPRoute\",\n        \"name\": \"example-route\"\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"mcp.kuadrant.io/v1\",\n    \"kind\": \"MCPVirtualServer\",\n    \"metadata\": {\n      \"name\": \"example-vs\",\n      \"namespace\": \"default\"\n    },\n    \"spec\": {\n      \"description\": \"example virtual server\",\n      \"tools\": [\n        \"server1_tool1\",\n        \"server2_tool2\"\n      ]\n    }\n  }\n]"
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:latest
-    createdAt: "2026-07-30T11:43:33Z"
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.9.0
+    createdAt: "2026-08-14T14:44:20Z"
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.0.0
+  name: mcp-gateway.v0.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -190,8 +190,8 @@ spec:
                       - --log-level=0
                     env:
                       - name: RELATED_IMAGE_ROUTER_BROKER
-                        value: ghcr.io/kuadrant/mcp-gateway:latest
-                    image: ghcr.io/kuadrant/mcp-controller:latest
+                        value: ghcr.io/kuadrant/mcp-gateway:v0.9.0
+                    image: ghcr.io/kuadrant/mcp-controller:v0.9.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -251,6 +251,6 @@ spec:
     name: Kuadrant
     url: https://kuadrant.io
   relatedImages:
-    - image: ghcr.io/kuadrant/mcp-gateway:latest
+    - image: ghcr.io/kuadrant/mcp-gateway:v0.9.0
       name: router-broker
-  version: 0.0.0
+  version: 0.9.0

--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-gateway
 description: A Kubernetes gateway for aggregating and routing Model Context Protocol (MCP) servers
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.9.0
+appVersion: "0.9.0"
 home: https://github.com/Kuadrant/mcp-gateway
 sources:
   - https://github.com/Kuadrant/mcp-gateway

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -7,7 +7,7 @@ set -e
 
 # Allow specifying a different GitHub org/user and version via environment variables
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.8.0}
+VERSION=${MCP_GATEWAY_VERSION:-0.9.0}
 GIT_REF="v${VERSION}"
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}
 echo "Using GitHub org: $GITHUB_ORG"

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcp-gateway-catalog
 spec:
   sourceType: grpc
-  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.8.0
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.9.0
   displayName: MCP Gateway
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.9.0
+    containerImage: ghcr.io/kuadrant/mcp-controller:latest
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.9.0
+  name: mcp-gateway.v0.0.0
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.9.0
+  version: 0.0.0

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:latest
+    containerImage: ghcr.io/kuadrant/mcp-controller:v0.9.0
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.0.0
+  name: mcp-gateway.v0.9.0
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.0.0
+  version: 0.9.0

--- a/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
+++ b/config/manifests/bases/mcp-gateway.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: ghcr.io/kuadrant/mcp-controller:v0.8.0
+    containerImage: ghcr.io/kuadrant/mcp-controller:latest
     description: An Envoy-based gateway for Model Context Protocol (MCP) servers
     repository: https://github.com/Kuadrant/mcp-gateway
     support: kuadrant
-  name: mcp-gateway.v0.8.0
+  name: mcp-gateway.v0.0.0
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -119,4 +119,4 @@ spec:
   provider:
     name: Kuadrant
     url: https://kuadrant.io
-  version: 0.8.0
+  version: 0.0.0

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:latest
+          image: ghcr.io/kuadrant/mcp-controller:v0.9.0
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:latest
+              value: ghcr.io/kuadrant/mcp-gateway:v0.9.0
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-gateway/components/controller/deployment-controller.yaml
+++ b/config/mcp-gateway/components/controller/deployment-controller.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.8.0
+          image: ghcr.io/kuadrant/mcp-controller:latest
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller
             - --log-level=0 # info level
           env:
             - name: RELATED_IMAGE_ROUTER_BROKER
-              value: ghcr.io/kuadrant/mcp-gateway:v0.8.0
+              value: ghcr.io/kuadrant/mcp-gateway:latest
           ports:
             - name: health
               containerPort: 8081

--- a/config/mcp-gateway/overlays/mcp-system-local/kustomization.yaml
+++ b/config/mcp-gateway/overlays/mcp-system-local/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# local dev overlay - identical to mcp-system but points at the images
+# built and `kind load`-ed by `make build-and-load-image` (tagged 'latest')
+# instead of the release version hardcoded in the base manifests
+resources:
+  - ../mcp-system
+
+images:
+  - name: ghcr.io/kuadrant/mcp-controller
+    newTag: latest
+  - name: ghcr.io/kuadrant/mcp-gateway
+    newTag: latest
+
+patches:
+  # kustomize images: transformer only patches `image:` fields, not env var
+  # values, so patch RELATED_IMAGE_ROUTER_BROKER directly
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: mcp-gateway-controller
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: mcp-gateway-controller
+      spec:
+        template:
+          spec:
+            containers:
+              - name: mcp-controller
+                env:
+                  - name: RELATED_IMAGE_ROUTER_BROKER
+                    value: ghcr.io/kuadrant/mcp-gateway:latest

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kuadrant/mcp-gateway:v0.8.0
+          image: ghcr.io/kuadrant/mcp-gateway:v0.9.0
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_gateway

--- a/config/mcp-system/deployment-controller.yaml
+++ b/config/mcp-system/deployment-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kuadrant/mcp-controller:v0.8.0
+          image: ghcr.io/kuadrant/mcp-controller:v0.9.0
           imagePullPolicy: IfNotPresent
           command:
             - ./mcp_controller

--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.8.0}"
+MCP_GATEWAY_VERSION="${MCP_GATEWAY_VERSION:-0.9.0}"
 MCP_GATEWAY_HOST="${MCP_GATEWAY_HOST:-mcp.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')}"
 MCP_GATEWAY_NAMESPACE="${MCP_GATEWAY_NAMESPACE:-mcp-system}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-gateway-system}"

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -27,7 +27,7 @@ MCP Gateway runs on Kubernetes and integrates with Gateway API and Istio. You sh
 ### Step 1: Install CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.8.0
+export MCP_GATEWAY_VERSION=0.9.0
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/isolated-gateway-deployment.md
+++ b/docs/guides/isolated-gateway-deployment.md
@@ -33,7 +33,7 @@ helm upgrade -i mcp-controller oci://ghcr.io/kuadrant/charts/mcp-gateway \
 ## Step 1: Install MCP Gateway CRDs
 
 ```bash
-export MCP_GATEWAY_VERSION=0.8.0
+export MCP_GATEWAY_VERSION=0.9.0
 kubectl apply -k "https://github.com/kuadrant/mcp-gateway/config/crd?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -15,7 +15,7 @@ make olm-install
 Deploy from a release tag using kustomize with a remote ref:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.8.0
+export MCP_GATEWAY_VERSION=0.9.0
 kubectl apply -k "https://github.com/Kuadrant/mcp-gateway/config/deploy/olm?ref=v${MCP_GATEWAY_VERSION}"
 ```
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ Get MCP Gateway running locally in a Kind cluster.
 Set the release version and run the setup script:
 
 ```bash
-export MCP_GATEWAY_VERSION=0.8.0
+export MCP_GATEWAY_VERSION=0.9.0
 curl -sSL https://raw.githubusercontent.com/Kuadrant/mcp-gateway/main/scripts/quick-start.sh | bash
 ```
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_ORG=${MCP_GATEWAY_ORG:-Kuadrant}
-VERSION=${MCP_GATEWAY_VERSION:-0.8.0}
+VERSION=${MCP_GATEWAY_VERSION:-0.9.0}
 GIT_REF="v${VERSION}"
 REPO="https://github.com/${GITHUB_ORG}/mcp-gateway"
 RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/mcp-gateway/${GIT_REF}"


### PR DESCRIPTION
Post-release version bump for 0.9.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Updates**
  * Updated the default MCP Gateway release from 0.8.0 to 0.9.0 across deployment configurations, container images, Helm charts, and quick-start tooling.
  * Updated installation metadata and release bundles to reference version 0.9.0.

* **Documentation**
  * Updated installation, deployment, OLM, and quick-start guides to use MCP Gateway 0.9.0.

* **Developer Experience**
  * Added streamlined local deployment support, including local controller and gateway setup with readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->