### PR TITLE
feat: grant operator RBAC to manage NetworkPolicies

### DIFF
--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -165,6 +165,18 @@ spec:
                 - list
                 - update
                 - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: mcp-controller
       deployments:
         - label:

--- a/charts/mcp-gateway/templates/rbac.yaml
+++ b/charts/mcp-gateway/templates/rbac.yaml
@@ -116,6 +116,18 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/mcp-gateway/components/controller/rbac-controller.yaml
+++ b/config/mcp-gateway/components/controller/rbac-controller.yaml
@@ -117,6 +117,18 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,3 +111,15 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -128,6 +128,7 @@ type MCPGatewayExtensionReconciler struct {
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile reconciles an MCPGatewayExtension resource. Deploying and configuring a MCP Gateway instance configured to integrate and provide MCP functionality with the targeted gateway
 func (r *MCPGatewayExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary

- Adds a `+kubebuilder:rbac` marker for `networking.k8s.io/networkpolicies` (`create`, `delete`, `get`, `list`, `patch`, `update`, `watch`) to the `MCPGatewayExtension` controller
- Regenerates the downstream RBAC artifacts from that marker: `config/rbac/role.yaml`, the kustomize `rbac-controller.yaml`, the Helm chart `rbac.yaml`, and the OLM bundle CSV `clusterPermissions`
- The EC policy rule `olm.required_network_policy_rbac_for_operands` (effective 2026-08-07) requires operator CSVs to declare NetworkPolicy RBAC, which was blocking the Konflux `verify-conforma` task
- The operator does not create NetworkPolicies yet, but operator-managed NetworkPolicies are planned. Full lifecycle verbs (including read verbs) are granted so the operator can reconcile them when that lands, rather than adding a Konflux exception that would later need removing

## Notes

- The kubebuilder marker is the source of truth — `config/rbac/role.yaml` is generated by `controller-gen`, so editing it directly does not survive `make generate`. All other RBAC files are synced/generated from it.
- Generated via `make generate-all && make bundle`; re-running is idempotent (no further diff).

## Test plan

- [ ] `make generate-all && make bundle` produces no diff after this change
- [ ] Confirm conforma passes on the next nightly build after the product-build submodule is bumped to this commit