### PR TITLE
feat: report build version in MCP serverInfo instead of hardcoded value

### DIFF
--- a/cmd/mcp-broker-router/broker.go
+++ b/cmd/mcp-broker-router/broker.go
@@ -32,6 +32,7 @@ func (a *app) createBroker() {
 		broker.WithDiscoveryToolsEnabled(a.brokerCfg.discoveryToolsEnabled),
 		broker.WithDiscoveryToolThreshold(a.brokerCfg.discoveryToolThreshold),
 		broker.WithSessionCache(a.sessionCache),
+		broker.WithVersion(version),
 	}
 	if a.jwtMgr != nil {
 		brokerOpts = append(brokerOpts,

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -183,6 +183,9 @@ type mcpBrokerImpl struct {
 	// protocol handlers encapsulate version-specific broker behavior
 	handler2025 ProtocolHandler
 	handler2026 ProtocolHandler
+
+	// version is the injected build version
+	version string
 }
 
 // this ensures that mcpBrokerImpl implements the MCPBroker interface
@@ -275,6 +278,13 @@ func WithUserSpecificFetchTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithVersion sets the build version of the MCP Broker
+func WithVersion(version string) Option {
+	return func(mb *mcpBrokerImpl) {
+		mb.version = version
+	}
+}
+
 // NewBroker creates a new MCPBroker accepts optional config functions such as WithEnforceCapabilityFilter
 func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	mcpBkr := &mcpBrokerImpl{
@@ -284,6 +294,7 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 		managerTickerInterval:    time.Second * 60,
 		discovery:                discoveryConfig{enabled: true},
 		userSpecificFetchTimeout: 30 * time.Second,
+		version:                  "dev",
 	}
 
 	for _, option := range opts {
@@ -323,7 +334,7 @@ func NewBroker(logger *slog.Logger, opts ...Option) MCPBroker {
 	srv := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "Kuadrant MCP Gateway",
-			Version: "0.0.1",
+			Version: mcpBkr.version,
 		},
 		serverOpts,
 	)


### PR DESCRIPTION
## Description
This PR resolves #1410 by dynamically reporting the actual build version in the MCP `serverInfo` instead of using a hardcoded `"0.0.1"` string. 

The build process already injects `main.version` via `ldflags`. This change successfully threads that existing variable into the broker initialization so it surfaces accurately to connected clients.

## Changes Made
* **`internal/broker/broker.go`**:
  * Added a `version` field to the `mcpBrokerImpl` struct.
  * Created a `WithVersion(version string)` Option to inject the version.
  * Defaults the version to `"dev"` if none is provided.
  * Swapped out the hardcoded `"0.0.1"` for the dynamic `version` field.
* **`cmd/mcp-broker-router/broker.go`**:
  * Updated `createBroker()` to pass the package-level `version` variable using `broker.WithVersion(version)`.

## Acceptance Criteria Met
- [x] `serverInfo.version` now correctly reflects the build version.
- [x] Tagged builds will report the release version (via existing `ldflags`).
- [x] Untagged/local builds will report `"dev"`.
- [x] `go build ./...` completes successfully with no regressions.

Fixes #1410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The application now reports its configured build version in server metadata.
  * Development builds continue to use a default version when none is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->