### PR TITLE
refactor(resources): consolidate resource prefix inject/strip logic

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"regexp"
 	"slices"
 	"strings"
@@ -948,26 +947,12 @@ func (m *mcpBrokerImpl) fetchResourcesFromServer(ctx context.Context, srv upstre
 			continue
 		}
 		copied := *r
-		copied.URI = rewriteResourceURI(r.URI, prefix)
+		copied.URI, _ = routing.InjectResourcePrefix(r.URI, prefix)
 		out = append(out, &copied)
 	}
 
 	span.SetAttributes(attribute.Int("mcp.resources.resources_count", len(out)))
 	return out, nil
-}
-
-// rewriteResourceURI injects prefix into a ui:// URI's authority segment
-// (ui://template.html -> ui://<prefix_>template.html). Non-ui:// and
-// malformed URIs are returned unchanged, matching how the tools/call
-// response rewrite (resourceURIRewriter) treats them.
-func rewriteResourceURI(uri, prefix string) string {
-	u, err := url.Parse(uri)
-	if err != nil || u.Scheme != "ui" {
-		return uri
-	}
-	u.User = nil // never forward upstream credentials to clients
-	u.Host = routing.EnsureSeparator(prefix) + u.Host
-	return u.String()
 }
 
 // IsReady reports whether the broker can serve traffic.

--- a/internal/broker/filtered_resources_handler.go
+++ b/internal/broker/filtered_resources_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -84,7 +83,7 @@ func (broker *mcpBrokerImpl) filterResourcesByServerMap(ctx context.Context, all
 
 		// extract original authority by stripping the prefix from the URI authority
 		prefixedAuthority := resourceAuthorityFromURI(resource.URI)
-		originalAuthority := stripResourcePrefix(prefixedAuthority, serverInfo.Prefix)
+		originalAuthority := routing.StripAuthorityPrefix(prefixedAuthority, serverInfo.Prefix)
 
 		allowed := false
 		for _, authority := range allowedAuthorities {
@@ -102,20 +101,6 @@ func (broker *mcpBrokerImpl) filterResourcesByServerMap(ctx context.Context, all
 	}
 
 	return filtered
-}
-
-// stripResourcePrefix removes the prefix and separator from a prefixed authority.
-// For authority "app_example.com" with prefix "app", returns "example.com".
-// For authority without matching prefix, returns the authority unchanged.
-func stripResourcePrefix(authority, prefix string) string {
-	if prefix == "" {
-		return authority
-	}
-	separator := routing.EnsureSeparator(prefix)
-	if strings.HasPrefix(authority, separator) {
-		return authority[len(separator):]
-	}
-	return authority
 }
 
 // resourceAuthorityFromURI extracts the authority (host) from a resource URI.

--- a/internal/mcp-router/resource_rewrite.go
+++ b/internal/mcp-router/resource_rewrite.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"net/url"
 
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 )
@@ -153,7 +152,7 @@ func (r *resourceURIRewriter) rewriteToolResultJSON(ctx context.Context, jsonDat
 		return jsonData, false
 	}
 
-	newURI, ok := injectResourcePrefix(uri, r.prefix)
+	newURI, ok := routing.InjectResourcePrefix(uri, r.prefix)
 	if !ok {
 		return jsonData, false // not a ui:// URI - left untouched per design
 	}
@@ -192,18 +191,4 @@ func (r *resourceURIRewriter) rewriteToolResultJSON(ctx context.Context, jsonDat
 		return jsonData, false
 	}
 	return out, true
-}
-
-// injectResourcePrefix injects the server prefix into a ui:// URI's authority
-// segment (ui://template.html -> ui://<prefix_>template.html), mirroring
-// broker.go's rewriteResourceURI so resources/list and tools/call responses stay
-// consistent. Non-ui:// or malformed URIs are returned unchanged with ok=false.
-func injectResourcePrefix(uri, prefix string) (rewritten string, ok bool) {
-	u, err := url.Parse(uri)
-	if err != nil || u.Scheme != "ui" {
-		return uri, false
-	}
-	u.User = nil // never forward upstream credentials to clients
-	u.Host = routing.EnsureSeparator(prefix) + u.Host
-	return u.String(), true
 }

--- a/internal/mcp-router/resource_rewrite_test.go
+++ b/internal/mcp-router/resource_rewrite_test.go
@@ -203,33 +203,6 @@ func TestResourceURIRewriter_OversizedLineForwardedUnrewrittenNotBufferedForever
 	}
 }
 
-func TestInjectResourcePrefix(t *testing.T) {
-	tests := []struct {
-		name    string
-		uri     string
-		prefix  string
-		wantURI string
-		wantOK  bool
-	}{
-		{"basic prefix injection", "ui://template.html", "insights", "ui://insights_template.html", true},
-		{"prefix already has separator", "ui://template.html", "insights_", "ui://insights_template.html", true},
-		{"non-ui scheme untouched", "https://example.com/x.html", "insights", "https://example.com/x.html", false},
-		{"malformed uri untouched", "ui://\x7fbad", "insights", "ui://\x7fbad", false},
-		{"empty prefix untouched host", "ui://template.html", "", "ui://template.html", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok := injectResourcePrefix(tt.uri, tt.prefix)
-			if ok != tt.wantOK {
-				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
-			}
-			if got != tt.wantURI {
-				t.Errorf("got %q, want %q", got, tt.wantURI)
-			}
-		})
-	}
-}
-
 func contains(haystack []byte, needle string) bool {
 	return bytes.Contains(haystack, []byte(needle))
 }

--- a/internal/routing/mcp_request.go
+++ b/internal/routing/mcp_request.go
@@ -333,3 +333,39 @@ func EnsureSeparator(prefix string) string {
 	}
 	return prefix
 }
+
+// InjectResourcePrefix injects prefix into a ui:// URI's authority segment
+// (ui://template.html -> ui://<prefix_>template.html). Non-ui:// and
+// malformed URIs are returned unchanged with ok=false.
+func InjectResourcePrefix(uri, prefix string) (rewritten string, ok bool) {
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != "ui" {
+		return uri, false
+	}
+	u.User = nil // never forward upstream credentials to clients
+	u.Host = EnsureSeparator(prefix) + u.Host
+	return u.String(), true
+}
+
+// StripResourcePrefix removes prefix from a ui:// URI's authority segment,
+// the inverse of InjectResourcePrefix. Non-ui:// and malformed URIs are
+// returned unchanged.
+func StripResourcePrefix(uri, prefix string) string {
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != "ui" || u.Host == "" {
+		return uri
+	}
+	u.Host = StripAuthorityPrefix(u.Host, prefix)
+	return u.String()
+}
+
+// StripAuthorityPrefix removes prefix and its separator from an authority
+// string. For authority "app_example.com" with prefix "app", returns
+// "example.com". If the authority doesn't start with the prefix, it's
+// returned unchanged.
+func StripAuthorityPrefix(authority, prefix string) string {
+	if prefix == "" {
+		return authority
+	}
+	return strings.TrimPrefix(authority, EnsureSeparator(prefix))
+}

--- a/internal/routing/mcp_request_test.go
+++ b/internal/routing/mcp_request_test.go
@@ -1,0 +1,89 @@
+package routing
+
+import "testing"
+
+func TestInjectResourcePrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		prefix  string
+		wantURI string
+		wantOK  bool
+	}{
+		{"basic prefix injection", "ui://template.html", "insights", "ui://insights_template.html", true},
+		{"prefix already has separator", "ui://template.html", "insights_", "ui://insights_template.html", true},
+		{"non-ui scheme untouched", "https://example.com/x.html", "insights", "https://example.com/x.html", false},
+		{"malformed uri untouched", "ui://\x7fbad", "insights", "ui://\x7fbad", false},
+		{"empty prefix untouched host", "ui://template.html", "", "ui://template.html", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := InjectResourcePrefix(tt.uri, tt.prefix)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.wantURI {
+				t.Errorf("got %q, want %q", got, tt.wantURI)
+			}
+		})
+	}
+}
+
+func TestStripResourcePrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		prefix  string
+		wantURI string
+	}{
+		{"basic prefix stripped", "ui://insights_template.html", "insights", "ui://template.html"},
+		{"prefix already has separator", "ui://insights_template.html", "insights_", "ui://template.html"},
+		{"non-ui scheme untouched", "https://example.com/x.html", "insights", "https://example.com/x.html"},
+		{"malformed uri untouched", "ui://\x7fbad", "insights", "ui://\x7fbad"},
+		{"host without prefix untouched", "ui://template.html", "insights", "ui://template.html"},
+		{"empty prefix untouched", "ui://template.html", "", "ui://template.html"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripResourcePrefix(tt.uri, tt.prefix)
+			if got != tt.wantURI {
+				t.Errorf("got %q, want %q", got, tt.wantURI)
+			}
+		})
+	}
+}
+
+func TestInjectThenStripResourcePrefix_RoundTrips(t *testing.T) {
+	uri := "ui://template.html"
+	prefix := "insights"
+
+	injected, ok := InjectResourcePrefix(uri, prefix)
+	if !ok {
+		t.Fatalf("InjectResourcePrefix(%q, %q) returned ok=false", uri, prefix)
+	}
+	if got := StripResourcePrefix(injected, prefix); got != uri {
+		t.Errorf("StripResourcePrefix(%q, %q) = %q, want %q", injected, prefix, got, uri)
+	}
+}
+
+func TestStripAuthorityPrefix(t *testing.T) {
+	tests := []struct {
+		name          string
+		authority     string
+		prefix        string
+		wantAuthority string
+	}{
+		{"basic prefix stripped", "app_example.com", "app", "example.com"},
+		{"prefix already has separator", "app_example.com", "app_", "example.com"},
+		{"authority without matching prefix untouched", "example.com", "app", "example.com"},
+		{"empty prefix untouched", "example.com", "", "example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripAuthorityPrefix(tt.authority, tt.prefix)
+			if got != tt.wantAuthority {
+				t.Errorf("got %q, want %q", got, tt.wantAuthority)
+			}
+		})
+	}
+}

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -323,24 +322,12 @@ func (r *Router202511) routeResourceRead(ctx context.Context, table RoutingTable
 
 	headers[MethodHeader] = mcpReq.Method
 	mcpReq.ServerName = serverInfo.Name
-	upstreamURI := stripResourcePrefix(resourceURI, serverInfo.Prefix)
+	upstreamURI := StripResourcePrefix(resourceURI, serverInfo.Prefix)
 	headers[ResourceHeader] = upstreamURI
 	mcpReq.ReWriteResourceURI(upstreamURI)
 	headers[MCPServerNameHeader] = serverInfo.Name
 
 	return r.routeToUpstream(ctx, span, mcpReq, serverInfo, headers)
-}
-
-// stripResourcePrefix removes prefix from a ui:// URI's authority segment,
-// reconstructing the original upstream URI - the inverse of the broker's
-// rewriteResourceURI. Non-ui:// and malformed URIs are returned unchanged.
-func stripResourcePrefix(uri, prefix string) string {
-	u, err := url.Parse(uri)
-	if err != nil || u.Scheme != "ui" || u.Host == "" {
-		return uri
-	}
-	u.Host = strings.TrimPrefix(u.Host, EnsureSeparator(prefix))
-	return u.String()
 }
 
 func (r *Router202511) routeToUpstream(ctx context.Context, span trace.Span, mcpReq *MCPRequest, serverInfo *config.MCPServer, headers map[string]string) *Decision {


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/Kuadrant/mcp-gateway/pull/1391#pullrequestreview-4963470610, where @david-martin  flagged `injectResourcePrefix`/`rewriteResourceURI` and the two `stripResourcePrefix` implementations were duplicated between the router and broker.

Consolidates all four into `internal/routing`, next to `EnsureSeparator`, which they already both depend on:

- `InjectResourcePrefix` — absorbs the router's `injectResourcePrefix` and the broker's `rewriteResourceURI` (identical bodies)
- `StripResourcePrefix` — promoted from the router's already-`internal/routing`-local `stripResourcePrefix`, now exported
- `StripAuthorityPrefix` — absorbs the broker's authority-string `stripResourcePrefix`

## Test plan

- `go test -race ./...` passes
-  `make lint-go` passes
- Added direct unit test coverage for `StripResourcePrefix`/`StripAuthorityPrefix` (previously only covered indirectly), plus an inject/strip round-trip test
