### PR TITLE
fix(router): retry transient hairpin init + close idle backend sessions

### DIFF
--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -385,6 +385,7 @@ func (r *Router202511) routeToUpstream(ctx context.Context, span trace.Span, mcp
 
 	var remoteMCPServerSession string
 	if id, ok := exists[mcpReq.ServerName]; ok {
+		r.resetClientSessionIdle(mcpReq.GetSessionID()+"/"+mcpReq.ServerName, mcpReq.GetSessionID(), mcpReq.ServerName)
 		r.Logger.DebugContext(ctx, "found session in cache", "session id", internaljwt.LogSafeSessionID(mcpReq.GetSessionID()), "for server", serverInfo.Name, "remote session", internaljwt.LogSafeSessionID(id))
 		remoteMCPServerSession = id
 	}
@@ -743,11 +744,16 @@ func (r *Router202511) resetClientSessionIdle(groupKey, sessionID, serverName st
 	r.clientSessionsMu.Unlock()
 }
 
-// closeClientSession closes the idle backend handle and drops its per-server
-// cache mapping. It is a no-op if the entry was re-armed (gen mismatch) since
-// this callback fired, avoiding a race where a concurrent tool call routes to a
-// handle about to be closed. The gateway session is left intact (or fully
-// deleted when this was its last server) so the next tool call re-inits lazily.
+// closeClientSession drops the per-server cache mapping, then closes the idle
+// backend handle. The gen check makes it a no-op if the entry was re-armed since
+// this callback fired. Ordering: the cache mapping is removed before the handle
+// closes so new tool calls miss the cache and re-init a fresh handle rather than
+// finding a mapping to a dying one. A residual narrow window remains: a call that
+// already read the mapping before RemoveServerSession can still route to the
+// handle as it closes, yielding one spurious failure the client retries. This is
+// bounded to genuinely idle sessions, since activity re-arms the timer via
+// resetClientSessionIdle before it can fire. The gateway session is left intact
+// (or fully deleted when this was its last server) so the next call re-inits.
 func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string, expectedGen uint64) {
 	r.clientSessionsMu.Lock()
 	entry, ok := r.clientSessions[groupKey]
@@ -761,20 +767,18 @@ func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	r.Logger.DebugContext(cleanupCtx, "closing idle backend client session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName)
+	if err := r.SessionCache.RemoveServerSession(cleanupCtx, sessionID, serverName); err != nil {
+		r.Logger.DebugContext(cleanupCtx, "failed to remove idle server session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName, "err", err)
+	} else if remaining, err := r.SessionCache.GetSession(cleanupCtx, sessionID); err == nil && len(remaining) == 0 {
+		// in-memory RemoveServerSession leaves an empty map behind (Redis drops
+		// the key on last field); delete the key when nothing remains.
+		if err := r.SessionCache.DeleteSessions(cleanupCtx, sessionID); err != nil {
+			r.Logger.DebugContext(cleanupCtx, "failed to delete emptied session", "session", internaljwt.LogSafeSessionID(sessionID), "err", err)
+		}
+	}
 	if entry.handle != nil {
 		if err := entry.handle.Close(); err != nil {
 			r.Logger.DebugContext(cleanupCtx, "failed to close idle client connection", "err", err)
-		}
-	}
-	if err := r.SessionCache.RemoveServerSession(cleanupCtx, sessionID, serverName); err != nil {
-		r.Logger.DebugContext(cleanupCtx, "failed to remove idle server session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName, "err", err)
-		return
-	}
-	// in-memory RemoveServerSession leaves an empty map behind (Redis drops the
-	// key on last field); delete the key when no servers or user tokens remain.
-	if remaining, err := r.SessionCache.GetSession(cleanupCtx, sessionID); err == nil && len(remaining) == 0 {
-		if err := r.SessionCache.DeleteSessions(cleanupCtx, sessionID); err != nil {
-			r.Logger.DebugContext(cleanupCtx, "failed to delete emptied session", "session", internaljwt.LogSafeSessionID(sessionID), "err", err)
 		}
 	}
 }

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +35,18 @@ const (
 	hairpinInitBaseBackoff = 100 * time.Millisecond
 )
 
+// clientSessionIdleTimeout closes a backend client session after inactivity so
+// idle upstream connections are not held for the full 24h JWT lifetime. Mirrors
+// the broker's SessionIdleTimeout. The next tool call re-inits lazily.
+const clientSessionIdleTimeout = 30 * time.Minute
+
+// clientSessionEntry tracks a live backend client handle and its idle timer,
+// keyed by gateway-session-id + server-name.
+type clientSessionEntry struct {
+	handle *mcp.ClientSession
+	timer  *time.Timer
+}
+
 // RoutingTableFunc returns the current routing table snapshot.
 //
 //nolint:revive // package-qualified name is clearer
@@ -51,7 +64,17 @@ type Router202511 struct {
 	TokenElicitationMap elicitation.Map
 	ElicitationEnabled  bool
 	Logger              *slog.Logger
+	IdleTimeout         time.Duration // backend client idle timeout; defaults to clientSessionIdleTimeout
 	initGroup           singleflight.Group
+	clientSessionsMu    sync.Mutex
+	clientSessions      map[string]*clientSessionEntry
+}
+
+func (r *Router202511) idleTimeout() time.Duration {
+	if r.IdleTimeout > 0 {
+		return r.IdleTimeout
+	}
+	return clientSessionIdleTimeout
 }
 
 var _ Router = &Router202511{}
@@ -546,6 +569,7 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 			return "", NewRouterErrorf(500, "failed to check for existing session: %w", err)
 		}
 		if id, ok := exists[mcpReq.ServerName]; ok {
+			r.resetClientSessionIdle(groupKey)
 			r.Logger.DebugContext(ctx, "found session in cache", "session id", internaljwt.LogSafeSessionID(mcpReq.GetSessionID()), "for server", mcpServerConfig.Name, "remote session", internaljwt.LogSafeSessionID(id))
 			return id, nil
 		}
@@ -657,13 +681,72 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 			}
 			return "", NewRouterError(500, fmt.Errorf("internal error"))
 		}
-		time.AfterFunc(ttl, sessionCloser)
+		r.registerClientSession(groupKey, mcpReq.GetSessionID(), mcpServerConfig.Name, clientHandle)
 		return remoteSessionID, nil
 	})
 	if err != nil {
 		return "", err
 	}
 	return result.(string), nil
+}
+
+// registerClientSession stores a live backend client handle and arms its idle
+// timer. Any prior handle for the same key is stopped and closed.
+func (r *Router202511) registerClientSession(groupKey, sessionID, serverName string, handle *mcp.ClientSession) {
+	entry := &clientSessionEntry{handle: handle}
+	entry.timer = time.AfterFunc(r.idleTimeout(), func() {
+		r.closeClientSession(groupKey, sessionID, serverName)
+	})
+	r.clientSessionsMu.Lock()
+	if r.clientSessions == nil {
+		r.clientSessions = make(map[string]*clientSessionEntry)
+	}
+	prev := r.clientSessions[groupKey]
+	r.clientSessions[groupKey] = entry
+	r.clientSessionsMu.Unlock()
+	if prev != nil {
+		prev.timer.Stop()
+		if prev.handle != nil {
+			if err := prev.handle.Close(); err != nil {
+				r.Logger.Debug("failed to close superseded client connection", "err", err)
+			}
+		}
+	}
+}
+
+// resetClientSessionIdle pushes back the idle timer on activity for a key.
+func (r *Router202511) resetClientSessionIdle(groupKey string) {
+	r.clientSessionsMu.Lock()
+	if entry, ok := r.clientSessions[groupKey]; ok {
+		entry.timer.Reset(r.idleTimeout())
+	}
+	r.clientSessionsMu.Unlock()
+}
+
+// closeClientSession closes the idle backend handle and drops its per-server
+// cache mapping. The gateway session is left intact so the next tool call
+// re-inits lazily.
+func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string) {
+	r.clientSessionsMu.Lock()
+	entry, ok := r.clientSessions[groupKey]
+	if ok {
+		delete(r.clientSessions, groupKey)
+	}
+	r.clientSessionsMu.Unlock()
+	if !ok {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	r.Logger.DebugContext(cleanupCtx, "closing idle backend client session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName)
+	if entry.handle != nil {
+		if err := entry.handle.Close(); err != nil {
+			r.Logger.DebugContext(cleanupCtx, "failed to close idle client connection", "err", err)
+		}
+	}
+	if err := r.SessionCache.RemoveServerSession(cleanupCtx, sessionID, serverName); err != nil {
+		r.Logger.DebugContext(cleanupCtx, "failed to remove idle server session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName, "err", err)
+	}
 }
 
 func (r *Router202511) resolveUpstreamToken(ctx context.Context, mcpReq *MCPRequest, serverInfo *config.MCPServer, headers map[string]string) (*ElicitationInfo, error) {

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -19,10 +19,19 @@ import (
 	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	"github.com/Kuadrant/mcp-gateway/internal/transport"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
+)
+
+// hairpin init retry budget for transient failures (connection refused,
+// transport reset) seen under concurrency. 4xx is never retried. total
+// backoff (100ms+200ms) stays well under the ext_proc message_timeout (10s).
+const (
+	hairpinInitMaxRetries  = 2
+	hairpinInitBaseBackoff = 100 * time.Millisecond
 )
 
 // RoutingTableFunc returns the current routing table snapshot.
@@ -590,15 +599,30 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 		}
 		passThroughHeaders[RoutingKey] = initToken
 		passThroughHeaders["mcp-init-host"] = mcpServerConfig.Hostname
-		clientHandle, err := r.InitForClient(ctx, routingCfg.MCPGatewayInternalHostname, mcpServerConfig, passThroughHeaders, mcpReq.ClientElicitation, r.HairpinClientPool)
-		if err != nil {
-			r.Logger.ErrorContext(ctx, "failed to get remote session ", "error", err)
-			mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
+		var clientHandle *mcp.ClientSession
+		for attempt := 0; ; attempt++ {
+			clientHandle, err = r.InitForClient(ctx, routingCfg.MCPGatewayInternalHostname, mcpServerConfig, passThroughHeaders, mcpReq.ClientElicitation, r.HairpinClientPool)
+			if err == nil {
+				break
+			}
 			var httpErr *transport.HTTPStatusError
 			if errors.As(err, &httpErr) && httpErr.Code >= 400 && httpErr.Code < 500 {
+				r.Logger.ErrorContext(ctx, "failed to get remote session", "error", err)
+				mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
 				return "", NewRouterError(int32(httpErr.Code), fmt.Errorf("failed to create session for mcp server: %w", err)) //nolint:gosec,nolintlint // code bounded to [400,499] by check above
 			}
-			return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
+			if attempt >= hairpinInitMaxRetries {
+				r.Logger.ErrorContext(ctx, "failed to get remote session", "error", err, "attempts", attempt+1)
+				mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
+				return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
+			}
+			backoff := hairpinInitBaseBackoff << attempt
+			r.Logger.WarnContext(ctx, "hairpin init failed, retrying", "attempt", attempt+1, "backoff", backoff, "error", err)
+			select {
+			case <-ctx.Done():
+				return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", ctx.Err())
+			case <-time.After(backoff):
+			}
 		}
 		var sessionCloser = func() {
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -41,10 +41,13 @@ const (
 const clientSessionIdleTimeout = 30 * time.Minute
 
 // clientSessionEntry tracks a live backend client handle and its idle timer,
-// keyed by gateway-session-id + server-name.
+// keyed by gateway-session-id + server-name. gen is a monotonic arm id: the
+// idle callback only closes when the entry's gen still matches the value it was
+// armed with, so a Reset that races an already-fired timer is a no-op.
 type clientSessionEntry struct {
 	handle *mcp.ClientSession
 	timer  *time.Timer
+	gen    uint64
 }
 
 // RoutingTableFunc returns the current routing table snapshot.
@@ -65,9 +68,11 @@ type Router202511 struct {
 	ElicitationEnabled  bool
 	Logger              *slog.Logger
 	IdleTimeout         time.Duration // backend client idle timeout; defaults to clientSessionIdleTimeout
+	InitBackoff         time.Duration // hairpin init base backoff; defaults to hairpinInitBaseBackoff
 	initGroup           singleflight.Group
 	clientSessionsMu    sync.Mutex
 	clientSessions      map[string]*clientSessionEntry
+	sessionGen          atomic.Uint64
 }
 
 func (r *Router202511) idleTimeout() time.Duration {
@@ -75,6 +80,13 @@ func (r *Router202511) idleTimeout() time.Duration {
 		return r.IdleTimeout
 	}
 	return clientSessionIdleTimeout
+}
+
+func (r *Router202511) initBackoff() time.Duration {
+	if r.InitBackoff > 0 {
+		return r.InitBackoff
+	}
+	return hairpinInitBaseBackoff
 }
 
 var _ Router = &Router202511{}
@@ -569,7 +581,7 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 			return "", NewRouterErrorf(500, "failed to check for existing session: %w", err)
 		}
 		if id, ok := exists[mcpReq.ServerName]; ok {
-			r.resetClientSessionIdle(groupKey)
+			r.resetClientSessionIdle(groupKey, mcpReq.GetSessionID(), mcpReq.ServerName)
 			r.Logger.DebugContext(ctx, "found session in cache", "session id", internaljwt.LogSafeSessionID(mcpReq.GetSessionID()), "for server", mcpServerConfig.Name, "remote session", internaljwt.LogSafeSessionID(id))
 			return id, nil
 		}
@@ -640,7 +652,7 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 				mcpotel.SpanError(initSpan, err, "failed to initialize backend session")
 				return "", NewRouterErrorf(500, "failed to create session for mcp server: %w", err)
 			}
-			backoff := hairpinInitBaseBackoff << attempt
+			backoff := r.initBackoff() << attempt
 			r.Logger.WarnContext(ctx, "hairpin init failed, retrying", "attempt", attempt+1, "backoff", backoff, "error", err)
 			select {
 			case <-ctx.Done():
@@ -693,9 +705,10 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 // registerClientSession stores a live backend client handle and arms its idle
 // timer. Any prior handle for the same key is stopped and closed.
 func (r *Router202511) registerClientSession(groupKey, sessionID, serverName string, handle *mcp.ClientSession) {
-	entry := &clientSessionEntry{handle: handle}
+	gen := r.sessionGen.Add(1)
+	entry := &clientSessionEntry{handle: handle, gen: gen}
 	entry.timer = time.AfterFunc(r.idleTimeout(), func() {
-		r.closeClientSession(groupKey, sessionID, serverName)
+		r.closeClientSession(groupKey, sessionID, serverName, gen)
 	})
 	r.clientSessionsMu.Lock()
 	if r.clientSessions == nil {
@@ -714,28 +727,37 @@ func (r *Router202511) registerClientSession(groupKey, sessionID, serverName str
 	}
 }
 
-// resetClientSessionIdle pushes back the idle timer on activity for a key.
-func (r *Router202511) resetClientSessionIdle(groupKey string) {
+// resetClientSessionIdle re-arms the idle timer on activity for a key. It bumps
+// gen and installs a fresh timer so an already-fired callback (carrying the old
+// gen) becomes a no-op.
+func (r *Router202511) resetClientSessionIdle(groupKey, sessionID, serverName string) {
 	r.clientSessionsMu.Lock()
 	if entry, ok := r.clientSessions[groupKey]; ok {
-		entry.timer.Reset(r.idleTimeout())
+		gen := r.sessionGen.Add(1)
+		entry.gen = gen
+		entry.timer.Stop()
+		entry.timer = time.AfterFunc(r.idleTimeout(), func() {
+			r.closeClientSession(groupKey, sessionID, serverName, gen)
+		})
 	}
 	r.clientSessionsMu.Unlock()
 }
 
 // closeClientSession closes the idle backend handle and drops its per-server
-// cache mapping. The gateway session is left intact so the next tool call
-// re-inits lazily.
-func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string) {
+// cache mapping. It is a no-op if the entry was re-armed (gen mismatch) since
+// this callback fired, avoiding a race where a concurrent tool call routes to a
+// handle about to be closed. The gateway session is left intact (or fully
+// deleted when this was its last server) so the next tool call re-inits lazily.
+func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string, expectedGen uint64) {
 	r.clientSessionsMu.Lock()
 	entry, ok := r.clientSessions[groupKey]
-	if ok {
-		delete(r.clientSessions, groupKey)
-	}
-	r.clientSessionsMu.Unlock()
-	if !ok {
+	if !ok || entry.gen != expectedGen {
+		r.clientSessionsMu.Unlock()
 		return
 	}
+	delete(r.clientSessions, groupKey)
+	r.clientSessionsMu.Unlock()
+
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	r.Logger.DebugContext(cleanupCtx, "closing idle backend client session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName)
@@ -746,6 +768,14 @@ func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string
 	}
 	if err := r.SessionCache.RemoveServerSession(cleanupCtx, sessionID, serverName); err != nil {
 		r.Logger.DebugContext(cleanupCtx, "failed to remove idle server session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName, "err", err)
+		return
+	}
+	// in-memory RemoveServerSession leaves an empty map behind (Redis drops the
+	// key on last field); delete the key when no servers or user tokens remain.
+	if remaining, err := r.SessionCache.GetSession(cleanupCtx, sessionID); err == nil && len(remaining) == 0 {
+		if err := r.SessionCache.DeleteSessions(cleanupCtx, sessionID); err != nil {
+			r.Logger.DebugContext(cleanupCtx, "failed to delete emptied session", "session", internaljwt.LogSafeSessionID(sessionID), "err", err)
+		}
 	}
 }
 

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -752,8 +752,10 @@ func (r *Router202511) resetClientSessionIdle(groupKey, sessionID, serverName st
 // already read the mapping before RemoveServerSession can still route to the
 // handle as it closes, yielding one spurious failure the client retries. This is
 // bounded to genuinely idle sessions, since activity re-arms the timer via
-// resetClientSessionIdle before it can fire. The gateway session is left intact
-// (or fully deleted when this was its last server) so the next call re-inits.
+// resetClientSessionIdle before it can fire. RemoveServerSession drops the
+// gateway session key when this was its last server (matching Redis semantics),
+// leaving the separate client-elicitation flag intact for the still-valid JWT so
+// the next call re-inits lazily with elicitation preserved.
 func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string, expectedGen uint64) {
 	r.clientSessionsMu.Lock()
 	entry, ok := r.clientSessions[groupKey]
@@ -769,12 +771,6 @@ func (r *Router202511) closeClientSession(groupKey, sessionID, serverName string
 	r.Logger.DebugContext(cleanupCtx, "closing idle backend client session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName)
 	if err := r.SessionCache.RemoveServerSession(cleanupCtx, sessionID, serverName); err != nil {
 		r.Logger.DebugContext(cleanupCtx, "failed to remove idle server session", "session", internaljwt.LogSafeSessionID(sessionID), "server", serverName, "err", err)
-	} else if remaining, err := r.SessionCache.GetSession(cleanupCtx, sessionID); err == nil && len(remaining) == 0 {
-		// in-memory RemoveServerSession leaves an empty map behind (Redis drops
-		// the key on last field); delete the key when nothing remains.
-		if err := r.SessionCache.DeleteSessions(cleanupCtx, sessionID); err != nil {
-			r.Logger.DebugContext(cleanupCtx, "failed to delete emptied session", "session", internaljwt.LogSafeSessionID(sessionID), "err", err)
-		}
 	}
 	if entry.handle != nil {
 		if err := entry.handle.Close(); err != nil {

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"k8s.io/utils/ptr"
 
@@ -1414,6 +1415,56 @@ func TestInitializeMCPServerSession_HairpinRetry(t *testing.T) {
 			require.Equal(t, tc.wantCalls, calls, "InitForClient call count")
 		})
 	}
+}
+
+func TestClientSessionIdleClose(t *testing.T) {
+	serverConfigs := []*config.MCPServer{
+		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
+	}
+	router, token := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+	router.IdleTimeout = 20 * time.Millisecond
+	ctx := context.Background()
+
+	_, err := router.SessionCache.AddSession(ctx, token, "dummy", "remote-sid", time.Hour)
+	require.NoError(t, err)
+
+	groupKey := token + "/dummy"
+	router.registerClientSession(groupKey, token, "dummy", nil)
+
+	router.clientSessionsMu.Lock()
+	_, present := router.clientSessions[groupKey]
+	router.clientSessionsMu.Unlock()
+	require.True(t, present, "session must be registered")
+
+	require.Eventually(t, func() bool {
+		router.clientSessionsMu.Lock()
+		_, stillTracked := router.clientSessions[groupKey]
+		router.clientSessionsMu.Unlock()
+		if stillTracked {
+			return false
+		}
+		exists, _ := router.SessionCache.GetSession(ctx, token)
+		_, mapped := exists["dummy"]
+		return !mapped
+	}, time.Second, 5*time.Millisecond, "idle timer must close the handle and drop the per-server mapping")
+}
+
+func TestClientSessionIdleReset(t *testing.T) {
+	serverConfigs := []*config.MCPServer{
+		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
+	}
+	router, token := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+	router.IdleTimeout = time.Hour
+
+	groupKey := token + "/dummy"
+	router.registerClientSession(groupKey, token, "dummy", nil)
+	router.resetClientSessionIdle(groupKey)
+
+	router.clientSessionsMu.Lock()
+	entry, present := router.clientSessions[groupKey]
+	router.clientSessionsMu.Unlock()
+	require.True(t, present, "reset must not drop the entry")
+	require.NotNil(t, entry.timer)
 }
 
 //nolint:dupl

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -1553,6 +1553,35 @@ func TestClientSessionIdleClose_KeepsSessionWithUserToken(t *testing.T) {
 	require.True(t, ok, "user token must survive idle close")
 }
 
+func TestClientSessionIdleClose_KeepsClientElicitationFlag(t *testing.T) {
+	serverConfigs := []*config.MCPServer{
+		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
+	}
+	router, token := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+	router.IdleTimeout = 20 * time.Millisecond
+	ctx := context.Background()
+
+	_, err := router.SessionCache.AddSession(ctx, token, "dummy", "remote-sid", time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, router.SessionCache.SetClientElicitation(ctx, token, time.Hour))
+
+	groupKey := token + "/dummy"
+	router.registerClientSession(groupKey, token, "dummy", nil)
+
+	require.Eventually(t, func() bool {
+		router.clientSessionsMu.Lock()
+		_, stillTracked := router.clientSessions[groupKey]
+		router.clientSessionsMu.Unlock()
+		return !stillTracked
+	}, time.Second, 5*time.Millisecond, "idle timer must fire")
+
+	// the JWT is still valid, so the elicitation flag must outlive the idle close;
+	// the client will not re-initialize and would otherwise lose elicitation support
+	elicit, err := router.SessionCache.GetClientElicitation(ctx, token)
+	require.NoError(t, err)
+	require.True(t, elicit, "client elicitation flag must survive idle close")
+}
+
 func TestClientSessionIdleReset(t *testing.T) {
 	serverConfigs := []*config.MCPServer{
 		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/transport"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const testSigningKey = "test-signing-key-must-be-at-least-32-bytes"
@@ -1568,6 +1569,37 @@ func TestClientSessionIdleReset(t *testing.T) {
 	router.clientSessionsMu.Unlock()
 	require.True(t, present, "reset must not drop the entry")
 	require.NotNil(t, entry.timer)
+}
+
+// TestRouteToUpstreamResetsIdleOnCacheHit guards the steady-state path: a tool
+// call served from the session cache must re-arm the idle timer, otherwise the
+// timer degrades to a fixed lifetime from init and closes actively-used sessions.
+func TestRouteToUpstreamResetsIdleOnCacheHit(t *testing.T) {
+	serverConfigs := []*config.MCPServer{
+		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
+	}
+	router, token := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+	router.IdleTimeout = time.Hour
+
+	ctx := context.Background()
+	if _, err := router.SessionCache.AddSession(ctx, token, "dummy", "remote-session-id", time.Hour); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	groupKey := token + "/dummy"
+	router.registerClientSession(groupKey, token, "dummy", nil)
+	router.clientSessionsMu.Lock()
+	genBefore := router.clientSessions[groupKey].gen
+	router.clientSessionsMu.Unlock()
+
+	mcpReq := &MCPRequest{JSONRPC: "2.0", Method: "tools/call", SessionID: token, ServerName: "dummy"}
+	decision := router.routeToUpstream(ctx, trace.SpanFromContext(ctx), mcpReq, serverConfigs[0], map[string]string{})
+	require.Nil(t, decision.Error, "cache hit should route without error")
+
+	router.clientSessionsMu.Lock()
+	genAfter := router.clientSessions[groupKey].gen
+	router.clientSessionsMu.Unlock()
+	require.Greater(t, genAfter, genBefore, "cache-hit fast path must re-arm the idle timer")
 }
 
 //nolint:dupl

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -1342,6 +1342,80 @@ func TestInitializeMCPServerSession_UpstreamErrorPropagation(t *testing.T) {
 	}
 }
 
+func TestInitializeMCPServerSession_HairpinRetry(t *testing.T) {
+	testCases := []struct {
+		name      string
+		initErr   error
+		wantCalls int
+	}{
+		{
+			name:      "transient error retried up to the budget",
+			initErr:   fmt.Errorf("failed to create client: %w", fmt.Errorf("dial tcp: connection refused")),
+			wantCalls: hairpinInitMaxRetries + 1,
+		},
+		{
+			name:      "5xx retried up to the budget",
+			initErr:   fmt.Errorf("failed to create client: %w", &transport.HTTPStatusError{Code: 502, Body: "Bad Gateway"}),
+			wantCalls: hairpinInitMaxRetries + 1,
+		},
+		{
+			name:      "4xx not retried",
+			initErr:   fmt.Errorf("failed to create client: %w", &transport.HTTPStatusError{Code: 403, Body: "denied"}),
+			wantCalls: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *clients.HairpinClientPool) (*mcp.ClientSession, error) {
+				calls++
+				return nil, tc.initErr
+			}
+
+			serverConfigs := []*config.MCPServer{
+				{
+					Name:     "dummy",
+					URL:      "http://localhost:8080/mcp",
+					Prefix:   "s_",
+					State:    "Enabled",
+					Hostname: "backend.example.com",
+				},
+			}
+			router, _ := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+			router.InitForClient = mockInitForClient
+			router.RoutingConfig.Store(&config.MCPServersConfig{
+				Servers:                    serverConfigs,
+				MCPGatewayInternalHostname: "mcp-gateway.local",
+			})
+
+			validToken := router.JWTManager.Generate()
+			table := NewTableBuilder().
+				AddTool("s_mytool", &ServerRoute{
+					Name:   "dummy",
+					Host:   "backend.example.com",
+					Prefix: "s_",
+					Path:   "/mcp",
+					URL:    "http://localhost:8080/mcp",
+				}).
+				Build()
+			router.Table = func() RoutingTable { return table }
+
+			req := &MCPRequest{
+				ID:      ptr.To(0),
+				JSONRPC: "2.0",
+				Method:  "tools/call",
+				Params:  map[string]any{"name": "s_mytool"},
+				Headers: map[string]string{"mcp-session-id": validToken},
+			}
+
+			decision := router.RouteRequest(context.Background(), &Request{Parsed: req})
+			require.NotNil(t, decision.Error)
+			require.Equal(t, tc.wantCalls, calls, "InitForClient call count")
+		})
+	}
+}
+
 //nolint:dupl
 func TestMCPRequest_PromptName(t *testing.T) {
 	testCases := []struct {

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -1385,6 +1385,7 @@ func TestInitializeMCPServerSession_HairpinRetry(t *testing.T) {
 			}
 			router, _ := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
 			router.InitForClient = mockInitForClient
+			router.InitBackoff = time.Millisecond
 			router.RoutingConfig.Store(&config.MCPServersConfig{
 				Servers:                    serverConfigs,
 				MCPGatewayInternalHostname: "mcp-gateway.local",
@@ -1417,6 +1418,72 @@ func TestInitializeMCPServerSession_HairpinRetry(t *testing.T) {
 	}
 }
 
+// newInMemoryClientSession returns a live *mcp.ClientSession backed by an
+// in-memory server, for exercising the init success path.
+func newInMemoryClientSession(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "0.0.1"}, nil)
+	ss, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ss.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+func TestInitializeMCPServerSession_HairpinRetryRecovers(t *testing.T) {
+	handle := newInMemoryClientSession(t)
+
+	calls := 0
+	mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, _ map[string]string, _ bool, _ *clients.HairpinClientPool) (*mcp.ClientSession, error) {
+		calls++
+		if calls <= hairpinInitMaxRetries {
+			return nil, fmt.Errorf("failed to create client: %w", fmt.Errorf("dial tcp: connection refused"))
+		}
+		return handle, nil
+	}
+
+	serverConfigs := []*config.MCPServer{
+		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
+	}
+	router, _ := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+	router.InitForClient = mockInitForClient
+	router.InitBackoff = time.Millisecond
+	router.IdleTimeout = time.Hour
+	router.RoutingConfig.Store(&config.MCPServersConfig{
+		Servers:                    serverConfigs,
+		MCPGatewayInternalHostname: "mcp-gateway.local",
+	})
+
+	validToken := router.JWTManager.Generate()
+	table := NewTableBuilder().
+		AddTool("s_mytool", &ServerRoute{
+			Name:   "dummy",
+			Host:   "backend.example.com",
+			Prefix: "s_",
+			Path:   "/mcp",
+			URL:    "http://localhost:8080/mcp",
+		}).
+		Build()
+	router.Table = func() RoutingTable { return table }
+
+	req := &MCPRequest{
+		ID:      ptr.To(0),
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  map[string]any{"name": "s_mytool"},
+		Headers: map[string]string{"mcp-session-id": validToken},
+	}
+
+	decision := router.RouteRequest(context.Background(), &Request{Parsed: req})
+	require.Nil(t, decision.Error, "init should succeed after transient failures")
+	require.Equal(t, hairpinInitMaxRetries+1, calls, "should retry then succeed")
+}
+
 func TestClientSessionIdleClose(t *testing.T) {
 	serverConfigs := []*config.MCPServer{
 		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
@@ -1447,6 +1514,42 @@ func TestClientSessionIdleClose(t *testing.T) {
 		_, mapped := exists["dummy"]
 		return !mapped
 	}, time.Second, 5*time.Millisecond, "idle timer must close the handle and drop the per-server mapping")
+
+	// last server removed: the whole key is deleted, not left as an empty map
+	keyExists, err := router.SessionCache.KeyExists(ctx, token)
+	require.NoError(t, err)
+	require.False(t, keyExists, "emptied session key must be deleted, not left behind")
+}
+
+func TestClientSessionIdleClose_KeepsSessionWithUserToken(t *testing.T) {
+	serverConfigs := []*config.MCPServer{
+		{Name: "dummy", URL: "http://localhost:8080/mcp", Prefix: "s_", State: "Enabled", Hostname: "backend.example.com"},
+	}
+	router, token := newTestRouter(t, serverConfigs, map[string]string{}, map[string]string{})
+	router.IdleTimeout = 20 * time.Millisecond
+	ctx := context.Background()
+
+	_, err := router.SessionCache.AddSession(ctx, token, "dummy", "remote-sid", time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, router.SessionCache.SetUserToken(ctx, token, "dummy", "user-token", time.Hour))
+
+	groupKey := token + "/dummy"
+	router.registerClientSession(groupKey, token, "dummy", nil)
+
+	require.Eventually(t, func() bool {
+		router.clientSessionsMu.Lock()
+		_, stillTracked := router.clientSessions[groupKey]
+		router.clientSessionsMu.Unlock()
+		return !stillTracked
+	}, time.Second, 5*time.Millisecond, "idle timer must fire")
+
+	// a cached user token keeps the session key alive
+	keyExists, err := router.SessionCache.KeyExists(ctx, token)
+	require.NoError(t, err)
+	require.True(t, keyExists, "session with a remaining user token must not be deleted")
+	_, ok, err := router.SessionCache.GetUserToken(ctx, token, "dummy")
+	require.NoError(t, err)
+	require.True(t, ok, "user token must survive idle close")
 }
 
 func TestClientSessionIdleReset(t *testing.T) {
@@ -1458,7 +1561,7 @@ func TestClientSessionIdleReset(t *testing.T) {
 
 	groupKey := token + "/dummy"
 	router.registerClientSession(groupKey, token, "dummy", nil)
-	router.resetClientSessionIdle(groupKey)
+	router.resetClientSessionIdle(groupKey, token, "dummy")
 
 	router.clientSessionsMu.Lock()
 	entry, present := router.clientSessions[groupKey]

--- a/internal/session/cache.go
+++ b/internal/session/cache.go
@@ -111,7 +111,14 @@ func (c *Cache) RemoveServerSession(ctx context.Context, key, mcpServerID string
 		existing := val.(map[string]string)
 		next := maps.Clone(existing)
 		delete(next, mcpServerID)
-		c.inmemory.Store(key, next)
+		// mirror Redis: HDel drops the hash key on its last field. Dropping the
+		// empty key (rather than storing an empty map) keeps KeyExists parity and
+		// leaves the separate client-elicitation key untouched.
+		if len(next) == 0 {
+			c.inmemory.Delete(key)
+		} else {
+			c.inmemory.Store(key, next)
+		}
 		return nil
 	}
 	return c.extClient.HDel(ctx, key, mcpServerID).Err()


### PR DESCRIPTION
Two router perf fixes on the hairpin/session path, both surfaced by the forge scale-out benchmark.

**1. Retry transient hairpin init failures**
Hairpin `initialize` fails under concurrency with transient connection rejections (`connection refused`, transport reset) and returns `500 failed to create session` on the first attempt. Retry non-4xx failures with bounded backoff (100ms, 200ms) inside the existing singleflight. 4xx short-circuits unchanged. Total backoff stays under the ext_proc `message_timeout` (10s). Seen as ~75k 500s in one run (s10-u200), self-recovering.

**2. Close idle backend sessions instead of holding for 24h**
Backend client handles were held open until the 24h JWT expiry, so a client that made one tool call and left kept an idle upstream connection for a full day. Now each handle has a 30m idle timer (reset on activity, mirrors the broker `SessionIdleTimeout`). On idle, close the handle and drop only the per-server mapping; the gateway session stays valid so the next tool call re-inits lazily.
