### PR TITLE
fix(broker): log upstream tool add/remove/change at Info for auditing

### DIFF
--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -941,16 +941,20 @@ func (man *MCPManager) diffTools(oldTools, newTools []mcp.Tool) ([]GatewayTool, 
 
 	addedTools := make([]GatewayTool, 0)
 	for _, newTool := range newToolMap {
-		_, ok := oldToolMap[newTool.Name]
-		if !ok {
+		prev, ok := oldToolMap[newTool.Name]
+		// add new tools, and re-add tools whose spec changed under an
+		// unchanged name so the gateway serves the new description/schema
+		if !ok || toolSpecChanged(&prev, &newTool) {
 			addedTools = append(addedTools, man.toolToServerTool(newTool))
 		}
 	}
 
 	removedTools := make([]string, 0)
 	for _, oldTool := range oldToolMap {
-		_, ok := newToolMap[oldTool.Name]
-		if !ok {
+		next, ok := newToolMap[oldTool.Name]
+		// remove dropped tools, and drop the stale entry for a same-name
+		// spec change before its replacement is added
+		if !ok || toolSpecChanged(&oldTool, &next) {
 			removedTools = append(removedTools, prefixedName(man.mcp.GetPrefix(), oldTool.Name))
 		}
 	}
@@ -988,10 +992,10 @@ func (man *MCPManager) logToolChanges(ctx context.Context, oldTools, newTools []
 }
 
 // toolSpecChanged reports whether two tools differ in description or schema.
-func toolSpecChanged(a, b *mcp.Tool) bool {
-	return a.Description != b.Description ||
-		!reflect.DeepEqual(a.InputSchema, b.InputSchema) ||
-		!reflect.DeepEqual(a.OutputSchema, b.OutputSchema)
+func toolSpecChanged(oldTool, newTool *mcp.Tool) bool {
+	return oldTool.Description != newTool.Description ||
+		!reflect.DeepEqual(oldTool.InputSchema, newTool.InputSchema) ||
+		!reflect.DeepEqual(oldTool.OutputSchema, newTool.OutputSchema)
 }
 
 func prefixedName(prefix, tool string) string {

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -573,7 +573,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 						man.toolsListBytes.Record(ctx, rawBytes, metric.WithAttributes(serverAttr))
 					}
 
-					man.logger.DebugContext(ctx, "updating gateway tools", "upstream mcp server", man.mcp.ID(), "adding", len(toAdd), "removing", len(toRemove))
+					man.logToolChanges(ctx, current, fetched)
 					if len(toRemove) > 0 {
 						man.gatewayServer.DeleteTools(toRemove...)
 					}
@@ -956,6 +956,42 @@ func (man *MCPManager) diffTools(oldTools, newTools []mcp.Tool) ([]GatewayTool, 
 	}
 
 	return addedTools, removedTools
+}
+
+// logToolChanges logs an info line per tool added, removed, or changed for auditing.
+func (man *MCPManager) logToolChanges(ctx context.Context, oldTools, newTools []mcp.Tool) {
+	oldByName := make(map[string]*mcp.Tool, len(oldTools))
+	for i := range oldTools {
+		oldByName[oldTools[i].Name] = &oldTools[i]
+	}
+	newByName := make(map[string]*mcp.Tool, len(newTools))
+	for i := range newTools {
+		newByName[newTools[i].Name] = &newTools[i]
+	}
+
+	serverID := man.mcp.ID()
+	for i := range newTools {
+		newTool := &newTools[i]
+		prev, existed := oldByName[newTool.Name]
+		switch {
+		case !existed:
+			man.logger.InfoContext(ctx, "upstream tool added", "upstream mcp server", serverID, "tool", newTool.Name)
+		case toolSpecChanged(prev, newTool):
+			man.logger.InfoContext(ctx, "upstream tool changed", "upstream mcp server", serverID, "tool", newTool.Name)
+		}
+	}
+	for i := range oldTools {
+		if _, ok := newByName[oldTools[i].Name]; !ok {
+			man.logger.InfoContext(ctx, "upstream tool removed", "upstream mcp server", serverID, "tool", oldTools[i].Name)
+		}
+	}
+}
+
+// toolSpecChanged reports whether two tools differ in description or schema.
+func toolSpecChanged(a, b *mcp.Tool) bool {
+	return a.Description != b.Description ||
+		!reflect.DeepEqual(a.InputSchema, b.InputSchema) ||
+		!reflect.DeepEqual(a.OutputSchema, b.OutputSchema)
 }
 
 func prefixedName(prefix, tool string) string {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -897,6 +897,22 @@ func TestDiffTools(t *testing.T) {
 					assert.Contains(t, removed, expectedName)
 				}
 			}
+
+			// every added tool must carry the new spec, not a stale copy: this is
+			// what makes the gateway serve the updated description/schema after a
+			// same-name change. match each added tool back to its newTools entry
+			// by served (prefixed) name and compare the spec fields.
+			newByServedName := make(map[string]mcp.Tool, len(tt.newTools))
+			for _, nt := range tt.newTools {
+				newByServedName[mock.GetPrefix()+nt.Name] = nt
+			}
+			for _, at := range added {
+				want, ok := newByServedName[at.Tool.Name]
+				require.True(t, ok, "added tool %q has no matching newTools entry", at.Tool.Name)
+				assert.Equal(t, want.Description, at.Tool.Description, "added tool must carry the new description")
+				assert.Equal(t, want.InputSchema, at.Tool.InputSchema, "added tool must carry the new input schema")
+				assert.Equal(t, want.OutputSchema, at.Tool.OutputSchema, "added tool must carry the new output schema")
+			}
 		})
 	}
 }

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -828,6 +828,52 @@ func TestDiffTools(t *testing.T) {
 			expectedAdded:   0,
 			expectedRemoved: 0,
 		},
+		{
+			// same name, changed description: drop stale entry and re-add new spec
+			name:            "description change under same name",
+			oldTools:        []mcp.Tool{{Name: "tool1", Description: "old", InputSchema: map[string]any{"type": "object"}}},
+			newTools:        []mcp.Tool{{Name: "tool1", Description: "new", InputSchema: map[string]any{"type": "object"}}},
+			expectedAdded:   1,
+			expectedRemoved: 1,
+			addedNames:      []string{"test_tool1"},
+			removedNames:    []string{"test_tool1"},
+		},
+		{
+			name:            "input schema change under same name",
+			oldTools:        []mcp.Tool{{Name: "tool1", InputSchema: map[string]any{"type": "object"}}},
+			newTools:        []mcp.Tool{{Name: "tool1", InputSchema: map[string]any{"type": "object", "properties": map[string]any{"q": map[string]any{"type": "string"}}}}},
+			expectedAdded:   1,
+			expectedRemoved: 1,
+			addedNames:      []string{"test_tool1"},
+			removedNames:    []string{"test_tool1"},
+		},
+		{
+			name:            "output schema change under same name",
+			oldTools:        []mcp.Tool{{Name: "tool1", InputSchema: map[string]any{"type": "object"}}},
+			newTools:        []mcp.Tool{{Name: "tool1", InputSchema: map[string]any{"type": "object"}, OutputSchema: map[string]any{"type": "object"}}},
+			expectedAdded:   1,
+			expectedRemoved: 1,
+			addedNames:      []string{"test_tool1"},
+			removedNames:    []string{"test_tool1"},
+		},
+		{
+			// identical spec must not be churned (no spurious add/remove)
+			name:            "identical spec not churned",
+			oldTools:        []mcp.Tool{{Name: "tool1", Description: "same", InputSchema: map[string]any{"type": "object"}}},
+			newTools:        []mcp.Tool{{Name: "tool1", Description: "same", InputSchema: map[string]any{"type": "object"}}},
+			expectedAdded:   0,
+			expectedRemoved: 0,
+		},
+		{
+			// spec change alongside an unrelated add and remove
+			name:            "spec change with add and remove",
+			oldTools:        []mcp.Tool{{Name: "tool1", Description: "old", InputSchema: map[string]any{"type": "object"}}, validTool("tool2")},
+			newTools:        []mcp.Tool{{Name: "tool1", Description: "new", InputSchema: map[string]any{"type": "object"}}, validTool("tool3")},
+			expectedAdded:   2,
+			expectedRemoved: 2,
+			addedNames:      []string{"test_tool1", "test_tool3"},
+			removedNames:    []string{"test_tool1", "test_tool2"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does this PR do?

<!-- One or two sentences. Link the issue if there is one. -->

Addresses --> https://github.com/Kuadrant/mcp-gateway/issues/1393

Tool list changes were logged only at Debug with counts and no tool
names, so with Debug off in production they left no trace. Same-name
description or schema drift was never logged at all, because diffTools
only compares by name.

Add `logToolChanges`, which emits one Info line per tool added, removed,
or changed, naming the tool (unprefixed) and the upstream. Same-name
description/schema drift is detected via `toolSpecChanged`, which
diffTools ignores. The helper logs only on real changes, so it no
longer fires every reconcile.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved tool-change auditing by recording each added, removed, or modified tool individually.
  * Enhanced change detection to identify updates to tool descriptions and input or output schemas.
  * Audit events are now logged at the informational level for better visibility.
  * Tool updates now accurately reflect specification changes while preserving unchanged tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->