### PR TITLE
test(e2e): derive resources-federation server hostnames from E2E_DOMAIN

### DIFF
--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -164,6 +164,11 @@ func resourcesFederationPublicHostDefault() string {
 	return "mcp.resources-federation." + e2eDomain
 }
 
+// resourcesFederationServerHost returns a server hostname for the resources-federation listener.
+func resourcesFederationServerHost(subdomain string) string {
+	return subdomain + ".resources-federation." + e2eDomain
+}
+
 // public hosts - derived from E2E_DOMAIN
 var (
 	gatewayPublicHost             = goenv.GetDefault("GATEWAY_PUBLIC_HOST", gatewayPublicHostDefault())

--- a/tests/e2e/resources_federation_test.go
+++ b/tests/e2e/resources_federation_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("jwttest_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("jwtserver.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("jwtserver")).
 			Build()
 		regObjects := reg.GetObjects()
 		testResources = append(testResources, regObjects...)
@@ -157,7 +157,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("emptyclaim_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("emptyclaimserver.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("emptyclaimserver")).
 			Build()
 		regObjects := reg.GetObjects()
 		testResources = append(testResources, regObjects...)
@@ -199,7 +199,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("everything-server", 9090).
 			WithPrefix("elicit_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("elicitserver.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("elicitserver")).
 			Build()
 		regObjects := reg.GetObjects()
 		testResources = append(testResources, regObjects...)
@@ -253,7 +253,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("widget_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("widgetserver.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("widgetserver")).
 			Build()
 		regObjects := reg.GetObjects()
 		testResources = append(testResources, regObjects...)
@@ -288,7 +288,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("widgeta_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("widgetservera.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("widgetservera")).
 			Build()
 		testResources = append(testResources, regA.GetObjects()...)
 		serverA := regA.Register(ctx)
@@ -297,7 +297,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("widgetb_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("widgetserverb.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("widgetserverb")).
 			Build()
 		testResources = append(testResources, regB.GetObjects()...)
 		serverB := regB.Register(ctx)
@@ -336,7 +336,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("plain_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("plainserver.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("plainserver")).
 			Build()
 		regObjects := reg.GetObjects()
 		testResources = append(testResources, regObjects...)
@@ -377,7 +377,7 @@ var _ = Describe("Resources Federation", Ordered, func() {
 			ForInternalService("mcp-test-server1", 9090).
 			WithPrefix("nonui_").
 			WithSectionName(ResourcesFederationListenerName).
-			WithHostname("nonuiserver.resources-federation.127-0-0-1.sslip.io").
+			WithHostname(resourcesFederationServerHost("nonuiserver")).
 			Build()
 		regObjects := reg.GetObjects()
 		testResources = append(testResources, regObjects...)


### PR DESCRIPTION
The resources federation e2e suite hardcoded `*.resources-federation.127-0-0-1.sslip.io` server hostnames. On non-Kind clusters the `resources-federation` listener hostname is `*.resources-federation.<cluster-domain>`, so the per-registration HTTPRoutes never attached to the listener and the suite couldn't pass there.

Every other isolated-listener suite derives server hostnames from `E2E_DOMAIN` (`toolDiscServerHostDefault`, `protocol2026ServerHost`). This adds `resourcesFederationServerHost(subdomain)` in the same shape and uses it for all 8 registrations.

Surfaced by the OpenShift e2e pipeline nightly, which failed in `BeforeAll` on the resources federation suite. That run also needs a matching `resources-federation` listener added in the pipeline (separate change in testsuite-pipelines); this PR is the mcp-gateway side.

No behaviour change on Kind: `resourcesFederationServerHost` resolves to the same `*.resources-federation.127-0-0-1.sslip.io` under the default domain.
