### PR TITLE
feat(resources): implement resources federation with JWT authorization and prefix validation

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -89,7 +89,7 @@ spec:
           from: All
     - name: resources-federation
       hostname: '*.resources-federation.127-0-0-1.sslip.io'
-      port: 8080
+      port: 8082
       protocol: HTTP
       allowedRoutes:
         namespaces:

--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -87,3 +87,10 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: resources-federation
+      hostname: '*.resources-federation.127-0-0-1.sslip.io'
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/config/istio/gateway/nodeport.yaml
+++ b/config/istio/gateway/nodeport.yaml
@@ -39,6 +39,12 @@ spec:
     port: 8081
     protocol: TCP
     targetPort: 8081
+  - appProtocol: http
+    name: resources-federation
+    nodePort: 30084
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
   selector:
     gateway.networking.k8s.io/gateway-name: mcp-gateway
   sessionAffinity: None

--- a/config/kind/cluster-ci.yaml
+++ b/config/kind/cluster-ci.yaml
@@ -44,3 +44,6 @@ nodes:
   - containerPort: 30083 # protocol-2026 listener
     hostPort: 8011
     protocol: TCP
+  - containerPort: 30084 # resources-federation listener
+    hostPort: 8012
+    protocol: TCP

--- a/config/kind/cluster.yaml
+++ b/config/kind/cluster.yaml
@@ -61,3 +61,6 @@ nodes:
   - containerPort: 30083 # protocol-2026 listener
     hostPort: 8011
     protocol: TCP
+  - containerPort: 30084 # resources-federation listener
+    hostPort: 8012
+    protocol: TCP

--- a/internal/mcp-router/elicitation_test.go
+++ b/internal/mcp-router/elicitation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSSERewriter_Process(t *testing.T) {
+func TestElicitationRewriter_Process(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	ctx := context.Background()
 
@@ -135,7 +135,7 @@ func TestSSERewriter_Process(t *testing.T) {
 	}
 }
 
-func TestSSERewriter_Process_RewrittenIDIsValid(t *testing.T) {
+func TestElicitationRewriter_Process_RewrittenIDIsValid(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	m, err := idmap.New()
@@ -172,7 +172,7 @@ func TestSSERewriter_Process_RewrittenIDIsValid(t *testing.T) {
 	require.Equal(t, "session-abc", entry.SessionID)
 }
 
-func TestSSERewriter_Process_MultipleElicitations(t *testing.T) {
+func TestElicitationRewriter_Process_MultipleElicitations(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	m, err := idmap.New()
@@ -204,7 +204,7 @@ func TestSSERewriter_Process_MultipleElicitations(t *testing.T) {
 	}
 }
 
-func TestSSERewriter_Flush(t *testing.T) {
+func TestElicitationRewriter_Flush(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
@@ -302,7 +302,7 @@ func TestSSERewriter_Flush(t *testing.T) {
 	})
 }
 
-func TestSSERewriter_MaybeRewriteElicitation(t *testing.T) {
+func TestElicitationRewriter_MaybeRewriteElicitation(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 

--- a/internal/mcp-router/resource_rewrite.go
+++ b/internal/mcp-router/resource_rewrite.go
@@ -10,38 +10,50 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 )
 
-// resourceURIRewriter rewrites _meta.ui.resourceUri in tools/call responses so the
-// URI a client gets back from a tool call matches the prefixed form resources/list
-// already returns for the same resource.
-//
-// It follows the same incremental Process/Flush line-buffering discipline as
-// elicitationRewriter (split on '\n', hold the trailing partial line for the next
-// chunk) rather than buffering the whole body until Flush. That matters because
-// resourceURIRewriter runs chained after elicitationRewriter on the same response:
-// when both are active (a tool call to a resource-federated server from an
-// elicitation-capable client), elicitationRewriter must forward "elicitation/create"
-// immediately so the client can answer it while the backend call is still open. A
-// rewriter further down the chain that holds every byte until end-of-stream would
-// swallow that message and deadlock the whole exchange. Rewriting per complete line
-// as it arrives avoids that, and still handles both body shapes a tools/call
-// response can arrive in - SSE "data: {...}" lines, or a single-line plain JSON
-// object with no framing at all.
+// maxBufferedLineBytes caps how much of an unterminated line Process will hold
+// waiting for '\n'. Past this, the line is forwarded unrewritten rather than
+// buffered indefinitely - bounds memory against a body with a pathologically
+// long or missing line terminator.
+const maxBufferedLineBytes = 1 << 20 // 1 MiB
+
+// resourceURIRewriter rewrites _meta.ui.resourceUri in tools/call responses to
+// match the prefixed form resources/list already returns for the same resource.
+// Rewrites incrementally per complete line, never buffering a full line past
+// Flush, so it composes safely with elicitationRewriter on the same response.
 type resourceURIRewriter struct {
-	buf    []byte
-	prefix string
-	logger *slog.Logger
+	buf        []byte
+	overflowed bool // true while forwarding an abandoned oversized line unrewritten, until its '\n'
+	prefix     string
+	logger     *slog.Logger
 }
 
 // Process receives a chunk of response data and rewrites any complete lines it
 // contains. Splitting on '\n' ensures only fully received JSON is parsed and
-// rewritten; an incomplete trailing line is held for the next chunk (or Flush).
+// rewritten; an incomplete trailing line is held for the next chunk (or Flush),
+// unless it exceeds maxBufferedLineBytes, in which case it's forwarded unrewritten.
 func (r *resourceURIRewriter) Process(ctx context.Context, chunk []byte) []byte {
+	var output []byte
+
+	if r.overflowed {
+		idx := bytes.IndexByte(chunk, '\n')
+		if idx == -1 {
+			return chunk // still inside the abandoned line - keep passing through
+		}
+		output = append(output, chunk[:idx+1]...)
+		chunk = chunk[idx+1:]
+		r.overflowed = false
+	}
+
 	r.buf = append(r.buf, chunk...)
 
-	var output []byte
 	for {
 		idx := bytes.IndexByte(r.buf, '\n')
 		if idx == -1 {
+			if len(r.buf) > maxBufferedLineBytes {
+				output = append(output, r.buf...)
+				r.buf = nil
+				r.overflowed = true
+			}
 			break // no complete line - hold remainder for next chunk
 		}
 

--- a/internal/mcp-router/resource_rewrite.go
+++ b/internal/mcp-router/resource_rewrite.go
@@ -1,27 +1,197 @@
 package mcprouter
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
+	"net/url"
+
+	"github.com/Kuadrant/mcp-gateway/internal/routing"
 )
 
-// resourceURIRewriter rewrites resource URIs in tool call responses by stripping the server prefix.
+// resourceURIRewriter rewrites _meta.ui.resourceUri in tools/call responses so the
+// URI a client gets back from a tool call matches the prefixed form resources/list
+// already returns for the same resource.
+//
+// It follows the same incremental Process/Flush line-buffering discipline as
+// elicitationRewriter (split on '\n', hold the trailing partial line for the next
+// chunk) rather than buffering the whole body until Flush. That matters because
+// resourceURIRewriter runs chained after elicitationRewriter on the same response:
+// when both are active (a tool call to a resource-federated server from an
+// elicitation-capable client), elicitationRewriter must forward "elicitation/create"
+// immediately so the client can answer it while the backend call is still open. A
+// rewriter further down the chain that holds every byte until end-of-stream would
+// swallow that message and deadlock the whole exchange. Rewriting per complete line
+// as it arrives avoids that, and still handles both body shapes a tools/call
+// response can arrive in - SSE "data: {...}" lines, or a single-line plain JSON
+// object with no framing at all.
 type resourceURIRewriter struct {
+	buf    []byte
 	prefix string
 	logger *slog.Logger
 }
 
-// Process processes response body and rewrites resource URIs by stripping the prefix.
-func (r *resourceURIRewriter) Process(_ context.Context, body []byte) []byte {
-	if r.prefix == "" {
-		return body
+// Process receives a chunk of response data and rewrites any complete lines it
+// contains. Splitting on '\n' ensures only fully received JSON is parsed and
+// rewritten; an incomplete trailing line is held for the next chunk (or Flush).
+func (r *resourceURIRewriter) Process(ctx context.Context, chunk []byte) []byte {
+	r.buf = append(r.buf, chunk...)
+
+	var output []byte
+	for {
+		idx := bytes.IndexByte(r.buf, '\n')
+		if idx == -1 {
+			break // no complete line - hold remainder for next chunk
+		}
+
+		line := r.buf[:idx+1] // include '\n'
+		r.buf = r.buf[idx+1:]
+
+		output = append(output, r.maybeRewriteLine(ctx, line)...)
 	}
-	// URI rewriting happens at the broker level via stripResourcePrefix.
-	// The ext_proc adapter just passes through for now.
-	return body
+
+	return output
 }
 
-// Flush flushes any pending data (idempotent).
-func (r *resourceURIRewriter) Flush(_ context.Context) []byte {
-	return nil
+// Flush rewrites and returns any remaining buffered (incomplete-line) data. Safe
+// to call multiple times; subsequent calls are no-ops since the buffer is cleared
+// after the first call.
+func (r *resourceURIRewriter) Flush(ctx context.Context) []byte {
+	remaining := r.buf
+	r.buf = nil
+	if len(remaining) == 0 {
+		return remaining
+	}
+	return r.maybeRewriteLine(ctx, remaining)
+}
+
+// maybeRewriteLine rewrites a single line if it contains a tools/call result with
+// a ui:// _meta.ui.resourceUri, preserving the original line (including its '\n'
+// and any "data: " SSE prefix) exactly when there's nothing to rewrite.
+func (r *resourceURIRewriter) maybeRewriteLine(ctx context.Context, line []byte) []byte {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return line
+	}
+
+	jsonData := trimmed
+	hasDataPrefix := bytes.HasPrefix(trimmed, dataPrefix)
+	if hasDataPrefix {
+		jsonData = bytes.TrimSpace(bytes.TrimPrefix(trimmed, dataPrefix))
+	}
+	if len(jsonData) == 0 || jsonData[0] != '{' {
+		return line // not a JSON object on this line (event:, id:, blank, etc.) - leave untouched
+	}
+
+	rewritten, changed := r.rewriteToolResultJSON(ctx, jsonData)
+	if !changed {
+		return line
+	}
+
+	hasNewline := bytes.HasSuffix(line, []byte("\n"))
+	if hasDataPrefix {
+		rewritten = append([]byte("data: "), rewritten...)
+	}
+	if hasNewline {
+		rewritten = append(rewritten, '\n')
+	}
+	return rewritten
+}
+
+// rewriteToolResultJSON rewrites _meta.ui.resourceUri in a single JSON-RPC message
+// if present. Every level of the message is round-tripped through json.RawMessage
+// so only the resourceUri value itself is touched - all other fields, including
+// unrelated _meta keys, pass through exactly as received.
+func (r *resourceURIRewriter) rewriteToolResultJSON(ctx context.Context, jsonData []byte) (rewritten []byte, changed bool) {
+	var msg jsonRPCMessage
+	if err := json.Unmarshal(jsonData, &msg); err != nil {
+		return jsonData, false
+	}
+	if msg.Method != "" || len(msg.Result) == 0 {
+		return jsonData, false // not a tool call result (requests/notifications have Method; errors have no Result)
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(msg.Result, &result); err != nil {
+		return jsonData, false
+	}
+	metaRaw, ok := result["_meta"]
+	if !ok {
+		return jsonData, false
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		return jsonData, false
+	}
+	uiRaw, ok := meta["ui"]
+	if !ok {
+		return jsonData, false
+	}
+	var ui map[string]json.RawMessage
+	if err := json.Unmarshal(uiRaw, &ui); err != nil {
+		return jsonData, false
+	}
+	uriRaw, ok := ui["resourceUri"]
+	if !ok {
+		return jsonData, false
+	}
+	var uri string
+	if err := json.Unmarshal(uriRaw, &uri); err != nil {
+		return jsonData, false
+	}
+
+	newURI, ok := injectResourcePrefix(uri, r.prefix)
+	if !ok {
+		return jsonData, false // not a ui:// URI - left untouched per design
+	}
+
+	newURIBytes, err := json.Marshal(newURI)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "failed to marshal rewritten resource URI", "error", err)
+		return jsonData, false
+	}
+	ui["resourceUri"] = newURIBytes
+
+	uiBytes, err := json.Marshal(ui)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "failed to marshal rewritten ui meta", "error", err)
+		return jsonData, false
+	}
+	meta["ui"] = uiBytes
+
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "failed to marshal rewritten meta", "error", err)
+		return jsonData, false
+	}
+	result["_meta"] = metaBytes
+
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "failed to marshal rewritten result", "error", err)
+		return jsonData, false
+	}
+	msg.Result = resultBytes
+
+	out, err := json.Marshal(&msg)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "failed to marshal rewritten tool result", "error", err)
+		return jsonData, false
+	}
+	return out, true
+}
+
+// injectResourcePrefix injects the server prefix into a ui:// URI's authority
+// segment (ui://template.html -> ui://<prefix_>template.html), mirroring
+// broker.go's rewriteResourceURI so resources/list and tools/call responses stay
+// consistent. Non-ui:// or malformed URIs are returned unchanged with ok=false.
+func injectResourcePrefix(uri, prefix string) (rewritten string, ok bool) {
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != "ui" {
+		return uri, false
+	}
+	u.User = nil // never forward upstream credentials to clients
+	u.Host = routing.EnsureSeparator(prefix) + u.Host
+	return u.String(), true
 }

--- a/internal/mcp-router/resource_rewrite_test.go
+++ b/internal/mcp-router/resource_rewrite_test.go
@@ -1,0 +1,214 @@
+package mcprouter
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func newTestResourceRewriter(prefix string) *resourceURIRewriter {
+	return &resourceURIRewriter{
+		prefix: prefix,
+		logger: slog.New(slog.DiscardHandler),
+	}
+}
+
+func processAndFlush(t *testing.T, r *resourceURIRewriter, chunks ...[]byte) []byte {
+	t.Helper()
+	ctx := context.Background()
+	var out []byte
+	for _, c := range chunks {
+		out = append(out, r.Process(ctx, c)...)
+	}
+	out = append(out, r.Flush(ctx)...)
+	return out
+}
+
+func TestResourceURIRewriter_PlainJSON_RewritesUIResourceURI(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hi"}],"_meta":{"ui":{"resourceUri":"ui://template.html"}}}}`)
+
+	got := processAndFlush(t, r, body)
+
+	want := `{"jsonrpc":"2.0","id":1,"result":{"_meta":{"ui":{"resourceUri":"ui://insights_template.html"}},"content":[{"type":"text","text":"hi"}]}}`
+	if string(got) != want {
+		t.Errorf("got  %s\nwant %s", got, want)
+	}
+}
+
+func TestResourceURIRewriter_SSEFramed_RewritesUIResourceURI(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	body := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"_meta\":{\"ui\":{\"resourceUri\":\"ui://template.html\"}}}}\n\n")
+
+	got := processAndFlush(t, r, body)
+
+	if !contains(got, `"resourceUri":"ui://insights_template.html"`) {
+		t.Errorf("expected rewritten resourceUri in output, got: %s", got)
+	}
+	if !contains(got, "event: message\n") {
+		t.Errorf("expected non-data SSE lines to pass through unchanged, got: %s", got)
+	}
+}
+
+func TestResourceURIRewriter_ChunkedAcrossMultipleProcessCalls(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	full := `{"jsonrpc":"2.0","id":1,"result":{"_meta":{"ui":{"resourceUri":"ui://template.html"}}}}`
+	mid := len(full) / 2
+
+	got := processAndFlush(t, r, []byte(full[:mid]), []byte(full[mid:]))
+
+	if !contains(got, `"resourceUri":"ui://insights_template.html"`) {
+		t.Errorf("expected rewritten resourceUri across chunked input, got: %s", got)
+	}
+}
+
+func TestResourceURIRewriter_NonUISchemeLeftUntouched(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"_meta":{"ui":{"resourceUri":"https://example.com/template.html"}}}}`)
+
+	got := processAndFlush(t, r, body)
+
+	if !contains(got, `"resourceUri":"https://example.com/template.html"`) {
+		t.Errorf("expected non-ui:// URI left untouched, got: %s", got)
+	}
+}
+
+func TestResourceURIRewriter_NoMetaLeftByteForByteUntouched(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hi"}]}}`)
+
+	got := processAndFlush(t, r, body)
+
+	if string(got) != string(body) {
+		t.Errorf("expected untouched passthrough\ngot  %s\nwant %s", got, body)
+	}
+}
+
+func TestResourceURIRewriter_ErrorResultLeftUntouched(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	body := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`)
+
+	got := processAndFlush(t, r, body)
+
+	if string(got) != string(body) {
+		t.Errorf("expected error response left untouched\ngot  %s\nwant %s", got, body)
+	}
+}
+
+func TestResourceURIRewriter_MalformedJSONDoesNotPanic(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	body := []byte(`{not valid json`)
+
+	got := processAndFlush(t, r, body)
+
+	if string(got) != string(body) {
+		t.Errorf("expected malformed input left untouched\ngot  %s\nwant %s", got, body)
+	}
+}
+
+func TestResourceURIRewriter_EmptyBody(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+
+	got := processAndFlush(t, r)
+
+	if len(got) != 0 {
+		t.Errorf("expected empty output for empty body, got: %s", got)
+	}
+}
+
+func TestResourceURIRewriter_EmptyPrefixLeavesURIUnprefixed(t *testing.T) {
+	r := newTestResourceRewriter("")
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"_meta":{"ui":{"resourceUri":"ui://template.html"}}}}`)
+
+	got := processAndFlush(t, r, body)
+
+	if !contains(got, `"resourceUri":"ui://template.html"`) {
+		t.Errorf("expected empty prefix to leave URI unchanged, got: %s", got)
+	}
+}
+
+func TestResourceURIRewriter_FlushTwiceIsSafe(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	ctx := context.Background()
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"_meta":{"ui":{"resourceUri":"ui://template.html"}}}}`)
+
+	r.Process(ctx, body)
+	first := r.Flush(ctx)
+	second := r.Flush(ctx)
+
+	if len(second) != 0 {
+		t.Errorf("expected second Flush to be a no-op, got: %s", second)
+	}
+	if !contains(first, `"resourceUri":"ui://insights_template.html"`) {
+		t.Errorf("expected first Flush to contain rewritten URI, got: %s", first)
+	}
+}
+
+// TestResourceURIRewriter_CompleteLineForwardedByProcessNotHeldUntilFlush guards
+// against the deadlock this design specifically exists to avoid: when composed
+// with elicitationRewriter on the same response, a complete SSE line (e.g.
+// "elicitation/create") must be forwarded by Process() itself, not held until
+// Flush() - the client needs to see it while the backend call is still open, and
+// Flush() only happens at end-of-stream, which the backend won't reach until the
+// client answers a message it never received.
+func TestResourceURIRewriter_CompleteLineForwardedByProcessNotHeldUntilFlush(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	ctx := context.Background()
+	line := []byte("data: {\"jsonrpc\":\"2.0\",\"method\":\"elicitation/create\",\"id\":1,\"params\":{}}\n")
+
+	out := r.Process(ctx, line)
+
+	if len(out) == 0 {
+		t.Fatal("expected complete line to be forwarded immediately by Process, got nothing (would deadlock a live elicitation exchange)")
+	}
+	if !contains(out, "elicitation/create") {
+		t.Errorf("expected forwarded output to contain the original message, got: %s", out)
+	}
+}
+
+func TestResourceURIRewriter_PartialLineHeldUntilComplete(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	ctx := context.Background()
+
+	out := r.Process(ctx, []byte(`{"jsonrpc":"2.0","id":1,"result":`))
+	if len(out) != 0 {
+		t.Errorf("expected no output for an incomplete line, got: %s", out)
+	}
+
+	out = r.Process(ctx, []byte("{\"_meta\":{\"ui\":{\"resourceUri\":\"ui://template.html\"}}}}\n"))
+	if !contains(out, `"resourceUri":"ui://insights_template.html"`) {
+		t.Errorf("expected rewritten resourceUri once the line completed, got: %s", out)
+	}
+}
+
+func TestInjectResourcePrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		prefix  string
+		wantURI string
+		wantOK  bool
+	}{
+		{"basic prefix injection", "ui://template.html", "insights", "ui://insights_template.html", true},
+		{"prefix already has separator", "ui://template.html", "insights_", "ui://insights_template.html", true},
+		{"non-ui scheme untouched", "https://example.com/x.html", "insights", "https://example.com/x.html", false},
+		{"malformed uri untouched", "ui://\x7fbad", "insights", "ui://\x7fbad", false},
+		{"empty prefix untouched host", "ui://template.html", "", "ui://template.html", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := injectResourcePrefix(tt.uri, tt.prefix)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.wantURI {
+				t.Errorf("got %q, want %q", got, tt.wantURI)
+			}
+		})
+	}
+}
+
+func contains(haystack []byte, needle string) bool {
+	return bytes.Contains(haystack, []byte(needle))
+}

--- a/internal/mcp-router/resource_rewrite_test.go
+++ b/internal/mcp-router/resource_rewrite_test.go
@@ -145,13 +145,8 @@ func TestResourceURIRewriter_FlushTwiceIsSafe(t *testing.T) {
 	}
 }
 
-// TestResourceURIRewriter_CompleteLineForwardedByProcessNotHeldUntilFlush guards
-// against the deadlock this design specifically exists to avoid: when composed
-// with elicitationRewriter on the same response, a complete SSE line (e.g.
-// "elicitation/create") must be forwarded by Process() itself, not held until
-// Flush() - the client needs to see it while the backend call is still open, and
-// Flush() only happens at end-of-stream, which the backend won't reach until the
-// client answers a message it never received.
+// guards against holding a complete line until Flush, which would deadlock a
+// live elicitation exchange composed on the same response.
 func TestResourceURIRewriter_CompleteLineForwardedByProcessNotHeldUntilFlush(t *testing.T) {
 	r := newTestResourceRewriter("insights_")
 	ctx := context.Background()
@@ -179,6 +174,32 @@ func TestResourceURIRewriter_PartialLineHeldUntilComplete(t *testing.T) {
 	out = r.Process(ctx, []byte("{\"_meta\":{\"ui\":{\"resourceUri\":\"ui://template.html\"}}}}\n"))
 	if !contains(out, `"resourceUri":"ui://insights_template.html"`) {
 		t.Errorf("expected rewritten resourceUri once the line completed, got: %s", out)
+	}
+}
+
+func TestResourceURIRewriter_OversizedLineForwardedUnrewrittenNotBufferedForever(t *testing.T) {
+	r := newTestResourceRewriter("insights_")
+	ctx := context.Background()
+
+	oversized := bytes.Repeat([]byte("x"), maxBufferedLineBytes+1)
+	out := r.Process(ctx, oversized)
+	if len(out) != len(oversized) {
+		t.Fatalf("expected the oversized unterminated chunk to be forwarded once the cap is exceeded, got %d bytes, want %d", len(out), len(oversized))
+	}
+	if r.buf != nil {
+		t.Errorf("expected buf to be cleared after overflow, got %d bytes still buffered", len(r.buf))
+	}
+
+	// the rest of the abandoned line, plus its terminator, should still pass through unrewritten
+	out = r.Process(ctx, []byte("tail\n"))
+	if string(out) != "tail\n" {
+		t.Errorf("expected the remainder of the abandoned line to pass through unrewritten, got: %s", out)
+	}
+
+	// normal rewriting resumes for the next line
+	out = r.Process(ctx, []byte(`{"jsonrpc":"2.0","id":1,"result":{"_meta":{"ui":{"resourceUri":"ui://template.html"}}}}`+"\n"))
+	if !contains(out, `"resourceUri":"ui://insights_template.html"`) {
+		t.Errorf("expected rewriting to resume on the next line after overflow, got: %s", out)
 	}
 }
 

--- a/internal/routing/response.go
+++ b/internal/routing/response.go
@@ -117,8 +117,11 @@ func (h *ResponseHandler202511) HandleResponse(ctx context.Context, input *Respo
 		}
 	}
 
-	// enable streamed response body mode for elicitation ID rewriting
-	if req != nil && req.IsToolCall() && req.ClientElicitation && input.StatusCode == strconv.Itoa(http.StatusOK) {
+	// enable streamed response body mode for elicitation ID rewriting and/or
+	// resource URI rewriting - either gate is sufficient on its own, tool calls
+	// to servers with no prefix and no elicitation stay pass-through
+	if req != nil && req.IsToolCall() && input.StatusCode == strconv.Itoa(http.StatusOK) &&
+		(req.ClientElicitation || req.ServerPrefix != "") {
 		decision.StreamBody = true
 	}
 

--- a/internal/routing/response_test.go
+++ b/internal/routing/response_test.go
@@ -570,6 +570,110 @@ func TestResponseHandler_StreamBodyModeNotSetForNonSuccessStatus(t *testing.T) {
 	require.False(t, decision.StreamBody, "StreamBody should be false for non-200 status")
 }
 
+func TestResponseHandler_StreamBodyModeForResourcePrefixRewrite(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	handler := &ResponseHandler202511{
+		Logger:       logger,
+		SessionCache: cache,
+	}
+
+	mcpReq := &MCPRequest{
+		Method:       "tools/call",
+		ServerPrefix: "insights_",
+	}
+
+	input := &ResponseInput{
+		StatusCode: "200",
+		Request:    mcpReq,
+	}
+
+	decision := handler.HandleResponse(context.Background(), input)
+
+	require.NotNil(t, decision)
+	require.True(t, decision.StreamBody, "StreamBody should be true for tool/call to a server with a prefix on 200, even without client elicitation")
+}
+
+func TestResponseHandler_StreamBodyModeNotSetForNoPrefixNoElicitation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	handler := &ResponseHandler202511{
+		Logger:       logger,
+		SessionCache: cache,
+	}
+
+	mcpReq := &MCPRequest{
+		Method: "tools/call",
+	}
+
+	input := &ResponseInput{
+		StatusCode: "200",
+		Request:    mcpReq,
+	}
+
+	decision := handler.HandleResponse(context.Background(), input)
+
+	require.NotNil(t, decision)
+	require.False(t, decision.StreamBody, "StreamBody should stay false for tool calls with no prefix and no client elicitation")
+}
+
+func TestResponseHandler_StreamBodyModeForResourcePrefixNotSetForNonSuccessStatus(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	handler := &ResponseHandler202511{
+		Logger:       logger,
+		SessionCache: cache,
+	}
+
+	mcpReq := &MCPRequest{
+		Method:       "tools/call",
+		ServerPrefix: "insights_",
+	}
+
+	input := &ResponseInput{
+		StatusCode: "404",
+		Request:    mcpReq,
+	}
+
+	decision := handler.HandleResponse(context.Background(), input)
+
+	require.NotNil(t, decision)
+	require.False(t, decision.StreamBody, "StreamBody should be false for non-200 status even with a server prefix")
+}
+
+func TestResponseHandler_StreamBodyModeForBothElicitationAndResourcePrefix(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cache, err := session.NewCache()
+	require.NoError(t, err)
+
+	handler := &ResponseHandler202511{
+		Logger:       logger,
+		SessionCache: cache,
+	}
+
+	mcpReq := &MCPRequest{
+		Method:            "tools/call",
+		ClientElicitation: true,
+		ServerPrefix:      "insights_",
+	}
+
+	input := &ResponseInput{
+		StatusCode: "200",
+		Request:    mcpReq,
+	}
+
+	decision := handler.HandleResponse(context.Background(), input)
+
+	require.NotNil(t, decision)
+	require.True(t, decision.StreamBody, "StreamBody should be true when both elicitation and resource prefix apply")
+}
+
 func storeConfig(cfg *config.MCPServersConfig) *atomic.Pointer[config.MCPServersConfig] {
 	p := &atomic.Pointer[config.MCPServersConfig]{}
 	p.Store(cfg)

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -188,7 +188,7 @@ var (
 	URLElicitationGatewayURL      = goenv.GetDefault("URL_ELICITATION_GATEWAY_URL", gatewayURLDefault(URLElicitationPublicHost, "https://url-elicit.mcp-gateway.local:8010/mcp"))
 	ToolDiscoveryGatewayURL       = goenv.GetDefault("TOOL_DISCOVERY_GATEWAY_URL", gatewayURLDefault(ToolDiscoveryPublicHost, "http://mcp.tool-discovery.127-0-0-1.sslip.io:8001/mcp"))
 	Protocol2026GatewayURL        = goenv.GetDefault("PROTOCOL_2026_GATEWAY_URL", gatewayURLDefault(Protocol2026PublicHost, "http://mcp.protocol-2026.127-0-0-1.sslip.io:8011/mcp"))
-	ResourcesFederationGatewayURL = goenv.GetDefault("RESOURCES_FEDERATION_GATEWAY_URL", gatewayURLDefault(ResourcesFederationPublicHost, "http://mcp.resources-federation.127-0-0-1.sslip.io:8001/mcp"))
+	ResourcesFederationGatewayURL = goenv.GetDefault("RESOURCES_FEDERATION_GATEWAY_URL", gatewayURLDefault(ResourcesFederationPublicHost, "http://mcp.resources-federation.127-0-0-1.sslip.io:8012/mcp"))
 )
 
 // gatewayURLDefault returns the Kind-specific localhost URL when using the default domain,

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -70,6 +70,11 @@ const (
 	Protocol2026ListenerName = "protocol-2026"
 )
 
+// resources-federation listener on the shared mcp-gateway (isolated resources federation tests)
+const (
+	ResourcesFederationListenerName = "resources-federation"
+)
+
 const defaultE2EDomain = "127-0-0-1.sslip.io"
 
 // e2e environment configuration
@@ -151,29 +156,39 @@ func protocol2026ServerHost(subdomain string) string {
 	return subdomain + ".protocol-2026." + e2eDomain
 }
 
+// resourcesFederationPublicHostDefault returns the default public host for resources federation.
+func resourcesFederationPublicHostDefault() string {
+	if e2eDomain == defaultE2EDomain {
+		return "mcp.resources-federation.127-0-0-1.sslip.io"
+	}
+	return "mcp.resources-federation." + e2eDomain
+}
+
 // public hosts - derived from E2E_DOMAIN
 var (
-	gatewayPublicHost        = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())
-	E2E1PublicHost           = goenv.GetDefault("E2E1_PUBLIC_HOST", "e2e-1."+e2eDomain)
-	TeamAPublicHost          = goenv.GetDefault("TEAM_A_PUBLIC_HOST", "team-a."+e2eDomain)
-	TeamBPublicHost          = goenv.GetDefault("TEAM_B_PUBLIC_HOST", "team-b."+e2eDomain)
-	ElicitationPublicHost    = goenv.GetDefault("ELICITATION_PUBLIC_HOST", elicitationPublicHostDefault())
-	URLElicitationPublicHost = goenv.GetDefault("URL_ELICITATION_PUBLIC_HOST", urlElicitationPublicHostDefault())
-	ToolDiscoveryPublicHost  = goenv.GetDefault("TOOL_DISCOVERY_PUBLIC_HOST", toolDiscPublicHostDefault())
-	ToolDiscoveryServerHost  = goenv.GetDefault("TOOL_DISCOVERY_SERVER_HOST", toolDiscServerHostDefault())
-	Protocol2026PublicHost   = goenv.GetDefault("PROTOCOL_2026_PUBLIC_HOST", protocol2026PublicHostDefault())
+	gatewayPublicHost             = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())
+	E2E1PublicHost                = goenv.GetDefault("E2E1_PUBLIC_HOST", "e2e-1."+e2eDomain)
+	TeamAPublicHost               = goenv.GetDefault("TEAM_A_PUBLIC_HOST", "team-a."+e2eDomain)
+	TeamBPublicHost               = goenv.GetDefault("TEAM_B_PUBLIC_HOST", "team-b."+e2eDomain)
+	ElicitationPublicHost         = goenv.GetDefault("ELICITATION_PUBLIC_HOST", elicitationPublicHostDefault())
+	URLElicitationPublicHost      = goenv.GetDefault("URL_ELICITATION_PUBLIC_HOST", urlElicitationPublicHostDefault())
+	ToolDiscoveryPublicHost       = goenv.GetDefault("TOOL_DISCOVERY_PUBLIC_HOST", toolDiscPublicHostDefault())
+	ToolDiscoveryServerHost       = goenv.GetDefault("TOOL_DISCOVERY_SERVER_HOST", toolDiscServerHostDefault())
+	Protocol2026PublicHost        = goenv.GetDefault("PROTOCOL_2026_PUBLIC_HOST", protocol2026PublicHostDefault())
+	ResourcesFederationPublicHost = goenv.GetDefault("RESOURCES_FEDERATION_PUBLIC_HOST", resourcesFederationPublicHostDefault())
 )
 
 // gateway URLs - on Kind use localhost port mappings, on real clusters derive from public hosts
 var (
-	gatewayURL               = goenv.GetDefault("GATEWAY_URL", gatewayURLDefault(gatewayPublicHost, "https://mcp.mcp-gateway.local:8009/mcp"))
-	E2E1GatewayURL           = goenv.GetDefault("E2E1_GATEWAY_URL", gatewayURLDefault(E2E1PublicHost, "http://localhost:8004/mcp"))
-	TeamAGatewayURL          = goenv.GetDefault("TEAM_A_GATEWAY_URL", gatewayURLDefault(TeamAPublicHost, "http://localhost:8005/mcp"))
-	TeamBGatewayURL          = goenv.GetDefault("TEAM_B_GATEWAY_URL", gatewayURLDefault(TeamBPublicHost, "http://localhost:8006/mcp"))
-	ElicitationGatewayURL    = goenv.GetDefault("ELICITATION_GATEWAY_URL", gatewayURLDefault(ElicitationPublicHost, "https://elicit.mcp-gateway.local:8010/mcp"))
-	URLElicitationGatewayURL = goenv.GetDefault("URL_ELICITATION_GATEWAY_URL", gatewayURLDefault(URLElicitationPublicHost, "https://url-elicit.mcp-gateway.local:8010/mcp"))
-	ToolDiscoveryGatewayURL  = goenv.GetDefault("TOOL_DISCOVERY_GATEWAY_URL", gatewayURLDefault(ToolDiscoveryPublicHost, "http://mcp.tool-discovery.127-0-0-1.sslip.io:8001/mcp"))
-	Protocol2026GatewayURL   = goenv.GetDefault("PROTOCOL_2026_GATEWAY_URL", gatewayURLDefault(Protocol2026PublicHost, "http://mcp.protocol-2026.127-0-0-1.sslip.io:8011/mcp"))
+	gatewayURL                    = goenv.GetDefault("GATEWAY_URL", gatewayURLDefault(gatewayPublicHost, "https://mcp.mcp-gateway.local:8009/mcp"))
+	E2E1GatewayURL                = goenv.GetDefault("E2E1_GATEWAY_URL", gatewayURLDefault(E2E1PublicHost, "http://localhost:8004/mcp"))
+	TeamAGatewayURL               = goenv.GetDefault("TEAM_A_GATEWAY_URL", gatewayURLDefault(TeamAPublicHost, "http://localhost:8005/mcp"))
+	TeamBGatewayURL               = goenv.GetDefault("TEAM_B_GATEWAY_URL", gatewayURLDefault(TeamBPublicHost, "http://localhost:8006/mcp"))
+	ElicitationGatewayURL         = goenv.GetDefault("ELICITATION_GATEWAY_URL", gatewayURLDefault(ElicitationPublicHost, "https://elicit.mcp-gateway.local:8010/mcp"))
+	URLElicitationGatewayURL      = goenv.GetDefault("URL_ELICITATION_GATEWAY_URL", gatewayURLDefault(URLElicitationPublicHost, "https://url-elicit.mcp-gateway.local:8010/mcp"))
+	ToolDiscoveryGatewayURL       = goenv.GetDefault("TOOL_DISCOVERY_GATEWAY_URL", gatewayURLDefault(ToolDiscoveryPublicHost, "http://mcp.tool-discovery.127-0-0-1.sslip.io:8001/mcp"))
+	Protocol2026GatewayURL        = goenv.GetDefault("PROTOCOL_2026_GATEWAY_URL", gatewayURLDefault(Protocol2026PublicHost, "http://mcp.protocol-2026.127-0-0-1.sslip.io:8011/mcp"))
+	ResourcesFederationGatewayURL = goenv.GetDefault("RESOURCES_FEDERATION_GATEWAY_URL", gatewayURLDefault(ResourcesFederationPublicHost, "http://mcp.resources-federation.127-0-0-1.sslip.io:8001/mcp"))
 )
 
 // gatewayURLDefault returns the Kind-specific localhost URL when using the default domain,

--- a/tests/e2e/jwt_helpers.go
+++ b/tests/e2e/jwt_helpers.go
@@ -47,6 +47,14 @@ func CreateAuthorizedPromptsJWT(allowedPrompts map[string][]string) (string, err
 	return createCapabilitiesJWT(map[string]map[string][]string{"prompts": allowedPrompts})
 }
 
+// CreateAuthorizedResourcesJWT creates a signed JWT for the x-mcp-authorized header.
+// allowedResources is a map of server namespace/name to list of unprefixed resource
+// authorities; the broker strips the server prefix from each resource's authority
+// before comparing. An empty (non-nil) map denies all resources.
+func CreateAuthorizedResourcesJWT(allowedResources map[string][]string) (string, error) {
+	return createCapabilitiesJWT(map[string]map[string][]string{"resources": allowedResources})
+}
+
 func createCapabilitiesJWT(capabilities map[string]map[string][]string) (string, error) {
 	keyBytes := []byte(testHeaderSigningKey)
 	claimPayload, err := json.Marshal(capabilities)

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -132,7 +132,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -160,7 +160,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -3,9 +3,7 @@
 package e2e
 
 import (
-	"encoding/json"
-	"fmt"
-
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -5,10 +5,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"time"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -112,23 +112,13 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		newGatewayClient()
 
 		By("Calling resources/list without JWT header to get all resources")
-		listResult, err := mcpGatewayClient.CallTool(ctx, "resources/list", map[string]interface{}{})
+		listResult, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: "resources/list"})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(listResult).NotTo(BeNil())
 
-		// Parse the resources to get count
-		resourcesBytes, _ := json.Marshal(listResult)
-		var resourcesList struct {
-			Resources []struct {
-				URI string `json:"uri"`
-			} `json:"resources"`
-		}
-		err = json.Unmarshal(resourcesBytes, &resourcesList)
-		Expect(err).NotTo(HaveOccurred())
-		initialResourceCount := len(resourcesList.Resources)
-
-		By(fmt.Sprintf("Verified initial resources count: %d", initialResourceCount))
-		Expect(initialResourceCount).To(BeGreaterThan(0), "should have resources without JWT")
+		By("Verifying server is registered and ready to serve")
+		// Resources/list federation is wired in broker. This test verifies
+		// MCPServerRegistration setup for resources authorization filtering.
 	})
 
 	It("[Security,ResourcesFederation] Empty resources claim denies all resources", func() {
@@ -181,7 +171,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		newGatewayClient()
 
 		By("Listing tools to verify basic functionality after rename")
-		toolsList, err := mcpGatewayClient.ListTools(ctx)
+		toolsList, err := mcpGatewayClient.ListTools(ctx, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(toolsList).NotTo(BeNil())
 

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -10,6 +12,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// resourceURIs extracts the URI of each resource, for use with ContainElement assertions.
+func resourceURIs(resources []*mcp.Resource) []string {
+	uris := make([]string, len(resources))
+	for i, r := range resources {
+		uris[i] = r.URI
+	}
+	return uris
+}
 
 const (
 	resourcesFedExtName   = "resources-federation-ext"
@@ -89,8 +100,11 @@ var _ = Describe("Resources Federation", Ordered, func() {
 	}
 
 	It("[Happy,ResourcesFederation] JWT resources claim filters resources/list per server", func() {
-		By("Creating MCPServerRegistration with resources")
+		SetupTrustedHeadersAuthInNamespace(ctx, k8sClient, resourcesFedNamespace, resourcesFedExtName)
+
+		By("Creating MCPServerRegistration for server1")
 		reg := NewTestResourcesWithDefaults("jwt-filter-test", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("jwttest_").
 			WithSectionName(ResourcesFederationListenerName).
 			WithHostname("jwtserver.resources-federation.127-0-0-1.sslip.io").
@@ -105,22 +119,39 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-		By("Creating MCP client and connecting to gateway")
-		newGatewayClient()
+		serverKey := fmt.Sprintf("%s/%s", regServer.Namespace, regServer.Name)
+		wantURI := "ui://" + regServer.Spec.Prefix + "widget.html"
 
-		By("Calling resources/list without JWT header to get all resources")
-		listResult, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: "resources/list"})
+		By("Creating a JWT that allows widget.html for this server")
+		jwtToken, err := CreateAuthorizedResourcesJWT(map[string][]string{
+			serverKey: {"widget.html"},
+		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(listResult).NotTo(BeNil())
 
-		By("Verifying server is registered and ready to serve")
-		// Resources/list federation is wired in broker. This test verifies
-		// MCPServerRegistration setup for resources authorization filtering.
+		By("Creating a client with the x-mcp-authorized header and listing resources")
+		var authorizedClient *mcp.ClientSession
+		Eventually(func(g Gomega) {
+			var connErr error
+			authorizedClient, connErr = NewStatefulClientWithHeaders(ctx, resourcesFedURL, map[string]string{"X-Mcp-Authorized": jwtToken})
+			g.Expect(connErr).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		defer func() { _ = authorizedClient.Close() }()
+
+		Eventually(func(g Gomega) {
+			listResult, listErr := authorizedClient.ListResources(ctx, nil)
+			g.Expect(listErr).NotTo(HaveOccurred())
+			g.Expect(listResult).NotTo(BeNil())
+			g.Expect(resourceURIs(listResult.Resources)).To(ContainElement(wantURI),
+				"widget.html should be visible when the JWT claim allows it for this server")
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 	})
 
 	It("[Security,ResourcesFederation] Empty resources claim denies all resources", func() {
-		By("Creating MCPServerRegistration with resources")
+		SetupTrustedHeadersAuthInNamespace(ctx, k8sClient, resourcesFedNamespace, resourcesFedExtName)
+
+		By("Creating MCPServerRegistration for server1")
 		reg := NewTestResourcesWithDefaults("empty-claim-test", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("emptyclaim_").
 			WithSectionName(ResourcesFederationListenerName).
 			WithHostname("emptyclaimserver.resources-federation.127-0-0-1.sslip.io").
@@ -135,19 +166,34 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-		By("Creating MCP client with empty resources JWT claim")
-		// Create a client with JWT header that has empty resources claim
-		// This simulates authorization enforcement mode
-		newGatewayClient()
+		deniedURI := "ui://" + regServer.Spec.Prefix + "widget.html"
 
-		By("Verifying resources/list respects server registration")
-		// The server is properly registered and available
-		Expect(regServer.Spec.Prefix).To(Equal("emptyclaim_"))
+		By("Creating a JWT with an empty (present but empty) resources claim")
+		jwtToken, err := CreateAuthorizedResourcesJWT(map[string][]string{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a client with the empty-claim JWT and listing resources")
+		var deniedClient *mcp.ClientSession
+		Eventually(func(g Gomega) {
+			var connErr error
+			deniedClient, connErr = NewStatefulClientWithHeaders(ctx, resourcesFedURL, map[string]string{"X-Mcp-Authorized": jwtToken})
+			g.Expect(connErr).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		defer func() { _ = deniedClient.Close() }()
+
+		Eventually(func(g Gomega) {
+			listResult, listErr := deniedClient.ListResources(ctx, nil)
+			g.Expect(listErr).NotTo(HaveOccurred())
+			g.Expect(listResult).NotTo(BeNil())
+			g.Expect(resourceURIs(listResult.Resources)).NotTo(ContainElement(deniedURI),
+				"an empty resources claim should deny widget.html even though the server is registered")
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 	})
 
 	It("[Happy,Elicitation] Elicitation rewriting works after sseRewriter rename", func() {
 		By("Creating MCPServerRegistration for elicitation testing")
 		reg := NewTestResourcesWithDefaults("elicitation-rename-test", k8sClient).
+			ForInternalService("everything-server", 9090).
 			WithPrefix("elicit_").
 			WithSectionName(ResourcesFederationListenerName).
 			WithHostname("elicitserver.resources-federation.127-0-0-1.sslip.io").
@@ -162,18 +208,198 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-		By("Creating MCP client and verifying connection works")
+		toolName := regServer.Spec.Prefix + "trigger-elicitation-request"
+		handler := acceptElicitHandler(map[string]any{"name": "e2e-test-user"})
+
+		By("Creating an elicitation-capable MCP client")
+		var elicitClient *mcp.ClientSession
+		Eventually(func(g Gomega) {
+			var err error
+			elicitClient, err = NewStatefulClientWithElicitation(ctx, resourcesFedURL, handler)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+		defer func() { _ = elicitClient.Close() }()
+
+		By("Verifying the trigger-elicitation-request tool is visible")
+		Eventually(func(g Gomega) {
+			toolsList, err := elicitClient.ListTools(ctx, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(verifyMCPServerRegistrationToolPresent(toolName, toolsList)).To(BeTrueBecause("%s should exist", toolName))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Calling trigger-elicitation-request tool to exercise the renamed elicitationRewriter end to end")
+		Eventually(func(g Gomega) {
+			res, err := elicitClient.CallTool(ctx, &mcp.CallToolParams{Name: toolName, Arguments: map[string]any{}})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res).NotTo(BeNil())
+			g.Expect(len(res.Content)).To(BeNumerically(">=", 1))
+
+			responseText := ""
+			for _, c := range res.Content {
+				if tc, ok := c.(*mcp.TextContent); ok {
+					responseText += tc.Text
+				}
+			}
+			g.Expect(responseText).To(ContainSubstring("User provided the requested information"))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[Happy,ResourcesFederation] tools/call response resourceUri is rewritten to prefixed form", func() {
+		By("Creating MCPServerRegistration for server1")
+		reg := NewTestResourcesWithDefaults("resourceuri-rewrite-test", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
+			WithPrefix("widget_").
+			WithSectionName(ResourcesFederationListenerName).
+			WithHostname("widgetserver.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		regObjects := reg.GetObjects()
+		testResources = append(testResources, regObjects...)
+
+		regServer := reg.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client and connecting to gateway")
 		newGatewayClient()
 
-		By("Listing tools to verify basic functionality after rename")
-		toolsList, err := mcpGatewayClient.ListTools(ctx, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(toolsList).NotTo(BeNil())
+		toolName := regServer.Spec.Prefix + "show_widget"
 
-		By("Verifying the elicitationRewriter (renamed from sseRewriter) is active")
-		// After the rename from sseRewriter to elicitationRewriter, the functionality
-		// should be identical. This test verifies that tool listing works,
-		// which confirms the renamed type is properly integrated.
-		Expect(regServer.Spec.Prefix).To(Equal("elicit_"))
+		By("Calling show_widget and verifying the resourceUri comes back prefixed")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: toolName, Arguments: map[string]any{}})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res).NotTo(BeNil())
+
+			ui, ok := res.Meta["ui"].(map[string]any)
+			g.Expect(ok).To(BeTrueBecause("result._meta.ui should be present"))
+			g.Expect(ui["resourceUri"]).To(Equal("ui://" + regServer.Spec.Prefix + "widget.html"))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[ResourcesFederation] Multiple servers confirm prefix isolation in resourceUri rewrite", func() {
+		By("Creating two MCPServerRegistrations for server1 with different prefixes")
+		regA := NewTestResourcesWithDefaults("resourceuri-isolation-a", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
+			WithPrefix("widgeta_").
+			WithSectionName(ResourcesFederationListenerName).
+			WithHostname("widgetservera.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		testResources = append(testResources, regA.GetObjects()...)
+		serverA := regA.Register(ctx)
+
+		regB := NewTestResourcesWithDefaults("resourceuri-isolation-b", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
+			WithPrefix("widgetb_").
+			WithSectionName(ResourcesFederationListenerName).
+			WithHostname("widgetserverb.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		testResources = append(testResources, regB.GetObjects()...)
+		serverB := regB.Register(ctx)
+
+		By("Verifying both MCPServerRegistrations become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, serverA.Name, serverA.Namespace)).To(Succeed())
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, serverB.Name, serverB.Namespace)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client and connecting to gateway")
+		newGatewayClient()
+
+		By("Calling show_widget on server A and verifying its own prefix, not server B's")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: serverA.Spec.Prefix + "show_widget", Arguments: map[string]any{}})
+			g.Expect(err).NotTo(HaveOccurred())
+			ui, ok := res.Meta["ui"].(map[string]any)
+			g.Expect(ok).To(BeTrueBecause("result._meta.ui should be present"))
+			g.Expect(ui["resourceUri"]).To(Equal("ui://" + serverA.Spec.Prefix + "widget.html"))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Calling show_widget on server B and verifying its own prefix, not server A's")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: serverB.Spec.Prefix + "show_widget", Arguments: map[string]any{}})
+			g.Expect(err).NotTo(HaveOccurred())
+			ui, ok := res.Meta["ui"].(map[string]any)
+			g.Expect(ok).To(BeTrueBecause("result._meta.ui should be present"))
+			g.Expect(ui["resourceUri"]).To(Equal("ui://" + serverB.Spec.Prefix + "widget.html"))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[ResourcesFederation] Ordinary tool calls with no resourceUri are unaffected by the rewriter", func() {
+		By("Creating MCPServerRegistration for server1")
+		reg := NewTestResourcesWithDefaults("resourceuri-passthrough-test", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
+			WithPrefix("plain_").
+			WithSectionName(ResourcesFederationListenerName).
+			WithHostname("plainserver.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		regObjects := reg.GetObjects()
+		testResources = append(testResources, regObjects...)
+
+		regServer := reg.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client and connecting to gateway")
+		newGatewayClient()
+
+		toolName := regServer.Spec.Prefix + "greet"
+
+		By("Calling an ordinary tool with no _meta.ui and verifying the response is unaffected")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: toolName, Arguments: map[string]any{"name": "e2e"}})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res).NotTo(BeNil())
+			g.Expect(res.IsError).To(BeFalse())
+			g.Expect(len(res.Content)).To(BeNumerically(">=", 1))
+
+			responseText := ""
+			for _, c := range res.Content {
+				if tc, ok := c.(*mcp.TextContent); ok {
+					responseText += tc.Text
+				}
+			}
+			g.Expect(responseText).To(Equal("Hi e2e"))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+	})
+
+	It("[ResourcesFederation] Non-ui:// resourceUri values are left untouched", func() {
+		By("Creating MCPServerRegistration for server1")
+		reg := NewTestResourcesWithDefaults("resourceuri-nonui-test", k8sClient).
+			ForInternalService("mcp-test-server1", 9090).
+			WithPrefix("nonui_").
+			WithSectionName(ResourcesFederationListenerName).
+			WithHostname("nonuiserver.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		regObjects := reg.GetObjects()
+		testResources = append(testResources, regObjects...)
+
+		regServer := reg.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client and connecting to gateway")
+		newGatewayClient()
+
+		toolName := regServer.Spec.Prefix + "show_external_widget"
+
+		By("Calling show_external_widget and verifying the non-ui:// resourceUri is untouched")
+		Eventually(func(g Gomega) {
+			res, err := mcpGatewayClient.CallTool(ctx, &mcp.CallToolParams{Name: toolName, Arguments: map[string]any{}})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res).NotTo(BeNil())
+
+			ui, ok := res.Meta["ui"].(map[string]any)
+			g.Expect(ok).To(BeTrueBecause("result._meta.ui should be present"))
+			g.Expect(ui["resourceUri"]).To(Equal("https://example.com/widget.html"))
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 	})
 })

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			},
 		}
 		_ = k8sClient.Delete(ctx, ns)
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			err := k8sClient.Create(ctx, ns)
 			g.Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
 		}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
@@ -49,13 +49,13 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		resourcesFedExt.Clean(ctx).Register(ctx)
 
 		By("Waiting for MCPGatewayExtension to become ready")
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			err := VerifyMCPGatewayExtensionReady(ctx, k8sClient, resourcesFedExtName, resourcesFedNamespace)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 		By("Waiting for broker/router deployment to be ready")
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			err := WaitForDeploymentReady(ctx, resourcesFedNamespace, "mcp-gateway")
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -81,7 +81,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 	})
 
 	newGatewayClient := func() {
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			var err error
 			mcpGatewayClient, err = NewStatefulClientWithNotifications(ctx, resourcesFedURL, nil)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -101,7 +101,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -132,7 +132,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -160,7 +160,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(_ Gomega) {
+		Eventually(func(g Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -43,8 +43,8 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			WithName(resourcesFedExtName).
 			InNamespace(resourcesFedNamespace).
 			TargetingGateway(GatewayName, GatewayNamespace).
-			WithSectionName("resources-federation").
-			WithPublicHost("resources-federation.127-0-0-1.sslip.io").
+			WithSectionName(ResourcesFederationListenerName).
+			WithPublicHost(ResourcesFederationPublicHost).
 			Build()
 		resourcesFedExt.Clean(ctx).Register(ctx)
 
@@ -60,7 +60,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
-		resourcesFedURL = "http://mcp.resources-federation.127-0-0-1.sslip.io:8001/mcp"
+		resourcesFedURL = ResourcesFederationGatewayURL
 	})
 
 	AfterAll(func() {
@@ -92,7 +92,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		By("Creating MCPServerRegistration with resources")
 		reg := NewTestResourcesWithDefaults("jwt-filter-test", k8sClient).
 			WithPrefix("jwttest_").
-			WithSectionName("resources-federation").
+			WithSectionName(ResourcesFederationListenerName).
 			WithHostname("jwtserver.resources-federation.127-0-0-1.sslip.io").
 			Build()
 		regObjects := reg.GetObjects()
@@ -101,9 +101,8 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(_ Gomega) {
-			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 		By("Creating MCP client and connecting to gateway")
@@ -123,7 +122,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		By("Creating MCPServerRegistration with resources")
 		reg := NewTestResourcesWithDefaults("empty-claim-test", k8sClient).
 			WithPrefix("emptyclaim_").
-			WithSectionName("resources-federation").
+			WithSectionName(ResourcesFederationListenerName).
 			WithHostname("emptyclaimserver.resources-federation.127-0-0-1.sslip.io").
 			Build()
 		regObjects := reg.GetObjects()
@@ -132,9 +131,8 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(_ Gomega) {
-			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 		By("Creating MCP client with empty resources JWT claim")
@@ -151,7 +149,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		By("Creating MCPServerRegistration for elicitation testing")
 		reg := NewTestResourcesWithDefaults("elicitation-rename-test", k8sClient).
 			WithPrefix("elicit_").
-			WithSectionName("resources-federation").
+			WithSectionName(ResourcesFederationListenerName).
 			WithHostname("elicitserver.resources-federation.127-0-0-1.sslip.io").
 			Build()
 		regObjects := reg.GetObjects()
@@ -160,9 +158,8 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(_ Gomega) {
-			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)).To(Succeed())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 
 		By("Creating MCP client and verifying connection works")

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			},
 		}
 		_ = k8sClient.Delete(ctx, ns)
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := k8sClient.Create(ctx, ns)
 			g.Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
 		}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
@@ -49,13 +49,13 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		resourcesFedExt.Clean(ctx).Register(ctx)
 
 		By("Waiting for MCPGatewayExtension to become ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPGatewayExtensionReady(ctx, k8sClient, resourcesFedExtName, resourcesFedNamespace)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 
 		By("Waiting for broker/router deployment to be ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := WaitForDeploymentReady(ctx, resourcesFedNamespace, "mcp-gateway")
 			g.Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -81,7 +81,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 	})
 
 	newGatewayClient := func() {
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			var err error
 			mcpGatewayClient, err = NewStatefulClientWithNotifications(ctx, resourcesFedURL, nil)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -101,7 +101,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -132,7 +132,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
@@ -160,7 +160,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 		regServer := reg.Register(ctx)
 
 		By("Verifying MCPServerRegistration becomes ready")
-		Eventually(func(g Gomega) {
+		Eventually(func(_ Gomega) {
 			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -121,8 +121,9 @@ var _ = Describe("Resources Federation", Ordered, func() {
 
 		serverKey := fmt.Sprintf("%s/%s", regServer.Namespace, regServer.Name)
 		wantURI := "ui://" + regServer.Spec.Prefix + "widget.html"
+		excludedURI := "ui://" + regServer.Spec.Prefix + "gadget.html"
 
-		By("Creating a JWT that allows widget.html for this server")
+		By("Creating a JWT that allows widget.html but not gadget.html for this server")
 		jwtToken, err := CreateAuthorizedResourcesJWT(map[string][]string{
 			serverKey: {"widget.html"},
 		})
@@ -143,6 +144,8 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			g.Expect(listResult).NotTo(BeNil())
 			g.Expect(resourceURIs(listResult.Resources)).To(ContainElement(wantURI),
 				"widget.html should be visible when the JWT claim allows it for this server")
+			g.Expect(resourceURIs(listResult.Resources)).NotTo(ContainElement(excludedURI),
+				"gadget.html should be excluded since it's not in the JWT claim for this server")
 		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
 	})
 

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -1,0 +1,197 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	resourcesFedExtName   = "resources-federation-ext"
+	resourcesFedNamespace = "mcp-resources-fed"
+)
+
+var _ = Describe("Resources Federation", Ordered, func() {
+	var (
+		testResources    []client.Object
+		mcpGatewayClient *NotifyingMCPClient
+		resourcesFedExt  *MCPGatewayExtensionSetup
+		resourcesFedURL  string
+	)
+
+	BeforeAll(func() {
+		By("Creating resources-federation namespace")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   resourcesFedNamespace,
+				Labels: map[string]string{"e2e": "test"},
+			},
+		}
+		_ = k8sClient.Delete(ctx, ns)
+		Eventually(func(g Gomega) {
+			err := k8sClient.Create(ctx, ns)
+			g.Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+		}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCPGatewayExtension for resources federation")
+		resourcesFedExt = NewMCPGatewayExtensionSetup(k8sClient).
+			WithName(resourcesFedExtName).
+			InNamespace(resourcesFedNamespace).
+			TargetingGateway(GatewayName, GatewayNamespace).
+			WithSectionName("resources-federation").
+			WithPublicHost("resources-federation.127-0-0-1.sslip.io").
+			Build()
+		resourcesFedExt.Clean(ctx).Register(ctx)
+
+		By("Waiting for MCPGatewayExtension to become ready")
+		Eventually(func(g Gomega) {
+			err := VerifyMCPGatewayExtensionReady(ctx, k8sClient, resourcesFedExtName, resourcesFedNamespace)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		By("Waiting for broker/router deployment to be ready")
+		Eventually(func(g Gomega) {
+			err := WaitForDeploymentReady(ctx, resourcesFedNamespace, "mcp-gateway")
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		resourcesFedURL = "http://mcp.resources-federation.127-0-0-1.sslip.io:8001/mcp"
+	})
+
+	AfterAll(func() {
+		if resourcesFedExt != nil {
+			resourcesFedExt.TearDown(ctx)
+		}
+	})
+
+	AfterEach(func() {
+		if mcpGatewayClient != nil {
+			_ = mcpGatewayClient.Close()
+			mcpGatewayClient = nil
+		}
+		for _, obj := range testResources {
+			CleanupResource(ctx, k8sClient, obj)
+		}
+		testResources = nil
+	})
+
+	newGatewayClient := func() {
+		Eventually(func(g Gomega) {
+			var err error
+			mcpGatewayClient, err = NewStatefulClientWithNotifications(ctx, resourcesFedURL, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	}
+
+	It("[Happy,ResourcesFederation] JWT resources claim filters resources/list per server", func() {
+		By("Creating MCPServerRegistration with resources")
+		reg := NewTestResourcesWithDefaults("jwt-filter-test", k8sClient).
+			WithPrefix("jwttest_").
+			WithSectionName("resources-federation").
+			WithHostname("jwtserver.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		regObjects := reg.GetObjects()
+		testResources = append(testResources, regObjects...)
+
+		regServer := reg.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client and connecting to gateway")
+		newGatewayClient()
+
+		By("Calling resources/list without JWT header to get all resources")
+		listResult, err := mcpGatewayClient.CallTool(ctx, "resources/list", map[string]interface{}{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listResult).NotTo(BeNil())
+
+		// Parse the resources to get count
+		resourcesBytes, _ := json.Marshal(listResult)
+		var resourcesList struct {
+			Resources []struct {
+				URI string `json:"uri"`
+			} `json:"resources"`
+		}
+		err = json.Unmarshal(resourcesBytes, &resourcesList)
+		Expect(err).NotTo(HaveOccurred())
+		initialResourceCount := len(resourcesList.Resources)
+
+		By(fmt.Sprintf("Verified initial resources count: %d", initialResourceCount))
+		Expect(initialResourceCount).To(BeGreaterThan(0), "should have resources without JWT")
+	})
+
+	It("[Security,ResourcesFederation] Empty resources claim denies all resources", func() {
+		By("Creating MCPServerRegistration with resources")
+		reg := NewTestResourcesWithDefaults("empty-claim-test", k8sClient).
+			WithPrefix("emptyclaim_").
+			WithSectionName("resources-federation").
+			WithHostname("emptyclaimserver.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		regObjects := reg.GetObjects()
+		testResources = append(testResources, regObjects...)
+
+		regServer := reg.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client with empty resources JWT claim")
+		// Create a client with JWT header that has empty resources claim
+		// This simulates authorization enforcement mode
+		newGatewayClient()
+
+		By("Verifying resources/list respects server registration")
+		// The server is properly registered and available
+		Expect(regServer.Spec.Prefix).To(Equal("emptyclaim_"))
+	})
+
+	It("[Happy,Elicitation] Elicitation rewriting works after sseRewriter rename", func() {
+		By("Creating MCPServerRegistration for elicitation testing")
+		reg := NewTestResourcesWithDefaults("elicitation-rename-test", k8sClient).
+			WithPrefix("elicit_").
+			WithSectionName("resources-federation").
+			WithHostname("elicitserver.resources-federation.127-0-0-1.sslip.io").
+			Build()
+		regObjects := reg.GetObjects()
+		testResources = append(testResources, regObjects...)
+
+		regServer := reg.Register(ctx)
+
+		By("Verifying MCPServerRegistration becomes ready")
+		Eventually(func(g Gomega) {
+			err := VerifyMCPServerRegistrationReady(ctx, k8sClient, regServer.Name, regServer.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCP client and verifying connection works")
+		newGatewayClient()
+
+		By("Listing tools to verify basic functionality after rename")
+		toolsList, err := mcpGatewayClient.ListTools(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(toolsList).NotTo(BeNil())
+
+		By("Verifying the elicitationRewriter (renamed from sseRewriter) is active")
+		// After the rename from sseRewriter to elicitationRewriter, the functionality
+		// should be identical. This test verifies that tool listing works,
+		// which confirms the renamed type is properly integrated.
+		Expect(regServer.Spec.Prefix).To(Equal("elicit_"))
+	})
+})

--- a/tests/servers/server1/main.go
+++ b/tests/servers/server1/main.go
@@ -206,6 +206,15 @@ func main() {
 		URI:      "embedded:info",
 	}, handleEmbeddedResource)
 
+	server.AddResource(&mcp.Resource{
+		Name:     "widget",
+		MIMEType: "text/html",
+		URI:      "ui://widget.html",
+	}, handleWidgetResource)
+
+	mcp.AddTool(server, &mcp.Tool{Name: "show_widget", Description: "return a tool result with a _meta.ui.resourceUri"}, showWidgetTool)
+	mcp.AddTool(server, &mcp.Tool{Name: "show_external_widget", Description: "return a tool result with a non-ui:// _meta.ui.resourceUri"}, showExternalWidgetTool)
+
 	if *httpAddr != "" {
 		server.AddReceivingMiddleware(rpcPrintMiddleware)
 		handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
@@ -261,6 +270,47 @@ func rpcPrintMiddleware(
 		result, err := next(ctx, method, req)
 		return result, err
 	}
+}
+
+// showWidgetTool returns a tool result carrying _meta.ui.resourceUri, for
+// exercising the gateway's resource URI rewriting (resources-federation Task 6).
+func showWidgetTool(
+	_ context.Context,
+	_ *mcp.CallToolRequest,
+	_ struct{},
+) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Meta: mcp.Meta{"ui": map[string]any{"resourceUri": "ui://widget.html"}},
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "widget shown"},
+		},
+	}, nil, nil
+}
+
+// showExternalWidgetTool returns a tool result with a non-ui:// _meta.ui.resourceUri,
+// for exercising the gateway's rule that only ui:// values get rewritten.
+func showExternalWidgetTool(
+	_ context.Context,
+	_ *mcp.CallToolRequest,
+	_ struct{},
+) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Meta: mcp.Meta{"ui": map[string]any{"resourceUri": "https://example.com/widget.html"}},
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "external widget shown"},
+		},
+	}, nil, nil
+}
+
+func handleWidgetResource(
+	_ context.Context,
+	_ *mcp.ReadResourceRequest,
+) (*mcp.ReadResourceResult, error) {
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{URI: "ui://widget.html", MIMEType: "text/html", Text: "<div>widget</div>"},
+		},
+	}, nil
 }
 
 var embeddedResources = map[string]string{

--- a/tests/servers/server1/main.go
+++ b/tests/servers/server1/main.go
@@ -212,6 +212,12 @@ func main() {
 		URI:      "ui://widget.html",
 	}, handleWidgetResource)
 
+	server.AddResource(&mcp.Resource{
+		Name:     "gadget",
+		MIMEType: "text/html",
+		URI:      "ui://gadget.html",
+	}, handleGadgetResource)
+
 	mcp.AddTool(server, &mcp.Tool{Name: "show_widget", Description: "return a tool result with a _meta.ui.resourceUri"}, showWidgetTool)
 	mcp.AddTool(server, &mcp.Tool{Name: "show_external_widget", Description: "return a tool result with a non-ui:// _meta.ui.resourceUri"}, showExternalWidgetTool)
 
@@ -272,8 +278,7 @@ func rpcPrintMiddleware(
 	}
 }
 
-// showWidgetTool returns a tool result carrying _meta.ui.resourceUri, for
-// exercising the gateway's resource URI rewriting (resources-federation Task 6).
+// showWidgetTool returns a tool result carrying _meta.ui.resourceUri.
 func showWidgetTool(
 	_ context.Context,
 	_ *mcp.CallToolRequest,
@@ -309,6 +314,17 @@ func handleWidgetResource(
 	return &mcp.ReadResourceResult{
 		Contents: []*mcp.ResourceContents{
 			{URI: "ui://widget.html", MIMEType: "text/html", Text: "<div>widget</div>"},
+		},
+	}, nil
+}
+
+func handleGadgetResource(
+	_ context.Context,
+	_ *mcp.ReadResourceRequest,
+) (*mcp.ReadResourceResult, error) {
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{URI: "ui://gadget.html", MIMEType: "text/html", Text: "<div>gadget</div>"},
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary

Adds `_meta.ui.resourceUri` rewriting for `tools/call` responses, renames `sseRewriter` → `elicitationRewriter` to make room for it, and adds e2e coverage for JWT-based resource authorization filtering (implemented earlier in #1356).

Part of #1378

Prefix uniqueness enforcement (originally planned as part of this PR) has been split out to its own PR: #1398.

## Changes

### Response URI Rewriting

Rewrites `_meta.ui.resourceUri` in `tools/call` responses so the URI a client gets back from a tool call matches the prefixed form `resources/list` already returns for the same resource. Only `ui://` values are rewritten; everything else passes through untouched.

`resourceURIRewriter` rewrites incrementally per complete line (not buffered until end-of-stream) because it runs chained after `elicitationRewriter` on the same response — `elicitationRewriter` must forward `elicitation/create` immediately so the client can answer it while the backend call is still open, and a downstream rewriter holding every byte until end-of-stream would swallow that message and deadlock the exchange when both are active on the same response.

- Bounded line buffering (1 MiB, matching the existing `maxSSELineBytes` convention) — an oversized unterminated line is forwarded unrewritten rather than held indefinitely
- Streaming is only enabled for tool calls to servers with a prefix, not every tool call

### Rename `sseRewriter` → `elicitationRewriter`

No behavior change. Renamed for clarity ahead of `resourceURIRewriter` (above) to avoid a naming collision.

### JWT Resource Authorization Filtering (e2e coverage only)

The broker-side filtering itself already shipped in #1356; this PR adds e2e tests for it (inclusion/exclusion filtering by JWT claim, empty-claim-denies-all) alongside the router-side work above.

## Testing

- Unit tests covering response URI rewriting (including a regression guard for the composition deadlock described above)
- E2E tests covering JWT resource claim filtering (inclusion and exclusion), elicitation rewriting post-rename, and resource URI rewriting (prefixed form, multi-server isolation, non-`ui://` passthrough, ordinary-tool-call regression guard)

Verified against a live kind cluster: rebuilt and loaded the gateway and server1 images, ran all Resources Federation e2e specs against the real broker/router/controller.