### PR TITLE
Docs: optional TOA verify for policy / MCPServer promote

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ In controller mode:
 - Generates aggregated configuration in `ConfigMap`, for use by the broker/router
 - Exposes health endpoints on `:8081` and metrics on `:8082`
 
+## Optional TOA policy gate
+
+Offline [TOA](https://github.com/Carmel-Labs-Inc/toa) verify before attaching or promoting an MCPServer: [docs/guides/toa-optional-policy-gate.md](docs/guides/toa-optional-policy-gate.md).
+
 ## Configuration
 
 ### Standalone Configuration

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -26,3 +26,4 @@
 - [Vault Integration](./vault-integration.md)
 - [Vault Token Exchange](./vault-token-exchange.md)
 - [Troubleshooting](./troubleshooting.md)
+- [Optional TOA policy gate](toa-optional-policy-gate.md)

--- a/docs/guides/toa-optional-policy-gate.md
+++ b/docs/guides/toa-optional-policy-gate.md
@@ -1,0 +1,20 @@
+# Optional TOA verify with policy attachment
+
+Kuadrant MCP Gateway aggregates MCP servers behind Envoy with authN/authZ and
+rate-limit policy attachment. That answers gateway policy. It does not prove
+tool delivery from an outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is optional offline
+delivery evidence before attaching a new `MCPServer` or promoting a route.
+
+```yaml
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Example: [`../../examples/toa-after-policy.yml`](../../examples/toa-after-policy.yml).
+
+Not per-call. No AgentStatus account required to verify.

--- a/examples/toa-after-policy.yml
+++ b/examples/toa-after-policy.yml
@@ -1,0 +1,13 @@
+# Example only.
+name: Kuadrant MCP policy and optional TOA
+on: [workflow_dispatch]
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before attaching or promoting an MCPServer.

- `docs/guides/toa-optional-policy-gate.md`
- `examples/toa-after-policy.yml`
- README pointer

Does not change Envoy/policy runtime. No AgentStatus account required to verify.

## Test plan

- [ ] Docs clearly optional
- [ ] Example YAML gated on `toa.json`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional offline TOA policy gate to verify tool delivery before attaching an MCPServer or promoting a route.
  * Added a manually triggered workflow example that validates TOA attestations when configured.

* **Documentation**
  * Added setup instructions, configuration examples, and implementation guidance for TOA verification.
  * Added the new guide to the documentation table of contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->