### PR TITLE
chore: stop serving v1alpha1 APIs

### DIFF
--- a/api/v1alpha1/mcpgatewayextension_types.go
+++ b/api/v1alpha1/mcpgatewayextension_types.go
@@ -237,6 +237,7 @@ type MCPGatewayExtensionStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="mcp.kuadrant.io/v1alpha1 MCPGatewayExtension is deprecated; migrate to mcp.kuadrant.io/v1"
@@ -270,6 +271,7 @@ type MCPGatewayExtension struct {
 	Status MCPGatewayExtensionStatus `json:"status,omitzero"`
 }
 
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 
 // MCPGatewayExtensionList contains a list of MCPGatewayExtension

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -27,6 +27,7 @@ const (
 	UserSpecificListDisabled UserSpecificListPolicy = "Disabled"
 )
 
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="mcp.kuadrant.io/v1alpha1 MCPServerRegistration is deprecated; migrate to mcp.kuadrant.io/v1"
@@ -218,6 +219,7 @@ type MCPServerRegistrationStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 
 // MCPServerRegistrationList contains a list of MCPServerRegistration
@@ -227,6 +229,7 @@ type MCPServerRegistrationList struct {
 	Items           []MCPServerRegistration `json:"items"`
 }
 
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="mcp.kuadrant.io/v1alpha1 MCPVirtualServer is deprecated; migrate to mcp.kuadrant.io/v1"
@@ -286,6 +289,7 @@ type MCPVirtualServerStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 
 // MCPVirtualServerList contains a list of MCPVirtualServer

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -21,27 +21,12 @@ spec:
       - kind: MCPGatewayExtension
         name: mcpgatewayextensions.mcp.kuadrant.io
         version: v1
-      - description: Extends a Gateway API Gateway to handle MCP traffic by deploying a broker-router and configuring Envoy.
-        displayName: MCP Gateway Extension
-        kind: MCPGatewayExtension
-        name: mcpgatewayextensions.mcp.kuadrant.io
-        version: v1alpha1
       - kind: MCPServerRegistration
         name: mcpserverregistrations.mcp.kuadrant.io
         version: v1
-      - description: Registers an upstream MCP server for tool federation through the gateway.
-        displayName: MCP Server Registration
-        kind: MCPServerRegistration
-        name: mcpserverregistrations.mcp.kuadrant.io
-        version: v1alpha1
       - kind: MCPVirtualServer
         name: mcpvirtualservers.mcp.kuadrant.io
         version: v1
-      - description: Defines a virtual MCP server that exposes a curated subset of tools from registered servers.
-        displayName: MCP Virtual Server
-        kind: MCPVirtualServer
-        name: mcpvirtualservers.mcp.kuadrant.io
-        version: v1alpha1
   description: |-
     MCP Gateway is an Envoy-based gateway for Model Context Protocol (MCP) servers.
     It federates tools from multiple upstream MCP servers behind a single gateway endpoint,

--- a/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -669,7 +669,7 @@ spec:
         required:
         - spec
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -581,7 +581,7 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/bundle/manifests/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -281,7 +281,7 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -669,7 +669,7 @@ spec:
         required:
         - spec
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -581,7 +581,7 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -281,7 +281,7 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/charts/mcp-gateway/templates/mcpgatewayextension.yaml
+++ b/charts/mcp-gateway/templates/mcpgatewayextension.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.mcpGatewayExtension.create }}
-apiVersion: mcp.kuadrant.io/v1alpha1
+apiVersion: mcp.kuadrant.io/v1
 kind: MCPGatewayExtension
 metadata:
   name: {{ include "mcp-gateway.fullname" . }}-extension

--- a/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -669,7 +669,7 @@ spec:
         required:
         - spec
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -581,7 +581,7 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -281,7 +281,7 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/docs/release-notes/1376-unserve-v1alpha1.md
+++ b/docs/release-notes/1376-unserve-v1alpha1.md
@@ -1,0 +1,47 @@
+# v1alpha1 API No Longer Served
+
+The deprecated `mcp.kuadrant.io/v1alpha1` API version is no longer served. This
+is the removal step promised in the [v1 migration](1109-api-v1-migration.md):
+the deprecation-warning grace period has ended. `v1` remains the storage version
+and is unaffected.
+
+## What's Changed
+
+- **`v1alpha1` unserved**: The API server no longer advertises or accepts
+  `v1alpha1` for `MCPServerRegistration`, `MCPGatewayExtension`, and
+  `MCPVirtualServer`. Requests to the `v1alpha1` endpoint now return `404`.
+- **`v1alpha1` not removed**: The version and its schema remain in each CRD
+  (marked `served: false`), so existing resources are never orphaned.
+
+## Impact
+
+Any manifest, GitOps repository, controller, or script that still targets
+`apiVersion: mcp.kuadrant.io/v1alpha1` will fail:
+
+```
+error: unable to recognize "server.yaml": no matches for kind
+"MCPServerRegistration" in version "mcp.kuadrant.io/v1alpha1"
+```
+
+Previously these requests succeeded with a deprecation warning; they now fail.
+
+## Migration
+
+### 1. Update Manifests
+
+Change the `apiVersion` in your YAML manifests from `mcp.kuadrant.io/v1alpha1`
+to `mcp.kuadrant.io/v1`. The schemas are identical, so no other changes are
+required. See the [v1 migration guide](1109-api-v1-migration.md) for examples.
+
+### 2. Existing Resources
+
+No manual migration is needed. Resources already in the cluster remain fully
+accessible via `v1`, including any still stored as `v1alpha1` in etcd (the
+identical schema is converted transparently on read). You do **not** need to
+export and re-apply resources before upgrading.
+
+```bash
+kubectl get mcpsr    # returns your resources as v1
+kubectl get mcpge
+kubectl get mcpvs
+```


### PR DESCRIPTION
## Description
This PR stops the Kubernetes API server from serving the `v1alpha1` API endpoints, as requested in #1376. 

Since `v1` is already the designated storage version, setting `served: false` on `v1alpha1` gracefully deprecates the old API version without deleting or modifying any existing resources stored in the cluster backend. Any clients attempting to use `v1alpha1` will now correctly receive a 404 error and must switch to `v1`.

### Changes Made
* Added the `// +kubebuilder:unservedversion` marker to `v1alpha1` Go types.
* Regenerated CRD manifests via `make manifests` to update the `versions` array (setting `served: false` for `v1alpha1`).

### Testing Performed
- [x] Verified via local Kind cluster that the API server no longer advertises `v1alpha1`.
- [x] Verified the CRDs natively report that `v1alpha1` has `served: false`.
- [x] Confirmed `v1` remains fully intact as the active storage version.

Fixes #1376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - The `mcp.kuadrant.io/v1alpha1` API is no longer served for MCP Gateway Extension, MCP Server Registration, and MCP Virtual Server resources.
  - Requests using `v1alpha1` may return `404`; existing resources require no manual migration.

- **Updates**
  - Manifests and Helm templates now use `mcp.kuadrant.io/v1`.
  - Updated release documentation explains the API transition and required client changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->