### PR TITLE
test(e2e): improve wait for deployment rollout in AuthPolicy suite

### DIFF
--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -34,6 +34,9 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		ext := &mcpv1.MCPGatewayExtension{}
 		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: MCPExtensionName, Namespace: SystemNamespace}, ext)).To(Succeed())
 		if ext.Spec.TrustedHeadersKey == nil {
+			gen, err := GetDeploymentGeneration(ctx, SystemNamespace, "mcp-gateway")
+			Expect(err).NotTo(HaveOccurred())
+
 			patch := client.MergeFrom(ext.DeepCopy())
 			ext.Spec.TrustedHeadersKey = &mcpv1.TrustedHeadersKey{
 				SecretName: "trusted-headers-public-key",
@@ -42,7 +45,7 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 			Expect(k8sClient.Patch(ctx, ext, patch)).To(Succeed())
 
 			By("Waiting for gateway to roll out with trusted headers")
-			Expect(WaitForDeploymentReady(ctx, SystemNamespace, "mcp-gateway")).To(Succeed())
+			Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, "mcp-gateway", 1, gen)).To(Succeed())
 		}
 
 		By("Creating MCPServerRegistrations matching Keycloak client IDs")


### PR DESCRIPTION
## What does this PR do?

Using more reliable wait for Deployment to get ready. Similar approach is used in the testsuite in several places already.

### Verification Steps
Eye review only, all check passing should suffice for verification.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [ ] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability when updating trusted-header configuration by waiting for the updated deployment generation to become available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->