### PR TITLE
feat(broker): federate stateless upstreams on older 2025 protocol revisions

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -988,16 +988,14 @@ func (m *mcpBrokerImpl) IsReady() bool {
 	return false
 }
 
-// ServerSupportsVersion returns true if the given upstream server supports the specified protocol version.
-// Returns false if the server is not found or version info is unavailable. Lazily populates the cache
-// from the manager on first access.
-func (m *mcpBrokerImpl) ServerSupportsVersion(id config.UpstreamMCPID, version string) bool {
+// serverProtocolVersions returns the protocol versions the given upstream
+// supports, lazily populating the cache from the manager on first access.
+// Returns nil if the server is unknown or has not reported versions yet.
+func (m *mcpBrokerImpl) serverProtocolVersions(id config.UpstreamMCPID) []string {
 	// try cached value first
-	val, ok := m.serverVersions.Load(id)
-	if ok {
-		versions, ok := val.([]string)
-		if ok {
-			return slices.Contains(versions, version)
+	if val, ok := m.serverVersions.Load(id); ok {
+		if versions, ok := val.([]string); ok {
+			return versions
 		}
 	}
 
@@ -1006,15 +1004,22 @@ func (m *mcpBrokerImpl) ServerSupportsVersion(id config.UpstreamMCPID, version s
 	mgr, found := m.mcpServers[id]
 	m.mcpLock.RUnlock()
 	if !found {
-		return false
+		return nil
 	}
 
 	versions := mgr.SupportedVersions()
 	if versions == nil {
-		return false
+		return nil
 	}
 
 	// cache for next time
 	m.serverVersions.Store(id, versions)
-	return slices.Contains(versions, version)
+	return versions
+}
+
+// ServerSupportsVersion returns true if the given upstream server supports the specified protocol version.
+// Returns false if the server is not found or version info is unavailable. Lazily populates the cache
+// from the manager on first access.
+func (m *mcpBrokerImpl) ServerSupportsVersion(id config.UpstreamMCPID, version string) bool {
+	return slices.Contains(m.serverProtocolVersions(id), version)
 }

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -3,11 +3,43 @@ package broker
 import (
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// statefulVersionPrefix matches every revision in the stateful protocol family
+// (2025-03-26, 2025-06-18, 2025-11-25, ...). The broker requests Version2025
+// (2025-11-25) at initialize, but upstreams built on older MCP SDKs downgrade
+// to an earlier 2025 revision. Their tools/list and tools/call payloads are
+// wire-compatible with what the broker serves downstream, so an upstream that
+// advertises any 2025-series revision is served on the stateful route rather
+// than silently dropped from every served set.
+const statefulVersionPrefix = "2025-"
+
+// supportsStatefulRoute reports whether any of the given advertised protocol
+// versions belongs to the stateful (2025) family. Lock-free so it can be
+// called from paths that already hold mcpLock (e.g. buildRoutingTable).
+func supportsStatefulRoute(versions []string) bool {
+	for _, v := range versions {
+		if strings.HasPrefix(v, statefulVersionPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// serverServesOnStatefulRoute reports whether the upstream advertises any
+// revision in the stateful (2025) protocol family. Used in place of an exact
+// Version2025 match so upstreams pinned to an older 2025 revision still
+// federate. See rebuildProtocolCaches. Must NOT be called while holding
+// mcpLock — serverProtocolVersions may take it; use supportsStatefulRoute
+// directly on already-held versions in that case.
+func (m *mcpBrokerImpl) serverServesOnStatefulRoute(id config.UpstreamMCPID) bool {
+	return supportsStatefulRoute(m.serverProtocolVersions(id))
+}
 
 // computeGatewaySupportedVersions returns the union of protocol versions
 // supported by all registered upstream servers. Used to populate the
@@ -74,7 +106,7 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 		}
 		serverID := config.UpstreamMCPID(serverIDStr)
 
-		if m.ServerSupportsVersion(serverID, protocol.Version2025) {
+		if m.serverServesOnStatefulRoute(serverID) {
 			statefulT.items = append(statefulT.items, tool)
 			if !statefulServersSeen[serverID] {
 				statefulServersSeen[serverID] = true
@@ -144,7 +176,7 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 		}
 		serverID := config.UpstreamMCPID(serverIDStr)
 
-		if m.ServerSupportsVersion(serverID, protocol.Version2025) {
+		if m.serverServesOnStatefulRoute(serverID) {
 			statefulP.items = append(statefulP.items, prompt)
 			if !statefulServersSeen[serverID] {
 				statefulServersSeen[serverID] = true

--- a/internal/broker/protocol_filter_stateful_route_test.go
+++ b/internal/broker/protocol_filter_stateful_route_test.go
@@ -1,0 +1,47 @@
+package broker
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+)
+
+// TestBroker_serverServesOnStatefulRoute verifies that an upstream advertising
+// any 2025-series protocol revision is routed onto the stateful set, so that
+// upstreams pinned to an older MCP SDK (which downgrade to 2025-03-26 /
+// 2025-06-18 rather than the requested 2025-11-25) are no longer silently
+// dropped from every served set.
+func TestBroker_serverServesOnStatefulRoute(t *testing.T) {
+	cases := []struct {
+		name     string
+		versions []string
+		want     bool
+	}{
+		{"exact 2025-11-25 (broker-requested)", []string{"2025-11-25"}, true},
+		{"older 2025-03-26 (e.g. SDK 1.11 upstream)", []string{"2025-03-26"}, true},
+		{"older 2025-06-18", []string{"2025-06-18", "2025-03-26"}, true},
+		{"2026 only is stateless route, not stateful", []string{"2026-07-28"}, false},
+		{"2024 only is pre-stateful family", []string{"2024-11-05"}, false},
+		{"mixed 2024 + 2025 still qualifies", []string{"2024-11-05", "2025-03-26"}, true},
+		{"no versions reported yet", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+			id := config.UpstreamMCPID("srv")
+			broker.mcpServers[id] = &mockActiveServer{supportedVersions: tc.versions}
+
+			if got := broker.serverServesOnStatefulRoute(id); got != tc.want {
+				t.Errorf("serverServesOnStatefulRoute(%v) = %v, want %v", tc.versions, got, tc.want)
+			}
+		})
+	}
+
+	// An unknown server must not qualify.
+	broker := NewBroker(slog.Default()).(*mcpBrokerImpl)
+	if broker.serverServesOnStatefulRoute("unknown") {
+		t.Error("serverServesOnStatefulRoute(unknown) = true, want false")
+	}
+}

--- a/internal/broker/protocol_filter_test.go
+++ b/internal/broker/protocol_filter_test.go
@@ -155,6 +155,29 @@ func TestRebuildProtocolCaches(t *testing.T) {
 			wantStatelessCount: 1,
 		},
 		{
+			name: "older 2025 revision (e.g. SDK 1.11 upstream) served on stateful route",
+			tools: []upstream.GatewayTool{
+				{Tool: mcp.Tool{Name: "tool1", InputSchema: objectSchema, Meta: map[string]any{"kuadrant/id": "server1"}}, Handler: upstream.NoopToolHandler},
+				{Tool: mcp.Tool{Name: "tool2", InputSchema: objectSchema, Meta: map[string]any{"kuadrant/id": "server1"}}, Handler: upstream.NoopToolHandler},
+			},
+			serverVersions: map[config.UpstreamMCPID][]string{
+				"server1": {"2025-03-26"},
+			},
+			wantStatefulCount:  2,
+			wantStatelessCount: 0,
+		},
+		{
+			name: "pre-2025 upstream stays dropped from both sets",
+			tools: []upstream.GatewayTool{
+				{Tool: mcp.Tool{Name: "tool1", InputSchema: objectSchema, Meta: map[string]any{"kuadrant/id": "server1"}}, Handler: upstream.NoopToolHandler},
+			},
+			serverVersions: map[config.UpstreamMCPID][]string{
+				"server1": {"2024-11-05"},
+			},
+			wantStatefulCount:  0,
+			wantStatelessCount: 0,
+		},
+		{
 			name: "tool without kuadrant/id excluded from all sets",
 			tools: []upstream.GatewayTool{
 				{Tool: mcp.Tool{Name: "tool1", InputSchema: objectSchema, Meta: map[string]any{"other": "value"}}, Handler: upstream.NoopToolHandler},

--- a/internal/broker/routing_table.go
+++ b/internal/broker/routing_table.go
@@ -19,9 +19,12 @@ func (m *mcpBrokerImpl) buildRoutingTable() *routing.Table {
 			URL:              cfg.URL,
 			UserSpecificList: cfg.UserSpecificList,
 			// dual-protocol servers have both set to true; each router
-			// checks its own flag independently
+			// checks its own flag independently. Stateful matches the whole
+			// 2025 family (not just Version2025) so upstreams pinned to an
+			// older 2025 revision route on the stateful path, consistent with
+			// rebuildProtocolCaches.
 			Stateless: up.SupportsVersion(protocol.Version2026),
-			Stateful:  up.SupportsVersion(protocol.Version2025),
+			Stateful:  supportsStatefulRoute(up.SupportedVersions()),
 		}
 		if p, err := cfg.Path(); err == nil {
 			route.Path = p

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -107,6 +107,9 @@ type MCP interface {
 	PromptsCacheMetadata() CacheMetadata
 	// UsesStatelessProtocol returns true if the upstream negotiated 2026-07-28 or later.
 	UsesStatelessProtocol() bool
+	// IsSessionless returns true if the upstream connection has no server-assigned
+	// Mcp-Session-Id (stateless transport), independent of the negotiated version.
+	IsSessionless() bool
 }
 
 // ActiveMCPServer is the handle returned by Start. It exposes read-only
@@ -490,11 +493,14 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	numberOfTools := len(man.tools)
 	numberOfPrompts := len(man.prompts)
 
-	// 2026 upstreams rely on subscriptions/listen for notifications. the SDK
-	// silently drops the listen stream when the upstream restarts without
-	// closing the session, so the broker never learns notifications stopped.
-	// force a fresh connection on each health tick to re-establish the stream.
-	if event == eventTypeTimer && man.mcp.UsesStatelessProtocol() {
+	// Stateless upstreams are recycled on each health tick: a fresh Connect is
+	// the liveness+recovery signal for them (Ping is a no-op and there is no
+	// session whose loss the SDK reports), so a dead upstream is caught by the
+	// next Connect failure rather than lingering with stale tools. This covers
+	// both 2026 upstreams (which also rely on re-establishing the SDK's
+	// subscriptions/listen stream, silently dropped on restart) and session-less
+	// 2025 upstreams (stateless streamable-HTTP transport, no Mcp-Session-Id).
+	if event == eventTypeTimer && (man.mcp.UsesStatelessProtocol() || man.mcp.IsSessionless()) {
 		man.logger.DebugContext(ctx, "recycling stateless connection", "upstream mcp server", man.mcp.ID())
 		_ = man.mcp.Disconnect()
 	}

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -44,10 +44,12 @@ type MockMCP struct {
 	resources           []mcp.Resource
 	listResourcesErr    error
 	protocolVersion     string
+	sessionless         bool
 	hasToolsCap         bool
 	hasPromptsCap       bool
 	hasResourcesCap     bool
 	connected           atomic.Bool
+	disconnectCount     atomic.Int32
 	notificationHandler func(method string)
 }
 
@@ -84,6 +86,7 @@ func (m *MockMCP) SupportsToolsListChanged() bool {
 
 func (m *MockMCP) Disconnect() error {
 	m.connected.Store(false)
+	m.disconnectCount.Add(1)
 	return nil
 }
 
@@ -191,6 +194,7 @@ func (m *MockMCP) SupportsVersion(v string) bool {
 func (m *MockMCP) ToolsCacheMetadata() CacheMetadata   { return CacheMetadata{} }
 func (m *MockMCP) PromptsCacheMetadata() CacheMetadata { return CacheMetadata{} }
 func (m *MockMCP) UsesStatelessProtocol() bool         { return m.protocolVersion >= "2026-07-28" }
+func (m *MockMCP) IsSessionless() bool                 { return m.sessionless }
 
 // newMockMCP creates a MockMCP with sensible defaults for testing
 func newMockMCP(name, prefix string) *MockMCP {
@@ -734,6 +738,41 @@ func TestMCPManager_manage_Success(t *testing.T) {
 	assert.Len(t, gateway.tools, 2)
 	assert.Contains(t, gateway.tools, "test_tool1")
 	assert.Contains(t, gateway.tools, "test_tool2")
+}
+
+func TestMCPManager_manage_RecyclesSessionlessUpstream(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// A session-less 2025 upstream (older-SDK stateless streamable-HTTP
+	// transport, no Mcp-Session-Id) must be recycled on each health tick: a
+	// fresh Connect is its only liveness signal, since Ping is a no-op and the
+	// SDK reports no session loss. Without the recycle a dead upstream would
+	// keep serving stale tools indefinitely.
+	sessionless := newMockMCP("stateless-2025", "s25_")
+	sessionless.protocolVersion = "2025-03-26"
+	sessionless.sessionless = true
+	sessionless.tools = []mcp.Tool{validTool("tool1")}
+	sessionless.hasToolsCap = false
+	mgr, err := NewUpstreamMCPManager(sessionless, newMockToolsAdderDeleter(), nil, logger, 0, InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	mgr.manage(context.Background(), eventTypeTimer)
+	assert.GreaterOrEqual(t, sessionless.disconnectCount.Load(), int32(1),
+		"session-less 2025 upstream should be recycled (Disconnect) on a timer tick")
+
+	// A session-ful stateful upstream (real Mcp-Session-Id) must NOT be
+	// recycled — its session-loss watcher and ping cover liveness.
+	stateful := newMockMCP("stateful-2025", "sf25_")
+	stateful.protocolVersion = "2025-11-25"
+	stateful.sessionless = false
+	stateful.tools = []mcp.Tool{validTool("tool1")}
+	stateful.hasToolsCap = false
+	sfMgr, err := NewUpstreamMCPManager(stateful, newMockToolsAdderDeleter(), nil, logger, 0, InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	sfMgr.manage(context.Background(), eventTypeTimer)
+	assert.Equal(t, int32(0), stateful.disconnectCount.Load(),
+		"session-ful stateful upstream should not be recycled on a timer tick")
 }
 
 func TestMCPManager_manage_UserSpecificList_SkipsToolCaching(t *testing.T) {

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -329,11 +329,17 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 	// 2026 upstreams receive notifications via the SDK's subscriptions/listen
 	// stream (opened automatically because ToolListChangedHandler is set).
 	// 2025 upstreams use the custom GET SSE notificationWatcher.
-	if !up.UsesStatelessProtocol() {
+	if up.UsesStatelessProtocol() {
+		up.logger.Debug("using subscriptions/listen for notifications (2026 upstream)", "upstream", up.ID())
+	} else if session.ID() == "" {
+		// Session-less 2025 upstream (stateless streamable-HTTP transport): the
+		// standalone GET SSE stream is keyed by Mcp-Session-Id, which this
+		// server never issued, so there is nothing to watch. The manager's
+		// periodic re-list backstops tool/prompt freshness.
+		up.logger.Debug("skipping GET SSE notification watcher (session-less 2025 upstream)", "upstream", up.ID())
+	} else {
 		up.logger.Debug("starting GET SSE notification watcher (2025 upstream)", "upstream", up.ID())
 		up.startNotificationWatcher(ctx, httpC, session)
-	} else {
-		up.logger.Debug("using subscriptions/listen for notifications (2026 upstream)", "upstream", up.ID())
 	}
 
 	// register notification and connection-lost handlers after session is
@@ -464,6 +470,16 @@ func (up *MCPServer) UsesStatelessProtocol() bool {
 	return up.init != nil && up.init.ProtocolVersion >= protocol.Version2026
 }
 
+// IsSessionless reports whether the current upstream connection has no
+// server-assigned Mcp-Session-Id. This is distinct from UsesStatelessProtocol:
+// a 2025 upstream running the streamable-HTTP transport in stateless mode
+// (sessionIdGenerator disabled) issues no session ID. Returns false when not
+// connected — there is no session to classify yet.
+func (up *MCPServer) IsSessionless() bool {
+	session := up.currentSession()
+	return session != nil && session.ID() == ""
+}
+
 // SupportedVersions returns the list of protocol versions this upstream supports.
 // Returns nil if not yet connected (init is nil).
 func (up *MCPServer) SupportedVersions() []string {
@@ -492,6 +508,13 @@ func (up *MCPServer) Ping(ctx context.Context) error {
 	session := up.currentSession()
 	if session == nil {
 		return fmt.Errorf("client not connected")
+	}
+	// A session-less upstream (stateless streamable-HTTP transport, no
+	// Mcp-Session-Id) has no session to ping; the SDK's session ping is
+	// rejected by strict stateless servers. A successful Connect is proof of
+	// connectivity, matching the stateless (2026) path above.
+	if session.ID() == "" {
+		return nil
 	}
 	return session.Ping(ctx, nil)
 }

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -71,7 +71,18 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 	seen := make(map[config.UpstreamMCPID]bool, len(crdServers))
 	var matching []userSpecificServer
 	for _, srv := range crdServers {
-		if broker.ServerSupportsVersion(srv.id, clientVersion) {
+		// A stateful (2025) client is served by any upstream in the 2025
+		// family, not only one advertising exactly Version2025 — mirrors the
+		// broadened match in rebuildProtocolCaches so an older-SDK upstream's
+		// per-user tools are still fetched. The stateless (2026) route stays an
+		// exact match.
+		var matches bool
+		if clientVersion == protocol.Version2026 {
+			matches = broker.ServerSupportsVersion(srv.id, protocol.Version2026)
+		} else {
+			matches = broker.serverServesOnStatefulRoute(srv.id)
+		}
+		if matches {
 			matching = append(matching, srv)
 		}
 		seen[srv.id] = true


### PR DESCRIPTION
Closes #1436

## Problem

The broker only federates an upstream whose advertised protocol versions contain **exactly** `2025-11-25` (`Version2025`) or `2026-07-28` (`Version2026`). `rebuildProtocolCaches` partitions each upstream's tools/prompts into the stateful or stateless served set on that exact match; an upstream that advertises neither lands in **neither set and is silently served to no client** — no error, no log.

In practice this drops any upstream built on an older MCP SDK. The broker requests `2025-11-25` at initialize, the upstream down-negotiates to the newest revision *it* knows (e.g. `2025-03-26` on `@modelcontextprotocol/sdk` ≤ 1.24.x), and its tools vanish. Separately, such upstreams frequently run the streamable-HTTP transport in **stateless** mode (`sessionIdGenerator` disabled → no `Mcp-Session-Id`); the broker treats any non-2026 upstream as stateful and (a) sends a session ping and (b) opens a session-keyed GET SSE watcher, both of which a session-less server rejects — de-federating it after the failure threshold.

Net effect: a perfectly functional, spec-compliant stateless `2025-xx` MCP server cannot be used through the gateway.

## Change

Decouple two things the broker currently conflates: which upstreams are *served*, and which are *stateless*.

**1. Serve the whole 2025 family, not just `2025-11-25`.** An upstream is routed onto the stateful set if it advertises **any** `2025-` revision (`serverServesOnStatefulRoute`). `tools/list` and `tools/call` payloads are wire-compatible across 2025 revisions, so they are served on the existing stateful route. Applied consistently at every stateful decision point so tools don't just *list* but also *route* and *fetch*:
- `rebuildProtocolCaches` (tools + prompts served-set partition)
- `buildRoutingTable` (`Stateful` flag → so calls route)
- `FetchUserSpecificTools` (per-user fetch for `userSpecificList` upstreams)

The stateless (`2026-07-28`) route stays an exact match. (Refactored the version lookup into `serverProtocolVersions`, shared by a lock-free `supportsStatefulRoute` helper.)

**2. Detect statelessness by transport, not by version.** Statelessness is "the upstream issued no `Mcp-Session-Id`" — independent of protocol version (`IsSessionless()`). For a session-less upstream:
- `Ping()` returns nil — a session ping is rejected by strict stateless servers; a successful `Connect` is the connectivity proof, matching the existing 2026 path.
- the GET SSE notification watcher is skipped — there is no session-keyed stream to watch.
- the connection is **recycled on every health tick** (same as 2026 upstreams), so liveness/recovery is preserved: a dead upstream is caught by the next `Connect` failure → failure threshold → tools dropped + reconnect. (Without this, a session-less upstream had *no* working liveness signal once the session-ping was dropped — it would keep serving stale tools indefinitely.)

## Tests (all green: `go test ./internal/broker/...`, `go vet` clean, gofmt clean)

- `TestBroker_serverServesOnStatefulRoute` — the family predicate (exact `2025-11-25`, older `2025-03-26`/`2025-06-18`, `2026`-only → not stateful, `2024`-only, mixed, empty, unknown).
- `TestRebuildProtocolCaches` — two new cases: an older-2025 upstream's tools land in `statefulTools`; a pre-2025 upstream stays dropped.
- `TestMCPManager_manage_RecyclesSessionlessUpstream` — a session-less upstream is recycled on a timer tick (liveness); a session-ful stateful upstream is not.
- Existing `TestBroker_ServerSupportsVersion` still passes through the `serverProtocolVersions` refactor.

## Verification scope

Unit/component-tested against the mock upstream. **Not** yet exercised end-to-end against a real session-less `2025-03-26` server over the wire — happy to add an integration test if you point me at the preferred harness. Verified locally with Go 1.26.6 (`go.mod` toolchain).

## Motivating case

A stock `baruchiro/paperless-mcp` (stateless streamable-HTTP, `@modelcontextprotocol/sdk` 1.11 → negotiates `2025-03-26`) currently connects but is served to no client. With this change its tools federate on the stateful route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for all 2025 protocol revisions, improving routing for stateful connections.
  - Added support for sessionless 2025 upstream connections without unnecessary session handling.
- **Bug Fixes**
  - Corrected tool and prompt routing for older 2025 protocol versions.
  - Improved connection health checks and recycling for sessionless upstreams.
  - Prevented unsupported session pings and notification watchers for sessionless connections.
- **Tests**
  - Added coverage for mixed, older, newer, and unknown protocol configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
