### PR TITLE
Upgrade Go to 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kuadrant/mcp-gateway
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
## Summary

- Upgrade Go toolchain from 1.26.6 to 1.26.7

## Test plan

- [ ] Unit tests pass
- [ ] Image builds successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go language version to 1.26.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->