### PR TITLE
chore: bump Go toolchain from 1.26.0 to 1.26.5

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.26.5']
+        go-version: ['1.26.6']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -44,7 +44,6 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.26.6']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.26']
+        go-version: ['1.26.5']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: "1.26.6"
+          go-version-file: 'go.mod'
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install tools
         run: make tools

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install tools
         run: make tools

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: '1.26.6'
+          go-version-file: 'go.mod'
 
       - name: Install tools
         run: make tools

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,20 +28,19 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.26.6']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # ratchet:actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go-version }}
-        id: go
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # ratchet:actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+        id: go
       - name: Run make unit test
         run: |
           make test-unit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.26.5']
+        go-version: ['1.26.6']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.26']
+        go-version: ['1.26.5']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Verify generated code is up-to-date
         run: |

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Verify generated code is up-to-date
         run: |

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version: '1.26.6'
+          go-version-file: 'go.mod'
 
       - name: Verify generated code is up-to-date
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.5 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.5 AS builder
 
 WORKDIR /workspace
 

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -22,7 +22,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 
 ## Prerequisites
 
-- [Go 1.26.5+](https://golang.org/doc/install) installed (for building from source)
+- [Go 1.26.6+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
 - [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed (or Docker to run it as a container)
 - `openssl` (for generating the signing key)

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -22,7 +22,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 
 ## Prerequisites
 
-- [Go 1.26+](https://golang.org/doc/install) installed (for building from source)
+- [Go 1.26.5+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
 - [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed (or Docker to run it as a container)
 - `openssl` (for generating the signing key)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kuadrant/mcp-gateway
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kuadrant/mcp-gateway
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/tests/perf/mock-server/Dockerfile
+++ b/tests/perf/mock-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tests/perf/mock-server/Dockerfile
+++ b/tests/perf/mock-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.5 AS builder
 WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tests/servers/server2/Dockerfile
+++ b/tests/servers/server2/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/server2/Dockerfile
+++ b/tests/servers/server2/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/stateless-server/Dockerfile
+++ b/tests/servers/stateless-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/stateless-server/Dockerfile
+++ b/tests/servers/stateless-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/user-specific-server/Dockerfile
+++ b/tests/servers/user-specific-server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/user-specific-server/Dockerfile
+++ b/tests/servers/user-specific-server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
This PR bumps the project's Go toolchain to **1.26.6** to resolve security vulnerabilities initially reported in #1348.

While the original issue requested a bump to `1.26.5`, running `govulncheck` revealed that `1.26.5` introduced 6 new standard library vulnerabilities (spanning `net/url`, `html/template`, `crypto/tls`, etc.). Based on automated feedback from CodeRabbit, this PR bumps the toolchain directly to **1.26.6**, which successfully achieves a completely clean security scan.

⚠️ **Note regarding CI Warnings (Trivy DS-0002):**
The security scanner in this PR flagged a pre-existing issue in the Dockerfiles regarding running the final Alpine stages as `root`. As agreed with the CodeRabbit bot during review, fixing the Docker containers to run as non-root is out-of-scope for this Go version bump and will be tracked and addressed in a separate follow-up issue.

### Changes Made
* Updated the Go version directive to `1.26.6` in `go.mod`.
* Updated all CI GitHub Actions workflows to use `1.26.6`.
* Updated all Dockerfile builder and base images to `1.26.6`.
* Updated binary installation prerequisites in documentation.
* Ran `go mod tidy` to sync dependencies.

### Testing Performed
- [x] Ran `go test ./...` (All tests pass locally).
- [x] Ran `govulncheck ./...` (Verified a clean scan with 0 vulnerabilities).
- [x] Verified project builds successfully with the updated Dockerfiles.

Fixes #1348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go version to 1.26.6 across builds, test environments, and container images.
  * Continuous integration workflows now automatically use the Go version defined by the project.
* **Documentation**
  * Updated installation prerequisites to require Go 1.26.6 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->