### PR TITLE
docs: add resources federation to registration and authorization guides

### DIFF
--- a/docs/guides/authorization.md
+++ b/docs/guides/authorization.md
@@ -4,10 +4,10 @@ This guide covers configuring fine-grained authorization and access control for 
 
 ## Overview
 
-Authorization in MCP Gateway controls which authenticated users can access specific MCP tools and prompts. This guide demonstrates using Kuadrant's AuthPolicy with Common Expression Language (CEL) to implement role-based access control.
+Authorization in MCP Gateway controls which authenticated users can access specific MCP tools, prompts, and resources. This guide demonstrates using Kuadrant's AuthPolicy with Common Expression Language (CEL) to implement role-based access control.
 
 Key concepts:
-- **Tool and Prompt-Level Authorization**: Control access to individual MCP tools and prompts
+- **Tool, Prompt, and Resource-Level Authorization**: Control access to individual MCP tools, prompts, and resources
 - **Role-Based Access**: Use Keycloak client roles and group bindings for permission decisions
 - **Self-contained ACL**: Access control lists stored in the signed JWT tokens
 - **CEL Expressions**: Define complex authorization logic using Common Expression Language
@@ -41,7 +41,7 @@ The issued OAuth token should include claims similar to:
       "roles": ["tool:add", "tool:sum", "tool:multiply", "tool:divide", "prompt:math_tutor"] // roles prefixed with capability type
     },
     "mcp-ns/geometry-mcp-server": {
-      "roles": ["tool:area", "tool:distance", "tool:volume", "prompt:calculate_area"]
+      "roles": ["tool:area", "tool:distance", "tool:volume", "prompt:calculate_area", "resource:ui://widget.html"] // resource roles use the full unprefixed URI (prefix stripped, scheme kept)
     }
   }
 }
@@ -49,9 +49,9 @@ The issued OAuth token should include claims similar to:
 
 > **Note:** The test Keycloak instance deployed in the [authentication guide](./authentication.md) is already configured to include these claims based on user group membership. The `mcp` user is part of the `accounting` group, which maps to specific tool permissions.
 
-## Step 2: Configure Tool and Prompt Authorization
+## Step 2: Configure Tool, Prompt, and Resource Authorization
 
-Apply an AuthPolicy that enforces access control for both tools and prompts:
+Apply an AuthPolicy that enforces access control for tools, prompts, and resources:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -86,6 +86,13 @@ spec:
           patterns:
             - predicate: |
                 ('prompt:' + request.headers['x-mcp-promptname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
+      'resource-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-resourceuri')"
+        patternMatching:
+          patterns:
+            - predicate: |
+                ('resource:' + request.headers['x-mcp-resourceuri']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
     response:
       unauthenticated:
         headers:
@@ -110,12 +117,14 @@ EOF
 **Key Configuration Explained:**
 
 - **Authentication**: Validates the JWT token using the configured issuer URL
-- **Authorization Logic**: CEL expressions check if the user's roles allow access to the requested tool or prompt. The appropriate check is triggered based on the presence of the `x-mcp-toolname` or `x-mcp-promptname` header.
+- **Authorization Logic**: CEL expressions check if the user's roles allow access to the requested tool, prompt, or resource. The appropriate check is triggered based on the presence of the `x-mcp-toolname`, `x-mcp-promptname`, or `x-mcp-resourceuri` header.
 - **CEL Breakdown**:
-  - `request.headers['x-mcp-toolname']` / `x-mcp-promptname`: The name of the requested capability
+  - `request.headers['x-mcp-toolname']` / `x-mcp-promptname` / `x-mcp-resourceuri`: The name (or, for resources, the full unprefixed `ui://` URI) of the requested capability
   - `request.headers['x-mcp-servername']`: The namespaced name of the MCP server matching the MCPServerRegistration resource
-  - `auth.identity.resource_access`: The JWT claim containing roles prefixed by capability type (e.g. `tool:greet`, `prompt:math_tutor`), grouped by MCP server
+  - `auth.identity.resource_access`: The JWT claim containing roles prefixed by capability type (e.g. `tool:greet`, `prompt:math_tutor`, `resource:ui://widget.html`), grouped by MCP server
 - **Response Handling**: Custom 401 and 403 responses for unauthenticated and unauthorized access attempts
+
+> **Note:** `resource-access-check` governs whether a specific resource can be fetched via `resources/read`. It does not control whether that resource appears in `resources/list`; that's a separate, list-time filter driven by the `resources` claim inside the `allowed-capabilities` JWT claim (see below), keyed per-server by resource authority rather than by role name. The two checks are independent: a client can be authorized to read a resource that's hidden from its `resources/list` response, or the reverse.
 
 For more advanced policy examples covering token exchange and `tools/list` filtering, see the [Vault Token Exchange guide](./vault-token-exchange.md).
 
@@ -145,6 +154,8 @@ authorization:
         }
       allValues: true
 ```
+
+> **Note:** Resource visibility in `resources/list` is filtered separately from tools/prompts above, and expects a different claim shape: a per-server map of allowed resource authorities (the unprefixed `ui://` host, not a role-prefixed name), e.g. `{"resources": {"mcp-ns/geometry-mcp-server": ["widget.html"]}}`. How you derive that shape from your identity provider's roles depends on your setup; there's no single `role-prefix` convention for it the way `tool:`/`prompt:` works above. If the token has no `resources` claim at all, all resources are visible (unless the broker enforces capability filtering, in which case none are). Once the claim is present, though, a server missing from its map, or listed with an empty array, has all of its resources excluded with no fallback.
 
 ## Step 3: Test Authorization
 

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -212,9 +212,6 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
       }
     }
   }'
-
-# Clean up
-rm -f /tmp/mcp_headers
 ```
 
 You should now see your MCP server tools and prompts in the response, prefixed with your configured `prefix` (e.g., `myserver_`).

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -123,7 +123,7 @@ spec:
 EOF
 ```
 
-> **Note:** An exact-duplicate `prefix` across two registrations sharing a gateway is rejected at registration time. A prefix that's a substring of another (e.g. `app_` vs. `app_admin_`) is not rejected; resource URI lookups resolve it via longest-prefix match, and the shorter-prefix server's colliding resource becomes unreachable via `resources/read`. Choose prefixes that aren't prefixes of one another.
+> **Note:** An exact-duplicate `prefix` across two registrations sharing a gateway is rejected at registration time. A prefix that's itself a prefix of another (e.g. `app_` and `app_admin_`) is not rejected; resource URI lookups resolve it via longest-prefix match, and the shorter-prefix server's colliding resource becomes unreachable via `resources/read`. Choose prefixes that aren't prefixes of one another.
 
 ## Step 4: Verify Registration
 
@@ -256,7 +256,7 @@ curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
 rm -f /tmp/mcp_headers
 ```
 
-You should see the resource's contents (`uri`, `mimeType`, and body) in the response.
+You should see the resource's contents (`uri`, `mimeType`, and `text` or `blob` depending on whether the resource is text or binary) in the response.
 
 ## Disabling a Server
 

--- a/docs/guides/register-mcp-servers.md
+++ b/docs/guides/register-mcp-servers.md
@@ -1,14 +1,16 @@
 # MCP Server Registration
 
-You must register your MCP servers to be discovered and routed by the MCP Gateway. When a server is registered, the gateway automatically discovers and federates its capabilities (tools and prompts), applying a prefix to avoid name collisions across multiple servers.
+You must register your MCP servers to be discovered and routed by the MCP Gateway. When a server is registered, the gateway automatically discovers and federates its capabilities (tools, prompts, and resources), applying a prefix to avoid name collisions across multiple servers.
 
 ## Overview
 
-MCP Gateway supports federating both MCP Tools and MCP Prompts.
+MCP Gateway supports federating MCP Tools, MCP Prompts, and MCP Resources.
 
-- **Discovery**: The gateway's broker automatically discovers available tools and prompts from registered upstream servers.
-- **Prefixing**: To prevent collisions between capabilities with the same name on different servers, the gateway applies the `prefix` defined in the `MCPServerRegistration` to each tool and prompt name (e.g., `greet` becomes `myserver_greet`).
-- **Routing**: When a client calls a tool or requests a prompt, the gateway identifies the target upstream server by the prefix, strips the prefix, and routes the request to the correct server.
+- **Discovery**: The gateway's broker automatically discovers available tools, prompts, and resources from registered upstream servers.
+- **Prefixing**: To prevent collisions between capabilities with the same name on different servers, the gateway applies the `prefix` defined in the `MCPServerRegistration` to each tool and prompt name (e.g., `greet` becomes `myserver_greet`), and to the authority of each `ui://` resource URI (e.g., `ui://widget.html` becomes `ui://myserver_widget.html`).
+- **Routing**: When a client calls a tool, requests a prompt, or reads a resource, the gateway identifies the target upstream server by the prefix, strips the prefix, and routes the request to the correct server.
+
+> **Note:** Resource federation only covers `ui://` resources (MCP Apps / SEP-1865). Only servers with a `prefix` set participate; a server registered without one is silently excluded from `resources/list`.
 
 To connect an MCP server to MCP Gateway, you must create an `HTTPRoute` that routes to your MCP server and an `MCPServerRegistration` resource that references the `HTTPRoute`.
 
@@ -121,6 +123,8 @@ spec:
 EOF
 ```
 
+> **Note:** An exact-duplicate `prefix` across two registrations sharing a gateway is rejected at registration time. A prefix that's a substring of another (e.g. `app_` vs. `app_admin_`) is not rejected; resource URI lookups resolve it via longest-prefix match, and the shorter-prefix server's colliding resource becomes unreachable via `resources/read`. Choose prefixes that aren't prefixes of one another.
+
 ## Step 4: Verify Registration
 
 Wait for the MCPServerRegistration to become ready (Ready means the config has been written to the gateway config secret; the broker discovers tools asynchronously after that):
@@ -214,6 +218,45 @@ rm -f /tmp/mcp_headers
 ```
 
 You should now see your MCP server tools and prompts in the response, prefixed with your configured `prefix` (e.g., `myserver_`).
+
+## Step 8: Test Resource Discovery
+
+If your MCP server exposes `ui://` resources, verify they're also federated:
+
+```bash
+# Use the same SESSION_ID from the previous steps
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc": "2.0", "id": 5, "method": "resources/list"}'
+```
+
+You should see your MCP server's resources in the response, with the authority of each `ui://` URI prefixed with your configured `prefix` (e.g., `ui://widget.html` becomes `ui://myserver_widget.html`).
+
+> **Note:** Only the first page of each upstream's resources is fetched. If an upstream server errors or times out during `resources/list`, its resources are skipped rather than failing the whole request; other servers' resources still return.
+
+## Step 9: Getting a Resource
+
+To retrieve a specific resource, use the `resources/read` method with the federated (prefixed) URI:
+
+```bash
+curl -X POST http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "resources/read",
+    "params": {
+      "uri": "ui://myserver_widget.html"
+    }
+  }'
+
+# Clean up
+rm -f /tmp/mcp_headers
+```
+
+You should see the resource's contents (`uri`, `mimeType`, and body) in the response.
 
 ## Disabling a Server
 


### PR DESCRIPTION
Adds user-facing documentation for the resources federation feature (#788), which shipped without a user guide.

- Extends register-mcp-servers.md with resource discovery/read steps and prefix-collision behavior, following the existing tools/prompts sections
- Extends authorization.md with a resource-access-check AuthPolicy rule and notes on the separate resources claim used for resources/list visibility

Folded into existing guides rather than a new standalone file, per the precedent set on #973 (prompt federation docs).

Closes #1430

cc @Patryk-Stefanski @david-martin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded authorization guidance to cover resource-level access control, JWT claims, policy checks, configuration, and testing.
  * Clarified the distinction between resource reads and resource discovery visibility.
  * Added guidance for federating MCP resources, including URI prefixes, collision handling, discovery, and retrieval.
  * Documented duplicate or overlapping prefixes and how resource errors and timeouts are handled during discovery.
  * Clarified resource response formats, including text and binary content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->