### PR TITLE
docs: graceful drain design and implementation plan

### DIFF
--- a/docs/design/graceful-drain/graceful-drain-design.md
+++ b/docs/design/graceful-drain/graceful-drain-design.md
@@ -2,14 +2,14 @@
 
 ## Problem
 
-`failure_mode_allow` is `false` on the ext_proc filter (`internal/controller/mcpgatewayextension_controller.go:738`). That is deliberate and must stay: a router that is down must never become an auth bypass. The consequence is that any request Envoy sends to a router whose gRPC server has gone away is rejected with a local 5xx rather than degraded.
+`failure_mode_allow` is `false` on the ext_proc filter (`internal/controller/mcpgatewayextension_controller.go:752`). That is deliberate and must stay: a router that is down must never become an auth bypass. The consequence is that any request Envoy sends to a router whose gRPC server has gone away is rejected with a local 5xx rather than degraded.
 
 Pod termination produces exactly that window. When a pod is marked Terminating, endpoint removal and the `preStop` hook begin **in parallel**, and endpoint removal is eventually consistent: it propagates through the endpoints controller, then to istiod, then into the gateway's Envoy configuration. Until that completes Envoy still routes to the terminating pod.
 
 Nothing in the process currently accounts for that window:
 
 - There is no notion of a draining state. The process serves normally until SIGTERM, then tears down.
-- `/readyz` gates on `mcpBroker.IsReady()` (`cmd/mcp-broker-router/broker.go:57`), which reports whether any upstream is reachable — not whether this pod is terminating.
+- `/readyz` gates on `mcpBroker.IsReady()` (`cmd/mcp-broker-router/broker.go:65`), which reports whether any upstream is reachable — not whether this pod is terminating.
 - The pod spec sets no `preStop` hook and no `terminationGracePeriodSeconds` (`internal/controller/broker_router.go`), so the default 30s applies with nothing using it.
 
 Two prior fixes bounded the teardown but did not drain anything. #1362 registered SIGTERM, so the shutdown path runs at all under Kubernetes. #1390 bounded `GracefulStop`, bounded the broker shutdown, and moved telemetry flushing last so drain-window traces and metrics survive. What remains is coordination: nothing tells the pod to stop taking new work, and nothing waits for the work it already has.
@@ -25,7 +25,7 @@ Add an explicit lifecycle state to the broker/router process — `serving`, `dra
 - No new stateful backend sessions once draining begins, with a retryable response where the protocol and response state allow one.
 - In-flight HTTP and ext_proc work is waited for within a configured deadline.
 - `preStop` and `terminationGracePeriodSeconds` wired so the drain fits inside the grace period by construction.
-- Drain observability: duration, requests completed during drain, forced terminations.
+- Drain observability that survives the pod: see [Where drain telemetry goes](#where-drain-telemetry-goes).
 - A rollout-under-load e2e that asserts the drain guarantee.
 
 ## Non-Goals
@@ -33,7 +33,7 @@ Add an explicit lifecycle state to the broker/router process — `serving`, `dra
 - **Durable cleanup of backend sessions owned by a departing pod.** Declined in #1363: replaying an upstream `DELETE` from another process requires that session's credentials, and persisting per-user credentials for later replay is a security trade the gateway should not make. Legacy sessions fall back to Redis TTL and the upstream's own session timeout.
 - **Live session migration.** Reusing a backend session ID from Redis is not the same problem as transferring an active SDK transport or an in-flight request.
 - **Zero client-visible errors.** See [What this cannot promise](#what-this-cannot-promise).
-- **Configurable replica count.** `replicas` is hardcoded to `int32(1)` (`internal/controller/broker_router.go:93`) with no field in `api/v1alpha1`. Out of scope here.
+- **Configurable replica count.** `replicas` is hardcoded to `int32(1)` (`internal/controller/broker_router.go:101`) with no field in `api/v1alpha1`. Out of scope here.
 - **Making broker cleanup context-aware.** `mcpBrokerImpl.Shutdown` discards its context; #1390 bounded the *wait* rather than the work. The deeper fix belongs with in-flight work tracking, see [Future Considerations](#future-considerations).
 
 ## Job Stories
@@ -83,7 +83,7 @@ Both merged:
 
 Two mechanisms could withdraw traffic before teardown, and the choice is not arbitrary.
 
-**Readiness cannot do it.** The generated probe is `PeriodSeconds: 10`, `FailureThreshold: 3` (`internal/controller/broker_router.go:235-248`). Failing `/readyz` therefore takes up to 30 seconds to mark the pod unready — longer than the entire 27s shutdown budget. Readiness gating is worth having for observability and for cases where the pod is not being deleted, but it cannot be the mechanism that stops traffic during termination.
+**Readiness cannot do it.** The generated probe is `PeriodSeconds: 10`, `FailureThreshold: 3` (`internal/controller/broker_router.go:235-247`). Failing `/readyz` therefore takes up to 30 seconds to mark the pod unready — longer than the entire 27s shutdown budget. Readiness gating is worth having for observability and for cases where the pod is not being deleted, but it cannot be the mechanism that stops traffic during termination.
 
 **Pod deletion does it, and `preStop` buys the time.** Endpoint removal starts when the pod is marked Terminating, independent of readiness. `preStop` runs in the same window, so a sleep there lets propagation complete while the process is still serving.
 
@@ -129,7 +129,7 @@ sequenceDiagram
 | Broker/router `main.go` | Owns the lifecycle state; registers SIGTERM; sequences drain then the existing bounded teardown. |
 | Health handlers (`broker.go`) | `/readyz` fails while `draining` or `terminating`; `/healthz` reflects only whether the process can still operate. |
 | Router (`Router202511`) | Refuses to initialize new stateful backend sessions while draining; returns a retryable error. Existing sessions continue to route. |
-| ext_proc server | Tracks in-flight streams so the drain can wait on them; stops accepting new streams while draining. |
+| ext_proc server | Tracks in-flight **requests** so the drain can wait on them. Keeps accepting and serving streams throughout — see [What draining does not do](#what-draining-does-not-do). |
 | Broker HTTP server | `http.Server.Shutdown` is started at the beginning of the drain rather than in the teardown, so HTTP requests drain concurrently with ext_proc streams under `drainDeadline`. The `serverDrainTimeout` call in the teardown remains as the backstop for anything still open. |
 | Metrics | Exports drain duration, requests completed during drain, forced terminations. |
 
@@ -142,6 +142,43 @@ sequenceDiagram
 | `terminating` | drain deadline reached or work complete | 200 until teardown | 503 | refused | abandoned to the bounded teardown |
 
 The state is a single atomic value read on the request path. `/healthz` deliberately stays green through `draining` and `terminating`: a draining pod is not unhealthy, and failing liveness would invite the kubelet to restart a pod that is intentionally going away.
+
+### What draining does not do
+
+Two things a draining pod must keep doing, both of which an earlier draft of this design got wrong.
+
+**It keeps accepting ext_proc streams.** Refusing a stream is not a polite signal — with `failure_mode_allow: false`, Envoy turns a failed ext_proc stream into a local 5xx. Refusing streams while draining would manufacture exactly the failure this design exists to remove, and would be worst precisely in the window the design admits is unbounded, where propagation is slower than `drainPropagationDelay`. Refusal is scoped to new backend *session initialization*, which the router answers with an immediate response rather than a transport failure.
+
+**It keeps serving existing sessions.** Backend session mappings outlive pod replacement by design, so a draining pod continues routing requests that already have one.
+
+### What counts as in-flight work
+
+`ExtProcServer.Process` runs one goroutine per ext_proc stream, looping on `stream.Recv()` until the stream ends (`internal/mcp-router/ext_proc_adapter.go`). A stream's lifetime is the HTTP stream's lifetime, and MCP streamable-HTTP clients hold a long-lived `GET /mcp` SSE response open — so counting *streams* would count idle held-open connections as work. Every termination would then burn the full `drainDeadline` waiting on connections that have nothing in flight, and `grpcDrainTimeout` behind it on the same streams, turning a worst-case bound into the normal cost of every rollout.
+
+The tracked unit is therefore an **in-flight request**: incremented when a request's headers are received, released when that request's terminal response has been sent. An idle SSE stream holds no in-flight requests and does not delay the drain.
+
+> Open verification: whether Envoy holds the ext_proc stream open for the duration of an SSE body under the current `response_body_mode` has not been confirmed against a live gateway. It belongs with the propagation measurement in Task 6, since both are cluster-observable facts this design currently assumes.
+
+### Where drain telemetry goes
+
+Drain outcomes cannot be reported as Prometheus metrics, and an earlier draft of this design assumed they could.
+
+`NewMetricsProvider` builds a Prometheus **pull** exporter (`internal/otel/metrics.go`) served from the metrics HTTP server — the code comment says "no OTLP endpoint needed". There is nothing to flush: `MetricsProvider.Shutdown` stops the MeterProvider and no value leaves the process. Scraping cannot rescue it either, because `metricsServer.Shutdown` runs early in the teardown and the pod exits inside a single scrape interval. Any counter incremented during drain is written to a registry nobody will ever read. #1390's ordering change saves traces and OTLP log export; it does not and cannot save pull-based metrics.
+
+Drain outcome is therefore reported on the two transports that do leave the process before it exits:
+
+- **An OTLP span** covering the drain, with duration, requests completed, requests outstanding at the deadline, and whether termination was forced. Traces flush last, inside `telemetryFlushTimeout`.
+- **A structured log record** carrying the same fields. `MultiHandler` (`internal/otel/logging.go`) fans records to stdout as well as OTLP, so this survives even with OTLP disabled — and stdout is what an e2e can assert against.
+
+Prometheus counters may still be registered for steady-state observability, but nothing — design, tasks, or e2e — may depend on a drain-time metric being scraped. If push metrics are wanted later, that means an OTLP metric exporter with an explicit `ForceFlush` inside the telemetry budget, which is a larger change than this design takes on.
+
+### The retryable response
+
+The refusal needs a concrete contract, since documentation and three e2e cases turn on it.
+
+A draining pod answers a request that would create a new backend session with **HTTP 503** and a `Retry-After: 1` header, carrying a JSON-RPC error body with code **-32000** (implementation-defined server error) and a message identifying gateway drain. 503 is the correct HTTP semantic — the condition is transient and the request should be retried elsewhere — and the router already returns typed HTTP statuses through `RouterError`, so this needs no new mechanism.
+
+> Open verification: whether the official Go SDK retries a 503 from `initialize` transparently, or surfaces it to the caller, has not been confirmed. The job story above assumes an SDK that reconnects. Task 8 must observe actual client behaviour and, if the SDK surfaces it, the guidance in the user documentation changes from "your client will retry" to "your client must retry". The gateway's contract is unaffected either way.
 
 ### Linearization point for session refusal
 
@@ -156,16 +193,22 @@ The transition to `draining` therefore does not need to cancel work already admi
 `preStop` consumes `terminationGracePeriodSeconds` — the grace clock starts when the pod is marked Terminating, and `preStop` runs inside it. The merged teardown already spends 27s, so the default 30s grace period leaves no room for a `preStop` sleep or a drain wait. The controller must therefore compute the grace period rather than leave it defaulted:
 
 ```text
-terminationGracePeriodSeconds = drainPropagationDelay   (preStop sleep)
-                              + drainDeadline           (wait for in-flight work)
-                              + serverDrainTimeout      (8s, merged)
-                              + brokerDrainTimeout      (5s, merged)
-                              + grpcDrainTimeout        (10s, merged)
-                              + telemetryFlushTimeout   (4s, merged)
-                              + safetyMargin
+terminationGracePeriodSeconds = drainPropagationDelay   (preStop sleep, 5s)
+                              + drainDeadline           (HTTP + ext_proc drained concurrently, 8s)
+                              + brokerDrainTimeout       (5s, merged)
+                              + grpcDrainTimeout         (10s, merged)
+                              + telemetryFlushTimeout    (4s, merged)
+                              + safetyMargin             (5s)
+                              = 37s
 ```
 
-With `drainPropagationDelay` 5s, `drainDeadline` 15s and a 5s margin that is 52s.
+Three things this arithmetic gets right that an earlier draft did not.
+
+`serverDrainTimeout` does not appear as a separate term. Task 5 starts `brokerServer.Shutdown` at the beginning of the drain, so the HTTP drain happens *inside* `drainDeadline`; charging both would bill the same wait twice. The `serverDrainTimeout` call remains in the teardown as a backstop, but it can only be reached with an already-drained server, so it contributes nothing to the worst case. `metricsServer.Shutdown` shares it and is likewise not a separate term.
+
+`drainDeadline` is 8s, not 15s, because Envoy's ext_proc `message_timeout` is `"10s"` (`internal/controller/mcpgatewayextension_controller.go:757`). Waiting longer than that means spending the tail of the budget on work Envoy has already abandoned. The deadline is deliberately set below the message timeout so the two cannot disagree about whether a request is still alive; if `message_timeout` is ever raised, `drainDeadline` should move with it.
+
+37s rather than 52s matters beyond tidiness. `RestartDeploymentAndWait` (`tests/e2e/kubectl_helpers.go`) blocks until the old pod is gone, and with `replicas=1` and `maxUnavailable=0` that is the full grace period on every e2e that restarts the deployment. A loose bound is paid on every CI run.
 
 The constants live in an importable package (`internal/drain`) rather than in `cmd/mcp-broker-router`, because `main` cannot be imported and the controller must derive the pod spec from the same source. Duplicating them would reintroduce exactly the drift this arithmetic exists to prevent.
 

--- a/docs/design/graceful-drain/graceful-drain-design.md
+++ b/docs/design/graceful-drain/graceful-drain-design.md
@@ -1,0 +1,204 @@
+# Graceful Drain Design
+
+## Problem
+
+`failure_mode_allow` is `false` on the ext_proc filter (`internal/controller/mcpgatewayextension_controller.go:738`). That is deliberate and must stay: a router that is down must never become an auth bypass. The consequence is that any request Envoy sends to a router whose gRPC server has gone away is rejected with a local 5xx rather than degraded.
+
+Pod termination produces exactly that window. When a pod is marked Terminating, endpoint removal and the `preStop` hook begin **in parallel**, and endpoint removal is eventually consistent: it propagates through the endpoints controller, then to istiod, then into the gateway's Envoy configuration. Until that completes Envoy still routes to the terminating pod.
+
+Nothing in the process currently accounts for that window:
+
+- There is no notion of a draining state. The process serves normally until SIGTERM, then tears down.
+- `/readyz` gates on `mcpBroker.IsReady()` (`cmd/mcp-broker-router/broker.go:57`), which reports whether any upstream is reachable — not whether this pod is terminating.
+- The pod spec sets no `preStop` hook and no `terminationGracePeriodSeconds` (`internal/controller/broker_router.go`), so the default 30s applies with nothing using it.
+
+Two prior fixes bounded the teardown but did not drain anything. #1362 registered SIGTERM, so the shutdown path runs at all under Kubernetes. #1390 bounded `GracefulStop`, bounded the broker shutdown, and moved telemetry flushing last so drain-window traces and metrics survive. What remains is coordination: nothing tells the pod to stop taking new work, and nothing waits for the work it already has.
+
+## Summary
+
+Add an explicit lifecycle state to the broker/router process — `serving`, `draining`, `terminating` — driven by pod lifecycle rather than inferred. A `preStop` hook sleeps long enough for endpoint removal to reach Envoy while the pod keeps serving normally. SIGTERM then moves the process into `draining`: `/readyz` starts failing, new stateful backend sessions are refused with a retryable response, and the process waits for in-flight HTTP and ext_proc work up to a deadline before running the bounded teardown that already exists. `terminationGracePeriodSeconds` is computed from the sum of the budgets so the two cannot drift apart.
+
+## Goals
+
+- An explicit, observable process state: `serving`, `draining`, `terminating`.
+- `/readyz` fails while draining; `/healthz` stays healthy until the process genuinely cannot operate.
+- No new stateful backend sessions once draining begins, with a retryable response where the protocol and response state allow one.
+- In-flight HTTP and ext_proc work is waited for within a configured deadline.
+- `preStop` and `terminationGracePeriodSeconds` wired so the drain fits inside the grace period by construction.
+- Drain observability: duration, requests completed during drain, forced terminations.
+- A rollout-under-load e2e that asserts the drain guarantee.
+
+## Non-Goals
+
+- **Durable cleanup of backend sessions owned by a departing pod.** Declined in #1363: replaying an upstream `DELETE` from another process requires that session's credentials, and persisting per-user credentials for later replay is a security trade the gateway should not make. Legacy sessions fall back to Redis TTL and the upstream's own session timeout.
+- **Live session migration.** Reusing a backend session ID from Redis is not the same problem as transferring an active SDK transport or an in-flight request.
+- **Zero client-visible errors.** See [What this cannot promise](#what-this-cannot-promise).
+- **Configurable replica count.** `replicas` is hardcoded to `int32(1)` (`internal/controller/broker_router.go:93`) with no field in `api/v1alpha1`. Out of scope here.
+- **Making broker cleanup context-aware.** `mcpBrokerImpl.Shutdown` discards its context; #1390 bounded the *wait* rather than the work. The deeper fix belongs with in-flight work tracking, see [Future Considerations](#future-considerations).
+
+## Job Stories
+
+### When a platform engineer rolls out a new gateway version
+
+When a platform engineer runs `kubectl rollout restart` during business hours, they want in-flight tool calls to finish and clients to see retryable errors rather than transport resets, so that a routine deploy is not a customer-visible incident.
+
+### When a platform engineer drains a node
+
+When a platform engineer cordons and drains a node hosting the gateway, they want the pod to stop accepting new work before it stops serving, so that the disruption is bounded and attributable rather than a burst of unexplained 5xx.
+
+### When an MCP client is mid tool call
+
+When an MCP client has a `tools/call` in flight and the serving pod begins terminating, they want that call to complete if it can, so that a deploy does not surface as a failed user action.
+
+### When an MCP client starts a new session during a rollout
+
+When an MCP client initializes a new session against a pod that has begun draining, they want a retryable protocol error rather than a connection reset, so that the client SDK can reconnect to a healthy pod instead of surfacing a hard failure.
+
+### When a non-interactive agent is fanning out tool calls
+
+When an agent issues many concurrent `tools/call` requests across a rollout, they want failures to be distinguishable from upstream tool errors, so that the agent's retry logic can act on them safely rather than treating a side-effecting call as failed.
+
+### When a platform engineer investigates a slow rollout
+
+When a rollout takes longer than expected, they want drain duration, requests completed during drain, and forced terminations exported as metrics, so that they can tell a slow drain from a stuck one without reading pod logs.
+
+## Design
+
+### Prerequisites
+
+Both merged:
+
+- #1362 — SIGTERM registered, so the shutdown path executes under Kubernetes at all.
+- #1390 — `GracefulStop` bounded with a fallback to `Stop`, broker shutdown bounded, telemetry flush moved last with its own budget. Current budgets are `serverDrainTimeout` 8s, `brokerDrainTimeout` 5s, `grpcDrainTimeout` 10s, `telemetryFlushTimeout` 4s (`cmd/mcp-broker-router/main.go`).
+
+### Why `preStop` sleeps rather than triggers the drain
+
+Two mechanisms could withdraw traffic before teardown, and the choice is not arbitrary.
+
+**Readiness cannot do it.** The generated probe is `PeriodSeconds: 10`, `FailureThreshold: 3` (`internal/controller/broker_router.go:235-248`). Failing `/readyz` therefore takes up to 30 seconds to mark the pod unready — longer than the entire 27s shutdown budget. Readiness gating is worth having for observability and for cases where the pod is not being deleted, but it cannot be the mechanism that stops traffic during termination.
+
+**Pod deletion does it, and `preStop` buys the time.** Endpoint removal starts when the pod is marked Terminating, independent of readiness. `preStop` runs in the same window, so a sleep there lets propagation complete while the process is still serving.
+
+That ordering also decides what `preStop` should *do*. Having `preStop` trigger the drain would mean the process starts refusing work while Envoy is still routing to it — turning requests that would have succeeded into errors. Serving normally through propagation and draining only once traffic should have stopped is strictly better. So `preStop` sleeps; SIGTERM initiates the drain.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant K as kubelet
+    participant EP as endpoints/istiod
+    participant E as Envoy
+    participant P as broker-router pod
+    participant C as MCP client
+
+    Note over P: state = serving
+    K->>P: pod marked Terminating
+    par endpoint withdrawal
+        EP->>E: remove pod from cluster
+    and preStop
+        K->>P: preStop sleep (drainPropagationDelay)
+        C->>E: requests
+        E->>P: still routed here
+        P-->>C: served normally
+    end
+    K->>P: SIGTERM
+    Note over P: state = draining
+    P->>P: /readyz starts failing
+    C->>E: new session request
+    E->>P: (only if propagation lagged)
+    P-->>C: retryable error, no new backend session
+    P->>P: wait for in-flight HTTP + ext_proc work (drainDeadline)
+    Note over P: state = terminating
+    P->>P: bounded teardown from #1390
+    P->>K: exit
+```
+
+### Component Responsibilities
+
+| Component | Responsibility |
+| --- | --- |
+| Controller (`broker_router.go`) | Emits `preStop` hook and `terminationGracePeriodSeconds` on the generated Deployment, derived from the drain budgets so they cannot drift. |
+| Broker/router `main.go` | Owns the lifecycle state; registers SIGTERM; sequences drain then the existing bounded teardown. |
+| Health handlers (`broker.go`) | `/readyz` fails while `draining` or `terminating`; `/healthz` reflects only whether the process can still operate. |
+| Router (`Router202511`) | Refuses to initialize new stateful backend sessions while draining; returns a retryable error. Existing sessions continue to route. |
+| ext_proc server | Tracks in-flight streams so the drain can wait on them; stops accepting new streams while draining. |
+| Broker HTTP server | Tracks in-flight requests; `http.Server.Shutdown` already waits for them within `serverDrainTimeout`. |
+| Metrics | Exports drain duration, requests completed during drain, forced terminations. |
+
+### State machine
+
+| State | Entered by | `/healthz` | `/readyz` | New stateful sessions | In-flight work |
+| --- | --- | --- | --- | --- | --- |
+| `serving` | process start | 200 | `IsReady()` | accepted | served |
+| `draining` | SIGTERM | 200 | 503 | refused, retryable | waited for, up to `drainDeadline` |
+| `terminating` | drain deadline reached or work complete | 200 until teardown | 503 | refused | abandoned to the bounded teardown |
+
+The state is a single atomic value read on the request path. `/healthz` deliberately stays green through `draining` and `terminating`: a draining pod is not unhealthy, and failing liveness would invite the kubelet to restart a pod that is intentionally going away.
+
+### Budget arithmetic
+
+`preStop` consumes `terminationGracePeriodSeconds` — the grace clock starts when the pod is marked Terminating, and `preStop` runs inside it. The merged teardown already spends 27s, so the default 30s grace period leaves no room for a `preStop` sleep or a drain wait. The controller must therefore compute the grace period rather than leave it defaulted:
+
+```
+terminationGracePeriodSeconds = drainPropagationDelay   (preStop sleep)
+                              + drainDeadline           (wait for in-flight work)
+                              + serverDrainTimeout      (8s, merged)
+                              + brokerDrainTimeout      (5s, merged)
+                              + grpcDrainTimeout        (10s, merged)
+                              + telemetryFlushTimeout   (4s, merged)
+                              + safetyMargin
+```
+
+With `drainPropagationDelay` 5s, `drainDeadline` 15s and a 5s margin that is 52s. The constants must be shared between `main.go` and the controller so the pod spec and the process cannot disagree; a mismatch means the kubelet kills the process mid-drain, which is the failure this design exists to prevent.
+
+### API Changes
+
+No CRD changes in this iteration. The budgets are package constants shared between the process and the controller, and the controller derives the pod spec from them. Operators using the controller-generated Deployment get correct values without configuration.
+
+Exposing the budgets on `MCPGatewayExtension` is deferred — see [Future Considerations](#future-considerations). Because the controller owns the Deployment, an operator cannot currently override them, so if tuning turns out to be needed the CRD is the right surface rather than flags.
+
+### Data storage
+
+None. The lifecycle state is process-local and deliberately not persisted: it describes this pod's relationship to its own termination, and has no meaning to another replica.
+
+## Failure-mode inventory
+
+| Failure | Current behaviour | After this design |
+| --- | --- | --- |
+| Rollout while requests are in flight | Envoy routes to a terminating pod during propagation; ext_proc fails closed; local 5xx | `preStop` sleep covers propagation; requests served normally |
+| New session arrives after SIGTERM | Backend session initialized, then abandoned mid-teardown | Refused with a retryable error; no orphaned backend session created |
+| In-flight `tools/call` at SIGTERM | Cut at the socket when the servers stop | Waited for within `drainDeadline`; completes if it can |
+| Long-lived ext_proc stream at SIGTERM | Bounded by `grpcDrainTimeout` (#1390), forced at 10s | Unchanged; drain gives it a chance to finish first |
+| Drain exceeds its deadline | n/a | Forced into `terminating`, counted in metrics, bounded teardown proceeds |
+| `preStop` + drain exceeds grace period | Pod killed mid-drain | Grace period computed from the budgets, so it cannot by construction |
+| Node drain or eviction | Same as rollout, but no replacement pod is ready | Drain still bounded and clean; the window is an outage regardless |
+| Crash or SIGKILL | Nothing runs | Nothing runs. Backend sessions leak to Redis TTL and upstream timeout, per #1363 |
+| Upstream slow during teardown | Broker shutdown could block unboundedly | Bounded by `brokerDrainTimeout` (#1390) |
+
+## Security Considerations
+
+- **`failure_mode_allow` stays `false`.** Nothing in this design changes it. A draining router must still reject rather than bypass; the point is to stop traffic arriving, not to soften what happens when it does.
+- **`/healthz` and `/readyz` must not leak state.** Both remain unauthenticated status codes with no body describing internal condition.
+- **No new credential persistence.** The drain closes nothing that requires replaying upstream credentials, which is what kept #1363's durable-cleanup half out of scope.
+- **Retryable errors must not be forgeable.** The drain response is generated by the router from process state, never from a client-supplied header, consistent with the existing rule that `x-mcp-*` metadata is router-set.
+
+## Relationship to Existing Approaches
+
+This builds directly on the bounded teardown from #1390 rather than replacing it: drain is what happens *before* that sequence, and the sequence remains the backstop when the drain deadline is hit. The existing Redis session store is unaffected — backend session mappings survive pod replacement exactly as they do today, and the drain deliberately does not close handles for sessions that remain valid, since a replacement pod is expected to keep using them.
+
+## What this cannot promise
+
+Not zero client-visible errors. If an upstream tool performs a side effect and the pod dies before delivering the response, the gateway cannot know whether retrying is safe. Once a streaming response has started, a broken stream may not be replaceable with a well-formed JSON-RPC error. The achievable goal is bounded disruption, completion of requests that can safely finish, and retryable signalling where possible.
+
+On the ceiling: no rollout `Strategy` is set, so Kubernetes defaults apply and at `replicas=1` that means `maxSurge=1`, `maxUnavailable=0` — during `kubectl rollout restart` the replacement pod is Ready before the old one terminates, so draining genuinely avoids disruption. For node drain, eviction or crash there is no second pod and the window is an outage regardless of how clean the drain is.
+
+## Future Considerations
+
+- **Context-aware broker cleanup.** `mcpBrokerImpl.Shutdown` discards its context; `activeMCP.Stop` blocks on `<-a.manager.done` and the pooled-session drain performs a blocking upstream `DELETE` per entry. #1390 bounded the wait, not the work. Threading a context through would make the bound real, and the in-flight tracking added here is the natural place to build from.
+- **Budgets on `MCPGatewayExtension`.** If operators need to tune the drain, the CRD is the right surface, since the controller owns the Deployment.
+- **Durable cleanup obligations.** Declined in #1363 on security and lifetime grounds. If `Router202511` outlives expectations, or if a configurable replica count arrives, the analysis in that issue is the starting point.
+- **Drain on config change.** The same machinery could quiesce a pod during a disruptive config reload rather than only at termination.
+
+## Execution
+
+See [tasks/tasks.md](tasks/tasks.md) for the implementation plan, [tasks/e2e_test_cases.md](tasks/e2e_test_cases.md) for e2e coverage, and [tasks/documentation.md](tasks/documentation.md) for the documentation plan.

--- a/docs/design/graceful-drain/graceful-drain-design.md
+++ b/docs/design/graceful-drain/graceful-drain-design.md
@@ -2,14 +2,14 @@
 
 ## Problem
 
-`failure_mode_allow` is `false` on the ext_proc filter (`internal/controller/mcpgatewayextension_controller.go:752`). That is deliberate and must stay: a router that is down must never become an auth bypass. The consequence is that any request Envoy sends to a router whose gRPC server has gone away is rejected with a local 5xx rather than degraded.
+`failure_mode_allow` is `false` on the ext_proc filter (`internal/controller/mcpgatewayextension_controller.go`). That is deliberate and must stay: a router that is down must never become an auth bypass. The consequence is that any request Envoy sends to a router whose gRPC server has gone away is rejected with a local 5xx rather than degraded.
 
 Pod termination produces exactly that window. When a pod is marked Terminating, endpoint removal and the `preStop` hook begin **in parallel**, and endpoint removal is eventually consistent: it propagates through the endpoints controller, then to istiod, then into the gateway's Envoy configuration. Until that completes Envoy still routes to the terminating pod.
 
 Nothing in the process currently accounts for that window:
 
 - There is no notion of a draining state. The process serves normally until SIGTERM, then tears down.
-- `/readyz` gates on `mcpBroker.IsReady()` (`cmd/mcp-broker-router/broker.go:65`), which reports whether any upstream is reachable — not whether this pod is terminating.
+- `/readyz` gates on `mcpBroker.IsReady()` (`cmd/mcp-broker-router/broker.go`), which reports whether any upstream is reachable — not whether this pod is terminating.
 - The pod spec sets no `preStop` hook and no `terminationGracePeriodSeconds` (`internal/controller/broker_router.go`), so the default 30s applies with nothing using it.
 
 Two prior fixes bounded the teardown but did not drain anything. #1362 registered SIGTERM, so the shutdown path runs at all under Kubernetes. #1390 bounded `GracefulStop`, bounded the broker shutdown, and moved telemetry flushing last so drain-window traces and metrics survive. What remains is coordination: nothing tells the pod to stop taking new work, and nothing waits for the work it already has.
@@ -33,7 +33,7 @@ Add an explicit lifecycle state to the broker/router process — `serving`, `dra
 - **Durable cleanup of backend sessions owned by a departing pod.** Declined in #1363: replaying an upstream `DELETE` from another process requires that session's credentials, and persisting per-user credentials for later replay is a security trade the gateway should not make. Legacy sessions fall back to Redis TTL and the upstream's own session timeout.
 - **Live session migration.** Reusing a backend session ID from Redis is not the same problem as transferring an active SDK transport or an in-flight request.
 - **Zero client-visible errors.** See [What this cannot promise](#what-this-cannot-promise).
-- **Configurable replica count.** `replicas` is hardcoded to `int32(1)` (`internal/controller/broker_router.go:101`) with no field in `api/v1alpha1`. Out of scope here.
+- **Configurable replica count.** `replicas` is hardcoded to `int32(1)` (`replicas := int32(1)` in `internal/controller/broker_router.go`) with no field in `api/v1alpha1`. Out of scope here.
 - **Making broker cleanup context-aware.** `mcpBrokerImpl.Shutdown` discards its context; #1390 bounded the *wait* rather than the work. The deeper fix belongs with in-flight work tracking, see [Future Considerations](#future-considerations).
 
 ## Job Stories
@@ -83,7 +83,7 @@ Both merged:
 
 Two mechanisms could withdraw traffic before teardown, and the choice is not arbitrary.
 
-**Readiness cannot do it.** The generated probe is `PeriodSeconds: 10`, `FailureThreshold: 3` (`internal/controller/broker_router.go:235-247`). Failing `/readyz` therefore takes up to 30 seconds to mark the pod unready — longer than the entire 27s shutdown budget. Readiness gating is worth having for observability and for cases where the pod is not being deleted, but it cannot be the mechanism that stops traffic during termination.
+**Readiness cannot do it.** The generated probe is `PeriodSeconds: 10`, `FailureThreshold: 3` (the `ReadinessProbe` in `internal/controller/broker_router.go`). Failing `/readyz` therefore takes up to 30 seconds to mark the pod unready — longer than the entire 27s shutdown budget. Readiness gating is worth having for observability and for cases where the pod is not being deleted, but it cannot be the mechanism that stops traffic during termination.
 
 **Pod deletion does it, and `preStop` buys the time.** Endpoint removal starts when the pod is marked Terminating, independent of readiness. `preStop` runs in the same window, so a sleep there lets propagation complete while the process is still serving.
 
@@ -206,7 +206,7 @@ Three things this arithmetic gets right that an earlier draft did not.
 
 `serverDrainTimeout` does not appear as a separate term. Task 5 starts `brokerServer.Shutdown` at the beginning of the drain, so the HTTP drain happens *inside* `drainDeadline`; charging both would bill the same wait twice. The `serverDrainTimeout` call remains in the teardown as a backstop, but it can only be reached with an already-drained server, so it contributes nothing to the worst case. `metricsServer.Shutdown` shares it and is likewise not a separate term.
 
-`drainDeadline` is 8s, not 15s, because Envoy's ext_proc `message_timeout` is `"10s"` (`internal/controller/mcpgatewayextension_controller.go:757`). Waiting longer than that means spending the tail of the budget on work Envoy has already abandoned. The deadline is deliberately set below the message timeout so the two cannot disagree about whether a request is still alive; if `message_timeout` is ever raised, `drainDeadline` should move with it.
+`drainDeadline` is 8s, not 15s, because Envoy's ext_proc `message_timeout` is `"10s"` (the `message_timeout` key in `internal/controller/mcpgatewayextension_controller.go`). Waiting longer than that means spending the tail of the budget on work Envoy has already abandoned. The deadline is deliberately set below the message timeout so the two cannot disagree about whether a request is still alive; if `message_timeout` is ever raised, `drainDeadline` should move with it.
 
 37s rather than 52s matters beyond tidiness. `RestartDeploymentAndWait` (`tests/e2e/kubectl_helpers.go`) blocks until the old pod is gone, and with `replicas=1` and `maxUnavailable=0` that is the full grace period on every e2e that restarts the deployment. A loose bound is paid on every CI run.
 

--- a/docs/design/graceful-drain/graceful-drain-design.md
+++ b/docs/design/graceful-drain/graceful-drain-design.md
@@ -259,7 +259,7 @@ On the ceiling: no rollout `Strategy` is set, so Kubernetes defaults apply and a
 ## Future Considerations
 
 - **Context-aware broker cleanup.** `mcpBrokerImpl.Shutdown` discards its context; `activeMCP.Stop` blocks on `<-a.manager.done` and the pooled-session drain performs a blocking upstream `DELETE` per entry. #1390 bounded the wait, not the work. Threading a context through would make the bound real, and the in-flight tracking added here is the natural place to build from.
-- **Budgets on `MCPGatewayExtension`.** If operators need to tune the drain, the CRD is the right surface, since the controller owns the Deployment.
+- **Budgets on `MCPGatewayExtension`.** Constants are the right default: the controller owns the Deployment, so flags are not a surface an operator can reach anyway. The kill criterion is concrete — a real deployment where measured endpoint propagation exceeds `drainPropagationDelay` and the operator cannot rebuild the controller to raise it. At that point the budgets move onto `MCPGatewayExtension`, not onto flags.
 - **Durable cleanup obligations.** Declined in #1363 on security and lifetime grounds. If `Router202511` outlives expectations, or if a configurable replica count arrives, the analysis in that issue is the starting point.
 - **Drain on config change.** The same machinery could quiesce a pod during a disruptive config reload rather than only at termination.
 

--- a/docs/design/graceful-drain/graceful-drain-design.md
+++ b/docs/design/graceful-drain/graceful-drain-design.md
@@ -58,6 +58,14 @@ When an MCP client initializes a new session against a pod that has begun draini
 
 When an agent issues many concurrent `tools/call` requests across a rollout, they want failures to be distinguishable from upstream tool errors, so that the agent's retry logic can act on them safely rather than treating a side-effecting call as failed.
 
+### When an MCP developer tests their server against the gateway
+
+When an MCP developer runs their server behind the gateway and redeploys it during development, they want drain behaviour to be identical whether or not their server supports session termination, so that they are not debugging gateway lifecycle behaviour while trying to debug their own tool.
+
+### When an MCP developer's tool is slow
+
+When an MCP developer's tool takes longer than the drain deadline to return and the pod is terminating, they want the truncation to be attributable to the gateway drain rather than to look like a fault in their server, so that they do not chase a bug that is not theirs.
+
 ### When a platform engineer investigates a slow rollout
 
 When a rollout takes longer than expected, they want drain duration, requests completed during drain, and forced terminations exported as metrics, so that they can tell a slow drain from a stuck one without reading pod logs.
@@ -122,7 +130,7 @@ sequenceDiagram
 | Health handlers (`broker.go`) | `/readyz` fails while `draining` or `terminating`; `/healthz` reflects only whether the process can still operate. |
 | Router (`Router202511`) | Refuses to initialize new stateful backend sessions while draining; returns a retryable error. Existing sessions continue to route. |
 | ext_proc server | Tracks in-flight streams so the drain can wait on them; stops accepting new streams while draining. |
-| Broker HTTP server | Tracks in-flight requests; `http.Server.Shutdown` already waits for them within `serverDrainTimeout`. |
+| Broker HTTP server | `http.Server.Shutdown` is started at the beginning of the drain rather than in the teardown, so HTTP requests drain concurrently with ext_proc streams under `drainDeadline`. The `serverDrainTimeout` call in the teardown remains as the backstop for anything still open. |
 | Metrics | Exports drain duration, requests completed during drain, forced terminations. |
 
 ### State machine
@@ -130,16 +138,24 @@ sequenceDiagram
 | State | Entered by | `/healthz` | `/readyz` | New stateful sessions | In-flight work |
 | --- | --- | --- | --- | --- | --- |
 | `serving` | process start | 200 | `IsReady()` | accepted | served |
-| `draining` | SIGTERM | 200 | 503 | refused, retryable | waited for, up to `drainDeadline` |
+| `draining` | SIGTERM | 200 | 503 | refused, retryable | HTTP and ext_proc drained concurrently, up to `drainDeadline` |
 | `terminating` | drain deadline reached or work complete | 200 until teardown | 503 | refused | abandoned to the bounded teardown |
 
 The state is a single atomic value read on the request path. `/healthz` deliberately stays green through `draining` and `terminating`: a draining pod is not unhealthy, and failing liveness would invite the kubelet to restart a pod that is intentionally going away.
+
+### Linearization point for session refusal
+
+Refusing new sessions is a race unless the check has a defined position. `initializeMCPServerSession` calls `InitForClient` inside `initGroup.Do`, so a lifecycle check placed *before* `Do` can admit a caller that goes on to create a backend session after the transition to `draining` — the outcome the refusal exists to prevent.
+
+The check therefore belongs **inside** the singleflight function, after the existing cache lookup and before `InitForClient`. That makes the atomic state read the linearization point: any initialization that observes `serving` proceeds to completion and is accounted for as in-flight work; any that observes `draining` is refused before an upstream session exists. Callers that joined an already-running `Do` share its result, which is correct — that session was admitted while the pod was still serving.
+
+The transition to `draining` therefore does not need to cancel work already admitted; it only has to be visible to the next observation. This is why the drain waits for in-flight work rather than interrupting it.
 
 ### Budget arithmetic
 
 `preStop` consumes `terminationGracePeriodSeconds` — the grace clock starts when the pod is marked Terminating, and `preStop` runs inside it. The merged teardown already spends 27s, so the default 30s grace period leaves no room for a `preStop` sleep or a drain wait. The controller must therefore compute the grace period rather than leave it defaulted:
 
-```
+```text
 terminationGracePeriodSeconds = drainPropagationDelay   (preStop sleep)
                               + drainDeadline           (wait for in-flight work)
                               + serverDrainTimeout      (8s, merged)
@@ -149,7 +165,11 @@ terminationGracePeriodSeconds = drainPropagationDelay   (preStop sleep)
                               + safetyMargin
 ```
 
-With `drainPropagationDelay` 5s, `drainDeadline` 15s and a 5s margin that is 52s. The constants must be shared between `main.go` and the controller so the pod spec and the process cannot disagree; a mismatch means the kubelet kills the process mid-drain, which is the failure this design exists to prevent.
+With `drainPropagationDelay` 5s, `drainDeadline` 15s and a 5s margin that is 52s.
+
+The constants live in an importable package (`internal/drain`) rather than in `cmd/mcp-broker-router`, because `main` cannot be imported and the controller must derive the pod spec from the same source. Duplicating them would reintroduce exactly the drift this arithmetic exists to prevent.
+
+Two distinct claims are involved here and only one of them is guaranteed. The **local** arithmetic is sound by construction: the process cannot spend more than the sum of its own budgets, so it cannot outlast a grace period computed from them. The **propagation** assumption is not. Whether endpoint removal reaches Envoy within `drainPropagationDelay` depends on the endpoints controller, istiod convergence and cluster load, none of which the gateway controls, and Istio publishes no bound for it. 5s is a starting value drawn from common practice, not a guarantee. It must be validated against a real cluster before the design claims anything about it, and it should be tunable so an operator on a slow or large cluster can raise it. If propagation exceeds the delay, the pod stops accepting new stateful sessions while Envoy is still routing to it — the drain degrades to retryable errors rather than losing work, but the window is not eliminated.
 
 ### API Changes
 
@@ -170,7 +190,8 @@ None. The lifecycle state is process-local and deliberately not persisted: it de
 | In-flight `tools/call` at SIGTERM | Cut at the socket when the servers stop | Waited for within `drainDeadline`; completes if it can |
 | Long-lived ext_proc stream at SIGTERM | Bounded by `grpcDrainTimeout` (#1390), forced at 10s | Unchanged; drain gives it a chance to finish first |
 | Drain exceeds its deadline | n/a | Forced into `terminating`, counted in metrics, bounded teardown proceeds |
-| `preStop` + drain exceeds grace period | Pod killed mid-drain | Grace period computed from the budgets, so it cannot by construction |
+| `preStop` + drain exceeds grace period | Pod killed mid-drain | Grace period computed from the same budget constants, so the process cannot outspend it |
+| Endpoint removal slower than `drainPropagationDelay` | Requests hit a terminating pod; ext_proc fails closed; local 5xx | Not eliminated. New sessions get a retryable error instead of a reset; existing sessions still route. Mitigated by raising the delay, not by the grace period |
 | Node drain or eviction | Same as rollout, but no replacement pod is ready | Drain still bounded and clean; the window is an outage regardless |
 | Crash or SIGKILL | Nothing runs | Nothing runs. Backend sessions leak to Redis TTL and upstream timeout, per #1363 |
 | Upstream slow during teardown | Broker shutdown could block unboundedly | Bounded by `brokerDrainTimeout` (#1390) |

--- a/docs/design/graceful-drain/tasks/documentation.md
+++ b/docs/design/graceful-drain/tasks/documentation.md
@@ -44,7 +44,8 @@ When an MCP client developer sees failures coincide with a gateway rollout, they
 
 **Cover:**
 
-- The retryable error returned when a draining pod refuses a new session, and the correct client response
+- The exact contract: HTTP 503 with `Retry-After`, JSON-RPC error code -32000, and what the client should do with it
+- Whether the official Go SDK retries this transparently or surfaces it — Task 8 establishes which, and the guidance is either "your client will retry" or "your client must retry"
 - Why a side-effecting tool call whose response was lost cannot be retried safely by the gateway on the client's behalf
 - Existing sessions are unaffected by drain; reconnection is not required
 

--- a/docs/design/graceful-drain/tasks/documentation.md
+++ b/docs/design/graceful-drain/tasks/documentation.md
@@ -12,8 +12,10 @@ When a platform engineer rolls out a gateway upgrade during working hours, they 
 
 **Cover:**
 
-- What a rollout looks like from the client's side: in-flight calls complete, new sessions against the draining pod get a retryable error, the replacement pod is already serving
+- What a rollout looks like from the client's side: calls that fit inside the drain deadline complete, new sessions against the draining pod get a retryable error, the replacement pod is already serving
+- The deadline boundary explicitly: a call that outlasts `drainDeadline` may lose its response when the bounded teardown begins. That is the contract, not a defect, and long-running tools should be sized against it
 - Why `maxSurge` matters, and why node drain, eviction and crash are different from `kubectl rollout restart`
+- That endpoint propagation is not something the gateway can bound; if a cluster is slow to converge, raising the propagation delay is the lever
 - What is explicitly not promised: side-effecting tool calls whose response was lost, and streams already in progress
 
 ### When I want to understand why pods take longer to terminate
@@ -48,6 +50,10 @@ When an MCP client developer sees failures coincide with a gateway rollout, they
 
 ## Security Architecture (`docs/design/security-architecture.md`)
 
+### When I want to confirm a draining pod cannot be exploited
+
+When a security reviewer assesses the drain feature, they want assurance that a terminating pod cannot be induced into a weaker enforcement posture so that graceful shutdown does not become an attack window.
+
 **Cover:**
 
 - Draining changes when traffic stops arriving, never what happens to traffic that arrives; `failure_mode_allow` stays `false`
@@ -55,6 +61,10 @@ When an MCP client developer sees failures coincide with a gateway rollout, they
 - No credential persistence is introduced, which is what kept durable cross-replica cleanup out of scope in #1363
 
 ## Release Notes (`docs/release-notes/`)
+
+### When I want to know what changes for me on upgrade
+
+When a platform engineer reads the release notes before upgrading, they want to know which observable behaviours change so that they can decide whether anything in their tooling or alerting needs adjusting first.
 
 **Cover:**
 

--- a/docs/design/graceful-drain/tasks/documentation.md
+++ b/docs/design/graceful-drain/tasks/documentation.md
@@ -1,0 +1,69 @@
+# Graceful Drain — Documentation Plan
+
+Design: [../graceful-drain-design.md](../graceful-drain-design.md)
+
+Drain changes observable pod behaviour — pods take longer to terminate, and clients see a new retryable error during rollouts — so it needs user-facing documentation rather than design notes alone.
+
+## User Guide (`docs/guides/`)
+
+### When I want to deploy a new gateway version without disrupting users
+
+When a platform engineer rolls out a gateway upgrade during working hours, they want to know what clients will experience so that they can decide whether a maintenance window is needed.
+
+**Cover:**
+
+- What a rollout looks like from the client's side: in-flight calls complete, new sessions against the draining pod get a retryable error, the replacement pod is already serving
+- Why `maxSurge` matters, and why node drain, eviction and crash are different from `kubectl rollout restart`
+- What is explicitly not promised: side-effecting tool calls whose response was lost, and streams already in progress
+
+### When I want to understand why pods take longer to terminate
+
+When a platform engineer notices termination taking tens of seconds after upgrading, they want to know whether that is expected so that they do not mistake a correct drain for a hung pod.
+
+**Cover:**
+
+- The termination sequence: `preStop` propagation delay, drain wait, bounded teardown
+- How `terminationGracePeriodSeconds` is derived, and why it is computed rather than defaulted
+- How to tell a slow drain from a stuck one
+
+### When I want to observe drain behaviour
+
+When a platform engineer investigates a slow rollout, they want the relevant signals so that they can diagnose it without reading pod logs.
+
+**Cover:**
+
+- Drain duration, requests completed during drain, forced terminations
+- What a rising forced-termination count indicates, and what to do about it
+- Why drain-window telemetry is exported at all, given that OTel shutdown ordering was previously wrong
+
+### When my client sees errors during a deploy
+
+When an MCP client developer sees failures coincide with a gateway rollout, they want to distinguish retryable gateway errors from upstream tool failures so that their retry logic does the right thing.
+
+**Cover:**
+
+- The retryable error returned when a draining pod refuses a new session, and the correct client response
+- Why a side-effecting tool call whose response was lost cannot be retried safely by the gateway on the client's behalf
+- Existing sessions are unaffected by drain; reconnection is not required
+
+## Security Architecture (`docs/design/security-architecture.md`)
+
+**Cover:**
+
+- Draining changes when traffic stops arriving, never what happens to traffic that arrives; `failure_mode_allow` stays `false`
+- The drain response is process-derived and cannot be induced by a client header
+- No credential persistence is introduced, which is what kept durable cross-replica cleanup out of scope in #1363
+
+## Release Notes (`docs/release-notes/`)
+
+**Cover:**
+
+- `terminationGracePeriodSeconds` is now set on the generated Deployment where it was previously defaulted — observable behaviour change, per `.claude/rules/breaking-changes.md`
+- Pods take longer to terminate by design
+- New retryable error during rollouts, and what clients should do with it
+
+## Not required
+
+No API reference changes: this iteration adds no CRD fields. If the budgets are later exposed on `MCPGatewayExtension`, `docs/reference/` needs updating at that point.
+
+No manual test cases: the rollout-under-load e2e covers the drain guarantee, which meets the bar in `.claude/rules/manual-test-cases.md` for adequate automated coverage.

--- a/docs/design/graceful-drain/tasks/e2e_test_cases.md
+++ b/docs/design/graceful-drain/tasks/e2e_test_cases.md
@@ -6,11 +6,11 @@ Format follows `tests/e2e/test_cases.md`. `Drain` is the feature tag; only the c
 
 ### [Happy,Drain] Test tool calls survive a rollout restart under load
 
-- When a client issues sustained concurrent tools/call requests against the gateway and the mcp-gateway deployment is restarted with `kubectl rollout restart`, every request should either complete successfully or fail with a retryable JSON-RPC error. No request should fail with a transport-level reset or an ext_proc 5xx. The test runs Serial because it restarts shared infrastructure.
+- When a client issues sustained concurrent tools/call requests whose individual durations are shorter than the drain deadline, and the mcp-gateway deployment is restarted with `kubectl rollout restart`, every request should either complete successfully or fail with a retryable JSON-RPC error. No request should fail with a transport-level reset or an ext_proc 5xx. The assertion is deliberately scoped to calls that fit inside the deadline; calls that outlast it are covered separately below, and the design does not promise them a clean outcome. The test runs Serial because it restarts shared infrastructure.
 
-### [Drain] Test readiness fails while draining but liveness stays healthy
+### [Drain] Test readiness reports draining while liveness stays healthy
 
-- When a broker-router pod receives SIGTERM, its /readyz endpoint should begin returning 503 while /healthz continues to return 200. This distinguishes a pod that is intentionally going away from one the kubelet should restart, and confirms the drain state is observable from outside the process.
+- When a broker-router pod receives SIGTERM, its /readyz endpoint should begin returning 503 while /healthz continues to return 200. This asserts that drain state is *reported*, not that readiness is the mechanism withdrawing traffic — endpoint removal is driven by pod deletion, and the readiness probe's 10s period with a 3-failure threshold is far too slow to serve that purpose. The value here is observability, and correctness on paths where a pod drains without being deleted.
 
 ### [Drain] Test no new backend sessions are created while draining
 
@@ -24,9 +24,13 @@ Format follows `tests/e2e/test_cases.md`. `Drain` is the feature tag; only the c
 
 - When a slow tool call is in flight and the serving pod receives SIGTERM, the call should complete and return its result rather than being cut at the socket, provided it finishes within the drain deadline. Uses a test server tool with a controllable delay shorter than the deadline.
 
-### [Drain] Test drain deadline is enforced
+### [Drain] Test drain deadline is enforced and overdue calls fail bounded
 
-- When a tool call outlasts the drain deadline, the pod should stop waiting, proceed to the bounded teardown, and exit within terminationGracePeriodSeconds rather than being killed by the kubelet. Uses a delay longer than the deadline and asserts the pod's exit is clean and the forced-termination metric is incremented.
+- When a tool call outlasts the drain deadline, the pod should stop waiting, proceed to the bounded teardown, and exit within terminationGracePeriodSeconds rather than being killed by the kubelet. The overdue call is permitted to fail, and this is the bound the Happy case above deliberately excludes: assert the failure is bounded in time and the forced-termination metric is incremented, rather than asserting the call succeeds. Uses a delay longer than the deadline.
+
+### [Drain] Test HTTP requests drain alongside ext_proc streams
+
+- When a slow HTTP request to the broker is in flight and the pod receives SIGTERM, the request should be given the drain deadline to complete rather than being cut when the teardown begins. Confirms brokerServer.Shutdown is started at the beginning of the drain rather than only in the later teardown, which is what makes the design's "HTTP and ext_proc work" guarantee true for both.
 
 ### [Drain] Test the pod exits within its grace period
 

--- a/docs/design/graceful-drain/tasks/e2e_test_cases.md
+++ b/docs/design/graceful-drain/tasks/e2e_test_cases.md
@@ -1,0 +1,45 @@
+# Graceful Drain — E2E Test Cases
+
+Design: [../graceful-drain-design.md](../graceful-drain-design.md)
+
+Format follows `tests/e2e/test_cases.md`. `Drain` is the feature tag; only the core rollout case is `Happy`, so that tag keeps its meaning.
+
+### [Happy,Drain] Test tool calls survive a rollout restart under load
+
+- When a client issues sustained concurrent tools/call requests against the gateway and the mcp-gateway deployment is restarted with `kubectl rollout restart`, every request should either complete successfully or fail with a retryable JSON-RPC error. No request should fail with a transport-level reset or an ext_proc 5xx. The test runs Serial because it restarts shared infrastructure.
+
+### [Drain] Test readiness fails while draining but liveness stays healthy
+
+- When a broker-router pod receives SIGTERM, its /readyz endpoint should begin returning 503 while /healthz continues to return 200. This distinguishes a pod that is intentionally going away from one the kubelet should restart, and confirms the drain state is observable from outside the process.
+
+### [Drain] Test no new backend sessions are created while draining
+
+- When a pod has entered the draining state and a client attempts to initialize a new stateful session against an upstream it has not used before, the gateway should refuse with a retryable error rather than creating a backend session it is about to abandon. Verified by asserting the upstream test server records no new session for that gateway session after drain begins.
+
+### [Drain] Test existing sessions continue routing while draining
+
+- When a pod is draining and a client issues a tools/call using a backend session mapping that already exists, the request should route and complete normally. Draining refuses new session creation only; it must not break sessions already established, since a replacement pod is expected to keep using them.
+
+### [Drain] Test in-flight tool calls complete during drain
+
+- When a slow tool call is in flight and the serving pod receives SIGTERM, the call should complete and return its result rather than being cut at the socket, provided it finishes within the drain deadline. Uses a test server tool with a controllable delay shorter than the deadline.
+
+### [Drain] Test drain deadline is enforced
+
+- When a tool call outlasts the drain deadline, the pod should stop waiting, proceed to the bounded teardown, and exit within terminationGracePeriodSeconds rather than being killed by the kubelet. Uses a delay longer than the deadline and asserts the pod's exit is clean and the forced-termination metric is incremented.
+
+### [Drain] Test the pod exits within its grace period
+
+- When the deployment is restarted, each terminating pod should exit before terminationGracePeriodSeconds elapses. A pod reaching the grace period would indicate the budget arithmetic has drifted from the pod spec, which is the failure the computed grace period exists to prevent.
+
+### [Drain,Security] Test draining does not weaken request rejection
+
+- When a pod is draining and a request arrives that would normally be rejected, it should still be rejected. Draining changes when traffic stops arriving, never what happens to traffic that does arrive; ext_proc failure_mode_allow remains false throughout.
+
+### [Drain,Security] Test the drain response cannot be induced by a client header
+
+- When a client sends headers attempting to signal drain state, the gateway should ignore them entirely. The drain response is derived from process state only, consistent with the rule that x-mcp-* routing metadata is router-set and never client-settable.
+
+### [Drain] Test steady-state behaviour is unaffected
+
+- When no pod is terminating, session creation, tool invocation, and readiness reporting should behave exactly as before this feature. Regression safety for the normal path, since the drain checks sit on the request path.

--- a/docs/design/graceful-drain/tasks/e2e_test_cases.md
+++ b/docs/design/graceful-drain/tasks/e2e_test_cases.md
@@ -26,7 +26,7 @@ Format follows `tests/e2e/test_cases.md`. `Drain` is the feature tag; only the c
 
 ### [Drain] Test drain deadline is enforced and overdue calls fail bounded
 
-- When a tool call outlasts the drain deadline, the pod should stop waiting, proceed to the bounded teardown, and exit within terminationGracePeriodSeconds rather than being killed by the kubelet. The overdue call is permitted to fail, and this is the bound the Happy case above deliberately excludes: assert the failure is bounded in time and the forced-termination metric is incremented, rather than asserting the call succeeds. Uses a delay longer than the deadline.
+- When a tool call outlasts the drain deadline, the pod should stop waiting, proceed to the bounded teardown, and exit within terminationGracePeriodSeconds rather than being killed by the kubelet. The overdue call is permitted to fail, and this is the bound the Happy case above deliberately excludes: assert the failure is bounded in time, and assert the forced termination via the drain log record on stdout rather than a Prometheus counter — the metrics endpoint is closed before the pod exits, so a drain-time counter can never be scraped. Uses a delay longer than the deadline.
 
 ### [Drain] Test HTTP requests drain alongside ext_proc streams
 
@@ -43,6 +43,18 @@ Format follows `tests/e2e/test_cases.md`. `Drain` is the feature tag; only the c
 ### [Drain,Security] Test the drain response cannot be induced by a client header
 
 - When a client sends headers attempting to signal drain state, the gateway should ignore them entirely. The drain response is derived from process state only, consistent with the rule that x-mcp-* routing metadata is router-set and never client-settable.
+
+### [Drain] Test endpoint propagation stays within the configured delay
+
+- When a broker-router pod is deleted, the interval between deletion and its endpoint disappearing from the gateway's Envoy configuration should remain below drainPropagationDelay. This is the design's one genuinely unbounded assumption — istiod convergence is not something the gateway controls — so it is worth a case that fails loudly if a cluster or Istio upgrade regresses it, rather than measuring it once during implementation and never again.
+
+### [Drain] Test an idle SSE stream does not delay the drain
+
+- When a client holds a GET /mcp SSE stream open with no request in flight and the pod is terminated, the drain should complete promptly rather than waiting out the full deadline. Guards the distinction between tracking in-flight requests and tracking ext_proc stream lifetimes; regressing to the latter would make every rollout pay the whole drain budget.
+
+### [Drain] Test the drain response carries the documented contract
+
+- When a draining pod refuses a new backend session, the response should be HTTP 503 with a Retry-After header and a JSON-RPC error body using the documented code, rather than a connection reset or an ext_proc 5xx. Also records what the official Go SDK does with that response, since the user documentation's retry guidance depends on whether the SDK reconnects transparently or surfaces the error.
 
 ### [Drain] Test steady-state behaviour is unaffected
 

--- a/docs/design/graceful-drain/tasks/tasks.md
+++ b/docs/design/graceful-drain/tasks/tasks.md
@@ -20,19 +20,26 @@ What does not exist and must be added: any notion of lifecycle state, any accoun
 
 ---
 
-### Task 1: Lifecycle state (CONNLINK-TBD)
+### Task 1: Lifecycle state and shared budgets (CONNLINK-TBD)
+
+The budgets cannot live in `cmd/mcp-broker-router`: that is `package main` and Go cannot import it, so the controller in Task 6 would have to duplicate the values — reintroducing exactly the drift the design exists to prevent. They go in an importable package from the start, alongside the lifecycle state that Tasks 2, 3 and 4 all depend on.
 
 **Files:**
 
-- `cmd/mcp-broker-router/lifecycle.go` (new)
-- `cmd/mcp-broker-router/lifecycle_test.go` (new)
+- `internal/drain/state.go` (new)
+- `internal/drain/state_test.go` (new)
+- `internal/drain/budget.go` (new)
+- `internal/drain/budget_test.go` (new)
 - `cmd/mcp-broker-router/main.go`
 
 **Acceptance criteria:**
 
-- [ ] A `State` type with `serving`, `draining`, `terminating`, stored as an atomic value on `app`.
+- [ ] A `State` type with `serving`, `draining`, `terminating`, held as an atomic value and exported for the router and health handlers to read.
 - [ ] Transitions are one-way and idempotent; a second SIGTERM does not reset state or restart the drain.
 - [ ] Reads are allocation-free and safe from request-path goroutines.
+- [ ] `internal/drain/budget.go` is the single home for `drainPropagationDelay`, `drainDeadline`, and the four teardown budgets merged in #1390, plus a `TotalGracePeriod()` derived from them.
+- [ ] `cmd/mcp-broker-router` consumes the constants from `internal/drain`; none are redeclared there.
+- [ ] A test asserts `TotalGracePeriod()` exceeds the sum of every individual budget.
 - [ ] Unit tests cover each transition and concurrent read/write under `-race`.
 
 **Verification:**
@@ -69,11 +76,14 @@ go test ./cmd/... -race -count=1
 
 ### Task 3: In-flight work accounting (CONNLINK-TBD)
 
+Depends on Task 1 for the state type and the tracker's home.
+
 **Files:**
 
+- `internal/drain/tracker.go` (new)
+- `internal/drain/tracker_test.go` (new)
 - `internal/mcp-router/ext_proc_adapter.go`
 - `internal/mcp-router/ext_proc_adapter_test.go`
-- `cmd/mcp-broker-router/lifecycle.go`
 
 **Acceptance criteria:**
 
@@ -100,13 +110,16 @@ go test ./internal/routing/... -bench=. -benchmem -run='^$'
 - `internal/routing/router_202511.go`
 - `internal/routing/router_test.go`
 
+Depends on Task 1 for the state type. The linearization point matters here: see the design's *Linearization point for session refusal*.
+
 **Acceptance criteria:**
 
-- [ ] `initializeMCPServerSession` refuses to create a new backend session while draining and returns a retryable error.
+- [ ] The lifecycle check sits **inside** `initGroup.Do`, after the cache lookup and before `InitForClient`, so the atomic state read is the linearization point.
+- [ ] An initialization that observes `serving` runs to completion and is counted as in-flight work; one that observes `draining` is refused before any upstream session exists.
+- [ ] Callers that joined an already-running `Do` share its result rather than being refused, since that session was admitted while the pod was serving.
 - [ ] Requests using an existing backend session mapping continue to route normally.
-- [ ] No backend session is created and then abandoned; the refusal happens before initialization, not after.
 - [ ] The drain response is derived from process state only, never from a client-supplied header.
-- [ ] Unit tests cover refusal, existing-session passthrough, and the singleflight interaction.
+- [ ] Unit tests cover refusal, existing-session passthrough, singleflight joiners, and a race test flipping state concurrently with initialization under `-race`.
 
 **Verification:**
 
@@ -123,13 +136,17 @@ go test ./internal/routing/... -race -count=1
 
 - `cmd/mcp-broker-router/main.go`
 
+Depends on Tasks 1, 3 and 4: the drain needs the state, something to wait on, and session gating.
+
 **Acceptance criteria:**
 
-- [ ] SIGTERM moves the process to `draining` before any server shutdown begins.
-- [ ] The drain waits for in-flight work up to `drainDeadline`, then moves to `terminating`.
-- [ ] The existing bounded teardown from #1390 runs unchanged after the drain.
-- [ ] Budgets are named constants in one place, and their sum is asserted against the grace period in a test.
-- [ ] Reaching the deadline is logged at warn with the counts still outstanding.
+- [ ] SIGTERM moves the process to `draining` before any shutdown begins.
+- [ ] `brokerServer.Shutdown` is started at the beginning of the drain so HTTP requests drain concurrently with ext_proc streams under `drainDeadline`, rather than only in the later teardown.
+- [ ] The drain waits for both to finish, or for `drainDeadline`, then moves to `terminating`.
+- [ ] The bounded teardown from #1390 runs unchanged afterwards, including its `serverDrainTimeout` call as the backstop for anything still open.
+- [ ] Budgets are consumed from `internal/drain`; none are redeclared here.
+- [ ] Reaching the deadline is logged at warn with the outstanding HTTP and ext_proc counts.
+- [ ] A test covers a delayed HTTP request completing inside the deadline, and one exceeding it.
 
 **Verification:**
 
@@ -151,8 +168,9 @@ go test ./cmd/... -race -count=1
 
 **Acceptance criteria:**
 
-- [ ] The generated Deployment sets a `preStop` hook sleeping `drainPropagationDelay`.
-- [ ] `terminationGracePeriodSeconds` is computed from the shared budget constants plus a safety margin, not hardcoded independently.
+- [ ] The generated Deployment sets a `preStop` hook sleeping `drainPropagationDelay`, imported from `internal/drain`.
+- [ ] `terminationGracePeriodSeconds` is `drain.TotalGracePeriod()`, never a literal.
+- [ ] `drainPropagationDelay` is validated against a real cluster: measure the interval between pod deletion and the endpoint disappearing from the gateway's Envoy config, and record the observed value in the design. Raise the default if 5s does not cover it.
 - [ ] The static manifest and the Helm chart match the controller output.
 - [ ] A controller test asserts the grace period is greater than the sum of all budgets.
 - [ ] `make generate-all` produces no diff.
@@ -236,6 +254,21 @@ make lint
 
 ## Ordering
 
-Tasks 1 and 2 are independent and can land together. Task 3 gates Task 5, since the drain has nothing to wait on without it. Task 4 is independent of 3 and can land in parallel. Task 6 depends on the budget constants settled in Task 5. Tasks 7 and 8 come last: metrics need the states to exist, and the e2e needs the whole sequence wired.
+Task 1 gates everything: it introduces both the lifecycle state and the shared budget package that Tasks 2, 3, 4 and 6 all consume.
 
-Task 9 can be drafted alongside Task 6 once the observable pod behaviour is fixed.
+```text
+Task 1 (state + budgets)
+ ├─ Task 2 (readiness)        ─┐
+ ├─ Task 3 (in-flight)        ─┤
+ ├─ Task 4 (session refusal)  ─┤
+ └─ Task 6 (pod spec)          │   ← needs budgets only, not 3/4
+                               ▼
+                        Task 5 (drain sequence)
+                               │
+                    ┌──────────┴──────────┐
+                 Task 7 (metrics)   Task 8 (e2e)
+```
+
+Tasks 2, 3 and 4 are independent of each other and can land in parallel once Task 1 is in. Task 5 needs 3 and 4, since the drain needs something to wait on and something to gate. Task 6 needs only the budgets from Task 1, so it can land early. Tasks 7 and 8 come last: metrics need the states to exist, and the e2e needs the whole sequence wired.
+
+Task 9 can be drafted alongside Task 6, once the observable pod behaviour is fixed.

--- a/docs/design/graceful-drain/tasks/tasks.md
+++ b/docs/design/graceful-drain/tasks/tasks.md
@@ -3,8 +3,6 @@
 Design: [../graceful-drain-design.md](../graceful-drain-design.md)
 Issue: #1363
 
-> Jira story references are placeholders pending stories under CONNLINK.
-
 ## Existing Code Analysis
 
 What this builds on, all already merged:
@@ -22,7 +20,7 @@ What does not exist and must be added: any notion of lifecycle state, any accoun
 
 ---
 
-### Task 1: Lifecycle state and shared budgets (CONNLINK-TBD)
+### Task 1: Lifecycle state and shared budgets
 
 The budgets cannot live in `cmd/mcp-broker-router`: that is `package main` and Go cannot import it, so the controller in Task 6 would have to duplicate the values — reintroducing exactly the drift the design exists to prevent. They go in an importable package from the start, alongside the lifecycle state that Tasks 2, 3 and 4 all depend on.
 
@@ -53,7 +51,7 @@ go test ./cmd/... -race -count=1
 
 ---
 
-### Task 2: Readiness reflects drain (CONNLINK-TBD)
+### Task 2: Readiness reflects drain
 
 **Files:**
 
@@ -76,7 +74,7 @@ go test ./cmd/... -race -count=1
 
 ---
 
-### Task 3: In-flight work accounting (CONNLINK-TBD)
+### Task 3: In-flight work accounting
 
 Depends on Task 1 for the state type and the tracker's home.
 
@@ -107,7 +105,7 @@ go test ./internal/mcp-router/... -bench=. -benchmem -run='^$'
 
 ---
 
-### Task 4: Refuse new stateful sessions while draining (CONNLINK-TBD)
+### Task 4: Refuse new stateful sessions while draining
 
 **Files:**
 
@@ -134,7 +132,7 @@ go test ./internal/routing/... -race -count=1
 
 ---
 
-### Task 5: Drain sequence in `run()` (CONNLINK-TBD)
+### Task 5: Drain sequence in `run()`
 
 **Files:**
 
@@ -161,7 +159,7 @@ go test ./cmd/... -race -count=1
 
 ---
 
-### Task 6: Pod lifecycle wiring (CONNLINK-TBD)
+### Task 6: Pod lifecycle wiring
 
 **Files:**
 
@@ -191,7 +189,7 @@ make test-controller-integration
 
 ---
 
-### Task 7: Drain telemetry (CONNLINK-TBD)
+### Task 7: Drain telemetry
 
 Not metrics. `internal/otel/metrics.go` builds a Prometheus **pull** exporter, so a counter incremented during drain is written to a registry that is never scraped: `metricsServer.Shutdown` closes the endpoint early in the teardown and the pod exits well inside one scrape interval. See the design's *Where drain telemetry goes*.
 
@@ -219,7 +217,7 @@ go test ./internal/drain/... ./internal/otel/... -race -count=1
 
 ---
 
-### Task 8: Rollout-under-load e2e (CONNLINK-TBD)
+### Task 8: Rollout-under-load e2e
 
 **Files:**
 
@@ -242,7 +240,7 @@ make test-e2e
 
 ---
 
-### Task 9: Documentation (CONNLINK-TBD)
+### Task 9: Documentation
 
 **Files:**
 

--- a/docs/design/graceful-drain/tasks/tasks.md
+++ b/docs/design/graceful-drain/tasks/tasks.md
@@ -1,0 +1,241 @@
+# Graceful Drain — Implementation Plan
+
+Design: [../graceful-drain-design.md](../graceful-drain-design.md)
+Issue: #1363
+
+> Jira story references are placeholders pending stories under CONNLINK.
+
+## Existing Code Analysis
+
+What this builds on, all already merged:
+
+- `cmd/mcp-broker-router/main.go` — SIGTERM registered (#1362). Shutdown sequence bounded (#1390): `serverDrainTimeout` 8s, `brokerDrainTimeout` 5s, `grpcDrainTimeout` 10s, `telemetryFlushTimeout` 4s, telemetry flushed last.
+- `cmd/mcp-broker-router/broker.go:53-63` — `/healthz` returns a static 200; `/readyz` gates on `mcpBroker.IsReady()`.
+- `internal/broker/broker.go` — `IsReady()` returns true when no servers are configured, or when any manager reports ready.
+- `internal/controller/broker_router.go` — generates the Deployment. `replicas := int32(1)` at `:93`; readiness probe at `:235-248` with `PeriodSeconds: 10`, `FailureThreshold: 3`; Service exposes `http` and `grpc` off the same pod at `:285-300`. No `preStop`, no `terminationGracePeriodSeconds`.
+- `internal/mcp-router/` — ext_proc server. No in-flight stream accounting today.
+- `internal/routing/router_202511.go` — `initializeMCPServerSession` creates backend sessions lazily, guarded by a singleflight group.
+
+What does not exist and must be added: any notion of lifecycle state, any accounting of in-flight work, and any pod-spec wiring for termination.
+
+---
+
+### Task 1: Lifecycle state (CONNLINK-TBD)
+
+**Files:**
+
+- `cmd/mcp-broker-router/lifecycle.go` (new)
+- `cmd/mcp-broker-router/lifecycle_test.go` (new)
+- `cmd/mcp-broker-router/main.go`
+
+**Acceptance criteria:**
+
+- [ ] A `State` type with `serving`, `draining`, `terminating`, stored as an atomic value on `app`.
+- [ ] Transitions are one-way and idempotent; a second SIGTERM does not reset state or restart the drain.
+- [ ] Reads are allocation-free and safe from request-path goroutines.
+- [ ] Unit tests cover each transition and concurrent read/write under `-race`.
+
+**Verification:**
+
+```bash
+make lint
+go test ./cmd/... -race -count=1
+```
+
+---
+
+### Task 2: Readiness reflects drain (CONNLINK-TBD)
+
+**Files:**
+
+- `cmd/mcp-broker-router/broker.go`
+- `cmd/mcp-broker-router/broker_test.go` (new)
+
+**Acceptance criteria:**
+
+- [ ] `/readyz` returns 503 in `draining` and `terminating`, regardless of `IsReady()`.
+- [ ] `/readyz` behaviour in `serving` is unchanged.
+- [ ] `/healthz` returns 200 in all three states; it reflects only whether the process can operate.
+- [ ] Neither endpoint exposes internal state in its body.
+
+**Verification:**
+
+```bash
+make lint
+go test ./cmd/... -race -count=1
+```
+
+---
+
+### Task 3: In-flight work accounting (CONNLINK-TBD)
+
+**Files:**
+
+- `internal/mcp-router/ext_proc_adapter.go`
+- `internal/mcp-router/ext_proc_adapter_test.go`
+- `cmd/mcp-broker-router/lifecycle.go`
+
+**Acceptance criteria:**
+
+- [ ] ext_proc streams are counted on open and released on close, including on error paths.
+- [ ] New ext_proc streams are refused once draining.
+- [ ] A `Wait(ctx)` returns when the count reaches zero or the context expires, whichever first.
+- [ ] Counting adds no allocation on the per-request path, consistent with `docs/design/performance.md`.
+- [ ] Unit tests with mock ext_proc streams cover open, close, error-path release, and refusal while draining.
+
+**Verification:**
+
+```bash
+make lint
+go test ./internal/mcp-router/... -race -count=1
+go test ./internal/routing/... -bench=. -benchmem -run='^$'
+```
+
+---
+
+### Task 4: Refuse new stateful sessions while draining (CONNLINK-TBD)
+
+**Files:**
+
+- `internal/routing/router_202511.go`
+- `internal/routing/router_test.go`
+
+**Acceptance criteria:**
+
+- [ ] `initializeMCPServerSession` refuses to create a new backend session while draining and returns a retryable error.
+- [ ] Requests using an existing backend session mapping continue to route normally.
+- [ ] No backend session is created and then abandoned; the refusal happens before initialization, not after.
+- [ ] The drain response is derived from process state only, never from a client-supplied header.
+- [ ] Unit tests cover refusal, existing-session passthrough, and the singleflight interaction.
+
+**Verification:**
+
+```bash
+make lint
+go test ./internal/routing/... -race -count=1
+```
+
+---
+
+### Task 5: Drain sequence in `run()` (CONNLINK-TBD)
+
+**Files:**
+
+- `cmd/mcp-broker-router/main.go`
+
+**Acceptance criteria:**
+
+- [ ] SIGTERM moves the process to `draining` before any server shutdown begins.
+- [ ] The drain waits for in-flight work up to `drainDeadline`, then moves to `terminating`.
+- [ ] The existing bounded teardown from #1390 runs unchanged after the drain.
+- [ ] Budgets are named constants in one place, and their sum is asserted against the grace period in a test.
+- [ ] Reaching the deadline is logged at warn with the counts still outstanding.
+
+**Verification:**
+
+```bash
+make lint
+go test ./cmd/... -race -count=1
+```
+
+---
+
+### Task 6: Pod lifecycle wiring (CONNLINK-TBD)
+
+**Files:**
+
+- `internal/controller/broker_router.go`
+- `internal/controller/broker_router_test.go`
+- `config/mcp-system/deployment-broker.yaml`
+- `charts/mcp-gateway/templates/`
+
+**Acceptance criteria:**
+
+- [ ] The generated Deployment sets a `preStop` hook sleeping `drainPropagationDelay`.
+- [ ] `terminationGracePeriodSeconds` is computed from the shared budget constants plus a safety margin, not hardcoded independently.
+- [ ] The static manifest and the Helm chart match the controller output.
+- [ ] A controller test asserts the grace period is greater than the sum of all budgets.
+- [ ] `make generate-all` produces no diff.
+
+**Verification:**
+
+```bash
+make lint
+make generate-all && git diff --exit-code
+make test-controller-integration
+```
+
+---
+
+### Task 7: Drain metrics (CONNLINK-TBD)
+
+**Files:**
+
+- `internal/otel/metrics.go`
+- `cmd/mcp-broker-router/lifecycle.go`
+
+**Acceptance criteria:**
+
+- [ ] Drain duration, requests completed during drain, and forced terminations are exported.
+- [ ] Naming follows the existing `mcp_broker_*` conventions.
+- [ ] Metrics emitted during drain are actually exported, which #1390's ordering change makes possible.
+- [ ] Unit tests assert the instruments are registered and recorded.
+
+**Verification:**
+
+```bash
+make lint
+go test ./internal/otel/... -race -count=1
+```
+
+---
+
+### Task 8: Rollout-under-load e2e (CONNLINK-TBD)
+
+**Files:**
+
+- `tests/e2e/graceful_drain_test.go` (new)
+- `tests/e2e/test_cases.md`
+
+**Acceptance criteria:**
+
+- [ ] Sustained concurrent `tools/call` load across a `kubectl rollout restart` completes with no transport-level resets.
+- [ ] Any failures observed are retryable protocol errors, not connection resets.
+- [ ] The pod exits within `terminationGracePeriodSeconds` without being killed.
+- [ ] Marked `Serial`, per `tests/e2e/CLAUDE.md`, since it restarts shared infrastructure.
+- [ ] Cases added to `tests/e2e/test_cases.md` with the tags in `e2e_test_cases.md`.
+
+**Verification:**
+
+```bash
+make test-e2e
+```
+
+---
+
+### Task 9: Documentation (CONNLINK-TBD)
+
+**Files:**
+
+- `docs/guides/` — per [documentation.md](documentation.md)
+- `docs/release-notes/`
+
+**Acceptance criteria:**
+
+- [ ] An operator-facing section covering what drain does, what it does not promise, and how to read the metrics.
+- [ ] The `terminationGracePeriodSeconds` change documented, since it alters observable pod behaviour.
+- [ ] Release notes entry per `.claude/rules/breaking-changes.md`.
+
+**Verification:**
+
+```bash
+make lint
+```
+
+---
+
+## Ordering
+
+Tasks 1 and 2 are independent and can land together. Task 3 gates Task 5, since the drain has nothing to wait on without it. Task 4 is independent of 3 and can land in parallel. Task 6 depends on the budget constants settled in Task 5. Tasks 7 and 8 come last: metrics need the states to exist, and the e2e needs the whole sequence wired.
+
+Task 9 can be drafted alongside Task 6 once the observable pod behaviour is fixed.

--- a/docs/design/graceful-drain/tasks/tasks.md
+++ b/docs/design/graceful-drain/tasks/tasks.md
@@ -8,11 +8,11 @@ Issue: #1363
 What this builds on, all already merged:
 
 - `cmd/mcp-broker-router/main.go` — SIGTERM registered (#1362). Shutdown sequence bounded (#1390): `serverDrainTimeout` 8s, `brokerDrainTimeout` 5s, `grpcDrainTimeout` 10s, `telemetryFlushTimeout` 4s, telemetry flushed last.
-- `cmd/mcp-broker-router/broker.go:61-70` — `/healthz` returns a static 200; `/readyz` gates on `mcpBroker.IsReady()`.
+- the `/healthz` and `/readyz` handlers in `cmd/mcp-broker-router/broker.go` — `/healthz` returns a static 200; `/readyz` gates on `mcpBroker.IsReady()`.
 - `internal/broker/broker.go` — `IsReady()` returns true when no servers are configured, or when any manager reports ready.
-- `internal/controller/broker_router.go` — generates the Deployment. `replicas := int32(1)` at `:101`; readiness probe at `:235-247` with `PeriodSeconds: 10`, `FailureThreshold: 3`; Service exposes `http` and `grpc` off the same pod at `:295-301`. No `preStop`, no `terminationGracePeriodSeconds`.
+- `internal/controller/broker_router.go` — generates the Deployment. `replicas := int32(1)`, hardcoded with no field in `api/v1alpha1`; a `ReadinessProbe` with `PeriodSeconds: 10` and `FailureThreshold: 3`; a Service exposing `http` and `grpc` off the same pod. No `preStop`, no `terminationGracePeriodSeconds`.
 - `internal/otel/metrics.go` — Prometheus **pull** exporter only; no OTLP metric push exists. Drain-time counters cannot be scraped, which is why Task 7 uses spans and logs.
-- `internal/controller/mcpgatewayextension_controller.go:757` — ext_proc `message_timeout` is `"10s"`, which bounds `drainDeadline` from above.
+- the `message_timeout` key in `internal/controller/mcpgatewayextension_controller.go` — ext_proc `message_timeout` is `"10s"`, which bounds `drainDeadline` from above.
 - `internal/mcp-router/` — ext_proc server. No in-flight stream accounting today.
 - `internal/routing/router_202511.go` — `initializeMCPServerSession` creates backend sessions lazily, guarded by a singleflight group.
 

--- a/docs/design/graceful-drain/tasks/tasks.md
+++ b/docs/design/graceful-drain/tasks/tasks.md
@@ -10,9 +10,11 @@ Issue: #1363
 What this builds on, all already merged:
 
 - `cmd/mcp-broker-router/main.go` — SIGTERM registered (#1362). Shutdown sequence bounded (#1390): `serverDrainTimeout` 8s, `brokerDrainTimeout` 5s, `grpcDrainTimeout` 10s, `telemetryFlushTimeout` 4s, telemetry flushed last.
-- `cmd/mcp-broker-router/broker.go:53-63` — `/healthz` returns a static 200; `/readyz` gates on `mcpBroker.IsReady()`.
+- `cmd/mcp-broker-router/broker.go:61-70` — `/healthz` returns a static 200; `/readyz` gates on `mcpBroker.IsReady()`.
 - `internal/broker/broker.go` — `IsReady()` returns true when no servers are configured, or when any manager reports ready.
-- `internal/controller/broker_router.go` — generates the Deployment. `replicas := int32(1)` at `:93`; readiness probe at `:235-248` with `PeriodSeconds: 10`, `FailureThreshold: 3`; Service exposes `http` and `grpc` off the same pod at `:285-300`. No `preStop`, no `terminationGracePeriodSeconds`.
+- `internal/controller/broker_router.go` — generates the Deployment. `replicas := int32(1)` at `:101`; readiness probe at `:235-247` with `PeriodSeconds: 10`, `FailureThreshold: 3`; Service exposes `http` and `grpc` off the same pod at `:295-301`. No `preStop`, no `terminationGracePeriodSeconds`.
+- `internal/otel/metrics.go` — Prometheus **pull** exporter only; no OTLP metric push exists. Drain-time counters cannot be scraped, which is why Task 7 uses spans and logs.
+- `internal/controller/mcpgatewayextension_controller.go:757` — ext_proc `message_timeout` is `"10s"`, which bounds `drainDeadline` from above.
 - `internal/mcp-router/` — ext_proc server. No in-flight stream accounting today.
 - `internal/routing/router_202511.go` — `initializeMCPServerSession` creates backend sessions lazily, guarded by a singleflight group.
 
@@ -87,18 +89,20 @@ Depends on Task 1 for the state type and the tracker's home.
 
 **Acceptance criteria:**
 
-- [ ] ext_proc streams are counted on open and released on close, including on error paths.
-- [ ] New ext_proc streams are refused once draining.
+- [ ] The tracked unit is an in-flight **request**, incremented when request headers are received and released when that request's terminal response has been sent — **not** the ext_proc stream. `Process` runs one goroutine per stream for the stream's lifetime, and MCP clients hold `GET /mcp` SSE responses open, so counting streams would count idle connections as work and burn the full deadline on every termination.
+- [ ] Streams are **not** refused while draining. With `failure_mode_allow: false` a refused stream is an Envoy local 5xx, which is the failure this design removes. Refusal belongs to session initialization (Task 4) only.
+- [ ] Release happens on error and cancellation paths, not only on clean completion.
 - [ ] A `Wait(ctx)` returns when the count reaches zero or the context expires, whichever first.
 - [ ] Counting adds no allocation on the per-request path, consistent with `docs/design/performance.md`.
-- [ ] Unit tests with mock ext_proc streams cover open, close, error-path release, and refusal while draining.
+- [ ] An idle SSE stream with no in-flight request does not delay the drain — covered by an explicit test.
+- [ ] Unit tests with mock ext_proc streams cover increment, terminal-response release, error-path release, and the idle-stream case.
 
 **Verification:**
 
 ```bash
 make lint
-go test ./internal/mcp-router/... -race -count=1
-go test ./internal/routing/... -bench=. -benchmem -run='^$'
+go test ./internal/mcp-router/... ./internal/drain/... -race -count=1
+go test ./internal/mcp-router/... -bench=. -benchmem -run='^$'
 ```
 
 ---
@@ -162,13 +166,14 @@ go test ./cmd/... -race -count=1
 **Files:**
 
 - `internal/controller/broker_router.go`
-- `internal/controller/broker_router_test.go`
+- `internal/controller/deployment_test.go` — existing home for generated-Deployment assertions; `broker_router_test.go` does not exist
 - `config/mcp-system/deployment-broker.yaml`
 - `charts/mcp-gateway/templates/`
 
 **Acceptance criteria:**
 
-- [ ] The generated Deployment sets a `preStop` hook sleeping `drainPropagationDelay`, imported from `internal/drain`.
+- [ ] The generated Deployment sets a `preStop` hook sleeping `drainPropagationDelay`, imported from `internal/drain`, as `exec: ["/bin/sh","-c","sleep N"]`. The final image is Alpine running as UID 65532 (`Dockerfile`), so a shell is available. Native `lifecycle.preStop.sleep` is cleaner and survives a move to distroless, but it is GA only from Kubernetes 1.32 and this repo declares no supported floor — note it as a follow-up rather than adopting it here.
+- [ ] Confirm against a live gateway whether Envoy holds the ext_proc stream open for the duration of an SSE body, since Task 3's in-flight accounting assumes it may. Record the finding in the design.
 - [ ] `terminationGracePeriodSeconds` is `drain.TotalGracePeriod()`, never a literal.
 - [ ] `drainPropagationDelay` is validated against a real cluster: measure the interval between pod deletion and the endpoint disappearing from the gateway's Envoy config, and record the observed value in the design. Raise the default if 5s does not cover it.
 - [ ] The static manifest and the Helm chart match the controller output.
@@ -179,31 +184,37 @@ go test ./cmd/... -race -count=1
 
 ```bash
 make lint
+make test-unit
 make generate-all && git diff --exit-code
 make test-controller-integration
 ```
 
 ---
 
-### Task 7: Drain metrics (CONNLINK-TBD)
+### Task 7: Drain telemetry (CONNLINK-TBD)
+
+Not metrics. `internal/otel/metrics.go` builds a Prometheus **pull** exporter, so a counter incremented during drain is written to a registry that is never scraped: `metricsServer.Shutdown` closes the endpoint early in the teardown and the pod exits well inside one scrape interval. See the design's *Where drain telemetry goes*.
 
 **Files:**
 
-- `internal/otel/metrics.go`
-- `cmd/mcp-broker-router/lifecycle.go`
+- `internal/drain/telemetry.go` (new)
+- `internal/drain/telemetry_test.go` (new)
+- `cmd/mcp-broker-router/main.go`
 
 **Acceptance criteria:**
 
-- [ ] Drain duration, requests completed during drain, and forced terminations are exported.
-- [ ] Naming follows the existing `mcp_broker_*` conventions.
-- [ ] Metrics emitted during drain are actually exported, which #1390's ordering change makes possible.
-- [ ] Unit tests assert the instruments are registered and recorded.
+- [ ] The drain emits an OTLP span carrying duration, requests completed, requests outstanding at the deadline, and whether termination was forced.
+- [ ] The same fields are emitted as a structured log record, which reaches stdout via `MultiHandler` even when OTLP is disabled.
+- [ ] The span is recorded before `telemetryFlushTimeout` begins, so it is flushed rather than dropped.
+- [ ] No acceptance criterion anywhere depends on a drain-time Prometheus counter being scraped.
+- [ ] Any steady-state counters added are documented as not observable during drain.
+- [ ] Unit tests assert the span attributes and log fields using the existing `tracetest` helpers.
 
 **Verification:**
 
 ```bash
 make lint
-go test ./internal/otel/... -race -count=1
+go test ./internal/drain/... ./internal/otel/... -race -count=1
 ```
 
 ---


### PR DESCRIPTION
Design and failure-mode inventory for the draining half of #1363, which is the part agreed on the issue ; the durable cross-replica cleanup half is recorded as a non-goal along with the reasoning that ruled it out, so the decision does not have to be rediscovered later.

Two findings from reading the generated pod spec shaped the design more than anything else. Readiness cannot be the mechanism that withdraws traffic during termination: the probe is `PeriodSeconds: 10` with `FailureThreshold: 3` (`internal/controller/broker_router.go:235-248`), so failing `/readyz` takes up to 30s, which is longer than the entire 27s shutdown budget. Pod deletion withdraws the endpoint independently of readiness, so `preStop` only has to buy time for that withdrawal to reach Envoy. That also settles what `preStop` should do, which was the open question I left on the issue: having it trigger the drain would make the process start refusing work while Envoy is still routing to it, converting requests that would have succeeded into errors. So `preStop` sleeps and SIGTERM initiates the drain, and `/readyz` gating stays for observability and the non-deletion cases rather than as the primary mechanism.

The second is budget arithmetic. `preStop` consumes `terminationGracePeriodSeconds`; the grace clock starts when the pod is marked Terminating; and the teardown bounded in #1390 already spends 27s of the 30s default. There is no room for a propagation delay or a drain wait, so the grace period is computed in the controller from the shared budget constants rather than defaulted. A mismatch between the pod spec and the process is precisely the failure the design exists to prevent, so the two should not be able to drift.

Contents follow `docs/design/CLAUDE.md` : the design doc with problem, goals, job stories, flow, component responsibilities and the state machine, plus the failure-mode inventory I promised on the issue ; nine ordered implementation tasks with acceptance criteria and `make` verification ; ten e2e cases in the tagged format, only the core rollout case marked `Happy` ; and a documentation plan, since `terminationGracePeriodSeconds` changing and pods taking longer to terminate are both observable behaviour changes.

Jira references in `tasks.md` are placeholders.., happy to fill them in if someone opens stories under CONNLINK, or to drop the field if that is not wanted for this one.

One thing I would particularly like a view on, and it is not the one I originally asked about. Task 3 counts in-flight work on the ext_proc path, and I first framed that as a performance question. It is not: an atomic counter is cheap and allocation-freeness was never the risk. The question that actually decides the drain's cost profile is **what gets counted — a stream or a request**. `Process` runs one goroutine per ext_proc stream for the stream's lifetime, and MCP clients hold `GET /mcp` SSE responses open, so counting streams would count idle connections as work and make every termination burn the whole drain budget rather than only the bad ones. The design now specifies an in-flight request, headers to terminal response. I would like that confirmed, since everything downstream follows from it.

Related and still unverified: whether Envoy holds the ext_proc stream open for the duration of an SSE body under the current `response_body_mode`. That is marked in the design as an assumption and assigned to Task 6 alongside the propagation measurement, rather than being quietly relied on.

On the budgets, I have settled on constants rather than `MCPGatewayExtension` fields and recorded the kill criterion in the design: a deployment where measured propagation exceeds the delay and the operator cannot rebuild the controller. At that point they go on the CRD, not onto flags.

One more worth a maintainer's nod: the drain refusal is specified as HTTP 503 with `Retry-After` and JSON-RPC `-32000`. The MCP path currently uses only the standard codes, so this would be the first implementation-defined one there — the `-32001`/`-32002` already in the tree are A2A spec codes in the A2A test server and do not collide.

Part of #1363.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded graceful-drain guidance for session termination, slow tools, in-flight requests, and existing connections.
  * Documented retry behavior, including HTTP 503 responses, `Retry-After` headers, and JSON-RPC error contracts.
  * Added observability guidance using traces and structured logs.
  * Added rollout, security, upgrade, and client SDK documentation plans.
  * Added end-to-end test plans covering draining, deadlines, health transitions, and connection handling.
  * Clarified shutdown timing, propagation limits, termination behavior, and implementation task sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
