### PR TITLE
feat(observability): add protocol.version span attribute to router an…

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -383,7 +384,7 @@ func (m *mcpBrokerImpl) onGatewaySessionEnd(sessionID string) {
 func (m *mcpBrokerImpl) tracingMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-			protoVersion := "2025-11-25"
+			protoVersion := protocol.Version2025
 			if extra := req.GetExtra(); extra != nil {
 				if v := extra.Header.Get("Mcp-Protocol-Version"); v != "" {
 					protoVersion = v

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -383,9 +383,17 @@ func (m *mcpBrokerImpl) onGatewaySessionEnd(sessionID string) {
 func (m *mcpBrokerImpl) tracingMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			protoVersion := "2025-11-25"
+			if extra := req.GetExtra(); extra != nil {
+				if v := extra.Header.Get("Mcp-Protocol-Version"); v != "" {
+					protoVersion = v
+				}
+			}
+
 			ctx, span := brokerTracer().Start(ctx, "mcp-broker.handle-request", trace.WithAttributes(
 				brokerComponentAttr,
 				attribute.String("mcp.method", method),
+				attribute.String("protocol.version", protoVersion),
 			))
 			defer span.End()
 			// LogSafeSessionID hashes/decodes per call; only pay for it when

--- a/internal/broker/filtered_prompts_handler.go
+++ b/internal/broker/filtered_prompts_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -13,7 +14,14 @@ import (
 
 // FilterPrompts reduces the prompt set based on authorization headers.
 func (broker *mcpBrokerImpl) FilterPrompts(ctx context.Context, headers http.Header, mcpRes *mcp.ListPromptsResult) {
-	attrs := []attribute.KeyValue{brokerComponentAttr}
+	protoVersion := protocol.Version2025
+	if v := headers.Get("Mcp-Protocol-Version"); v != "" {
+		protoVersion = v
+	}
+	attrs := []attribute.KeyValue{
+		brokerComponentAttr,
+		attribute.String("protocol.version", protoVersion),
+	}
 	ctx, span := brokerTracer().Start(ctx, "mcp-broker.prompts-list", trace.WithAttributes(attrs...))
 	defer span.End()
 

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 
 	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
@@ -25,7 +26,7 @@ const allowedCapabilitiesClaimKey = "allowed-capabilities"
 // FilterTools reduces the tool set based on authorization headers.
 // Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
 func (broker *mcpBrokerImpl) FilterTools(ctx context.Context, headers http.Header, sessionID string, mcpRes *mcp.ListToolsResult) {
-	protoVersion := "2025-11-25"
+	protoVersion := protocol.Version2025
 	if v := headers.Get("Mcp-Protocol-Version"); v != "" {
 		protoVersion = v
 	}

--- a/internal/broker/filtered_tools_handler.go
+++ b/internal/broker/filtered_tools_handler.go
@@ -25,7 +25,14 @@ const allowedCapabilitiesClaimKey = "allowed-capabilities"
 // FilterTools reduces the tool set based on authorization headers.
 // Priority: x-mcp-authorized JWT filtering, then x-mcp-virtualserver filtering.
 func (broker *mcpBrokerImpl) FilterTools(ctx context.Context, headers http.Header, sessionID string, mcpRes *mcp.ListToolsResult) {
-	attrs := []attribute.KeyValue{brokerComponentAttr}
+	protoVersion := "2025-11-25"
+	if v := headers.Get("Mcp-Protocol-Version"); v != "" {
+		protoVersion = v
+	}
+	attrs := []attribute.KeyValue{
+		brokerComponentAttr,
+		attribute.String("protocol.version", protoVersion),
+	}
 	ctx, span := brokerTracer().Start(ctx, "mcp-broker.tools-list", trace.WithAttributes(attrs...))
 	defer span.End()
 

--- a/internal/broker/tracing_test.go
+++ b/internal/broker/tracing_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,6 +119,57 @@ func TestTracingMiddleware_SpanPerRequestWithNesting(t *testing.T) {
 		"handler spans must share the request trace")
 	require.Equal(t, handle.SpanContext.SpanID(), filter.Parent.SpanID(),
 		"FilterTools span must nest under the request span")
+}
+
+// TestTracingMiddleware_ProtocolVersionFromHeader verifies that when the
+// Mcp-Protocol-Version header is explicitly set, the protocol.version span
+// attribute reflects the header value instead of the fallback default.
+//
+// The legacy compatHandler strips the protocol-version header, so we must
+// exercise the full protocolRouter (MCPHandler) which dispatches 2026-07-28
+// requests to the stateless StreamableHTTPHandler that preserves headers.
+func TestTracingMiddleware_ProtocolVersionFromHeader(t *testing.T) {
+	exporter := setupTestTracer(t)
+	b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+	ts := httptest.NewServer(b.MCPHandler())
+	t.Cleanup(ts.Close)
+
+	// The stateless handler (2026-07-28) requires _meta in params.
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"0.0.1"},"io.modelcontextprotocol/clientCapabilities":{}}}}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", "tools/list")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	spans := exporter.GetSpans()
+	var handle, filter tracetest.SpanStub
+	for _, s := range spans {
+		switch s.Name {
+		case "mcp-broker.handle-request":
+			if attr, ok := findAttribute(s.Attributes, "mcp.method"); ok && attr.Value.AsString() == "tools/list" {
+				handle = s
+			}
+		case "mcp-broker.tools-list":
+			filter = s
+		}
+	}
+
+	require.NotEmpty(t, handle.Name, "expected a handle-request span for tools/list")
+	attr, ok := findAttribute(handle.Attributes, "protocol.version")
+	require.True(t, ok, "expected protocol.version attribute on handle-request span")
+	require.Equal(t, "2026-07-28", attr.Value.AsString(), "handle-request span should use the header value")
+
+	require.NotEmpty(t, filter.Name, "expected the tools-list span")
+	attr, ok = findAttribute(filter.Attributes, "protocol.version")
+	require.True(t, ok, "expected protocol.version attribute on tools-list span")
+	require.Equal(t, "2026-07-28", attr.Value.AsString(), "tools-list span should use the header value")
 }
 
 func TestTracingMiddleware_ErrorRecordedOnSpan(t *testing.T) {

--- a/internal/broker/tracing_test.go
+++ b/internal/broker/tracing_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -103,14 +104,14 @@ func TestTracingMiddleware_SpanPerRequestWithNesting(t *testing.T) {
 	}
 	require.NotEmpty(t, handle.Name, "expected a handle-request span for tools/list")
 	if attr, ok := findAttribute(handle.Attributes, "protocol.version"); ok {
-		require.Equal(t, "2025-11-25", attr.Value.AsString(), "handle-request span should default to 2025-11-25")
+		require.Equal(t, protocol.Version2025, attr.Value.AsString(), "handle-request span should default to "+protocol.Version2025)
 	} else {
 		require.Fail(t, "expected protocol.version attribute on handle-request span")
 	}
 
 	require.NotEmpty(t, filter.Name, "expected the FilterTools span")
 	if attr, ok := findAttribute(filter.Attributes, "protocol.version"); ok {
-		require.Equal(t, "2025-11-25", attr.Value.AsString(), "tools-list span should default to 2025-11-25")
+		require.Equal(t, protocol.Version2025, attr.Value.AsString(), "tools-list span should default to "+protocol.Version2025)
 	} else {
 		require.Fail(t, "expected protocol.version attribute on tools-list span")
 	}
@@ -121,13 +122,7 @@ func TestTracingMiddleware_SpanPerRequestWithNesting(t *testing.T) {
 		"FilterTools span must nest under the request span")
 }
 
-// TestTracingMiddleware_ProtocolVersionFromHeader verifies that when the
-// Mcp-Protocol-Version header is explicitly set, the protocol.version span
-// attribute reflects the header value instead of the fallback default.
-//
-// The legacy compatHandler strips the protocol-version header, so we must
-// exercise the full protocolRouter (MCPHandler) which dispatches 2026-07-28
-// requests to the stateless StreamableHTTPHandler that preserves headers.
+// test tracing middleware sets protocol.version span attribute from header.
 func TestTracingMiddleware_ProtocolVersionFromHeader(t *testing.T) {
 	exporter := setupTestTracer(t)
 	b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
@@ -140,7 +135,7 @@ func TestTracingMiddleware_ProtocolVersionFromHeader(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
-	req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Protocol-Version", protocol.Version2026)
 	req.Header.Set("Mcp-Method", "tools/list")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/broker/tracing_test.go
+++ b/internal/broker/tracing_test.go
@@ -99,7 +99,18 @@ func TestTracingMiddleware_SpanPerRequestWithNesting(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, handle.Name, "expected a handle-request span for tools/list")
+	if attr, ok := findAttribute(handle.Attributes, "protocol.version"); ok {
+		require.Equal(t, "2025-11-25", attr.Value.AsString(), "handle-request span should default to 2025-11-25")
+	} else {
+		require.Fail(t, "expected protocol.version attribute on handle-request span")
+	}
+
 	require.NotEmpty(t, filter.Name, "expected the FilterTools span")
+	if attr, ok := findAttribute(filter.Attributes, "protocol.version"); ok {
+		require.Equal(t, "2025-11-25", attr.Value.AsString(), "tools-list span should default to 2025-11-25")
+	} else {
+		require.Fail(t, "expected protocol.version attribute on tools-list span")
+	}
 
 	require.Equal(t, handle.SpanContext.TraceID(), filter.SpanContext.TraceID(),
 		"handler spans must share the request trace")

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -100,7 +100,6 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 	if len(matching) == 0 {
 		return
 	}
-
 	protoVersion := protocol.Version2025
 	if v := headers.Get("Mcp-Protocol-Version"); v != "" {
 		protoVersion = v

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -101,10 +101,16 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 		return
 	}
 
+	protoVersion := protocol.Version2025
+	if v := headers.Get("Mcp-Protocol-Version"); v != "" {
+		protoVersion = v
+	}
+
 	ctx, span := brokerTracer().Start(ctx, "broker.user-specific-tools.fetch-all",
 		trace.WithAttributes(
 			attribute.Int("mcp.user_specific.server_count", len(matching)),
 			attribute.String("mcp.user_specific.client_version", clientVersion),
+			attribute.String("protocol.version", protoVersion),
 		),
 	)
 	defer span.End()

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Kuadrant/mcp-gateway/internal/idmap"
 	internaljwt "github.com/Kuadrant/mcp-gateway/internal/jwt"
 	mcpotel "github.com/Kuadrant/mcp-gateway/internal/otel"
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	"github.com/Kuadrant/mcp-gateway/internal/transport"
 	"go.opentelemetry.io/otel/attribute"
@@ -59,7 +60,7 @@ func (r *Router202511) RouteRequest(ctx context.Context, req *Request) *Decision
 		trace.WithAttributes(
 			componentAttr,
 			attribute.String("mcp.method.name", mcpReq.Method),
-			attribute.String("protocol.version", "2025-11-25"),
+			attribute.String("protocol.version", protocol.Version2025),
 		),
 	)
 	defer span.End()

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -59,6 +59,7 @@ func (r *Router202511) RouteRequest(ctx context.Context, req *Request) *Decision
 		trace.WithAttributes(
 			componentAttr,
 			attribute.String("mcp.method.name", mcpReq.Method),
+			attribute.String("protocol.version", "2025-11-25"),
 		),
 	)
 	defer span.End()


### PR DESCRIPTION
This PR resolves #1412 by ensuring the `protocol.version` OpenTelemetry span attribute is consistently applied across both the 2025 router and the broker handlers. This will allow proper filtering and debugging of traces by protocol version in observability tools.

### Changes Made
*   **Router202511:** Added the hardcoded `"2025-11-25"` `protocol.version` attribute to the `mcp-router.route-decision` span (bringing it to parity with Router202607).
*   **Broker Middleware:** Updated the `tracingMiddleware` (`mcp-broker.handle-request` span) to dynamically extract the `Mcp-Protocol-Version` from the request headers via `req.GetExtra()`.
*   **Broker Handlers:** Added dynamic protocol version extraction to the `mcp-broker.tools-list` span in `FilterTools` and the `broker.user-specific-tools.fetch-all` span in `FetchUserSpecificTools`.
*   **Defaults:** Ensured that if the `Mcp-Protocol-Version` header is omitted, the spans safely fall back to logging `"2025-11-25"`.
*   **Tests (Updated per Review):** 
    *   Maintained existing fallback tests for the `"2025-11-25"` default via in-memory transports.
    *   Added a new end-to-end `TestTracingMiddleware_ProtocolVersionFromHeader` test utilizing `httptest.NewServer(b.MCPHandler())`. This properly tests the stateless `2026-07-28` routing path, ensuring the `Mcp-Protocol-Version` and `Mcp-Method` headers are correctly extracted into the span attributes without being stripped by the legacy compatibility layer.

### Related Issues
Resolves [Add protocol.version span attribute consistently across router and broker #1412](#1412)

### Checklist
- [x] All router spans now include `protocol.version`.
- [x] `mcp-broker.handle-request` span includes `protocol.version`.
- [x] Broker spans in protocol-filtered handlers include `protocol.version`.
- [x] Unit tests verify the attribute is set for the default fallback.
- [x] **[NEW]** Unit tests verify the attribute is explicitly set when the `2026-07-28` header is provided.
- [x] Code compiles and `go test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Observability**
  * Trace data now records the MCP protocol version for broker requests, tool and prompt listings, user-specific tool retrieval, and routing decisions.
  * The version is taken from the request header when provided, with a default applied when absent.
* **Bug Fixes**
  * Improved routing validation for stateful requests involving stateless-only tool, prompt, or resource backends.
  * Excluded unroutable private servers from user-specific tool retrieval.
* **Tests**
  * Added coverage confirming protocol versions are correctly recorded for default and explicitly specified requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->