### PR TITLE
test(e2e): use TLS-aware HTTP client in A2A passthrough suite

### DIFF
--- a/tests/e2e/a2a_passthrough_test.go
+++ b/tests/e2e/a2a_passthrough_test.go
@@ -59,7 +59,14 @@ var _ = Describe("A2A Passthrough", Ordered, Label("A2A"), func() {
 			}
 			return e2eScheme + "://" + a2aPassthroughServerHost("a2a")
 		}()
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		httpClient = func() *http.Client {
+			c := e2eHTTPClient(a2aBaseURL)
+			if c == nil {
+				c = &http.Client{}
+			}
+			c.Timeout = 30 * time.Second
+			return c
+		}()
 	)
 
 	// a2aDo sends a raw HTTP request to the gateway and returns the status and body.


### PR DESCRIPTION
## What does this PR do?

It builds the client from e2eHTTPClient so HTTPS runs get InsecureSkipVerify and the .local dialer, while Kind HTTP runs keep the plain client.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by using the configured test client when available.
  * Added a 30-second timeout and a safe fallback client for test requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->