### PR TITLE
feat(resources-federation): enforce prefix uniqueness per MCPGatewayExtension

### DIFF
--- a/internal/controller/mcpserverregistration_controller.go
+++ b/internal/controller/mcpserverregistration_controller.go
@@ -44,6 +44,8 @@ const (
 	HTTPRouteIndex = "spec.targetRef.httproute"
 	// ProgrammedHTTPRouteIndex used to find programmed httproutes
 	ProgrammedHTTPRouteIndex = "status.hasProgrammedCondition"
+	// PrefixIndex used to find MCPServerRegistrations sharing a prefix, for conflict detection
+	PrefixIndex = "spec.prefix"
 
 	// conditionReasonReady is the reason used when the MCPServerRegistration is ready
 	conditionReasonReady = "Ready"
@@ -51,6 +53,9 @@ const (
 	conditionReasonNotReady = "NotReady"
 	// conditionReasonDisabled is the reason used when the MCPServerRegistration is disabled
 	conditionReasonDisabled = "Disabled"
+	// conditionReasonPrefixConflict is the reason used when another active MCPServerRegistration
+	// feeding the same MCPGatewayExtension already uses this prefix
+	conditionReasonPrefixConflict = "PrefixConflict"
 )
 
 // ServerInfo holds server information
@@ -229,6 +234,16 @@ func (r *MCPReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return ctrl.Result{}, nil
 	}
 
+	if err := r.checkPrefixConflict(ctx, mcpsr, validNamespaces); err != nil {
+		if err := r.updateStatus(ctx, mcpsr, false, conditionReasonPrefixConflict, err.Error()); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("reconcile failed: status update failed %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	mcpServerconfig, err := r.buildMCPServerConfig(ctx, targetRoute, mcpsr, hasGatewayCACertBundle)
 	if err != nil {
 		if err := r.updateStatus(ctx, mcpsr, false, conditionReasonNotReady, err.Error()); err != nil {
@@ -339,6 +354,115 @@ func (r *MCPReconciler) getTargetGatewaysFromParentRef(ctx context.Context, pare
 		return nil, fmt.Errorf("failed to get parent gateway for httproute: %w", err)
 	}
 	return g, nil
+}
+
+// resolveValidNamespaces resolves the set of MCPGatewayExtension namespaces mcpsr's
+// config would be written into: its target HTTPRoute's accepted parent gateways,
+// filtered to extensions whose listener the route actually attaches to. Returns nil
+// on any resolution failure rather than an error - callers needing config-writing to
+// succeed already surface those failures separately in Reconcile; this is also used
+// for conflict detection on sibling registrations, where an unresolvable sibling
+// simply can't conflict with anything yet.
+func (r *MCPReconciler) resolveValidNamespaces(ctx context.Context, mcpsr *mcpv1.MCPServerRegistration) []string {
+	targetRoute, err := r.getTargetHTTPRoute(ctx, mcpsr)
+	if err != nil {
+		return nil
+	}
+	validGateways, err := r.findValidGatewaysForMCPServer(ctx, targetRoute)
+	if err != nil {
+		return nil
+	}
+	var validNamespaces []string
+	for _, vg := range validGateways {
+		mcpGatewayExtensions, err := r.MCPExtFinderValidator.FindValidMCPGatewayExtsForGateway(ctx, vg)
+		if err != nil {
+			continue
+		}
+		for _, vext := range mcpGatewayExtensions {
+			if !httpRouteAttachesToListener(targetRoute, vg, vext) {
+				continue
+			}
+			validNamespaces = append(validNamespaces, vext.Namespace)
+		}
+	}
+	return validNamespaces
+}
+
+// checkPrefixConflict checks whether mcpsr's prefix exactly duplicates another active
+// MCPServerRegistration's prefix within any MCPGatewayExtension namespace mcpsr's own
+// config would be written into (validNamespaces). Two registrations whose configs never
+// reach the same broker/router instance can't actually collide - a single Gateway can
+// host multiple independent extensions, each with its own broker and its own federated
+// server list - so this only compares against siblings sharing at least one such
+// namespace, not every registration cluster-wide. The oldest (by creation timestamp)
+// registration wins, matching checkNamespaceConflict/checkListenerConflict in
+// mcpgatewayextension_controller.go. Substring-prefix collisions are not handled here;
+// see the design doc's Longest-prefix match section for why.
+func (r *MCPReconciler) checkPrefixConflict(ctx context.Context, mcpsr *mcpv1.MCPServerRegistration, validNamespaces []string) error {
+	if mcpsr.Spec.Prefix == "" || len(validNamespaces) == 0 {
+		return nil
+	}
+
+	ownNamespaces := make(map[string]bool, len(validNamespaces))
+	for _, ns := range validNamespaces {
+		ownNamespaces[ns] = true
+	}
+
+	siblings := &mcpv1.MCPServerRegistrationList{}
+	if err := r.List(ctx, siblings, client.MatchingFields{PrefixIndex: mcpsr.Spec.Prefix}); err != nil {
+		return fmt.Errorf("failed to list registrations for prefix conflict check: %w", err)
+	}
+
+	for i := range siblings.Items {
+		sibling := &siblings.Items[i]
+		if sibling.GetUID() == mcpsr.GetUID() || sibling.DeletionTimestamp != nil {
+			continue
+		}
+
+		overlaps := false
+		for _, ns := range r.resolveValidNamespaces(ctx, sibling) {
+			if ownNamespaces[ns] {
+				overlaps = true
+				break
+			}
+		}
+		if !overlaps {
+			continue
+		}
+
+		oldest := findOldestMCPServerRegistration([]mcpv1.MCPServerRegistration{*mcpsr, *sibling})
+		if oldest.GetUID() != mcpsr.GetUID() {
+			return fmt.Errorf("conflict: prefix %q is already used by MCPServerRegistration %s/%s in the same MCPGatewayExtension",
+				mcpsr.Spec.Prefix, sibling.Namespace, sibling.Name)
+		}
+	}
+
+	return nil
+}
+
+func findOldestMCPServerRegistration(regs []mcpv1.MCPServerRegistration) *mcpv1.MCPServerRegistration {
+	oldest := &regs[0]
+	for i := 1; i < len(regs); i++ {
+		if isOlderMCPServerRegistration(&regs[i], oldest) {
+			oldest = &regs[i]
+		}
+	}
+	return oldest
+}
+
+// isOlderMCPServerRegistration reports whether a should be treated as older than b.
+// CreationTimestamp only has second granularity, so two registrations created within
+// the same second compare equal there; breaking the tie on UID keeps the result
+// symmetric - both registrations agree on the same winner regardless of which one is
+// reconciling and therefore at index 0 of the comparison slice. Without this, an
+// index-0-wins tie-break (as in findOldestExtension) lets both sides see themselves
+// as oldest, so both a conflicting pair reconciled within the same second could reach
+// Ready.
+func isOlderMCPServerRegistration(a, b *mcpv1.MCPServerRegistration) bool {
+	if !a.CreationTimestamp.Equal(&b.CreationTimestamp) {
+		return a.CreationTimestamp.Before(&b.CreationTimestamp)
+	}
+	return a.UID < b.UID
 }
 
 func (r *MCPReconciler) buildMCPServerConfig(ctx context.Context, targetRoute *gatewayv1.HTTPRoute, mcpsr *mcpv1.MCPServerRegistration, hasGatewayCACertBundle bool) (*config.MCPServer, error) {
@@ -670,6 +794,10 @@ func (r *MCPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 		return fmt.Errorf("failed to setup required index for programmed httproutes %w", err)
 	}
 
+	if err := setupIndexMCPRegistrationToPrefix(ctx, mgr.GetFieldIndexer()); err != nil {
+		return fmt.Errorf("failed to setup required index from MCPServerRegistration to prefix %w", err)
+	}
+
 	controller := ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1.MCPServerRegistration{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
@@ -728,6 +856,19 @@ func setupIndexMCPRegistrationToHTTPRoute(ctx context.Context, indexer client.Fi
 			return []string{httpRouteIndexValue(namespace, targetRef.Name)}
 		}
 		return []string{}
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupIndexMCPRegistrationToPrefix(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &mcpv1.MCPServerRegistration{}, PrefixIndex, func(rawObj client.Object) []string {
+		mcpsr := rawObj.(*mcpv1.MCPServerRegistration)
+		if mcpsr.Spec.Prefix == "" {
+			return []string{}
+		}
+		return []string{mcpsr.Spec.Prefix}
 	}); err != nil {
 		return err
 	}

--- a/internal/controller/mcpserverregistration_controller_integration_test.go
+++ b/internal/controller/mcpserverregistration_controller_integration_test.go
@@ -1039,4 +1039,347 @@ var _ = Describe("MCPServerRegistration Controller", func() {
 		)
 	})
 
+	Context("When two MCPServerRegistrations feeding the same MCPGatewayExtension share a prefix", func() {
+		const (
+			resourceName1 = "test-prefix-conflict-1"
+			resourceName2 = "test-prefix-conflict-2"
+			httpRouteName = "test-prefix-conflict-route"
+			gatewayName   = "test-prefix-conflict-gw"
+			serviceName   = "test-prefix-conflict-svc"
+			extName       = "test-prefix-conflict-ext"
+		)
+
+		ctx := context.Background()
+
+		mcpsrNamespacedName1 := types.NamespacedName{Name: resourceName1, Namespace: "default"}
+		mcpsrNamespacedName2 := types.NamespacedName{Name: resourceName2, Namespace: "default"}
+
+		BeforeEach(func() {
+			gw := createTestGateway(gatewayName, "default")
+			Expect(testK8sClient.Create(ctx, gw)).To(Succeed())
+
+			svc := createTestService(serviceName, "default", 8080)
+			Expect(testK8sClient.Create(ctx, svc)).To(Succeed())
+
+			httpRoute := createTestHTTPRoute(httpRouteName, "default", "test.example.com", serviceName, 8080, gatewayName, "default")
+			Expect(testK8sClient.Create(ctx, httpRoute)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				route := &gatewayv1.HTTPRoute{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{Name: httpRouteName, Namespace: "default"}, route)).To(Succeed())
+				g.Expect(setHTTPRouteAcceptedStatus(ctx, route, gatewayName, "default")).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			mcpExt := createTestMCPGatewayExtension(extName, "default", gatewayName, "default")
+			Expect(testK8sClient.Create(ctx, mcpExt)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				ext := &mcpv1.MCPGatewayExtension{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{Name: extName, Namespace: "default"}, ext)).To(Succeed())
+				ext.SetReadyCondition(metav1.ConditionTrue, mcpv1.ConditionReasonSuccess, "ready")
+				g.Expect(testK8sClient.Status().Update(ctx, ext)).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			forceDeleteTestMCPServerRegistration(ctx, resourceName1, "default")
+			forceDeleteTestMCPServerRegistration(ctx, resourceName2, "default")
+			forceDeleteTestMCPGatewayExtension(ctx, extName, "default")
+			deleteTestHTTPRoute(ctx, httpRouteName, "default")
+			deleteTestService(ctx, serviceName, "default")
+			deleteTestGateway(ctx, gatewayName, "default")
+		})
+
+		It("rejects the second registration with a PrefixConflict status condition", func() {
+			reg1 := createTestMCPServerRegistration(resourceName1, "default", httpRouteName, "dup_")
+			Expect(testK8sClient.Create(ctx, reg1)).To(Succeed())
+
+			configWriter := newMockMCPServerConfigReaderWriter()
+			reconciler := newMCPServerReconciler(configWriter)
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName1)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName1})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName1)
+
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName1})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedName1, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			// ensure a distinct, later CreationTimestamp for the second registration
+			time.Sleep(1100 * time.Millisecond)
+
+			reg2 := createTestMCPServerRegistration(resourceName2, "default", httpRouteName, "dup_")
+			Expect(testK8sClient.Create(ctx, reg2)).To(Succeed())
+
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName2)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName2})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName2)
+
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName2})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedName2, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(conditionReasonPrefixConflict))
+				g.Expect(cond.Message).To(ContainSubstring("conflict"))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			// re-reconciling (what an update to any watched object triggers) must not
+			// flip the older, already-Ready registration to conflicted
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName1})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated1 := &mcpv1.MCPServerRegistration{}
+			Expect(testK8sClient.Get(ctx, mcpsrNamespacedName1, updated1)).To(Succeed())
+			cond1 := meta.FindStatusCondition(updated1.Status.Conditions, "Ready")
+			Expect(cond1).NotTo(BeNil())
+			Expect(cond1.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("does not reject a sibling with a substring-colliding but non-identical prefix", func() {
+			reg1 := createTestMCPServerRegistration(resourceName1, "default", httpRouteName, "app_")
+			Expect(testK8sClient.Create(ctx, reg1)).To(Succeed())
+			reg2 := createTestMCPServerRegistration(resourceName2, "default", httpRouteName, "app_admin_")
+			Expect(testK8sClient.Create(ctx, reg2)).To(Succeed())
+
+			configWriter := newMockMCPServerConfigReaderWriter()
+			reconciler := newMCPServerReconciler(configWriter)
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName1)
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName2)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName1})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName1)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName2})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName2)
+
+			for _, nn := range []types.NamespacedName{mcpsrNamespacedName1, mcpsrNamespacedName2} {
+				Eventually(func(g Gomega) {
+					_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+					g.Expect(reconcileErr).NotTo(HaveOccurred())
+
+					updated := &mcpv1.MCPServerRegistration{}
+					g.Expect(testK8sClient.Get(ctx, nn, updated)).To(Succeed())
+					cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+					g.Expect(cond).NotTo(BeNil())
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue),
+						"substring-colliding prefixes must not be rejected here - resolved deterministically by longest-prefix-match instead")
+				}, testTimeout, testRetryInterval).Should(Succeed())
+			}
+		})
+
+		It("stops rejecting once the conflicting sibling is deleted", func() {
+			reg1 := createTestMCPServerRegistration(resourceName1, "default", httpRouteName, "dup_")
+			Expect(testK8sClient.Create(ctx, reg1)).To(Succeed())
+
+			configWriter := newMockMCPServerConfigReaderWriter()
+			reconciler := newMCPServerReconciler(configWriter)
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName1)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName1})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName1)
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName1})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedName1, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			time.Sleep(1100 * time.Millisecond)
+
+			reg2 := createTestMCPServerRegistration(resourceName2, "default", httpRouteName, "dup_")
+			Expect(testK8sClient.Create(ctx, reg2)).To(Succeed())
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedName2)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName2})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedName2)
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName2})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedName2, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Reason).To(Equal(conditionReasonPrefixConflict))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			// delete the conflicting sibling (reg1) entirely
+			forceDeleteTestMCPServerRegistration(ctx, resourceName1, "default")
+
+			// reconciling reg2 again must now succeed - no active sibling shares its prefix
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedName2})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedName2, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+		})
+	})
+
+	Context("When two MCPServerRegistrations feeding different MCPGatewayExtensions share a prefix", func() {
+		const (
+			resourceNameA = "test-prefix-noconflict-a"
+			resourceNameB = "test-prefix-noconflict-b"
+			routeNameA    = "test-prefix-noconflict-route-a"
+			routeNameB    = "test-prefix-noconflict-route-b"
+			gatewayName   = "test-prefix-noconflict-gw"
+			serviceName   = "test-prefix-noconflict-svc"
+			extNamespaceA = "test-prefix-noconflict-ext-ns-a"
+			extNamespaceB = "test-prefix-noconflict-ext-ns-b"
+			extNameA      = "test-prefix-noconflict-ext-a"
+			extNameB      = "test-prefix-noconflict-ext-b"
+		)
+
+		ctx := context.Background()
+
+		mcpsrNamespacedNameA := types.NamespacedName{Name: resourceNameA, Namespace: "default"}
+		mcpsrNamespacedNameB := types.NamespacedName{Name: resourceNameB, Namespace: "default"}
+
+		var refGrantA, refGrantB client.Object
+
+		BeforeEach(func() {
+			createTestNamespace(ctx, extNamespaceA)
+			createTestNamespace(ctx, extNamespaceB)
+
+			// one Gateway, two listeners on different ports - mirrors how a single
+			// shared Gateway can host multiple independent MCPGatewayExtensions
+			// (see the resources-federation e2e listeners for the real-world example)
+			hostnameA := gatewayv1.Hostname("a.test.example.com")
+			hostnameB := gatewayv1.Hostname("b.test.example.com")
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: "default"},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "test-class",
+					Listeners: []gatewayv1.Listener{
+						{Name: "listener-a", Port: 8080, Protocol: gatewayv1.HTTPProtocolType, Hostname: &hostnameA},
+						{Name: "listener-b", Port: 8081, Protocol: gatewayv1.HTTPProtocolType, Hostname: &hostnameB},
+					},
+				},
+			}
+			Expect(testK8sClient.Create(ctx, gw)).To(Succeed())
+
+			svc := createTestService(serviceName, "default", 8080)
+			Expect(testK8sClient.Create(ctx, svc)).To(Succeed())
+
+			routeA := createTestHTTPRoute(routeNameA, "default", "a.test.example.com", serviceName, 8080, gatewayName, "default")
+			Expect(testK8sClient.Create(ctx, routeA)).To(Succeed())
+			routeB := createTestHTTPRoute(routeNameB, "default", "b.test.example.com", serviceName, 8080, gatewayName, "default")
+			Expect(testK8sClient.Create(ctx, routeB)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				route := &gatewayv1.HTTPRoute{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{Name: routeNameA, Namespace: "default"}, route)).To(Succeed())
+				g.Expect(setHTTPRouteAcceptedStatus(ctx, route, gatewayName, "default")).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				route := &gatewayv1.HTTPRoute{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{Name: routeNameB, Namespace: "default"}, route)).To(Succeed())
+				g.Expect(setHTTPRouteAcceptedStatus(ctx, route, gatewayName, "default")).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			// extensions live in different namespaces than the Gateway, so each needs a ReferenceGrant
+			gwNameForGrant := gatewayName
+			refGrantA = createTestReferenceGrant("allow-ext-a", "default", extNamespaceA, &gwNameForGrant)
+			Expect(testK8sClient.Create(ctx, refGrantA)).To(Succeed())
+			refGrantB = createTestReferenceGrant("allow-ext-b", "default", extNamespaceB, &gwNameForGrant)
+			Expect(testK8sClient.Create(ctx, refGrantB)).To(Succeed())
+
+			extA := createTestMCPGatewayExtension(extNameA, extNamespaceA, gatewayName, "default")
+			extA.Spec.TargetRef.SectionName = "listener-a"
+			Expect(testK8sClient.Create(ctx, extA)).To(Succeed())
+			extB := createTestMCPGatewayExtension(extNameB, extNamespaceB, gatewayName, "default")
+			extB.Spec.TargetRef.SectionName = "listener-b"
+			Expect(testK8sClient.Create(ctx, extB)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				ext := &mcpv1.MCPGatewayExtension{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{Name: extNameA, Namespace: extNamespaceA}, ext)).To(Succeed())
+				ext.SetReadyCondition(metav1.ConditionTrue, mcpv1.ConditionReasonSuccess, "ready")
+				g.Expect(testK8sClient.Status().Update(ctx, ext)).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				ext := &mcpv1.MCPGatewayExtension{}
+				g.Expect(testK8sClient.Get(ctx, types.NamespacedName{Name: extNameB, Namespace: extNamespaceB}, ext)).To(Succeed())
+				ext.SetReadyCondition(metav1.ConditionTrue, mcpv1.ConditionReasonSuccess, "ready")
+				g.Expect(testK8sClient.Status().Update(ctx, ext)).To(Succeed())
+			}, testTimeout, testRetryInterval).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			forceDeleteTestMCPServerRegistration(ctx, resourceNameA, "default")
+			forceDeleteTestMCPServerRegistration(ctx, resourceNameB, "default")
+			forceDeleteTestMCPGatewayExtension(ctx, extNameA, extNamespaceA)
+			forceDeleteTestMCPGatewayExtension(ctx, extNameB, extNamespaceB)
+			_ = testK8sClient.Delete(ctx, refGrantA)
+			_ = testK8sClient.Delete(ctx, refGrantB)
+			deleteTestHTTPRoute(ctx, routeNameA, "default")
+			deleteTestHTTPRoute(ctx, routeNameB, "default")
+			deleteTestService(ctx, serviceName, "default")
+			deleteTestGateway(ctx, gatewayName, "default")
+		})
+
+		It("does not reject either registration - they feed separate broker instances", func() {
+			regA := createTestMCPServerRegistration(resourceNameA, "default", routeNameA, "dup_")
+			Expect(testK8sClient.Create(ctx, regA)).To(Succeed())
+			regB := createTestMCPServerRegistration(resourceNameB, "default", routeNameB, "dup_")
+			Expect(testK8sClient.Create(ctx, regB)).To(Succeed())
+
+			configWriter := newMockMCPServerConfigReaderWriter()
+			reconciler := newMCPServerReconciler(configWriter)
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedNameA)
+			waitForMCPServerRegistrationCacheSync(ctx, mcpsrNamespacedNameB)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedNameA})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedNameA)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedNameB})
+			Expect(err).NotTo(HaveOccurred())
+			waitForMCPServerRegistrationFinalizer(ctx, mcpsrNamespacedNameB)
+
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedNameA})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedNameA, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: mcpsrNamespacedNameB})
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+
+				updated := &mcpv1.MCPServerRegistration{}
+				g.Expect(testK8sClient.Get(ctx, mcpsrNamespacedNameB, updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).NotTo(Equal(conditionReasonPrefixConflict))
+			}, testTimeout, testRetryInterval).Should(Succeed())
+		})
+	})
+
 })

--- a/internal/controller/mcpserverregistration_controller_test.go
+++ b/internal/controller/mcpserverregistration_controller_test.go
@@ -14,6 +14,7 @@ import (
 
 	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -299,3 +300,93 @@ func TestDetermineProtocol_InternalServiceAlwaysHTTP(t *testing.T) {
 }
 
 func ptrTo[T any](v T) *T { return &v }
+
+func TestFindOldestMCPServerRegistration(t *testing.T) {
+	newReg := func(name string, created time.Time) mcpv1.MCPServerRegistration {
+		return mcpv1.MCPServerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(created),
+			},
+		}
+	}
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		regs []mcpv1.MCPServerRegistration
+		want string
+	}{
+		{
+			name: "two registrations, first is older",
+			regs: []mcpv1.MCPServerRegistration{
+				newReg("first", base),
+				newReg("second", base.Add(time.Hour)),
+			},
+			want: "first",
+		},
+		{
+			name: "two registrations, second is older",
+			regs: []mcpv1.MCPServerRegistration{
+				newReg("first", base.Add(time.Hour)),
+				newReg("second", base),
+			},
+			want: "second",
+		},
+		{
+			name: "three registrations, oldest in the middle",
+			regs: []mcpv1.MCPServerRegistration{
+				newReg("newest", base.Add(2*time.Hour)),
+				newReg("oldest", base),
+				newReg("middle", base.Add(time.Hour)),
+			},
+			want: "oldest",
+		},
+		{
+			name: "single registration",
+			regs: []mcpv1.MCPServerRegistration{
+				newReg("only", base),
+			},
+			want: "only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findOldestMCPServerRegistration(tt.regs)
+			if got.Name != tt.want {
+				t.Errorf("findOldestMCPServerRegistration() = %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindOldestMCPServerRegistration_TieBreakIsSymmetric guards against the real
+// failure mode this tie-break exists to prevent: CreationTimestamp only has second
+// granularity, so two registrations created in the same second compare equal there.
+// checkPrefixConflict always puts the currently-reconciling registration at index 0
+// of the comparison slice, so if a tie resolved by index alone, EACH registration's
+// own reconcile would see itself as oldest and both would reach Ready - the exact
+// collision this check exists to prevent. The winner must be the same regardless of
+// which registration is asking (i.e. which one is at index 0).
+func TestFindOldestMCPServerRegistration_TieBreakIsSymmetric(t *testing.T) {
+	sameInstant := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	a := mcpv1.MCPServerRegistration{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", UID: "aaaa", CreationTimestamp: sameInstant},
+	}
+	b := mcpv1.MCPServerRegistration{
+		ObjectMeta: metav1.ObjectMeta{Name: "b", UID: "bbbb", CreationTimestamp: sameInstant},
+	}
+
+	fromA := findOldestMCPServerRegistration([]mcpv1.MCPServerRegistration{a, b})
+	fromB := findOldestMCPServerRegistration([]mcpv1.MCPServerRegistration{b, a})
+
+	if fromA.UID != fromB.UID {
+		t.Fatalf("tie-break is not symmetric: asking as %q picked %q, asking as %q picked %q",
+			a.Name, fromA.Name, b.Name, fromB.Name)
+	}
+	if fromA.UID != a.UID {
+		t.Errorf("expected the lower UID (%q) to win the tie, got %q", a.UID, fromA.UID)
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -99,6 +99,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = setupIndexExtensionToReferenceGrant(ctx, testMgr.GetFieldIndexer())
 	Expect(err).NotTo(HaveOccurred())
+	err = setupIndexMCPRegistrationToPrefix(ctx, testMgr.GetFieldIndexer())
+	Expect(err).NotTo(HaveOccurred())
 
 	// start the manager's cache
 	go func() {

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -1036,13 +1036,15 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 
-	It("[Happy] should become Ready even when tool conflicts exist from same prefix", func() {
+	It("[Happy] should reject the second registration when an exact-duplicate prefix conflicts", func() {
 		testResources := []client.Object{}
 		deferCleanupResources(&testResources)
 
-		// tool and prompt conflicts are detected by the broker at runtime, not
-		// by the controller. both registrations will be Ready in the CRD.
-		// conflicts surface through the broker's /status endpoint.
+		// exact-duplicate prefix conflicts are rejected by the controller at
+		// registration time (resources-federation Task 7): two registrations
+		// only collide if their configs reach the same broker/router instance,
+		// so the older registration (by creation time) stays Ready and the
+		// newer one is rejected with a PrefixConflict status condition.
 		By("Creating first MCPServerRegistration with a specific prefix pointing to server1")
 		registration1 := NewMCPServerResources("conflict-test-1", "conflict-s1.mcp-gateway.local", sharedMCPTestServer1, 9090, k8sClient).
 			WithPrefix("conflict_").Build()
@@ -1060,10 +1062,10 @@ var _ = Describe("MCP Gateway Registration Happy Path", func() {
 		testResources = append(testResources, registration2.GetObjects()...)
 		server2 := registration2.Register(ctx)
 
-		By("Verifying both MCPServerRegistrations become Ready (conflicts are broker-side)")
+		By("Verifying the first registration stays Ready and the second is rejected as a prefix conflict")
 		Eventually(func(g Gomega) {
 			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server1.Name, server1.Namespace)).To(BeNil())
-			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server2.Name, server2.Namespace)).To(BeNil())
+			g.Expect(VerifyMCPServerRegistrationNotReadyWithReason(ctx, k8sClient, server2.Name, server2.Namespace, "conflict")).To(BeNil())
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 

--- a/tests/e2e/user_specific_list_test.go
+++ b/tests/e2e/user_specific_list_test.go
@@ -36,7 +36,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		}
 	})
 
-	It("[Happy,UserSpecificList] user sees their own tools merged with cached tools", func() {
+	It("[Happy,UserSpecificList] user sees their own tools merged with cached tools", Serial, func() {
 		By("Creating a standard (cached) server registration")
 		stdReg := NewMCPServerResourcesWithDefaults("uspec-std", k8sClient).
 			WithPrefix("std_").Build()
@@ -79,7 +79,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 
-	It("[UserSpecificList] different users get different tool lists", func() {
+	It("[UserSpecificList] different users get different tool lists", Serial, func() {
 		By("Creating a user-specific server registration")
 		uspecReg := NewMCPServerResourcesWithDefaults("uspec-diff-users", k8sClient).
 			WithBackendTarget(userSpecificMCPTestServer, 9090).
@@ -169,7 +169,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
 
-	It("[UserSpecificList] standard servers unaffected by userSpecificList", func() {
+	It("[UserSpecificList] standard servers unaffected by userSpecificList", Serial, func() {
 		By("Creating a standard server registration")
 		stdReg := NewMCPServerResourcesWithDefaults("uspec-unaffected", k8sClient).
 			WithPrefix("std_").Build()
@@ -274,7 +274,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
 	})
 
-	It("[UserSpecificList] tool call routing works for user-specific tools", func() {
+	It("[UserSpecificList] tool call routing works for user-specific tools", Serial, func() {
 		By("Creating a user-specific server registration")
 		uspecReg := NewMCPServerResourcesWithDefaults("uspec-call", k8sClient).
 			WithBackendTarget(userSpecificMCPTestServer, 9090).
@@ -312,7 +312,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		Expect(content.Text).To(ContainSubstring("user=user-a-token"))
 	})
 
-	It("[Security,UserSpecificList] internal headers not forwarded to upstream", func() {
+	It("[Security,UserSpecificList] internal headers not forwarded to upstream", Serial, func() {
 		By("Creating a user-specific server registration")
 		uspecReg := NewMCPServerResourcesWithDefaults("uspec-security", k8sClient).
 			WithBackendTarget(userSpecificMCPTestServer, 9090).
@@ -359,7 +359,7 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 		Expect(headerText).To(ContainSubstring("authorization"))
 	})
 
-	It("[UserSpecificList] virtual server filter applies to user-specific tools", func() {
+	It("[UserSpecificList] virtual server filter applies to user-specific tools", Serial, func() {
 		By("Creating a user-specific server registration")
 		uspecReg := NewMCPServerResourcesWithDefaults("uspec-vs", k8sClient).
 			WithBackendTarget(userSpecificMCPTestServer, 9090).


### PR DESCRIPTION
## Summary

Rejects an `MCPServerRegistration` when its prefix exactly duplicates another active registration's prefix within any `MCPGatewayExtension` namespace it would feed. Closes the gap called out in the resources-federation design doc's "Conflict Detection" section: exact-duplicate prefixes are not currently rejected at registration time.

Part of #1378

## Design: scoped per-extension, not per-Gateway

Two registrations only collide if their configs reach the same broker/router instance. A single Gateway can host multiple independent `MCPGatewayExtension`s, each with its own broker deployment and its own federated server list — verified directly against a running cluster (`tool-discovery-ext`, `protocol-2026-ext`, and `resources-federation-ext` all target listeners on the same shared `mcp-gateway` Gateway object, each with a separate broker pod in a separate namespace). Two registrations with the same prefix feeding *different* extensions never share a routing table and can't actually conflict — scoping the check per-Gateway would reject that as a false positive.

## Changes

- `checkPrefixConflict`, `resolveValidNamespaces`, `findOldestMCPServerRegistration` in `mcpserverregistration_controller.go`
- New `PrefixIndex` field indexer, new `PrefixConflict` status condition reason
- Oldest registration (by creation time) wins, mirroring the existing `checkNamespaceConflict`/`checkListenerConflict` pattern in `mcpgatewayextension_controller.go`
- Symmetric UID tie-break for same-second creation: `CreationTimestamp` only has second granularity, so two registrations created in the same second compare equal there. An index-based tie-break (as used by the existing `findOldestExtension`) lets each registration see *itself* as oldest when reconciling, so both could reach Ready with a real collision. This is fixed for the new code here; the same latent behavior in `findOldestExtension` is unfixed and out of scope for this PR.
- Substring-prefix collisions (`app_` vs `app_admin_`) are explicitly not rejected — resolved deterministically by longest-prefix-match elsewhere, per the design doc's accepted trade-off

### Required test updates elsewhere

Rejecting same-prefix registrations is a real behavior change, and it broke two pre-existing assumptions in the e2e suite:

- `happy_path_test.go`: a test named "should become Ready even when tool conflicts exist from same prefix" explicitly asserted the old contract (both registrations Ready, conflicts resolved broker-side). Updated to assert the new one: the older registration stays Ready, the newer is rejected with `PrefixConflict`.
- `user_specific_list_test.go`: reuses the same registration prefixes (`std_`, `uspec_`) across 7 separate specs feeding the shared default extension — a pre-existing violation of this suite's own documented "every `MCPServerRegistration` must use a unique prefix" rule, harmless before this change but now a latent cross-process scheduling race under `--procs>1`. Marked the affected specs `Serial` rather than renaming prefixes, which would have required updating 27 hardcoded literal tool-name assertions for no behavioral benefit.

## Testing

- Unit tests: `findOldestMCPServerRegistration`, including a dedicated test proving the UID tie-break is symmetric regardless of which registration is reconciling
- Integration tests (envtest): same-extension conflict rejected, different-extension conflict allowed (the scoping this design hinges on), substring collisions not rejected, conflict clears once the sibling is deleted, older registration stays Ready across re-reconcile
- No dedicated e2e test: this is pure controller/CRD-level validation with no Envoy or broker runtime involved, and envtest already runs a real API server exercising the same code path
- Verified against a live kind cluster (manual smoke test): confirmed the same-second tie-break behavior and the fix, and re-ran the affected e2e specs with `--procs=2` after the test updates above.
