### PR TITLE
fix: compare only controller-owned managed volume fields

### DIFF
--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -554,7 +554,7 @@ func deploymentNeedsUpdate(desired, existing *appsv1.Deployment) (bool, string) 
 	}
 	desiredVolumes := filterManagedVolumes(desired.Spec.Template.Spec.Volumes)
 	existingVolumes := filterManagedVolumes(existing.Spec.Template.Spec.Volumes)
-	if !equality.Semantic.DeepEqual(desiredVolumes, existingVolumes) {
+	if !managedVolumesEqual(desiredVolumes, existingVolumes) {
 		return true, fmt.Sprintf("volumes changed: %+v -> %+v", existingVolumes, desiredVolumes)
 	}
 	// only compare env vars the controller manages; user-added env vars are preserved
@@ -631,6 +631,55 @@ func filterManagedVolumes(volumes []corev1.Volume) []corev1.Volume {
 		}
 	}
 	return out
+}
+
+// managedVolumesEqual compares only managed volume fields owned by the controller.
+func managedVolumesEqual(desired, existing []corev1.Volume) bool {
+	if len(desired) != len(existing) {
+		return false
+	}
+
+	existingByName := make(map[string]*corev1.Volume, len(existing))
+	for i := range existing {
+		existingByName[existing[i].Name] = &existing[i]
+	}
+
+	for i := range desired {
+		existingVolume, ok := existingByName[desired[i].Name]
+		if !ok {
+			return false
+		}
+
+		desiredSecret := desired[i].Secret
+		existingSecret := existingVolume.Secret
+		if desiredSecret == nil || existingSecret == nil {
+			return false
+		}
+
+		if desiredSecret.SecretName != existingSecret.SecretName {
+			return false
+		}
+
+		if desiredSecret.DefaultMode != nil &&
+			(existingSecret.DefaultMode == nil ||
+				*desiredSecret.DefaultMode != *existingSecret.DefaultMode) {
+			return false
+		}
+
+		if desiredSecret.Optional != nil &&
+			(existingSecret.Optional == nil ||
+				*desiredSecret.Optional != *existingSecret.Optional) {
+			return false
+		}
+
+		if len(desiredSecret.Items) > 0 &&
+			!equality.Semantic.DeepEqual(desiredSecret.Items,
+				existingSecret.Items) {
+			return false
+		}
+
+	}
+	return true
 }
 
 // mergeVolumes preserves user-added volumes while updating controller-managed ones.

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -57,9 +57,10 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		modify   func(d *appsv1.Deployment)
-		expected bool
+		name          string
+		modifyDesired func(d *appsv1.Deployment)
+		modify        func(d *appsv1.Deployment)
+		expected      bool
 	}{
 		{
 			name:     "no changes",
@@ -219,12 +220,119 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "server-defaulted managed volume mode does not trigger update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = ptr.To(int32(420))
+			},
+			expected: false,
+		},
+		{
+			name: "unowned non-default managed volume mode does not trigger update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = ptr.To(int32(0o400))
+			},
+			expected: false,
+		},
+		{
+			name: "owned managed volume mode change triggers update",
+			modifyDesired: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = ptr.To(int32(0o644))
+			},
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = ptr.To(int32(0o400))
+			},
+			expected: true,
+		},
+		{
+			name: "missing managed secret source triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret = nil
+			},
+			expected: true,
+		},
+		{
+			name: "missing managed volume triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes = nil
+			},
+			expected: true,
+		},
+		{
+			name: "stale managed volume triggers update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes = append(
+					d.Spec.Template.Spec.Volumes,
+					corev1.Volume{
+						Name: "gateway-ca",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "old-ca",
+							},
+						},
+					},
+				)
+			},
+			expected: true,
+		},
+		{
+			name: "unowned secret optional change does not trigger update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.Optional = ptr.To(true)
+			},
+			expected: false,
+		},
+		{
+			name: "owned secret optional change triggers update",
+			modifyDesired: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.Optional = ptr.To(true)
+			},
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.Optional = ptr.To(false)
+			},
+			expected: true,
+		},
+		{
+			name: "unowned secret items change does not trigger update",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.Items = []corev1.KeyToPath{
+					{
+						Key:  "config",
+						Path: "custom-config",
+					},
+				}
+			},
+			expected: false,
+		},
+		{
+			name: "owned secret items change triggers update",
+			modifyDesired: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.Items = []corev1.KeyToPath{
+					{
+						Key:  "config",
+						Path: "desired-config",
+					},
+				}
+			},
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Volumes[0].Secret.Items = []corev1.KeyToPath{
+					{
+						Key:  "config",
+						Path: "existing-config",
+					},
+				}
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			desired := baseDeployment()
 			existing := baseDeployment()
+			if tt.modifyDesired != nil {
+				tt.modifyDesired(desired)
+			}
 			tt.modify(existing)
 
 			result, reason := deploymentNeedsUpdate(desired, existing)


### PR DESCRIPTION
## What does this PR do?

`deploymentNeedsUpdate` compared complete managed `Volume` values, so Kubernetes defaults or user values in fields the controller left unset looked like drift and could trigger unnecessary broker-router rollouts.

This change matches managed volumes by name and only compares Secret fields that appear in desired state. It still catches changed Secret references, explicitly set fields, missing volumes, and stale `gateway-ca`, while leaving user-added volumes and controller-omitted fields alone.

Fixes #1396

## Verification

- `go test ./internal/controller -run '^(TestDeploymentNeedsUpdate|TestMergeVolumes)$' -count=1`
- `make test-unit`
- `make test-controller-integration` (45/45 specs passed)
- `git diff --check`

The local `make lint` run is currently blocked by 35 pre-existing findings (`gosec` and `noctx`); none point to lines added by this change.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [ ] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment update detection for managed secret volumes.
  * Prevents unnecessary updates when unrelated, user-managed volume settings change.
  * Ensures updates occur when controller-managed secret configuration is missing, stale, or changed.
  * Correctly distinguishes between controller-owned and unowned settings such as default modes, optional values, and item mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->