### PR TITLE
Enable browser access and publish MCP endpoints

### DIFF
--- a/api/v1/mcpgatewayextension_types.go
+++ b/api/v1/mcpgatewayextension_types.go
@@ -248,6 +248,10 @@ type MCPGatewayExtensionStatus struct {
 	// +patchMergeKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// mcpEndpoint is the public URL for MCP clients.
+	// +optional
+	MCPEndpoint string `json:"mcpEndpoint,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -345,6 +345,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              mcpEndpoint:
+                description: mcpEndpoint is the public URL for MCP clients.
+                type: string
             type: object
         required:
         - spec

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -345,6 +345,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              mcpEndpoint:
+                description: mcpEndpoint is the public URL for MCP clients.
+                type: string
             type: object
         required:
         - spec

--- a/cmd/mcp-broker-router/broker.go
+++ b/cmd/mcp-broker-router/broker.go
@@ -85,11 +85,6 @@ func (a *app) setUpHTTPServer() {
 		WriteTimeout: writeTimeout,
 	}
 
-	mux.HandleFunc("OPTIONS /mcp", func(w http.ResponseWriter, r *http.Request) {
-		a.logger.Debug("Handling OPTIONS", "Mcp-Session-Id", r.Header.Get("Mcp-Session-Id"))
-		w.WriteHeader(http.StatusOK)
-	})
-
 	mux.HandleFunc("/status", a.mcpBroker.HandleStatusRequest)
 	mux.HandleFunc("/status/", a.mcpBroker.HandleStatusRequest)
 	if cfg.enableURLElicitation {

--- a/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -345,6 +345,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              mcpEndpoint:
+                description: mcpEndpoint is the public URL for MCP clients.
+                type: string
             type: object
         required:
         - spec

--- a/docs/design/security-architecture.md
+++ b/docs/design/security-architecture.md
@@ -56,9 +56,9 @@ MCP Client
 |----------|---------------|
 | Client → Gateway | Bearer token, MCP JSON-RPC body, custom headers |
 | Gateway → Router (ext_proc) | Request headers, buffered body |
-| Gateway → Upstream MCP Server | All client headers, MCP JSON-RPC body |
+| Gateway → Upstream MCP Server | Client headers excluding gateway-internal headers and, for browser requests, browser-hop headers; MCP JSON-RPC body |
 | Gateway → Broker | MCP JSON-RPC body, gateway session JWT, `x-mcp-authorized` signed header |
-| Broker → Upstream (per-user fetch) | Client `Authorization` header; gateway-scoped credentials (`cookie`, `proxy-authorization`) stripped |
+| Broker → Upstream (per-user fetch) | Client `Authorization` header; gateway-scoped credentials and browser-hop headers from browser requests stripped |
 | Upstream MCP Server → Client | MCP JSON-RPC response body (streamed as-is), backend session IDs (rewritten to gateway session IDs) |
 
 ### Information shared with upstream MCP servers (model providers)
@@ -66,7 +66,7 @@ MCP Client
 When an MCP server sits in front of an LLM or model provider, the following data reaches it:
 
 - The full MCP JSON-RPC request body, including tool arguments
-- All client headers, barring those specifically managed by the gateway (e.g., `mcp-session-id`, pseudo-headers). This includes the `Authorization` header — the original bearer token is forwarded unless token exchange is configured, in which case a scoped token replaces it
+- Client headers except gateway-internal headers. Browser requests also drop browser-hop headers (`Origin`, `Referer`, `Cookie`, and `Sec-Fetch-*`). The `Authorization` header is forwarded unless token exchange replaces it with a scoped token
 
 The gateway does not add user identity claims, PII, or conversation context beyond what the client includes in the MCP request body.
 
@@ -92,10 +92,10 @@ The gateway is NOT responsible for:
 - The router (`internal/mcp-router/`) never accesses `credentialRef` values; it only reads routing headers and the JSON-RPC method/tool name from the request body
 - The broker (`internal/broker/`) never writes `credentialRef` values to client-facing responses, logs, or headers forwarded through Envoy
 - The controller (`internal/controller/`) scopes generated Secrets to the operator namespace and sets owner references for garbage collection. The controller's ClusterRole grants cluster-wide secrets access, but the informer cache is filtered by label (`mcp.kuadrant.io/secret: "true"`) to limit the working set
-- Routing headers set by the router (tool name, session ID, server name) are derived from parsed JSON-RPC bodies or gateway-issued JWTs, not from raw client input. Client-supplied headers are proxied through to upstream backends as-is — header filtering is the responsibility of the gateway HTTPRoute configuration and AuthPolicy
-- The router strips or rewrites gateway-internal headers (`mcp-session-id`, `mcp-init-host`, `router-key`) before traffic reaches upstream backends
+- Routing headers set by the router (tool name, session ID, server name) are derived from parsed JSON-RPC bodies or gateway-issued JWTs, not from raw client input. Other client-supplied headers are proxied unless explicitly stripped by the router or replaced by AuthPolicy
+- The router strips or rewrites gateway-internal headers (`mcp-session-id`, `mcp-init-host`, `router-key`, `x-mcp-authorized`, `x-mcp-virtualserver`, `x-mcp-verified-sub`) and strips browser-hop headers (`Origin`, `Referer`, `Cookie`, `Sec-Fetch-*`) from browser requests before traffic reaches upstream backends
 - **`cacheScope` correctness**: the broker uses pessimistic aggregation — any upstream with `cacheScope: "private"`, `ttlMs: 0`, or CRD `userSpecificList: true` makes the entire `tools/list` response `"private"`. Wrong `"public"` on a response containing per-user tools would leak tool lists across users. `cacheScope: "private"` triggers per-user fetching automatically, superseding the CRD field for 2026 upstreams
-- **User-specific fetch credential isolation**: when the broker fetches per-user tools from upstreams, `filterUserHeaders` strips gateway-scoped credentials (`cookie`, `proxy-authorization`) and transport headers (`content-type`, `mcp-session-id`, etc.) before forwarding. The client's `Authorization` header is preserved for upstream authentication
+- **User-specific fetch credential isolation**: when the broker fetches per-user tools from upstreams, `filterUserHeaders` strips gateway-scoped credentials, transport headers (`content-type`, `mcp-session-id`, etc.), and browser-hop headers from browser requests before forwarding. The client's `Authorization` header is preserved for upstream authentication
 
 ## Authentication and Authorization
 
@@ -204,12 +204,12 @@ Context pollution — where untrusted data from one tool call influences subsequ
 |------|----------|---------------|------------|
 | No payload-level prompt injection detection | Medium | By design — gateway for tool calls is just a routing layer | Use prompt guard tooling alongside the gateway |
 | Tool responses streamed as-is from backends | Medium | By design | Upstream servers must validate outputs; prompt guards can inspect, reject, modify responses |
-| Client custom headers forwarded to backends | Low | `mcp-session-id` replaced with specific target mcp backend session; `mcp-init-host` and `router-key` are stripped by the router before traffic reaches a backend | Review header forwarding policy if backends are untrusted |
+| Client custom headers forwarded to backends | Low | Gateway-internal headers are stripped; browser-hop headers are also stripped from browser requests; the backend session ID replaces `mcp-session-id` | Review the remaining header forwarding policy if backends are untrusted |
 | No response size limits on SSE streams | Low | Not implemented | Envoy buffer limits and timeouts provide partial mitigation |
 | JWT signing key absent | High | Mitigated | The broker/router refuses to start if `GATEWAY_SIGNING_KEY` is not set. In controller-managed deployments the controller generates a 32-byte random key and injects it via `env.valueFrom.secretKeyRef` ([#714](https://github.com/Kuadrant/mcp-gateway/issues/714)). |
 | Hairpin backend-init request bypass | Critical | Mitigated (GHSA-g53w-w6mj-hrpp) | The router only accepts an `mcp-init-host` rewrite when accompanied by a short-lived JWT (30s, `aud=mcp-router`, `purpose=backend-init`, host-bound, `jti`) signed by the gateway's HMAC session signing key. The static `--mcp-router-key` flag and `MCP_ROUTER_API_KEY` env var have been removed. |
 | MCPVirtualServer only hides tools from listing, does not prevent calling | Medium | By design — virtual servers filter tools/list but authorized clients can still call any tool directly | Use AuthPolicy with tool-level RBAC to enforce access control; virtual servers control visibility, not authorization. Document this clearly in virtual server docs |
-| Client OAuth tokens forwarded to backends without token exchange | Medium | By design — all headers forwarded | Configure token exchange via AuthPolicy to replace client tokens with scoped tokens |
+| Client OAuth tokens forwarded to backends without token exchange | Medium | By design — `Authorization` is forwarded | Configure token exchange via AuthPolicy to replace client tokens with scoped tokens |
 | TLS configurations are not included in examples | Low | Relies on infrastructure layer | Deploy behind Istio or configure TLS on Gateway listeners for production |
 
 ## Recommendations for Secure Deployment

--- a/docs/design/security-architecture.md
+++ b/docs/design/security-architecture.md
@@ -113,6 +113,27 @@ The client's Authorization header is always forwarded to upstream servers, allow
 
 AuthPolicy can enforce per-tool access control using the `x-mcp-toolname` and `x-mcp-servername` headers set by the router. JWT claims (e.g., `resource_access`) are matched against the requested tool to produce an `x-mcp-authorized` JWT signed header via Authorino. The broker verifies this signature and filters tool lists accordingly.
 
+### Browser access and Origin validation
+
+The router permits cross-origin browser access from any `Origin`. It returns
+unauthenticated CORS preflight requests directly, before AuthPolicy evaluates
+them. All subsequent MCP requests continue through the normal Envoy filter
+chain, so AuthPolicy still enforces authentication and authorization on browser
+tool calls. The gateway does not enable credentialed CORS; browser-managed
+credentials such as cookies are stripped, while an explicit `Authorization`
+header is preserved.
+
+The [MCP Streamable HTTP transport specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning)
+requires servers to validate `Origin` to prevent DNS rebinding. The router
+strips `Origin` before forwarding a browser request upstream, so the gateway
+assumes responsibility for this validation. Its current allow-all policy does
+not provide a restrictive origin allowlist. Deployments must therefore use
+AuthPolicy and must not treat VPN or private-network reachability as the only
+access control: otherwise, a malicious website visited by a network-connected
+user could invoke tools and read their responses. Deployments requiring a
+restrictive origin policy would need a configurable origin allowlist or explicit
+browser-access opt-in, neither of which is currently supported.
+
 ### Security properties
 
 - Client identity validation (JWT/OIDC) and token exchange (RFC 8693) are delegated to Authorino via AuthPolicy — the gateway contains no custom logic for these flows. URL token elicitation (`internal/broker/`, `internal/elicitation/`) is a separate path where the gateway stores and injects per-user tokens for upstream requests (see [URL Token Elicitation](#url-token-elicitation))

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -114,14 +114,19 @@ kubectl get httproute mcp-gateway-route -n mcp-system
 
 ### Browser access (CORS)
 
-The gateway allows non-credentialed requests from any browser origin and
-answers preflights before authentication policies run. Authentication still
-applies to the actual request, including bearer tokens. Cookies and other
-credentialed cross-origin requests are not allowed. Native MCP clients are
-unaffected.
+The gateway allows cross-origin requests from any browser origin. It answers
+preflight requests before authentication policies run, but authentication and
+authorization still apply to the subsequent MCP request. Cookies and other
+browser-managed credentials are not allowed; clients can send bearer tokens in
+the `Authorization` header. Native MCP clients are unaffected.
 
 Browser access is handled by the external processor, so it works with either
 the managed HTTPRoute or a custom one.
+
+> **Warning:** Protect the MCP endpoint with authentication even when it is only
+> reachable through a VPN or private network. Without authentication, a website
+> visited by a user connected to that network could invoke MCP tools through the
+> user's browser and read the responses.
 
 ### Custom HTTPRoute (Optional)
 

--- a/docs/guides/configure-mcp-gateway-listener-and-router.md
+++ b/docs/guides/configure-mcp-gateway-listener-and-router.md
@@ -1,7 +1,7 @@
 
 # Configure MCP Gateway Listener and Route
 
-This guide covers adding the required MCP listeners to your existing Gateway. The controller automatically creates an HTTPRoute when the MCPGatewayExtension becomes ready. This guide also covers how to use a custom HTTPRoute if you need CORS headers or additional path rules.
+This guide covers adding the required MCP listeners to your existing Gateway. The controller automatically creates an HTTPRoute when the MCPGatewayExtension becomes ready. It also shows how to manage a custom route.
 
 ## Prerequisites
 
@@ -112,9 +112,20 @@ Verify the HTTPRoute was created:
 kubectl get httproute mcp-gateway-route -n mcp-system
 ```
 
+### Browser access (CORS)
+
+The gateway allows non-credentialed requests from any browser origin and
+answers preflights before authentication policies run. Authentication still
+applies to the actual request, including bearer tokens. Cookies and other
+credentialed cross-origin requests are not allowed. Native MCP clients are
+unaffected.
+
+Browser access is handled by the external processor, so it works with either
+the managed HTTPRoute or a custom one.
+
 ### Custom HTTPRoute (Optional)
 
-If you need a custom HTTPRoute (e.g. with CORS headers, additional path rules, or OAuth well-known endpoints), disable automatic creation and manage your own:
+If you need a custom HTTPRoute for additional path rules or backends, disable automatic creation and manage your own:
 
 1. Find your MCPGatewayExtension name and set `httpRouteManagement: Disabled`:
    ```bash
@@ -148,20 +159,6 @@ If you need a custom HTTPRoute (e.g. with CORS headers, additional path rules, o
            - path:
                type: PathPrefix
                value: /mcp
-         filters:
-           - type: ResponseHeaderModifier
-             responseHeaderModifier:
-               add:
-                 - name: Access-Control-Allow-Origin
-                   value: "*"
-                 - name: Access-Control-Allow-Methods
-                   value: "GET, POST, PUT, DELETE, OPTIONS, HEAD"
-                 - name: Access-Control-Allow-Headers
-                   value: "Content-Type, Authorization, Accept, Origin, X-Requested-With"
-                 - name: Access-Control-Max-Age
-                   value: "3600"
-                 - name: Access-Control-Allow-Credentials
-                   value: "true"
          backendRefs:
            - name: mcp-gateway
              port: 8080
@@ -174,7 +171,6 @@ If you need a custom HTTPRoute (e.g. with CORS headers, additional path rules, o
              port: 8080
    EOF
    ```
-
 ## Step 3: Verify EnvoyFilter Configuration
 
 The MCP Gateway controller automatically creates the EnvoyFilter when the MCPGatewayExtension is ready. Check that it exists:

--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -67,8 +67,8 @@ This automatically installs:
 When the MCPGatewayExtension becomes ready, the controller automatically creates:
 - **MCP Broker/Router Deployment** - Aggregates tools from upstream MCP servers
 - **MCP Broker/Router Service** - Named `mcp-gateway` in the MCPGatewayExtension namespace
-- **HTTPRoute** - Named `mcp-gateway-route`, routes traffic from the Gateway listener to the broker service for `/mcp` and `/.well-known/oauth-protected-resource`. The hostname is derived from the listener (wildcards like `*.example.com` become `mcp.example.com`). This can be disabled by setting `spec.httpRouteManagement: Disabled` on the MCPGatewayExtension if you need a custom HTTPRoute (e.g. with CORS headers or custom filters). Note: disabling does not delete a previously created `mcp-gateway-route`; you must remove it manually
-- **EnvoyFilter** - Configures Istio to route requests through the external processor (created in the Gateway's namespace)
+- **HTTPRoute** - Named `mcp-gateway-route`, routes traffic from the Gateway listener to the broker service for `/mcp` and `/.well-known/oauth-protected-resource`. The hostname is derived from the listener (wildcards like `*.example.com` become `mcp.example.com`). This can be disabled by setting `spec.httpRouteManagement: Disabled` on the MCPGatewayExtension if you need a custom HTTPRoute. Note: disabling does not delete a previously created `mcp-gateway-route`; you must remove it manually
+- **EnvoyFilter** - Configures Istio to route requests through the external processor, which also enables browser access (created in the Gateway's namespace)
 - **ServiceAccount** - For the broker/router pods
 - **Configuration Secret** - `mcp-gateway-config` containing server configuration
 
@@ -130,7 +130,7 @@ After installation, the controller automatically creates the HTTPRoute for gatew
 1. **[Register MCP Servers](./register-mcp-servers.md)** - Connect internal MCP servers
 2. **[Connect to External MCP Servers](./external-mcp-server.md)** - Connect to external APIs
 
-If you need to customize the HTTPRoute (e.g. add CORS headers), see [Configure Gateway Listener and Route](./configure-mcp-gateway-listener-and-router.md).
+If you need to customize the HTTPRoute, see [Configure Gateway Listener and Route](./configure-mcp-gateway-listener-and-router.md).
 
 ## API Reference
 

--- a/docs/guides/migrating-mcpgatewayextension.md
+++ b/docs/guides/migrating-mcpgatewayextension.md
@@ -94,7 +94,7 @@ spec:
     sectionName: mcp
 ```
 
-This is useful when your HTTPRoute includes custom configuration such as CORS headers, additional path rules, or OAuth well-known endpoints that the auto-generated route does not include.
+This is useful when your HTTPRoute includes custom configuration such as additional path rules, backends, or filters that the auto-generated route does not include.
 
 > **Important:** Setting `httpRouteManagement: Disabled` prevents the controller from creating or updating the HTTPRoute, but does not delete a previously auto-created `mcp-gateway-route`. You must delete it manually once your custom HTTPRoute is in place:
 > ```bash
@@ -193,4 +193,3 @@ spec:
 | `kuadrant.io/alpha-disable-httproute` | `spec.httpRouteManagement` | `"true"` becomes `Disabled`, default is `Enabled` |
 | `kuadrant.io/alpha-gateway-listener-port` | removed | port is derived from `sectionName` listener |
 | (new) | `spec.privateHost` | overrides internal host for hair-pinning |
-

--- a/docs/reference/mcpgatewayextension.md
+++ b/docs/reference/mcpgatewayextension.md
@@ -82,6 +82,7 @@ Trust pool hierarchy: system roots, then gateway CA bundle (if set), then per-se
 | **Field** | **Type** | **Description** |
 |-----------|----------|-----------------|
 | `conditions` | [][Kubernetes meta/v1.Condition](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition) | List of conditions that define the status of the resource |
+| `mcpEndpoint` | String | The public MCP endpoint derived from the targeted listener, including a non-default listener port |
 
 ### Conditions
 

--- a/docs/release-notes/browser-access.md
+++ b/docs/release-notes/browser-access.md
@@ -1,8 +1,14 @@
 # Browser access for MCP gateways
 
-MCP gateways now allow non-credentialed cross-origin browser requests from any
-origin. The external processor answers browser preflights and adds the required
-response headers for both managed and custom HTTPRoutes.
+MCP gateways now allow cross-origin browser requests without cookie-based
+credentials from any origin. The external processor answers browser preflights
+and adds the required response headers for both managed and custom HTTPRoutes.
+
+Only preflight requests bypass authentication. Actual MCP requests still pass
+through `AuthPolicy`. Protect the gateway with authentication even on a VPN or
+private network; otherwise, a website visited by a network-connected user could
+invoke tools and read their responses. See
+[Browser access (CORS)](../guides/configure-mcp-gateway-listener-and-router.md#browser-access-cors).
 
 The controller also publishes the resolved MCP URL in
 `status.mcpEndpoint`, including a non-default listener port.

--- a/docs/release-notes/browser-access.md
+++ b/docs/release-notes/browser-access.md
@@ -1,0 +1,10 @@
+# Browser access for MCP gateways
+
+MCP gateways now allow non-credentialed cross-origin browser requests from any
+origin. The external processor answers browser preflights and adds the required
+response headers for both managed and custom HTTPRoutes.
+
+The controller also publishes the resolved MCP URL in
+`status.mcpEndpoint`, including a non-default listener port.
+
+Native MCP clients are unaffected.

--- a/internal/broker/oauth_protected_resource_handler.go
+++ b/internal/broker/oauth_protected_resource_handler.go
@@ -81,21 +81,9 @@ func getOAuthConfig() *OAuthProtectedResource {
 }
 
 // Handle handles the /.well-known/oauth-protected-resource endpoint
-func (prh *ProtectedResourceHandler) Handle(w http.ResponseWriter, r *http.Request) {
+func (prh *ProtectedResourceHandler) Handle(w http.ResponseWriter, _ *http.Request) {
 	prh.Logger.Info("service protected resource endpoint")
 	oauthConfig := getOAuthConfig()
-	// Set CORS headers
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept, Origin, X-Requested-With")
-	w.Header().Set("Access-Control-Max-Age", "3600")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-
-	// Handle preflight requests
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
 
 	// Set content type and return JSON response
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/broker/oauth_protected_resource_handler_test.go
+++ b/internal/broker/oauth_protected_resource_handler_test.go
@@ -58,12 +58,6 @@ func TestProtectedResourceHandler_Handle(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			checkBody:      true,
 		},
-		{
-			name:           "OPTIONS preflight request returns 200",
-			method:         http.MethodOptions,
-			expectedStatus: http.StatusOK,
-			checkBody:      false,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -77,10 +71,8 @@ func TestProtectedResourceHandler_Handle(t *testing.T) {
 
 			require.Equal(t, tc.expectedStatus, rec.Code)
 
-			// check CORS headers
-			require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
-			require.Contains(t, rec.Header().Get("Access-Control-Allow-Methods"), "GET")
-			require.Contains(t, rec.Header().Get("Access-Control-Allow-Headers"), "Authorization")
+			// CORS headers are emitted by the gateway, not this handler
+			require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
 
 			if tc.checkBody {
 				require.Equal(t, "application/json", rec.Header().Get("Content-Type"))

--- a/internal/broker/status.go
+++ b/internal/broker/status.go
@@ -93,9 +93,6 @@ func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (h *StatusHandler) setResponseHeaders(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 }
 
 func (h *StatusHandler) handleGetStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
+	sharedheaders "github.com/Kuadrant/mcp-gateway/internal/headers"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
 	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/Kuadrant/mcp-gateway/internal/transport"
@@ -477,15 +478,6 @@ func (broker *mcpBrokerImpl) fetchStatelessUserTools(ctx context.Context, server
 	}
 }
 
-// sensitiveForwardHeaders are client headers that must never be forwarded to
-// upstream MCP servers. cookie and proxy-authorization are scoped to the
-// gateway origin/hop, not the upstream, so forwarding them would leak
-// gateway-scoped credentials to every user-specific upstream queried.
-var sensitiveForwardHeaders = map[string]struct{}{
-	"cookie":              {},
-	"proxy-authorization": {},
-}
-
 // filterUserHeaders returns user headers suitable for forwarding to upstream,
 // stripping internal gateway headers and gateway-scoped credentials. the
 // client's Authorization header is intentionally preserved: user-specific
@@ -504,6 +496,7 @@ var transportHeaders = map[string]struct{}{
 
 func filterUserHeaders(h http.Header) map[string]string {
 	headers := make(map[string]string, len(h))
+	browserRequest := h.Get("Origin") != ""
 	for key, vals := range h {
 		lower := strings.ToLower(key)
 		if _, skip := transportHeaders[lower]; skip {
@@ -512,7 +505,7 @@ func filterUserHeaders(h http.Header) map[string]string {
 		if strings.HasPrefix(lower, "x-mcp-") {
 			continue
 		}
-		if _, sensitive := sensitiveForwardHeaders[lower]; sensitive {
+		if lower == "proxy-authorization" || lower == "cookie" || (browserRequest && sharedheaders.IsBrowserHop(lower)) {
 			continue
 		}
 		if len(vals) > 0 {

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -79,9 +79,11 @@ func TestFilterUserHeaders(t *testing.T) {
 			},
 		},
 		{
-			name: "strips cookie and proxy-authorization, preserves authorization",
+			name: "strips browser and proxy headers, preserves authorization",
 			input: http.Header{
 				"Cookie":              []string{"session=secret"},
+				"Origin":              []string{"https://console.example.com"},
+				"Sec-Fetch-Site":      []string{"cross-site"},
 				"Proxy-Authorization": []string{"Basic abc"},
 				"Authorization":       []string{"Bearer user-token"},
 			},

--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -364,6 +364,19 @@ func derivePrivateHost(mcpExt *mcpv1.MCPGatewayExtension, listenerConfig *Listen
 	return host
 }
 
+func mcpEndpoint(publicHost string, listenerConfig *ListenerConfig) string {
+	scheme := "http"
+	defaultPort := uint32(80)
+	if strings.EqualFold(listenerConfig.Protocol, "HTTPS") {
+		scheme = "https"
+		defaultPort = 443
+	}
+	if listenerConfig.Port == defaultPort {
+		return fmt.Sprintf("%s://%s/mcp", scheme, publicHost)
+	}
+	return fmt.Sprintf("%s://%s:%d/mcp", scheme, publicHost, listenerConfig.Port)
+}
+
 func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension, listenerConfig *ListenerConfig, gatewayClassName string) (bool, error) {
 	// derive values from listener config before building resources
 	publicHost, err := derivePublicHost(listenerConfig, mcpExt.Spec.PublicHost)
@@ -371,6 +384,8 @@ func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Contex
 		return false, newValidationError(mcpv1.ConditionReasonInvalid, err.Error())
 	}
 	internalHost := derivePrivateHost(mcpExt, listenerConfig, gatewayClassName)
+
+	mcpExt.Status.MCPEndpoint = mcpEndpoint(publicHost, listenerConfig)
 
 	// reconcile service account (must exist before deployment)
 	serviceAccount := r.buildBrokerRouterServiceAccount(mcpExt)

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -1193,6 +1193,28 @@ func TestDerivePrivateHost(t *testing.T) {
 	}
 }
 
+func TestMCPEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		listener ListenerConfig
+		want     string
+	}{
+		{name: "default HTTP port", listener: ListenerConfig{Protocol: "HTTP", Port: 80}, want: "http://mcp.example.com/mcp"},
+		{name: "default HTTPS port", listener: ListenerConfig{Protocol: "HTTPS", Port: 443}, want: "https://mcp.example.com/mcp"},
+		{name: "non-default HTTP port", listener: ListenerConfig{Protocol: "HTTP", Port: 8001}, want: "http://mcp.example.com:8001/mcp"},
+		{name: "non-default HTTPS port", listener: ListenerConfig{Protocol: "HTTPS", Port: 8443}, want: "https://mcp.example.com:8443/mcp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mcpEndpoint("mcp.example.com", &tt.listener); got != tt.want {
+				t.Fatalf("mcpEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindListenerConfig(t *testing.T) {
 	hostname := gatewayv1.Hostname("mcp.example.com")
 	wildcardHostname := gatewayv1.Hostname("*.example.com")

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -189,11 +189,17 @@ func (r *MCPGatewayExtensionReconciler) ensureFinalizer(ctx context.Context, mcp
 }
 
 func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension) (ctrl.Result, error) {
+	// retain status so endpoint changes trigger an update
+	originalStatus := mcpExt.Status.DeepCopy()
+	setStatus := func(status metav1.ConditionStatus, reason, message string) error {
+		return r.updateStatus(ctx, mcpExt, originalStatus, status, reason, message)
+	}
+
 	// check for namespace conflict first - only one MCPGatewayExtension per namespace
 	if err := r.checkNamespaceConflict(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -202,7 +208,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -210,7 +216,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err := r.checkListenerConflict(ctx, mcpExt, targetGateway, listenerConfig); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -222,7 +228,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err := r.reconcileTrustedHeaders(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -230,7 +236,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err := r.reconcileSessionSigningKey(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -238,7 +244,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err := r.validateSessionStore(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -246,7 +252,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err := r.reconcileCACertBundle(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -254,7 +260,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err := r.reconcileGuardrails(ctx, mcpExt); err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
@@ -263,13 +269,13 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 	if err != nil {
 		var valErr *validationError
 		if errors.As(err, &valErr) {
-			return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, valErr.reason, valErr.message)
+			return ctrl.Result{}, setStatus(metav1.ConditionFalse, valErr.reason, valErr.message)
 		}
 		return ctrl.Result{}, err
 	}
 
 	if !deploymentReady {
-		if err := r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, mcpv1.ConditionReasonDeploymentNotReady, "broker-router deployment is not ready"); err != nil {
+		if err := setStatus(metav1.ConditionFalse, mcpv1.ConditionReasonDeploymentNotReady, "broker-router deployment is not ready"); err != nil {
 			return ctrl.Result{}, err
 		}
 		// requeue to check deployment status again since Owns watch doesn't trigger on status-only changes
@@ -286,7 +292,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcp
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	return ctrl.Result{}, r.updateStatus(ctx, mcpExt, metav1.ConditionTrue, mcpv1.ConditionReasonSuccess, "successfully verified and configured")
+	return ctrl.Result{}, setStatus(metav1.ConditionTrue, mcpv1.ConditionReasonSuccess, "successfully verified and configured")
 }
 
 func (r *MCPGatewayExtensionReconciler) validateGatewayTarget(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension) (*gatewayv1.Gateway, *ListenerConfig, error) {
@@ -493,17 +499,10 @@ func findOldestExtension(exts []mcpv1.MCPGatewayExtension) *mcpv1.MCPGatewayExte
 	return oldest
 }
 
-func (r *MCPGatewayExtensionReconciler) updateStatus(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension, status metav1.ConditionStatus, reason, message string) error {
-	existing := meta.FindStatusCondition(mcpExt.Status.Conditions, mcpv1.ConditionTypeReady)
-	var existingCopy metav1.Condition
-	if existing != nil {
-		existingCopy = *existing
-	}
-
+func (r *MCPGatewayExtensionReconciler) updateStatus(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension, original *mcpv1.MCPGatewayExtensionStatus, status metav1.ConditionStatus, reason, message string) error {
 	mcpExt.SetReadyCondition(status, reason, message)
-	updated := meta.FindStatusCondition(mcpExt.Status.Conditions, mcpv1.ConditionTypeReady)
-
-	if existing != nil && equality.Semantic.DeepEqual(existingCopy, *updated) {
+	// persist endpoint changes as well as the ready condition
+	if original != nil && equality.Semantic.DeepEqual(*original, mcpExt.Status) {
 		return nil
 	}
 	return r.Status().Update(ctx, mcpExt)

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -1,6 +1,11 @@
 // Package headers defines shared HTTP header constants used across router and broker.
 package headers
 
+import (
+	"slices"
+	"strings"
+)
+
 // Elicitation headers used by both the ext-proc router and the broker HTTP handler.
 const (
 	ElicitationRequestID = "x-mcp-request-id"
@@ -12,6 +17,14 @@ const (
 	// Stripped from any client-supplied value by the router.
 	VerifiedSubHeader = "x-mcp-verified-sub"
 )
+
+// BrowserHopHeaders are removed before requests leave the gateway.
+var BrowserHopHeaders = []string{"origin", "referer", "cookie", "sec-fetch-site", "sec-fetch-mode", "sec-fetch-dest", "sec-fetch-user"}
+
+// IsBrowserHop reports whether name is scoped to the browser-to-gateway hop.
+func IsBrowserHop(name string) bool {
+	return slices.Contains(BrowserHopHeaders, strings.ToLower(name))
+}
 
 // A2A protocol-metadata headers, set by the ext-proc router from the request
 // path and body when A2A passthrough is enabled, so Istio Telemetry and

--- a/internal/mcp-router/ext_proc_adapter.go
+++ b/internal/mcp-router/ext_proc_adapter.go
@@ -26,6 +26,25 @@ import (
 
 var _ config.Observer = &ExtProcServer{}
 
+var browserCORSHeaders = []*basepb.HeaderValueOption{
+	corsHeader("access-control-allow-origin", "*"),
+	corsHeader("access-control-allow-methods", "GET,POST,DELETE,OPTIONS"),
+	corsHeader("access-control-allow-headers", "Content-Type,Authorization,Accept,Mcp-Session-Id,MCP-Protocol-Version,Last-Event-ID,Mcp-Method,Mcp-Name"),
+	corsHeader("access-control-expose-headers", "Mcp-Session-Id,MCP-Protocol-Version,WWW-Authenticate"),
+	corsHeader("access-control-max-age", "3600"),
+}
+
+func corsHeader(key, value string) *basepb.HeaderValueOption {
+	return &basepb.HeaderValueOption{
+		Header:       &basepb.HeaderValue{Key: key, RawValue: []byte(value)},
+		AppendAction: basepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+	}
+}
+
+func headerOption(key, value string) *basepb.HeaderValueOption {
+	return &basepb.HeaderValueOption{Header: &basepb.HeaderValue{Key: key, RawValue: []byte(value)}}
+}
+
 // ExtProcServer is the ext_proc adapter that translates between Envoy's
 // external processing protocol and the Router interface.
 type ExtProcServer struct {
@@ -64,8 +83,8 @@ func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, headers *extPr
 
 // decisionToResponse translates a transport-agnostic RoutingDecision into
 // ext_proc ProcessingResponse(s) for the body phase.
-func decisionToResponse(d *routing.Decision) []*extProcV3.ProcessingResponse {
-	rb := NewResponse()
+func decisionToResponse(d *routing.Decision, immediateHeaders ...*basepb.HeaderValueOption) []*extProcV3.ProcessingResponse {
+	rb := NewResponse(immediateHeaders...)
 
 	if d.Error != nil {
 		if d.Error.JSONRPCErr != "" {
@@ -96,35 +115,28 @@ func decisionToResponse(d *routing.Decision) []*extProcV3.ProcessingResponse {
 func decisionHeaders(d *routing.Decision) []*basepb.HeaderValueOption {
 	headers := make([]*basepb.HeaderValueOption, 0, len(d.SetHeaders)+2)
 	if d.Authority != "" {
-		headers = append(headers, &basepb.HeaderValueOption{
-			Header: &basepb.HeaderValue{Key: ":authority", RawValue: []byte(d.Authority)},
-		})
+		headers = append(headers, headerOption(":authority", d.Authority))
 	}
 	if d.Path != "" {
-		headers = append(headers, &basepb.HeaderValueOption{
-			Header: &basepb.HeaderValue{Key: ":path", RawValue: []byte(d.Path)},
-		})
+		headers = append(headers, headerOption(":path", d.Path))
 	}
 	for k, v := range d.SetHeaders {
 		if k == ":authority" || k == ":path" {
 			continue
 		}
-		headers = append(headers, &basepb.HeaderValueOption{
-			Header: &basepb.HeaderValue{Key: k, RawValue: []byte(v)},
-		})
+		headers = append(headers, headerOption(k, v))
 	}
 	return headers
 }
 
 // responseDecisionToResponse translates a ResponseDecision to ext_proc responses.
-func responseDecisionToResponse(d *routing.ResponseDecision) []*extProcV3.ProcessingResponse {
+func responseDecisionToResponse(d *routing.ResponseDecision, extraHeaders ...*basepb.HeaderValueOption) []*extProcV3.ProcessingResponse {
 	rb := NewResponse()
-	headers := make([]*basepb.HeaderValueOption, 0, len(d.SetHeaders))
+	headers := make([]*basepb.HeaderValueOption, 0, len(d.SetHeaders)+len(extraHeaders))
 	for k, v := range d.SetHeaders {
-		headers = append(headers, &basepb.HeaderValueOption{
-			Header: &basepb.HeaderValue{Key: k, RawValue: []byte(v)},
-		})
+		headers = append(headers, headerOption(k, v))
 	}
+	headers = append(headers, extraHeaders...)
 	responses := rb.WithResponseHeaderResponse(headers).Build()
 
 	if d.StreamBody && len(responses) > 0 {
@@ -170,6 +182,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 		isA2A               = false              // true for /a2a traffic when A2A passthrough is enabled
 		rewriter            *elicitationRewriter // nil until a tool call response arrives
 		resourceRewriter    *resourceURIRewriter // nil until a tool call response with resources arrives
+		corsHeaders         []*basepb.HeaderValueOption
 	)
 	span := trace.SpanFromContext(ctx)
 	defer func() { span.End() }()
@@ -192,7 +205,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			recordError(span, err, 500)
 			return err
 		}
-		responseBuilder := NewResponse()
+		responseBuilder := NewResponse(corsHeaders...)
 		switch r := req.Request.(type) {
 		case *extProcV3.ProcessingRequest_RequestHeaders:
 			if r.RequestHeaders == nil {
@@ -213,6 +226,18 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			requestID = getSingleValueHeader(localRequestHeaders.Headers, "x-request-id")
 			requestPath = getSingleValueHeader(localRequestHeaders.Headers, ":path")
 			method := getSingleValueHeader(localRequestHeaders.Headers, ":method")
+			if getSingleValueHeader(localRequestHeaders.Headers, "origin") != "" && !isA2APath(requestPath) {
+				corsHeaders = browserCORSHeaders
+				responseBuilder = NewResponse(corsHeaders...)
+				if method == http.MethodOptions && getSingleValueHeader(localRequestHeaders.Headers, "access-control-request-method") != "" {
+					for _, response := range responseBuilder.WithImmediateResponse(http.StatusNoContent, "").Build() {
+						if err := stream.Send(response); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+			}
 			protocolVersion = getSingleValueHeader(localRequestHeaders.Headers, "mcp-protocol-version")
 			mcpMethodHeader = getSingleValueHeader(localRequestHeaders.Headers, "mcp-method")
 			mcpNameHeader = getSingleValueHeader(localRequestHeaders.Headers, "mcp-name")
@@ -459,7 +484,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 					"session", internaljwt.LogSafeSessionID(mcpRequest.GetSessionID()),
 				)
 			}
-			routeResponses := decisionToResponse(decision)
+			routeResponses := decisionToResponse(decision, corsHeaders...)
 			for _, response := range routeResponses {
 				s.Logger.DebugContext(ctx, "sending mcp body routing instructions to envoy", "response", response)
 				if err := stream.Send(response); err != nil {
@@ -540,7 +565,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 				)
 			}
 
-			responses := responseDecisionToResponse(respDecision)
+			responses := responseDecisionToResponse(respDecision, corsHeaders...)
 
 			if respDecision.StreamBody {
 				rewriter = &elicitationRewriter{

--- a/internal/mcp-router/ext_proc_adapter_test.go
+++ b/internal/mcp-router/ext_proc_adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -557,8 +558,9 @@ func (m *mockProcessServer) Send(actualResp *extProcV3.ProcessingResponse) error
 		requireMatchingCommonHeaderMutation(m.t, v.RequestBody.Response, actualRequestBody.RequestBody.Response)
 		requireMatchingBodyMutation(m.t, v.RequestBody.Response, actualRequestBody.RequestBody.Response)
 	case *extProcV3.ProcessingResponse_ResponseHeaders:
-		_, ok := actualResp.Response.(*extProcV3.ProcessingResponse_ResponseHeaders)
+		actualResponseHeaders, ok := actualResp.Response.(*extProcV3.ProcessingResponse_ResponseHeaders)
 		require.True(m.t, ok, "expected response type to be ResponseHeaders, but it was a %T", actualResp.Response)
+		requireMatchingCommonHeaderMutation(m.t, v.ResponseHeaders.Response, actualResponseHeaders.ResponseHeaders.Response)
 	case *extProcV3.ProcessingResponse_ImmediateResponse:
 		actualImmediateBody, ok := actualResp.Response.(*extProcV3.ProcessingResponse_ImmediateResponse)
 		require.True(m.t, ok, "expected response type to be ImmediateResponse, but it was a %T", actualResp.Response)
@@ -604,8 +606,9 @@ func (m *mockProcessServer) SetTrailer(metadata.MD) {
 
 func requireMatchingCommonHeaderMutation(t *testing.T, expected, actual *extProcV3.CommonResponse) {
 	if expected == nil || expected.HeaderMutation == nil {
-		if actual != nil {
-			require.Nil(t, actual.HeaderMutation, "expected no response, got %+v", actual)
+		if actual != nil && actual.HeaderMutation != nil {
+			require.Empty(t, actual.HeaderMutation.SetHeaders)
+			require.Empty(t, actual.HeaderMutation.RemoveHeaders)
 		}
 		return
 	}
@@ -629,14 +632,16 @@ func requireMatchingHeaderMutation(t *testing.T, expected, actual *extProcV3.Hea
 		}
 	}
 	require.Equal(t, len(expected.SetHeaders), len(actual.SetHeaders))
-	actualByKey := make(map[string]*corev3.HeaderValue, len(actual.SetHeaders))
+	actualByKey := make(map[string]*corev3.HeaderValueOption, len(actual.SetHeaders))
 	for _, h := range actual.SetHeaders {
-		actualByKey[h.Header.Key] = h.Header
+		actualByKey[h.Header.Key] = h
 	}
 	for _, expOpt := range expected.SetHeaders {
 		exp := expOpt.Header
-		act, ok := actualByKey[exp.Key]
+		actOpt, ok := actualByKey[exp.Key]
 		require.True(t, ok, "expected header %q not found in actual headers", exp.Key)
+		require.Equal(t, expOpt.AppendAction, actOpt.AppendAction, "mismatch on header %q append action", exp.Key)
+		act := actOpt.Header
 		if exp.Value != "" || act.Value != "" {
 			require.Equal(t, exp.Value, act.Value, "mismatch on header %q Value", act.Key)
 		}
@@ -701,6 +706,56 @@ type stubErrorRouter struct{ statusCode int }
 
 func (s *stubErrorRouter) RouteRequest(_ context.Context, _ *routing.Request) *routing.Decision {
 	return &routing.Decision{Error: &routing.Error{StatusCode: s.statusCode, Message: "routing error"}}
+}
+
+func TestProcessBrowserCORS(t *testing.T) {
+	t.Run("answers preflight", func(t *testing.T) {
+		expected := immediateResponse(typev3.StatusCode_NoContent)
+		expected.Response.(*extProcV3.ProcessingResponse_ImmediateResponse).ImmediateResponse.Headers.SetHeaders = append(
+			append([]*corev3.HeaderValueOption{}, browserCORSHeaders...),
+			headerOption("content-type", "text/plain"),
+		)
+		mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{{
+			msg:  browserRequestHeaders(http.MethodOptions, true),
+			resp: []*extProcV3.ProcessingResponse{expected},
+		}})
+
+		require.NoError(t, newTestServer(t).Process(mock))
+		mock.verifyAllResponsesConsumed()
+	})
+
+	t.Run("adds response headers", func(t *testing.T) {
+		requestStep := requestHeadersStep()
+		requestStep.msg = browserRequestHeaders(http.MethodGet, false)
+		requestStep.msg.GetRequestHeaders().EndOfStream = true
+		responseStep := responseHeadersStep()
+		responseStep.resp[0].Response.(*extProcV3.ProcessingResponse_ResponseHeaders).ResponseHeaders.Response = &extProcV3.CommonResponse{
+			HeaderMutation: &extProcV3.HeaderMutation{SetHeaders: browserCORSHeaders},
+		}
+		mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+			requestStep,
+			responseStep,
+		})
+
+		require.NoError(t, newTestServer(t).Process(mock))
+		mock.verifyAllResponsesConsumed()
+	})
+}
+
+func browserRequestHeaders(method string, preflight bool) *extProcV3.ProcessingRequest {
+	headers := []*corev3.HeaderValue{
+		{Key: ":method", RawValue: []byte(method)},
+		{Key: "content-type", RawValue: []byte("application/json")},
+		{Key: "origin", RawValue: []byte("https://console.example.com")},
+	}
+	if preflight {
+		headers = append(headers, &corev3.HeaderValue{Key: "access-control-request-method", RawValue: []byte(http.MethodPost)})
+	}
+	return &extProcV3.ProcessingRequest{
+		Request: &extProcV3.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcV3.HttpHeaders{Headers: &corev3.HeaderMap{Headers: headers}},
+		},
+	}
 }
 
 // stubResponseHandler is a ResponseHandler that always returns an empty decision.

--- a/internal/mcp-router/response_builder.go
+++ b/internal/mcp-router/response_builder.go
@@ -10,7 +10,8 @@ import (
 
 // ResponseBuilder builds envoy external processor responses
 type ResponseBuilder struct {
-	response []*eppb.ProcessingResponse
+	response         []*eppb.ProcessingResponse
+	immediateHeaders []*basepb.HeaderValueOption
 }
 
 // WithRequestHeadersResponse adds a request headers response with header mutations, clears route cache
@@ -94,6 +95,11 @@ func (rb *ResponseBuilder) WithRequestBodySetUnsetHeadersResponse(set []*basepb.
 
 // WithImmediateResponse adds an immediate error response that terminates request processing
 func (rb *ResponseBuilder) WithImmediateResponse(statusCode int32, message string) *ResponseBuilder {
+	headers := make([]*basepb.HeaderValueOption, 0, len(rb.immediateHeaders)+1)
+	headers = append(headers, rb.immediateHeaders...)
+	headers = append(headers, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{Key: "content-type", RawValue: []byte("text/plain")},
+	})
 	rb.response = append(rb.response, &eppb.ProcessingResponse{
 		Response: &eppb.ProcessingResponse_ImmediateResponse{
 			ImmediateResponse: &eppb.ImmediateResponse{
@@ -103,11 +109,7 @@ func (rb *ResponseBuilder) WithImmediateResponse(statusCode int32, message strin
 				Body:    []byte(message),
 				Details: fmt.Sprintf("ext-proc error: %s", message),
 				Headers: &eppb.HeaderMutation{
-					SetHeaders: []*basepb.HeaderValueOption{
-						{
-							Header: &basepb.HeaderValue{Key: "content-type", RawValue: []byte("text/plain")},
-						},
-					},
+					SetHeaders: headers,
 				},
 			},
 		},
@@ -117,7 +119,8 @@ func (rb *ResponseBuilder) WithImmediateResponse(statusCode int32, message strin
 
 // WithImmediateJSONRPCResponse adds an immediate response that terminates request processing.
 func (rb *ResponseBuilder) WithImmediateJSONRPCResponse(statusCode int32, setHeaders []*basepb.HeaderValueOption, message, contentType string) *ResponseBuilder {
-	allHeaders := make([]*basepb.HeaderValueOption, 0, len(setHeaders)+1)
+	allHeaders := make([]*basepb.HeaderValueOption, 0, len(rb.immediateHeaders)+len(setHeaders)+1)
+	allHeaders = append(allHeaders, rb.immediateHeaders...)
 	allHeaders = append(allHeaders, setHeaders...)
 	allHeaders = append(allHeaders, &basepb.HeaderValueOption{
 		Header: &basepb.HeaderValue{Key: "content-type", RawValue: []byte(contentType)},
@@ -189,9 +192,10 @@ func (rb *ResponseBuilder) Build() []*eppb.ProcessingResponse {
 	return rb.response
 }
 
-// NewResponse creates a new response builder
-func NewResponse() *ResponseBuilder {
+// NewResponse creates a new response builder.
+func NewResponse(immediateHeaders ...*basepb.HeaderValueOption) *ResponseBuilder {
 	return &ResponseBuilder{
-		response: []*eppb.ProcessingResponse{},
+		response:         []*eppb.ProcessingResponse{},
+		immediateHeaders: immediateHeaders,
 	}
 }

--- a/internal/routing/mcp_request.go
+++ b/internal/routing/mcp_request.go
@@ -81,6 +81,16 @@ var MCPVerifiedSubHeader = sharedheaders.VerifiedSubHeader
 // and routing that must be stripped before forwarding to upstream MCP servers.
 var InternalOnlyHeaders = []string{MCPAuthorizedHeader, MCPVirtualServerHeader, MCPVerifiedSubHeader}
 
+var upstreamStripHeaders = append(append([]string{}, InternalOnlyHeaders...), "mcp-init-host", RoutingKey)
+var browserUpstreamStripHeaders = append(append([]string{}, upstreamStripHeaders...), sharedheaders.BrowserHopHeaders...)
+
+func stripHeadersForUpstream(req *MCPRequest) []string {
+	if req != nil && req.GetSingleHeaderValue("origin") != "" {
+		return browserUpstreamStripHeaders
+	}
+	return upstreamStripHeaders
+}
+
 // MCPRequest encapsulates a mcp protocol request to the gateway
 type MCPRequest struct {
 	ID                any               `json:"id"`

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -380,7 +381,7 @@ func (r *Router202511) routeToUpstream(ctx context.Context, span trace.Span, mcp
 		Authority:    serverInfo.Hostname,
 		Path:         path,
 		SetHeaders:   headers,
-		UnsetHeaders: InternalOnlyHeaders,
+		UnsetHeaders: stripHeadersForUpstream(mcpReq),
 		BodyMutation: body,
 	}
 }
@@ -448,7 +449,7 @@ func (r *Router202511) routeElicitationResponse(ctx context.Context, mcpReq *MCP
 			MCPServerNameHeader: entry.ServerName,
 			"content-length":    fmt.Sprintf("%d", len(body)),
 		},
-		UnsetHeaders: InternalOnlyHeaders,
+		UnsetHeaders: stripHeadersForUpstream(mcpReq),
 		BodyMutation: body,
 	}
 }
@@ -485,7 +486,7 @@ func (r *Router202511) routeBrokerPassthrough(ctx context.Context, mcpReq *MCPRe
 			return &Decision{
 				Authority:    remoteInitializeTarget,
 				SetHeaders:   headers,
-				UnsetHeaders: append([]string{"mcp-init-host", RoutingKey}, InternalOnlyHeaders...),
+				UnsetHeaders: stripHeadersForUpstream(mcpReq),
 			}
 		}
 	}
@@ -541,14 +542,15 @@ func (r *Router202511) initializeMCPServerSession(ctx context.Context, mcpReq *M
 			return id, nil
 		}
 		passThroughHeaders := map[string]string{}
+		browserRequest := mcpReq.GetSingleHeaderValue("origin") != ""
 		for key, val := range mcpReq.Headers {
 			k := strings.ToLower(key)
 			if strings.HasPrefix(k, ":") ||
 				k == SessionHeader ||
 				k == "mcp-init-host" ||
 				k == RoutingKey ||
-				k == MCPAuthorizedHeader ||
-				k == MCPVirtualServerHeader {
+				slices.Contains(InternalOnlyHeaders, k) ||
+				(browserRequest && sharedheaders.IsBrowserHop(k)) {
 				continue
 			}
 			passThroughHeaders[key] = val

--- a/internal/routing/router_202607.go
+++ b/internal/routing/router_202607.go
@@ -145,7 +145,7 @@ func (r *Router202607) routeToolCall(ctx context.Context, table RoutingTable, re
 		Authority:    serverInfo.Hostname,
 		Path:         path,
 		SetHeaders:   headers,
-		UnsetHeaders: InternalOnlyHeaders,
+		UnsetHeaders: stripHeadersForUpstream(req.Parsed),
 		BodyMutation: bodyMutation,
 	}
 }
@@ -215,7 +215,7 @@ func (r *Router202607) routePromptGet(ctx context.Context, table RoutingTable, r
 		Authority:    serverInfo.Hostname,
 		Path:         path,
 		SetHeaders:   headers,
-		UnsetHeaders: InternalOnlyHeaders,
+		UnsetHeaders: stripHeadersForUpstream(req.Parsed),
 		BodyMutation: bodyMutation,
 	}
 }

--- a/internal/routing/router_202607_test.go
+++ b/internal/routing/router_202607_test.go
@@ -88,6 +88,10 @@ func TestRouter202607_ToolCallWithoutPrefix(t *testing.T) {
 	require.Nil(t, decision.BodyMutation)
 	require.Contains(t, decision.UnsetHeaders, MCPAuthorizedHeader)
 	require.Contains(t, decision.UnsetHeaders, MCPVirtualServerHeader)
+	require.Contains(t, decision.UnsetHeaders, "mcp-init-host")
+	require.Contains(t, decision.UnsetHeaders, RoutingKey)
+	require.NotContains(t, decision.UnsetHeaders, "origin")
+	require.NotContains(t, decision.UnsetHeaders, "cookie")
 }
 
 func TestRouter202607_ToolCallWithPrefix(t *testing.T) {

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -321,6 +321,7 @@ func TestHandleRequestBody(t *testing.T) {
 		},
 		Headers: map[string]string{
 			"mcp-session-id": validToken,
+			"origin":         "https://console.example.com",
 		},
 	}
 
@@ -337,6 +338,9 @@ func TestHandleRequestBody(t *testing.T) {
 	// internal-only headers must be stripped before forwarding to upstream
 	require.Contains(t, decision.UnsetHeaders, "x-mcp-authorized")
 	require.Contains(t, decision.UnsetHeaders, "x-mcp-virtualserver")
+	require.Contains(t, decision.UnsetHeaders, "mcp-init-host")
+	require.Contains(t, decision.UnsetHeaders, RoutingKey)
+	require.Contains(t, decision.UnsetHeaders, "origin")
 
 	require.Equal(t,
 		`{"id":0,"jsonrpc":"2.0","method":"tools/call","params":{"name":"mytool","other":"other"}}`,
@@ -1172,9 +1176,8 @@ func TestHandleNoneToolCall_HairpinJWTValidation(t *testing.T) {
 // TestInitializeMCPServerSession_PassThroughHeaders verifies that headers
 // forwarded to the upstream initialize call drop the router-internal headers
 // (mcp-init-host, router-key) and the gateway-bound mcp-session-id even when
-// supplied by a client. Anything else is preserved so custom headers still
-// flow through. This is defense-in-depth on top of the explicit override in
-// clients.Initialize.
+// supplied by a client. Browser-hop headers are also dropped; custom headers
+// and authorization still flow through.
 func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 	var captured map[string]string
 	mockInitForClient := func(_ context.Context, _ string, _ *config.MCPServer, headers map[string]string, _ bool, _ *clients.HairpinClientPool) (*mcp.ClientSession, error) {
@@ -1226,6 +1229,8 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 			RoutingKey:            "attacker-supplied-key",
 			"x-custom-header":     "custom-value",
 			"authorization":       "Bearer client-token",
+			"origin":              "https://console.example.com",
+			"sec-fetch-site":      "cross-site",
 			"x-mcp-authorized":    "signed-jwt-value",
 			"x-mcp-virtualserver": "test/vs",
 		},
@@ -1240,6 +1245,8 @@ func TestInitializeMCPServerSession_PassThroughHeaders(t *testing.T) {
 	require.NotContains(t, captured, "mcp-session-id", "gateway session id must not be forwarded")
 	require.NotContains(t, captured, "x-mcp-authorized", "broker-only filtering header must not reach upstream")
 	require.NotContains(t, captured, "x-mcp-virtualserver", "broker-only filtering header must not reach upstream")
+	require.NotContains(t, captured, "origin")
+	require.NotContains(t, captured, "sec-fetch-site")
 
 	// router-key and mcp-init-host must be set by the router (not from client input)
 	require.Contains(t, captured, RoutingKey, "router must set the routing key")

--- a/tests/e2e/auth_policy_test.go
+++ b/tests/e2e/auth_policy_test.go
@@ -106,6 +106,49 @@ var _ = Describe("AuthPolicy Authentication and Authorization", Ordered, func() 
 		Expect(status).To(Equal(http.StatusUnauthorized))
 	})
 
+	It("[Auth] should bypass authentication only for browser preflight", func() {
+		const origin = "https://console.example.com"
+
+		By("Sending an unauthenticated browser preflight request")
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, authGatewayURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		req.Header.Set("Access-Control-Request-Headers", "authorization,content-type,mcp-session-id")
+
+		resp, err := getMCPHTTPClient().Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+		Expect(resp.Header.Get("Access-Control-Allow-Origin")).To(Equal("*"))
+		Expect(resp.Header.Get("Access-Control-Allow-Credentials")).To(BeEmpty())
+
+		By("Initialising a browser session with a valid token")
+		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")
+		Expect(err).NotTo(HaveOccurred())
+		authHeaders := map[string]string{
+			"Authorization": "Bearer " + token,
+			"Origin":        origin,
+		}
+		sessionID, err := mcpInitialize(ctx, authGatewayURL, authHeaders)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mcpNotifyInitialized(ctx, authGatewayURL, sessionID, authHeaders)).To(Succeed())
+
+		By("Calling a tool from the browser session without authentication")
+		status, _, responseHeaders, err := mcpCallToolRaw(
+			authGatewayURL,
+			sessionID,
+			"test1_greet",
+			map[string]any{"name": "e2e"},
+			map[string]string{"Origin": origin},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(http.StatusUnauthorized))
+		Expect(responseHeaders.Get("WWW-Authenticate")).To(ContainSubstring("Bearer"))
+		Expect(responseHeaders.Get("Access-Control-Allow-Origin")).To(Equal("*"))
+		Expect(responseHeaders.Get("Access-Control-Allow-Credentials")).To(BeEmpty())
+	})
+
 	It("[Auth] should allow initialize and tools/list with valid JWT, filtered by user roles", func() {
 		By("Obtaining a token from Keycloak")
 		token, err := GetKeycloakUserToken(ctx, "mcp", "mcp")

--- a/tests/e2e/raw_mcp_http.go
+++ b/tests/e2e/raw_mcp_http.go
@@ -386,7 +386,7 @@ func mcpInitializeWithElicitation(mcpURL string, headers map[string]string) (str
 
 // mcpCallToolRaw calls a tool and returns the raw SSE body without parsing the result.
 // This is needed for tests that expect -32042 errors which readJSONRPCResult treats as failures.
-func mcpCallToolRaw(mcpURL, sessionID, toolName string, args map[string]any, headers map[string]string) (int, string, http.Header, error) { //nolint:unparam
+func mcpCallToolRaw(mcpURL, sessionID, toolName string, args map[string]any, headers map[string]string) (int, string, http.Header, error) {
 	params := map[string]any{"name": toolName}
 	if len(args) > 0 {
 		params["arguments"] = args

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -142,7 +142,7 @@
 
 ### [Happy] MCPGatewayExtension with httpRouteManagement Disabled skips HTTPRoute creation
 
-- When an MCPGatewayExtension has `spec.httpRouteManagement: Disabled`, the controller should NOT create an HTTPRoute. This allows users to manage their own HTTPRoute with custom configuration (e.g. CORS response headers or custom filters). The MCPGatewayExtension should still become Ready and all other resources (Deployment, Service, EnvoyFilter) should be created normally.
+- When an MCPGatewayExtension has `spec.httpRouteManagement: Disabled`, the controller should NOT create an HTTPRoute. This allows users to manage their own HTTPRoute with custom path rules or filters. The MCPGatewayExtension should still become Ready and all other resources (Deployment, Service, EnvoyFilter) should be created normally.
 
 ### [multi-gateway] Each MCPGatewayExtension gets its own HTTPRoute
 

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -192,6 +192,10 @@
 
 - When a client authenticates via Keycloak and sends a prompts/list request, only prompts the user has `prompt:*` roles for should be returned. The `mcp` user in the `accounting` group should see `test1_greet` but not prompts from servers where they have no prompt roles.
 
+### [Auth] Browser preflight bypasses authentication, actual tool calls do not
+
+- An unauthenticated CORS preflight request should return 204 with wildcard CORS headers. A browser-originated `tools/call` using a valid gateway session but no bearer token should still pass through AuthPolicy and return 401 with both `WWW-Authenticate` and CORS response headers. Credentialed CORS must remain disabled.
+
 ### [Auth] prompts/get with auth as first request (hairpin test)
 
 - When a client sends a prompts/get request as the first request to a server (no prior tools/call), the hairpin initialize should pass through the AuthPolicy correctly and return prompt messages.


### PR DESCRIPTION
## Summary

- Enable browser access at the gateway without a CORS API or route config.
- Publish the client URL in `status.mcpEndpoint`.

## Test evidence

`make lint-go`, `make check`, `make test-unit`, and `make test-controller-integration`

Relates to #604 and Kuadrant/kuadrant-console-plugin#752.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser access for MCP gateways with cross-origin requests and CORS preflight support.
  * Browser requests require authentication for MCP operations; cookies are not forwarded.
  * Added the public MCP endpoint URL to gateway status, including configured non-default ports.

* **Documentation**
  * Updated setup, migration, security, reference, and release documentation for browser access, routing, and endpoint status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->