### PR TITLE
ci(conformance): run full 2025 suite with expected-failures baseline

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -132,32 +132,14 @@ jobs:
 
       - name: Run MCP conformance tests
         run: |
-          SCENARIOS=(
-            server-initialize
-            tools-list
-            ping
-            tools-call-simple-text
-            tools-call-image
-            tools-call-audio
-            tools-call-embedded-resource
-            tools-call-mixed-content
-            tools-call-error
-            tools-call-with-progress
-            json-schema-2020-12
-            server-sse-polling
-            server-sse-multiple-streams
-            prompts-list
-            prompts-get-simple
-            prompts-get-with-args
-            prompts-get-embedded-resource
-            prompts-get-with-image
-          )
-          for scenario in "${SCENARIOS[@]}"; do
-            echo "=== Running scenario: $scenario ==="
-            npx @modelcontextprotocol/conformance@${CONFORMANCE_VERSION} server \
-              --url ${MCP_URL} \
-              --scenario "$scenario"
-          done
+          # run the full 2025-11-25 server suite; known-unsupported scenarios
+          # are tracked in the baseline so new regressions fail the job
+          # unexpected passes also fail the job
+          npx @modelcontextprotocol/conformance@${CONFORMANCE_VERSION} server \
+            --url ${MCP_URL} \
+            --suite all \
+            --spec-version 2025-11-25 \
+            --expected-failures tests/conformance/baseline-202511.yaml
 
       - name: Collect logs on failure
         if: failure()

--- a/tests/conformance/baseline-202511.yaml
+++ b/tests/conformance/baseline-202511.yaml
@@ -1,0 +1,15 @@
+server:
+  - completion-complete
+  - dns-rebinding-protection
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+  - logging-set-level
+  - resources-read-binary
+  - resources-read-text
+  - resources-subscribe
+  - resources-templates-read
+  - resources-unsubscribe
+  - server-sse-polling
+  - tools-call-elicitation
+  - tools-call-sampling
+  - tools-call-with-logging

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -22,42 +22,42 @@ Tags currently in use: `[Happy]`, `[Full]`, `[multi-gateway]`, `[Auth]`, `[CACer
 - Tests clean up existing resources before creating to avoid conflicts
 - Structured JSON responses provide better debugging when tests fail
 
-## Conformance Tests
-MCP conformance tests verify that the gateway correctly implements the Model Context Protocol specification. These tests are sourced from the official `@modelcontextprotocol/conformance` npm package maintained by Anthropic.
-
 ## Useful test servers for inspecting responses
 
 Server1 and Server2 both offer tools for inspecting headers, which is useful for validating what was passed through to the backend MCP.
 
-**Test scenarios currently run in CI** (`.github/workflows/conformance.yaml`):
-- `server-initialize`: Server initialization handshake
-- `tools-list`: Tool listing and discovery
-- `tools-call-simple-text`: Simple text tool responses
-- `tools-call-image`: Image content in tool responses
-- `tools-call-audio`: Audio content in tool responses
-- `tools-call-embedded-resource`: Embedded resource handling
-- `tools-call-mixed-content`: Mixed content type responses
-- `tools-call-error`: Error handling and propagation
-- `tools-call-with-progress`: Progress notification support
+## Conformance Tests
+
+MCP conformance tests verify that the gateway correctly implements the Model
+Context Protocol specification. The tests come from the official
+`@modelcontextprotocol/conformance` npm package.
+
+CI runs the **full** server suite for a fixed spec version and ignores known
+unsupported scenarios through a baseline file: `tests/conformance/baseline-202511.yaml`.
+
+See `.github/workflows/conformance.yaml` for details.
 
 **Running conformance tests locally**:
 ```bash
 make deploy-conformance-server  # Deploy test server to Kind cluster
 
-# Run specific scenario
+# List available scenarios
+npx @modelcontextprotocol/conformance list
+
+# Run the full suite - as CI
+npx @modelcontextprotocol/conformance server \
+  --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
+  --suite all \
+  --spec-version 2025-11-25 \
+  --expected-failures tests/conformance/baseline-202511.yaml
+
+# Run a single scenario
 npx @modelcontextprotocol/conformance server \
   --url http://mcp.127-0-0-1.sslip.io:8001/mcp \
   --scenario server-initialize
-
-# Run all active scenarios
-npx @modelcontextprotocol/conformance server \
-  --url http://mcp.127-0-0-1.sslip.io:8001/mcp
 ```
 
-**Updating CI test scenarios**:
-1. Check available scenarios: `npx @modelcontextprotocol/conformance list`
-2. Add new scenario blocks to `.github/workflows/conformance.yaml` under the "Run MCP conformance tests" step
-3. Each scenario runs as a separate `npx @modelcontextprotocol/conformance server --url ... --scenario <name>` command
+**Updating the baseline**: add a scenario when it newly fails; remove it when it starts to pass (in the PR that adds support).
 
 ## Parallel test isolation via dedicated listeners
 


### PR DESCRIPTION
## What does this PR do?

Run all MCP Conformance server scenarios (for 2025-11-25 version) and ignore known failures - this is better than having to maintain white-list of scenarios to run.

Expected scenario failures are ignored. Unexpected passes are not, so if something start passing the baseline (expected failures list) will be updated as part of the PR implementing that feature

Note: `server-sse-polling` scenario used to be executed and now is in the baseline. The reason is that this scenario contains some warnings and when using `--expected-failures` flag warnings are counted as failures.

### Verification Steps
Eye review, passing conformance PR check should suffice for verification

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated conformance validation to run the complete MCP server test suite for the latest specification version.
  * Added baseline tracking for expected conformance outcomes across completion, security, elicitation, logging, resource, SSE, and tool capabilities.
  * Unexpected test failures or newly passing baseline cases now affect validation results.
  * Improved local and automated test guidance for running the full conformance suite consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->