### PR TITLE
fix: exclude private-scope server tools when no prefix configured

### DIFF
--- a/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
+++ b/docs/design/broker-2026-07-28/broker-2026-07-28-design.md
@@ -60,6 +60,10 @@ Any private-scoped upstream, `ttlMs: 0` upstream, or `userSpecificList` server m
 
 2025 upstreams: `userSpecificList: true` on CRD remains the fresh-fetch signal (no `cacheScope` or `ttlMs` in protocol). 2026 upstreams: `cacheScope: "private"` or `ttlMs: 0` triggers fresh fetching, CRD field ignored. All three signals feed the same internal `ShouldFetchFresh` path.
 
+### Private-scope servers require a prefix
+
+Servers with `cacheScope: "private"` or `userSpecificList: true` must configure a prefix on their MCPServerRegistration. Without a prefix, per-user tools not in the shared routing table cannot be routed by the router's `LookupPrefix` fallback, so the broker excludes them from `tools/list`.
+
 ## Design
 
 ### Prerequisites

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -67,7 +67,7 @@ func (m *mcpBrokerImpl) privateScopeServersWithoutPrefix() map[config.UpstreamMC
 		}
 		excluded[id] = struct{}{}
 		m.logger.Warn("private-scope server has no prefix configured, tools excluded from listing",
-			"server", mgr.Config().Name,
+			"server", mgr.MCPName(),
 			"reason", "tools would be unroutable without prefix for LookupPrefix fallback")
 	}
 	return excluded

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -44,11 +44,7 @@ type protocolCacheEntry[T any] struct {
 }
 
 // isPrivateScopeWithoutPrefix reports whether an upstream's tools are
-// unroutable and must be excluded from tools/list. A server whose list is
-// per-user — cacheScope:"private" (2026 upstream) or userSpecificList (CRD) —
-// returns tool names absent from the shared routing table; without a prefix the
-// router's LookupPrefix fallback has nothing to match, so the tools cannot be
-// routed.
+// unroutable and must be excluded from tools/list.
 func isPrivateScopeWithoutPrefix(s upstream.ActiveMCPServer) bool {
 	cfg := s.Config()
 	if cfg.Prefix != "" {

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
 	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -42,11 +43,48 @@ type protocolCacheEntry[T any] struct {
 	freshFetchServers []userSpecificServer
 }
 
+// isPrivateScopeWithoutPrefix reports whether an upstream's tools are
+// unroutable and must be excluded from tools/list. A server whose list is
+// per-user — cacheScope:"private" (2026 upstream) or userSpecificList (CRD) —
+// returns tool names absent from the shared routing table; without a prefix the
+// router's LookupPrefix fallback has nothing to match, so the tools cannot be
+// routed.
+func isPrivateScopeWithoutPrefix(s upstream.ActiveMCPServer) bool {
+	cfg := s.Config()
+	if cfg.Prefix != "" {
+		return false
+	}
+	return cfg.UserSpecificList || s.ToolsCacheMetadata().CacheScope == upstream.CacheScopePrivate
+}
+
+// privateScopeServersWithoutPrefix returns the set of connected upstreams whose
+// tools must be excluded from tools/list, logging one warning per server so
+// operators can diagnose the missing tools.
+func (m *mcpBrokerImpl) privateScopeServersWithoutPrefix() map[config.UpstreamMCPID]struct{} {
+	var excluded map[config.UpstreamMCPID]struct{}
+	for id, mgr := range m.mcpServers {
+		if !isPrivateScopeWithoutPrefix(mgr) {
+			continue
+		}
+		if excluded == nil {
+			excluded = make(map[config.UpstreamMCPID]struct{})
+		}
+		excluded[id] = struct{}{}
+		m.logger.Warn("private-scope server has no prefix configured, tools excluded from listing",
+			"server", mgr.Config().Name,
+			"reason", "tools would be unroutable without prefix for LookupPrefix fallback")
+	}
+	return excluded
+}
+
 // rebuildProtocolCaches partitions the current gateway server tools and
 // prompts into stateful (2025) and stateless (2026) sets based on each
 // upstream server's supportedVersions. Broker meta-tools (those without
 // kuadrant/id) are included only in the stateful set.
 func (m *mcpBrokerImpl) rebuildProtocolCaches() {
+	// per-user servers with no prefix serve unroutable tools; exclude them
+	excluded := m.privateScopeServersWithoutPrefix()
+
 	// partition tools
 	allTools := m.gatewayServer.ListTools()
 	var statefulT, statelessT protocolCacheEntry[*mcp.Tool]
@@ -74,6 +112,10 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 		}
 		serverID := config.UpstreamMCPID(serverIDStr)
 
+		if _, isExcluded := excluded[serverID]; isExcluded {
+			continue
+		}
+
 		if m.ServerSupportsVersion(serverID, protocol.Version2025) {
 			statefulT.items = append(statefulT.items, tool)
 			if !statefulServersSeen[serverID] {
@@ -100,6 +142,9 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 	}
 	for id, mgr := range m.mcpServers {
 		if crdUserSpecific[id] {
+			continue
+		}
+		if _, isExcluded := excluded[id]; isExcluded {
 			continue
 		}
 		if !m.ServerSupportsVersion(id, protocol.Version2026) {

--- a/internal/broker/protocol_filter_private_scope_test.go
+++ b/internal/broker/protocol_filter_private_scope_test.go
@@ -1,0 +1,135 @@
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/Kuadrant/mcp-gateway/internal/broker/upstream"
+	"github.com/Kuadrant/mcp-gateway/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerServer wires an upstream into the broker with the given prefix and
+// tools cache metadata, and registers one tool for it in the gateway server.
+func registerServer(t *testing.T, b *mcpBrokerImpl, id config.UpstreamMCPID, prefix string, meta upstream.CacheMetadata) {
+	t.Helper()
+	b.serverVersions.Store(id, []string{"2026-07-28"})
+	mcpServer := upstream.NewUpstreamMCP(&config.MCPServer{
+		Name:             string(id),
+		Prefix:           prefix,
+		URL:              "http://test.local/mcp",
+		UserSpecificList: meta.UserSpecificList,
+	}, "", nil)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, upstream.InvalidToolPolicyFilterOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetToolsForTesting([]mcp.Tool{{Name: "tool1", InputSchema: objectSchema}})
+	manager.SetCacheMetadataForTesting(meta, upstream.CacheMetadata{})
+	b.mcpServers[id] = upstream.NewActiveForTesting(manager)
+	b.gatewayServer.AddTools(upstream.GatewayTool{
+		Tool:    mcp.Tool{Name: prefix + "tool1", InputSchema: objectSchema, Meta: mcp.Meta{"kuadrant/id": string(id)}},
+		Handler: upstream.NoopToolHandler,
+	})
+}
+
+func TestRebuildProtocolCaches_ExcludesPrivateScopeWithoutPrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		prefix       string
+		meta         upstream.CacheMetadata
+		wantExcluded bool
+	}{
+		{
+			name:         "private scope, no prefix -> excluded",
+			prefix:       "",
+			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate},
+			wantExcluded: true,
+		},
+		{
+			name:         "private scope, with prefix -> included",
+			prefix:       "s1_",
+			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate},
+			wantExcluded: false,
+		},
+		{
+			name:         "public scope, no prefix -> included",
+			prefix:       "",
+			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
+			wantExcluded: false,
+		},
+		{
+			name:         "userSpecificList, no prefix -> excluded",
+			prefix:       "",
+			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePublic, UserSpecificList: true},
+			wantExcluded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+			id := config.UpstreamMCPID("srv1")
+			registerServer(t, b, id, tt.prefix, tt.meta)
+
+			b.rebuildProtocolCaches()
+
+			cached := b.statelessTools.Load()
+			if cached == nil {
+				t.Fatal("statelessTools is nil")
+			}
+			got := len(cached.items)
+			if tt.wantExcluded && got != 0 {
+				t.Errorf("expected tools excluded from listing, got %d", got)
+			}
+			if !tt.wantExcluded && got != 1 {
+				t.Errorf("expected 1 tool included in listing, got %d", got)
+			}
+			// an excluded server must not be scheduled for per-request fetching
+			if tt.wantExcluded && len(cached.freshFetchServers) != 0 {
+				t.Errorf("expected excluded server absent from freshFetchServers, got %d", len(cached.freshFetchServers))
+			}
+		})
+	}
+}
+
+// warnCounter counts warn records matching a specific message.
+type warnCounter struct {
+	slog.Handler
+	msg   string
+	count *int
+}
+
+// Enabled must return true: the embedded DiscardHandler disables all levels,
+// which would stop slog from ever calling Handle.
+func (h warnCounter) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h warnCounter) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn && r.Message == h.msg {
+		*h.count++
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func TestRebuildProtocolCaches_WarnsOncePerExcludedServer(t *testing.T) {
+	const msg = "private-scope server has no prefix configured, tools excluded from listing"
+	count := 0
+	logger := slog.New(warnCounter{Handler: slog.DiscardHandler, msg: msg, count: &count})
+
+	b := NewBroker(logger, WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+	id := config.UpstreamMCPID("srv1")
+	registerServer(t, b, id, "", upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate})
+	// second tool for the same excluded server: the warning must not fire per tool
+	b.gatewayServer.AddTools(upstream.GatewayTool{
+		Tool:    mcp.Tool{Name: "tool2", InputSchema: objectSchema, Meta: mcp.Meta{"kuadrant/id": string(id)}},
+		Handler: upstream.NoopToolHandler,
+	})
+
+	before := count
+	b.rebuildProtocolCaches()
+	got := count - before
+	if got != 1 {
+		t.Errorf("expected exactly one warning per excluded server per rebuild, got %d", got)
+	}
+}

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -418,6 +418,12 @@ func (broker *mcpBrokerImpl) filterUnroutablePrivateScope(matching []userSpecifi
 	defer broker.mcpLock.RUnlock()
 	filtered := matching[:0]
 	for _, srv := range matching {
+		// prefixed servers are always routable; short-circuit before touching the
+		// manager to avoid the Config() allocation on the common per-request path.
+		if srv.prefix != "" {
+			filtered = append(filtered, srv)
+			continue
+		}
 		if mgr, ok := broker.mcpServers[srv.id]; ok && isPrivateScopeWithoutPrefix(mgr) {
 			broker.logger.Debug("excluding private-scope server without prefix from user-specific fetch", "server", srv.name)
 			continue

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -93,6 +93,14 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 		return
 	}
 
+	// backstop against a rebuildProtocolCaches race: a server whose cacheScope
+	// metadata was not yet populated at the last rebuild can still be scheduled
+	// here. drop private-scope, no-prefix servers whose tools are unroutable.
+	matching = broker.filterUnroutablePrivateScope(matching)
+	if len(matching) == 0 {
+		return
+	}
+
 	ctx, span := brokerTracer().Start(ctx, "broker.user-specific-tools.fetch-all",
 		trace.WithAttributes(
 			attribute.Int("mcp.user_specific.server_count", len(matching)),
@@ -398,6 +406,25 @@ func gatewaySessionTTL(gatewaySessionID string) time.Duration {
 		return 0
 	}
 	return ttl
+}
+
+// filterUnroutablePrivateScope drops private-scope, no-prefix servers from the
+// per-request fetch set, reusing the same predicate as rebuildProtocolCaches so
+// tools excluded from the cached listing cannot reappear on the per-request
+// merge. Skips silently (Debug at most) — the warning is emitted once at
+// rebuild, never per request. Filters in place; the caller owns matching.
+func (broker *mcpBrokerImpl) filterUnroutablePrivateScope(matching []userSpecificServer) []userSpecificServer {
+	broker.mcpLock.RLock()
+	defer broker.mcpLock.RUnlock()
+	filtered := matching[:0]
+	for _, srv := range matching {
+		if mgr, ok := broker.mcpServers[srv.id]; ok && isPrivateScopeWithoutPrefix(mgr) {
+			broker.logger.Debug("excluding private-scope server without prefix from user-specific fetch", "server", srv.name)
+			continue
+		}
+		filtered = append(filtered, srv)
+	}
+	return filtered
 }
 
 // isUserSpecificByCRD checks if the server's CRD config declares userSpecificList.

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -650,6 +650,127 @@ func TestFetchUserSpecificTools_StatelessFetch(t *testing.T) {
 	assert.Equal(t, 0, poolSize(b), "stateless fetch should not cache sessions")
 }
 
+// registerActiveServer wires an upstream into b.mcpServers with the given
+// prefix, URL and tools cache metadata (so the exclusion predicate can read
+// them) and returns the userSpecificServer used to seed the fresh-fetch set.
+func registerActiveServer(t *testing.T, b *mcpBrokerImpl, id config.UpstreamMCPID, prefix, url string, meta upstream.CacheMetadata) userSpecificServer {
+	t.Helper()
+	b.serverVersions.Store(id, []string{"2026-07-28"})
+	mcpServer := upstream.NewUpstreamMCP(&config.MCPServer{
+		Name:             string(id),
+		Prefix:           prefix,
+		URL:              url,
+		UserSpecificList: meta.UserSpecificList,
+	}, "", nil)
+	manager, err := upstream.NewUpstreamMCPManager(mcpServer, newMockGateway(), nil, slog.Default(), 0, upstream.InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+	manager.SetCacheMetadataForTesting(meta, upstream.CacheMetadata{})
+	b.mcpServers[id] = upstream.NewActiveForTesting(manager)
+	return userSpecificServer{id: id, name: string(id), url: url, prefix: prefix}
+}
+
+// backstops rebuildProtocolCaches: a server whose cacheScope metadata was not
+// yet populated at the last rebuild can still be scheduled for per-request
+// fetch. The per-request path must drop private-scope, no-prefix servers whose
+// tools would be unroutable, without leaking them onto the merged list.
+func TestFetchUserSpecificTools_ExcludesPrivateScopeWithoutPrefix(t *testing.T) {
+	ts := newStatelessTestMCPServer(t) // serves a tool named "tool"
+	defer ts.Close()
+
+	tests := []struct {
+		name     string
+		prefix   string
+		meta     upstream.CacheMetadata
+		wantTool string // merged tool name; "" means the server must be excluded
+	}{
+		{
+			name:   "private scope, no prefix -> excluded",
+			prefix: "",
+			meta:   upstream.CacheMetadata{CacheScope: upstream.CacheScopePrivate},
+		},
+		{
+			name:     "private scope, with prefix -> included",
+			prefix:   "p_",
+			meta:     upstream.CacheMetadata{CacheScope: upstream.CacheScopePrivate},
+			wantTool: "p_tool",
+		},
+		{
+			name:     "public scope, no prefix (ttlMs:0) -> included",
+			prefix:   "",
+			meta:     upstream.CacheMetadata{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
+			wantTool: "tool",
+		},
+		{
+			name:   "userSpecificList, no prefix -> excluded",
+			prefix: "",
+			meta:   upstream.CacheMetadata{CacheScope: upstream.CacheScopePublic, UserSpecificList: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+			id := config.UpstreamMCPID("srv1")
+			srv := registerActiveServer(t, b, id, tt.prefix, ts.URL, tt.meta)
+
+			// simulate a prior rebuild having scheduled this server for per-request fetch
+			b.statelessTools.Store(&protocolCacheEntry[*mcp.Tool]{
+				freshFetchServers: []userSpecificServer{srv},
+			})
+
+			result := &mcp.ListToolsResult{Tools: []*mcp.Tool{{Name: "cached-tool"}}}
+			headers := http.Header{
+				"Mcp-Session-Id":       []string{"gw-session-1"},
+				"Mcp-Protocol-Version": []string{"2026-07-28"},
+				"Authorization":        []string{"Bearer user-token"},
+			}
+
+			b.FetchUserSpecificTools(context.Background(), headers, result)
+
+			names := make([]string, 0, len(result.Tools))
+			for _, tool := range result.Tools {
+				names = append(names, tool.Name)
+			}
+			assert.Contains(t, names, "cached-tool")
+			if tt.wantTool == "" {
+				assert.Len(t, result.Tools, 1, "excluded server must contribute no tools")
+			} else {
+				assert.Contains(t, names, tt.wantTool, "included server's tool must be merged")
+			}
+		})
+	}
+}
+
+// the per-request path must skip excluded servers silently: the warning is
+// emitted once at rebuild, never per request (hot-path rule).
+func TestFetchUserSpecificTools_NoWarnOnExclusion(t *testing.T) {
+	const msg = "private-scope server has no prefix configured, tools excluded from listing"
+	count := 0
+	logger := slog.New(warnCounter{Handler: slog.DiscardHandler, msg: msg, count: &count})
+
+	ts := newStatelessTestMCPServer(t)
+	defer ts.Close()
+
+	b := NewBroker(logger, WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+	id := config.UpstreamMCPID("srv1")
+	srv := registerActiveServer(t, b, id, "", ts.URL, upstream.CacheMetadata{CacheScope: upstream.CacheScopePrivate})
+	b.statelessTools.Store(&protocolCacheEntry[*mcp.Tool]{
+		freshFetchServers: []userSpecificServer{srv},
+	})
+
+	result := &mcp.ListToolsResult{}
+	headers := http.Header{
+		"Mcp-Session-Id":       []string{"gw-session-1"},
+		"Mcp-Protocol-Version": []string{"2026-07-28"},
+		"Authorization":        []string{"Bearer user-token"},
+	}
+
+	b.FetchUserSpecificTools(context.Background(), headers, result)
+
+	assert.Empty(t, result.Tools, "excluded server must contribute no tools")
+	assert.Equal(t, 0, count, "no per-request warning on the exclusion path")
+}
+
 func TestFetchUserSpecificTools_ProtocolFiltering(t *testing.T) {
 	// stateful (2025) test server
 	var initCount2025 atomic.Int32

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -741,36 +741,6 @@ func TestFetchUserSpecificTools_ExcludesPrivateScopeWithoutPrefix(t *testing.T) 
 	}
 }
 
-// the per-request path must skip excluded servers silently: the warning is
-// emitted once at rebuild, never per request (hot-path rule).
-func TestFetchUserSpecificTools_NoWarnOnExclusion(t *testing.T) {
-	const msg = "private-scope server has no prefix configured, tools excluded from listing"
-	count := 0
-	logger := slog.New(warnCounter{Handler: slog.DiscardHandler, msg: msg, count: &count})
-
-	ts := newStatelessTestMCPServer(t)
-	defer ts.Close()
-
-	b := NewBroker(logger, WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
-	id := config.UpstreamMCPID("srv1")
-	srv := registerActiveServer(t, b, id, "", ts.URL, upstream.CacheMetadata{CacheScope: upstream.CacheScopePrivate})
-	b.statelessTools.Store(&protocolCacheEntry[*mcp.Tool]{
-		freshFetchServers: []userSpecificServer{srv},
-	})
-
-	result := &mcp.ListToolsResult{}
-	headers := http.Header{
-		"Mcp-Session-Id":       []string{"gw-session-1"},
-		"Mcp-Protocol-Version": []string{"2026-07-28"},
-		"Authorization":        []string{"Bearer user-token"},
-	}
-
-	b.FetchUserSpecificTools(context.Background(), headers, result)
-
-	assert.Empty(t, result.Tools, "excluded server must contribute no tools")
-	assert.Equal(t, 0, count, "no per-request warning on the exclusion path")
-}
-
 func TestFetchUserSpecificTools_ProtocolFiltering(t *testing.T) {
 	// stateful (2025) test server
 	var initCount2025 atomic.Int32

--- a/internal/tests/user-specific-server/server.go
+++ b/internal/tests/user-specific-server/server.go
@@ -152,6 +152,9 @@ func toolFilterMiddleware() mcp.Middleware {
 				headers = extra.Header
 			}
 			filterToolsByAuth(headers, toolsResult)
+			// per-user list: advertise private scope so the broker treats it
+			// as unroutable without a prefix and excludes it from listing (#1385)
+			toolsResult.CacheScope = "private"
 			return result, nil
 		}
 	}

--- a/internal/tests/user-specific-server/server_test.go
+++ b/internal/tests/user-specific-server/server_test.go
@@ -68,6 +68,36 @@ func TestFilterToolsByAuth(t *testing.T) {
 	}
 }
 
+// the server advertises cacheScope:"private" on tools/list so the broker
+// treats it as per-user: a private-scope server with no prefix has its tools
+// excluded from the aggregated listing (see #1385).
+func TestToolsListEmitsPrivateCacheScope(t *testing.T) {
+	s := mcp.NewServer(&mcp.Implementation{Name: "user-specific-test-server", Version: "1.0.0"}, &mcp.ServerOptions{})
+	for _, tt := range allTools {
+		s.AddTool(&tt.tool, tt.handler)
+	}
+	s.AddReceivingMiddleware(toolFilterMiddleware())
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go func() { _, _ = s.Connect(ctx, st, nil) }()
+
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "0.0.1"}, nil).Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	assert.Equal(t, "private", res.CacheScope,
+		"tools/list must advertise cacheScope:private so the broker treats it as per-user")
+}
+
 // regression: requests with no HTTP extra (nil headers) skipped the filter
 // entirely, returning every tool to anonymous callers. in-memory transports
 // produce nil Extra, exercising exactly that path.

--- a/project-words.txt
+++ b/project-words.txt
@@ -408,6 +408,7 @@ unmarshalling
 unmarshals
 unparseable
 Unregistration
+unroutable
 upserted
 usercred
 Valkey

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -415,6 +415,10 @@ When the broker forwards headers to a user-specific upstream, internal gateway h
 
 When an MCPVirtualServer is configured that includes a specific user-specific tool, only that tool is returned — user-specific tools are subject to the same virtual server filtering as cached tools.
 
+### [Negative,UserSpecificList] Private-scope server with no prefix excludes its tools from tools/list
+
+When a server advertises `cacheScope: "private"` and is registered with no prefix, its per-user tool names are absent from the shared routing table and the router's `LookupPrefix` fallback cannot match them, so the broker excludes them from `tools/list` rather than advertise unroutable tools. A prefixed registration of the same backend is unaffected — its tools still appear.
+
 ### [Full] Large response payload from backend MCP
 
 - When a backend MCP server returns a large response (e.g. a tool that returns a multi-megabyte file or dataset), the gateway should stream the full response back to the client without truncation or corruption. The response body should match byte-for-byte what the upstream sent.

--- a/tests/e2e/user_specific_list_test.go
+++ b/tests/e2e/user_specific_list_test.go
@@ -445,4 +445,55 @@ var _ = Describe("MCP Gateway User-Specific Tool Lists", func() {
 			g.Expect(toolsList.Tools[0].Name).To(Equal(allowedTool))
 		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
 	})
+
+	// Serial: a no-prefix registration briefly risks registering bare tool
+	// names (e.g. headers, which mcp-test-server2 also exposes) into the shared
+	// routing table before its cacheScope metadata is read, which could flake
+	// parallel specs. #1385: a private-scope server (cacheScope:"private") with
+	// no prefix yields per-user tool names absent from the shared routing table
+	// that LookupPrefix cannot match either, so the broker excludes them from
+	// tools/list rather than advertise unroutable tools. A prefixed registration
+	// of the same backend is unaffected.
+	It("[Negative,UserSpecificList] private-scope server with no prefix excludes its tools from tools/list", Serial, func() {
+		By("Registering the user-specific (cacheScope:private) backend WITHOUT a prefix")
+		noPrefixReg := NewMCPServerResourcesWithDefaults("uspec-noprefix", k8sClient).
+			WithBackendTarget(userSpecificMCPTestServer, 9090).Build()
+		testResources = append(testResources, noPrefixReg.GetObjects()...)
+		noPrefixServer := noPrefixReg.Register(ctx)
+
+		By("Registering the same backend WITH a prefix as a control")
+		ctlReg := NewMCPServerResourcesWithDefaults("uspec-ctl", k8sClient).
+			WithBackendTarget(userSpecificMCPTestServer, 9090).
+			WithPrefix("uspecctl_").
+			WithUserSpecificList().Build()
+		testResources = append(testResources, ctlReg.GetObjects()...)
+		ctlServer := ctlReg.Register(ctx)
+
+		By("Waiting for both registrations to have a status condition")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationHasCondition(ctx, k8sClient, noPrefixServer.Name, noPrefixServer.Namespace)).To(BeNil())
+			g.Expect(VerifyMCPServerRegistrationHasCondition(ctx, k8sClient, ctlServer.Name, ctlServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("Creating a 2026 (stateless) client with user-a auth")
+		statelessClient, err := NewStatelessClientWithHeaders(ctx, gatewayURL, map[string]string{
+			"Authorization": "Bearer user-a-token",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = statelessClient.Close() }()
+
+		By("Verifying the prefixed control server's tools are present but the no-prefix server's tools are excluded")
+		Eventually(func(g Gomega) {
+			toolsList, err := statelessClient.ListTools(ctx, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(toolsList).NotTo(BeNil())
+			// prefixed control server is unaffected: its common tool is present
+			g.Expect(verifyMCPServerRegistrationToolPresent("uspecctl_server_info", toolsList)).To(BeTrueBecause("prefixed control server tools should still be listed"))
+			// no-prefix private-scope server contributes zero tools: per-user names
+			g.Expect(verifyMCPServerRegistrationToolPresent("list_repos", toolsList)).To(BeFalseBecause("no-prefix private-scope per-user tool must be excluded"))
+			g.Expect(verifyMCPServerRegistrationToolPresent("create_issue", toolsList)).To(BeFalseBecause("no-prefix private-scope per-user tool must be excluded"))
+			// ...and its cached common tool
+			g.Expect(verifyMCPServerRegistrationToolPresent("server_info", toolsList)).To(BeFalseBecause("no-prefix private-scope cached common tool must be excluded"))
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+	})
 })


### PR DESCRIPTION
## What does this PR do?

Excludes private scope server tools when no prefix is configured

Fixes https://github.com/Kuadrant/mcp-gateway/issues/1385

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private-scope servers without a configured prefix are excluded from shared tool listings when their tools cannot be routed.
  * Per-user tool requests now skip unroutable private-scope servers.
  * Unroutable tools are consistently excluded from cached and per-request results.
  * Private-scope servers with prefixes continue to function normally.
  * A2A passthrough now handles protocol metadata headers consistently, rejects unlabelable requests safely, and preserves GET behavior.

* **Documentation**
  * Documented the requirement for private-scope servers to configure a prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->