### PR TITLE
fix(ci): bake node image by fetching content, not unpacking

### DIFF
--- a/build/ci-node.mk
+++ b/build/ci-node.mk
@@ -18,8 +18,9 @@ TEST_SERVER_IMAGES = test-server1 test-server2 test-server3 test-api-key-server 
 	test-everything-server test-custom-response-server test-user-specific-server \
 	test-stateless-server test-a2a-server
 
-# buildx builder with the security.insecure entitlement: containerd's layer
-# extraction in the bake RUN step needs mount(2), which plain builds deny
+# dedicated docker-container buildx builder: needed to push straight from the
+# builder in CI. the bake RUN only fetches content (no layer unpack), so no
+# security.insecure entitlement is required
 CI_NODE_BUILDER = mcp-ci-node-baker
 # true pushes straight from the builder (CI), false loads into the local
 # docker image store
@@ -61,10 +62,9 @@ ci-node-image-build: ## Bake e2e infra and test server images into a kind node i
 	tag="$$(./utils/ci-node-image-hash.sh)"; \
 	if [ "$(CI_NODE_IMAGE_PUSH)" = "true" ]; then output_flag="--push"; else output_flag="--load"; fi; \
 	$(CONTAINER_ENGINE) buildx inspect $(CI_NODE_BUILDER) >/dev/null 2>&1 \
-		|| $(CONTAINER_ENGINE) buildx create --name $(CI_NODE_BUILDER) --driver docker-container \
-			--buildkitd-flags '--allow-insecure-entitlement security.insecure'; \
+		|| $(CONTAINER_ENGINE) buildx create --name $(CI_NODE_BUILDER) --driver docker-container; \
 	echo "Baking $(CI_NODE_IMAGE):$$tag ($$output_flag)"; \
-	$(CONTAINER_ENGINE) buildx build --builder $(CI_NODE_BUILDER) --allow security.insecure $$output_flag \
+	$(CONTAINER_ENGINE) buildx build --builder $(CI_NODE_BUILDER) $$output_flag \
 		-f $(CI_NODE_DOCKERFILE) \
 		--build-arg KIND_NODE_IMAGE="$(KIND_NODE_IMAGE)" \
 		--build-arg BAKED_IMAGE_REFS="$$refs" \

--- a/build/ci-node/Dockerfile
+++ b/build/ci-node/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1-labs
+# syntax=docker/dockerfile:1
 
 # kindest/node with the e2e infra and test-server images pre-seeded into the
 # containerd content store. built by `make ci-node-image-build` (which
@@ -6,22 +6,31 @@
 # published by .github/workflows/ci-node-image.yaml under the tag printed by
 # utils/ci-node-image-hash.sh, and consumed by the e2e workflows on a tag hit.
 # kubeadm init and the installs still run normally at cluster create time;
-# only the image pulls become no-ops. on a tag miss e2e falls back to stock
-# kindest/node and the standard pull path.
+# only the network image pulls become no-ops. on a tag miss e2e falls back to
+# stock kindest/node and the standard pull path.
 
 ARG KIND_NODE_IMAGE
 FROM ${KIND_NODE_IMAGE}
 
 # space-separated image refs to seed
 ARG BAKED_IMAGE_REFS
+# platform to fetch (linux/amd64 in CI); provided automatically by buildkit
+ARG TARGETPLATFORM
 
 # containerd is not running during build, so start it for the duration of the
-# RUN step, pull in parallel with one retry each (mirroring the Makefile's
-# pull-images-into-kind macro) and stop it cleanly so the image store the
-# layer captures is consistent. layer extraction mounts tmpmounts under
-# /var/lib/containerd, hence --security=insecure (granted by the buildx
-# builder ci-node-image-build creates)
-RUN --security=insecure \
+# RUN step, fetch each image's content in parallel with one retry each and stop
+# it cleanly so the content store the layer captures is consistent.
+#
+# `content fetch` seeds the blobs and registers the image without unpacking it
+# into snapshots. unpacking here is impossible: converting an image layer's
+# aufs whiteouts to overlayfs whiteouts creates device nodes in the overlay
+# snapshotter's upperdir, and that upperdir sits on buildkit's own overlay
+# rootfs (overlay-on-overlay), where the kernel denies whiteout creation
+# ("operation not permitted"). kind unpacks each image at runtime on first use,
+# on its single-level overlay where whiteout creation works. skipping the
+# build-time unpack also means this RUN needs no extra mounts, so no
+# security.insecure entitlement.
+RUN \
     [ -n "${BAKED_IMAGE_REFS}" ] || { echo "BAKED_IMAGE_REFS not set"; exit 1; }; \
     containerd >/var/log/containerd-bake.log 2>&1 & \
     containerd_pid=$!; \
@@ -33,14 +42,14 @@ RUN --security=insecure \
         || { echo "ERROR: containerd failed to start"; cat /var/log/containerd-bake.log; exit 1; }; \
     pids=""; \
     for ref in ${BAKED_IMAGE_REFS}; do \
-        ( ctr --namespace k8s.io images pull "${ref}" >/dev/null \
-            || { echo "Retrying pull of ${ref}..."; sleep 2; \
-                ctr --namespace k8s.io images pull "${ref}" >/dev/null; } ) & \
+        ( ctr --namespace k8s.io content fetch --platform "${TARGETPLATFORM}" "${ref}" >/dev/null \
+            || { echo "Retrying fetch of ${ref}..."; sleep 2; \
+                ctr --namespace k8s.io content fetch --platform "${TARGETPLATFORM}" "${ref}" >/dev/null; } ) & \
         pids="${pids} $!"; \
     done; \
     rc=0; \
     for pid in ${pids}; do wait "${pid}" || rc=1; done; \
-    [ "${rc}" -eq 0 ] || { echo "ERROR: failed to pull one or more images"; exit 1; }; \
+    [ "${rc}" -eq 0 ] || { echo "ERROR: failed to fetch one or more images"; exit 1; }; \
     echo "Seeded images:"; \
     ctr --namespace k8s.io images ls -q; \
     kill "${containerd_pid}"; \


### PR DESCRIPTION
The CI node bake has failed on every run since it was added (16/16). e2e falls back to normal pulls, so it went unnoticed.

## Problem
The bake ran `ctr images pull` inside a buildkit `RUN` step, which unpacks each layer. Unpacking creates overlayfs whiteouts on buildkit's own overlay rootfs (overlay-on-overlay), which the kernel refuses:

```
failed to convert whiteout file "var/log/apt/.wh.eipp.log.xz": operation not permitted
```

## Fix
Fetch content only (`ctr content fetch`), don't unpack. The images are baked in packed form; kind unpacks them at runtime where it works. Same benefit (no network pull during e2e), minus the step that can't work at build time. Also drops the now-unneeded `security.insecure` builder.

Reproduced the failure and verified the fix locally. Dockerfile change bumps the content hash, so merge auto-triggers a rebake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI image fetching to avoid requiring insecure build permissions.
  * Added platform-aware image retrieval for more reliable multi-platform builds.
  * Preserved retry handling and failure reporting during image preparation.

* **Chores**
  * Updated the CI builder configuration to use safer default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->