### PR TITLE
Downgrade go version to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS builder
+FROM golang:1.26.5 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS builder
+FROM golang:1.26.5 AS builder
 
 WORKDIR /workspace
 

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -22,7 +22,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 
 ## Prerequisites
 
-- [Go 1.26.6+](https://golang.org/doc/install) installed (for building from source)
+- [Go 1.26.5+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
 - [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed (or Docker to run it as a container)
 - `openssl` (for generating the signing key)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kuadrant/mcp-gateway
 
-go 1.26.6
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/tests/perf/mock-server/Dockerfile
+++ b/tests/perf/mock-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS builder
+FROM golang:1.26.5 AS builder
 WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tests/servers/server2/Dockerfile
+++ b/tests/servers/server2/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/stateless-server/Dockerfile
+++ b/tests/servers/stateless-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/user-specific-server/Dockerfile
+++ b/tests/servers/user-specific-server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What does this PR do?

The downstream build environment does not have access to 1.26.6 yet.


Downgrading to 1.26.5 will fix build failures downstream due to go toolchain mismatch.
