### PR TITLE
fix for 2025 stateless server

### DIFF
--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -423,15 +423,25 @@ func (up *MCPServer) notify(method string) {
 
 // OnConnectionLost registers a connection lost handler.
 // In the official SDK, connection loss is observed via session.Wait().
+// upstreams that return no Mcp-Session-Id from initialize do not need
+// connection-loss monitoring: the SDK's subscriptions/listen stream
+// will fail immediately with an empty session ID, which is expected
+// and not a real connection loss. the ticker health check and ping
+// handle failure detection for these upstreams.
 func (up *MCPServer) OnConnectionLost(handler func(err error)) {
 	session := up.currentSession()
-	if session != nil {
-		go func() {
-			if err := session.Wait(); err != nil {
-				handler(err)
-			}
-		}()
+	if session == nil {
+		return
 	}
+	if session.ID() == "" {
+		up.logger.Debug("skipping connection-lost watcher, no session ID from upstream", "upstream", up.ID())
+		return
+	}
+	go func() {
+		if err := session.Wait(); err != nil {
+			handler(err)
+		}
+	}()
 }
 
 // UsesStatelessProtocol returns true if the upstream negotiated protocol

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -409,6 +409,74 @@ func TestOnNotification_RegisteredBeforeConnect(t *testing.T) {
 	}
 }
 
+// regression: a stateless streamable-HTTP upstream (no Mcp-Session-Id)
+// caused OnConnectionLost to fire immediately after Connect because the
+// SDK's subscriptions/listen stream died with an empty session ID,
+// producing a tight reconnect loop with zero backoff. the fix: skip
+// session.Wait when session.ID() is empty.
+func TestOnConnectionLost_SkippedWhenNoSession(t *testing.T) {
+	up := NewUpstreamMCP(&config.MCPServer{Name: "stateless", URL: "http://unused"}, "", nil)
+
+	called := make(chan struct{}, 1)
+	up.OnConnectionLost(func(_ error) {
+		called <- struct{}{}
+	})
+
+	select {
+	case <-called:
+		t.Fatal("OnConnectionLost handler must not fire with nil session")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// regression: stateless streamable-HTTP upstream (responds to initialize but
+// returns no Mcp-Session-Id, returns 405 on GET). session.ID() is empty so
+// OnConnectionLost must not start a session.Wait goroutine.
+func TestOnConnectionLost_SkippedForStatelessUpstream(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "stateless", Version: "0.0.1"}, nil)
+	inner := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return srv }, nil)
+
+	// proxy that strips Mcp-Session-Id from all responses and rejects GET
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rec := httptest.NewRecorder()
+		inner.ServeHTTP(rec, r)
+		for k, vs := range rec.Header() {
+			if k == "Mcp-Session-Id" {
+				continue
+			}
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(rec.Code)
+		_, _ = w.Write(rec.Body.Bytes())
+	}))
+	defer ts.Close()
+
+	up := NewUpstreamMCP(&config.MCPServer{Name: "stateless", URL: ts.URL}, "", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, up.Connect(ctx, func() {}))
+	defer func() { _ = up.Disconnect() }()
+
+	require.Empty(t, up.currentSession().ID(), "session ID must be empty for stateless upstream")
+
+	connectionLost := make(chan error, 1)
+	up.OnConnectionLost(func(err error) {
+		connectionLost <- err
+	})
+
+	select {
+	case err := <-connectionLost:
+		t.Fatalf("OnConnectionLost fired for stateless upstream: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
 func TestBuildHTTPClient_GatewayCACertBundle(t *testing.T) {
 	caPEM, caKey, caCert := generateSelfSignedCA(t)
 	serverCert := generateServerCert(t, caCert, caKey)


### PR DESCRIPTION
Handles an empty session id from a 2025 server that responds to the initialize request but doesn't support a session. Stops the OnConnectionLost handler from firing in these cases. 

If the server is down, next time the timer triggers the manager will attempt to connect and fail as normal and backoff and retry

Fixes #1382 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection handling for stateless upstream connections that do not provide a session ID.
  - Prevented unnecessary connection-loss notifications when no active session exists.
  - Ensured connection-loss handling occurs only when an established session reports an error.

- **Tests**
  - Added coverage for stateless upstream connections and rejected monitoring requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->