### PR TITLE
fix(e2e): skip combined Full tier2 tags in PR gate

### DIFF
--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -5,7 +5,8 @@ GINKGO_VERSION = v2.27.2
 E2E_TIMEOUT ?=30m
 # Tier 2 (slow/heavy) suites, plus the experimental A2A suite, are excluded from the
 # PR gate; they run in the full/nightly suite. \[A2A matches [A2A] and [A2A,Negative].
-E2E_GINKGO_SKIP_TIER2 = --skip="\[Full\]|\[multi-gateway\]|\[A2A"
+# Match both standalone tags like [Full] / [multi-gateway] and combined tags like [Full,CACertBundle].
+E2E_GINKGO_SKIP_TIER2 = --skip="\[Full(,|\])|\[multi-gateway(,|\])|\[A2A"
 # Local quick run: happy-path specs only (matches [Happy] and combined [Happy,...] tags)
 E2E_GINKGO_FOCUS_HAPPY = --focus="\[Happy"
 E2E_PROCS ?= 2


### PR DESCRIPTION
Small fix for skip regex.
Saves ~1m45s on PR e2e tests. 
The intent was for them to be skipped already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end test filtering so exclusions correctly match standalone tags and tags combined with other labels.
  * Preserved existing filtering behavior for A2A-tagged tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->