### PR TITLE
chore: float Go patch version across upstream builds

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       - name: Install tools
         run: |

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26'
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4

--- a/.github/workflows/controller-integration-tests.yaml
+++ b/.github/workflows/controller-integration-tests.yaml
@@ -36,6 +36,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
       - name: Run controller integration tests
         run: make test-controller-integration

--- a/.github/workflows/e2e-auth.yaml
+++ b/.github/workflows/e2e-auth.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       # probe the baked CI node image (content-hash of version pins); on a
       # miss fall back to stock kindest/node via the default in kind.mk

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       # the published test-server images are built from main, so only pull
       # them when the checked-out ref has identical test-server sources

--- a/.github/workflows/e2e-on-demand.yaml
+++ b/.github/workflows/e2e-on-demand.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       # probe the baked CI node image (content-hash of version pins); on a
       # miss fall back to stock kindest/node via the default in kind.mk

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       # test-images.yaml publishes test-server images to ghcr.io on merges to
       # main but not from PRs, so runs with modified test-server sources must

--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26'
 
       - name: Install tools
         run: make tools

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       - name: Log in to Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
@@ -218,7 +218,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
 
       - name: Log in to Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3

--- a/.github/workflows/ratchet-check.yaml
+++ b/.github/workflows/ratchet-check.yaml
@@ -21,5 +21,5 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
       - run: make verify-ratchet

--- a/.github/workflows/ratchet-update.yaml
+++ b/.github/workflows/ratchet-update.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
       - run: make ratchet-update-all
       - name: Create pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # ratchet:peter-evans/create-pull-request@v7

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # ratchet:actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26'
         id: go
       - name: Run make unit test
         run: |

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26'
 
       - name: Verify generated code is up-to-date
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 

--- a/docs/guides/binary-install.md
+++ b/docs/guides/binary-install.md
@@ -22,7 +22,7 @@ This method runs MCP Gateway broker and router components as standalone binaries
 
 ## Prerequisites
 
-- [Go 1.26.6+](https://golang.org/doc/install) installed (for building from source)
+- [Go 1.26+](https://golang.org/doc/install) installed (for building from source)
 - [Git](https://git-scm.com/downloads) installed
 - [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install) installed (or Docker to run it as a container)
 - `openssl` (for generating the signing key)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/Kuadrant/mcp-gateway
 
+// Minimum floor, not a pin. Keep at the minor's .0 release so downstream builds
+// (which use their own toolchain image) are never blocked. CI and builder images
+// float to the latest patch of this minor. Bump only when moving to a new minor,
+// never for patch releases.
 go 1.26.0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kuadrant/mcp-gateway
 
-go 1.26.6
+go 1.26.0
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/tests/perf/mock-server/Dockerfile
+++ b/tests/perf/mock-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tests/servers/server2/Dockerfile
+++ b/tests/servers/server2/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/stateless-server/Dockerfile
+++ b/tests/servers/stateless-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/tests/servers/user-specific-server/Dockerfile
+++ b/tests/servers/user-specific-server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Stop pinning the exact Go **patch** version. Float it to the latest 1.26.x everywhere upstream, keep a low valid floor:
- `go.mod`: `go 1.26.6` → `go 1.26.0` (a *minimum floor*, not a pin)
- CI: setup-go steps use `go-version: '1.26'` (was `go-version-file: go.mod`) → installs the latest 1.26.x
- builder images: `golang:1.26.6[-alpine]` → `golang:1.26[-alpine]` (floating tag)
- docs: `Go 1.26.6+` → `Go 1.26+`

## Why

Two priorities:
1. Never pin an older Go for downstream's sake — upstream always builds on the latest patch so security/bug fixes land automatically.
2. No patch-bump churn in the repo — only minor bumps (1.26→1.27) should touch it.

In one week this repo saw three competing patch-pin PRs: #1427 (downgrade to 1.26.5, because a downstream build env lacked 1.26.6), #1434 and #1435 (both bump to 1.26.7). Go patch releases are security-only (1.26.6 alone fixed 10 CVEs including a `crypto/tls` KeyUpdate DoS reachable by this TLS-terminating gateway), so pinning to an older patch ships a knowingly-vulnerable stdlib, and every new patch forces another manual bump PR.

#1427 specifically broke because the `go.mod` floor was set high (`go 1.26.6`). The `go` directive is a minimum, not a hard pin: a low floor (`go 1.26.0`) is satisfied by any 1.26.x or 1.27 and never blocks downstream, which builds from its own toolchain image regardless. No dependency in the module graph requires a patch above 1.26.0, and no `toolchain` directive is added, so nothing forces a specific patch.

Result: patch releases require zero repo changes; only a minor bump touches the repo.

Supersedes #1427, #1434, #1435.

## Tradeoff

Floating tags trade byte-for-byte build reproducibility for always-current security patches (the stated goal). A digest-pin + Renovate approach would restore reproducibility but reintroduces exactly the patch-bump churn this removes. Go patch releases are low-risk in practice.

## Note

~8 test-server Dockerfiles (`tls-server`, `api-key-server`, `custom-path-server`, `custom-response-server`, `broken-server`, `a2a-server`, `server1`, `oidc-server`) are still on `golang:1.25-alpine` — pre-existing drift, left for a follow-up to keep this PR focused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized build, test, integration, and packaging environments on Go 1.26.
  - Updated container builds to use the Go 1.26 image tag rather than a patch-specific version.
  - Declared Go 1.26.0 as the project’s minimum supported version.

- **Documentation**
  - Updated binary installation requirements to Go 1.26 or newer.
  - Clarified that the declared Go version represents a minimum compatibility baseline, not a fixed toolchain pin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->