### PR TITLE
fix: bound grpc shutdown and flush telemetry after the drain

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -287,13 +287,14 @@ func (a *app) loadAndWatchConfig(ctx context.Context) {
 	})
 }
 
-// shutdown budgets, spent sequentially. their sum must fit inside the pod's
-// terminationGracePeriodSeconds (30s by default) or the kubelet SIGKILLs the
+// shutdown budgets, spent sequentially. their sum (27s) must fit inside the
+// pod's terminationGracePeriodSeconds (30s by default) or the kubelet kills the
 // process mid-drain and none of this runs to completion.
 const (
-	serverDrainTimeout    = 10 * time.Second
+	serverDrainTimeout    = 8 * time.Second
+	brokerDrainTimeout    = 5 * time.Second
 	grpcDrainTimeout      = 10 * time.Second
-	telemetryFlushTimeout = 5 * time.Second
+	telemetryFlushTimeout = 4 * time.Second
 )
 
 func (a *app) run(ctx context.Context) {
@@ -357,8 +358,24 @@ func (a *app) run(ctx context.Context) {
 	if err := a.metricsServer.Shutdown(shutdownCtx); err != nil {
 		a.logger.Error("metrics server shutdown error", "error", err)
 	}
-	if err := a.mcpBroker.Shutdown(shutdownCtx); err != nil {
-		a.logger.Error("broker shutdown error", "error", err)
+	// mcpBroker.Shutdown discards its context: activeMCP.Stop blocks on the
+	// manager goroutine, and draining the pooled user sessions closes each one
+	// with a blocking upstream DELETE. A slow or unreachable upstream would
+	// otherwise stall the grpc stop and the telemetry flush behind it. Bound
+	// the wait rather than the work: the process is exiting, so an overrun is
+	// left to finish in the background instead of consuming someone else's
+	// budget.
+	brokerDone := make(chan struct{})
+	go func() {
+		defer close(brokerDone)
+		if err := a.mcpBroker.Shutdown(shutdownCtx); err != nil {
+			a.logger.Error("broker shutdown error", "error", err)
+		}
+	}()
+	select {
+	case <-brokerDone:
+	case <-time.After(brokerDrainTimeout):
+		a.logger.Warn("broker shutdown exceeded budget, continuing", "budget", brokerDrainTimeout)
 	}
 
 	// GracefulStop takes no context and blocks until every in-flight RPC returns.

--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -287,6 +287,15 @@ func (a *app) loadAndWatchConfig(ctx context.Context) {
 	})
 }
 
+// shutdown budgets, spent sequentially. their sum must fit inside the pod's
+// terminationGracePeriodSeconds (30s by default) or the kubelet SIGKILLs the
+// process mid-drain and none of this runs to completion.
+const (
+	serverDrainTimeout    = 10 * time.Second
+	grpcDrainTimeout      = 10 * time.Second
+	telemetryFlushTimeout = 5 * time.Second
+)
+
 func (a *app) run(ctx context.Context) {
 	stop := make(chan os.Signal, 1)
 	// handle local interrupts and SIGTERM from kubernetes
@@ -339,14 +348,8 @@ func (a *app) run(ctx context.Context) {
 	<-stop
 
 	a.logger.Info("shutting down MCP Broker and MCP Router")
-	shutdownCtx, shutdownRelease := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, shutdownRelease := context.WithTimeout(context.Background(), serverDrainTimeout)
 	defer shutdownRelease()
-
-	if a.otelShutdown != nil {
-		if err := a.otelShutdown(shutdownCtx); err != nil {
-			a.logger.Error("OpenTelemetry shutdown error", "error", err)
-		}
-	}
 
 	if err := a.brokerServer.Shutdown(shutdownCtx); err != nil {
 		a.logger.Error("HTTP shutdown error", "error", err)
@@ -358,11 +361,29 @@ func (a *app) run(ctx context.Context) {
 		a.logger.Error("broker shutdown error", "error", err)
 	}
 
+	// GracefulStop takes no context and blocks until every in-flight RPC returns.
+	// ext_proc streams are long-lived RPCs, so on a busy pod that can outlast the
+	// grace period and end in SIGKILL. Stop() unblocks it once the budget is spent.
+	forceStop := time.AfterFunc(grpcDrainTimeout, func() {
+		a.logger.Warn("grpc graceful stop exceeded budget, forcing stop", "budget", grpcDrainTimeout)
+		a.grpcServer.Stop()
+	})
 	a.grpcServer.GracefulStop()
+	forceStop.Stop()
 
 	if a.redisClient != nil {
 		if err := a.redisClient.Close(); err != nil {
 			a.logger.Error("redis close error", "error", err)
+		}
+	}
+
+	// telemetry last, with its own budget: shutting the providers down before the
+	// drain discards the spans and metrics the drain itself emits.
+	if a.otelShutdown != nil {
+		otelCtx, otelRelease := context.WithTimeout(context.Background(), telemetryFlushTimeout)
+		defer otelRelease()
+		if err := a.otelShutdown(otelCtx); err != nil {
+			a.logger.Error("OpenTelemetry shutdown error", "error", err)
 		}
 	}
 }

--- a/project-words.txt
+++ b/project-words.txt
@@ -361,6 +361,7 @@ sesssion
 sharedheaders
 SIEM
 SIEMs
+SIGKILL
 Sjlm
 sjson
 socket


### PR DESCRIPTION
First of the drain work agreed in #1363 ; items 1 and 2, both narrow and independent of the drain state machine, and both direct consequences of #1362 making the shutdown path reachable in a cluster.

`GracefulStop` takes no context and blocks until every in-flight RPC returns, so the 10s `shutdownCtx` above it never applied to it. ext_proc streams are long-lived RPCs, so a pod with a connected Envoy could sit there past `terminationGracePeriodSeconds` and get killed mid-drain, which is a worse outcome than the hard kill we had before #1362. It is bounded now: a timer calls `Stop` once the budget is spent, which is what unblocks `GracefulStop`, and the timer is cancelled on the normal path so a quiet shutdown still returns immediately.

The other one is ordering. OTel shutdown ran first, before either server drained, so every span and metric emitted during the drain window was discarded before it could be exported ; stdout logging was unaffected since the logger fans out through `MultiHandler`, but nothing else survived. It now runs last with its own budget. On its own that changes little, but it is a prerequisite for any drain metrics, which would otherwise be written into an already-closed exporter.

Budgets are named constants, spent sequentially, summing to 25s so they fit inside the default 30s grace period with headroom. They are deliberately not configurable yet ; that belongs with the `preStop` and grace-period wiring in the larger drain work, where the budgets have to be defined against each other rather than in isolation.

Verified by building both binaries, holding an ext_proc stream open against each, and sending SIGTERM. Before, the process was still running 45 seconds later, which in a pod means SIGKILL. After, it force-stops at the 10s budget and exits cleanly with `grpc graceful stop exceeded budget, forcing stop` in the log. `make lint` and `make test-unit` pass.

No unit test here for the same reason as #1362 : `run()` binds listeners and blocks on the signal channel, so covering shutdown ordering in isolation needs it refactored for injection. That refactor is worth doing but belongs with the drain state machine, which will need the seam anyway ; the rollout-under-load e2e in #1363 is where this ends up properly covered.

One incidental change, `SIGKILL` added to `project-words.txt` since cspell does not know it and it appears nowhere else in the repo yet. Happy to reword instead if you would rather keep the dictionary untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service shutdown reliability by applying dedicated time limits to HTTP, gRPC, and telemetry shutdown processes.
  * Ensured telemetry can be flushed after active connections finish draining, while preventing shutdown from hanging indefinitely.

* **Chores**
  * Updated project terminology resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->