### PR TITLE
chore: harden Dockerfiles to run as non-root (DS-0002)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,18 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -o mcp_gateway ./cmd
 
 FROM alpine:3.22.1
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates \
+    && addgroup -S appgroup \
+    && adduser -S -G appgroup -u 65532 appuser
 
 WORKDIR /app
 
 COPY --from=builder /workspace/mcp_gateway .
 
-RUN chmod +x mcp_gateway
+RUN chmod +x mcp_gateway \
+    && chown appuser:appgroup mcp_gateway
+
+USER 65532
 
 # default to standalone mode with config file
 # add the `--controller` flag for controller mode

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -14,13 +14,18 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o mcp_controller cmd/main.go
 
 FROM alpine:3.22.1
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates \
+    && addgroup -S appgroup \
+    && adduser -S -G appgroup -u 65532 appuser
 
 WORKDIR /app
 
 COPY --from=builder /workspace/mcp_controller .
 
-RUN chmod +x mcp_controller
+RUN chmod +x mcp_controller \
+    && chown appuser:appgroup mcp_controller
+
+USER 65532
 
 # default to standalone mode with config file
 # add the `--controller` flag for controller mode

--- a/tests/perf/mock-server/Dockerfile
+++ b/tests/perf/mock-server/Dockerfile
@@ -6,7 +6,11 @@ COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -o perf-mock-server .
 
 FROM alpine:3.22.1
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates \
+    && addgroup -S appgroup \
+    && adduser -S -G appgroup -u 65532 appuser
 WORKDIR /app
 COPY --from=builder /workspace/perf-mock-server .
+RUN chown appuser:appgroup perf-mock-server
+USER 65532
 CMD ["./perf-mock-server", "--addr=:8080"]

--- a/tests/servers/server2/Dockerfile
+++ b/tests/servers/server2/Dockerfile
@@ -14,6 +14,10 @@ COPY tests/servers/server2/ tests/servers/server2/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server ./tests/servers/server2/
 
-FROM alpine:latest
+FROM alpine:3.22.1
+RUN addgroup -S appgroup \
+    && adduser -S -G appgroup -u 65532 appuser
 COPY --from=builder /mcp-test-server /mcp-test-server
+RUN chown appuser:appgroup /mcp-test-server
+USER 65532
 CMD ["/mcp-test-server"]

--- a/tests/servers/stateless-server/Dockerfile
+++ b/tests/servers/stateless-server/Dockerfile
@@ -12,6 +12,10 @@ COPY tests/servers/stateless-server/ tests/servers/stateless-server/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server ./tests/servers/stateless-server/
 
-FROM alpine:latest
+FROM alpine:3.22.1
+RUN addgroup -S appgroup \
+    && adduser -S -G appgroup -u 65532 appuser
 COPY --from=builder /mcp-test-server /mcp-test-server
+RUN chown appuser:appgroup /mcp-test-server
+USER 65532
 CMD ["/mcp-test-server"]

--- a/tests/servers/user-specific-server/Dockerfile
+++ b/tests/servers/user-specific-server/Dockerfile
@@ -14,6 +14,10 @@ COPY tests/servers/user-specific-server/ tests/servers/user-specific-server/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /mcp-test-server ./tests/servers/user-specific-server/
 
-FROM alpine:latest
+FROM alpine:3.22.1
+RUN addgroup -S appgroup \
+    && adduser -S -G appgroup -u 65532 appuser
 COPY --from=builder /mcp-test-server /mcp-test-server
+RUN chown appuser:appgroup /mcp-test-server
+USER 65532
 CMD ["/mcp-test-server"]


### PR DESCRIPTION
## Description

This PR addresses the security hardening requested in #1392 and resolves the pre-existing Trivy DS-0002 finding flagged during the recent Go toolchain bump. 

The final Alpine stages across the project's Dockerfiles have been updated to execute as a non-root user, reducing the potential impact in the event of a container compromise.

### Changes Made
* Created a dedicated non-root user/group (e.g., `appuser`) in the final Alpine runtime stages.
* Updated `COPY` commands and file permissions to ensure the newly created non-root user has the necessary execution rights for the compiled Go binaries.
* Added the `USER` directive to all affected final stages so the container defaults to the non-root user at runtime.

### Affected Files
* `Dockerfile`
* `Dockerfile.controller`
* `tests/perf/mock-server/Dockerfile`
* `tests/servers/server2/Dockerfile`
* `tests/servers/stateless-server/Dockerfile`
* `tests/servers/user-specific-server/Dockerfile`

### Testing Performed
* Built all affected Docker images locally to ensure the multi-stage builds complete successfully.
* Verified that the containers start and run their intended application processes correctly without permission errors.
* (Optional) Ran a local Trivy scan to confirm DS-0002 is no longer reported.

Fixes #1392