### PR TITLE
docs: add listener sections to MCP HTTPRoute examples

### DIFF
--- a/docs/guides/external-mcp-server.md
+++ b/docs/guides/external-mcp-server.md
@@ -76,6 +76,7 @@ spec:
     kind: Gateway
     name: mcp-gateway
     namespace: gateway-system
+    sectionName: mcps
   hostnames:
   - github.mcp.local
   rules:

--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -85,6 +85,7 @@ spec:
     kind: Gateway
     name: mcp-gateway
     namespace: gateway-system
+  sectionName: kubernetes-mcp
   hostnames:
   - $EXTERNAL_HOSTNAME
   rules:

--- a/docs/guides/kubernetes-mcp-server.md
+++ b/docs/guides/kubernetes-mcp-server.md
@@ -85,7 +85,7 @@ spec:
     kind: Gateway
     name: mcp-gateway
     namespace: gateway-system
-  sectionName: kubernetes-mcp
+    sectionName: kubernetes-mcp
   hostnames:
   - $EXTERNAL_HOSTNAME
   rules:

--- a/docs/tutorials/external-mcp-server.md
+++ b/docs/tutorials/external-mcp-server.md
@@ -87,6 +87,7 @@ spec:
     kind: Gateway
     name: mcp-gateway
     namespace: gateway-system
+  sectionName: mcps
   hostnames:
   - github.mcp.local
   rules:


### PR DESCRIPTION
## Summary

Add `spec.parentRefs.sectionName` to the upstream MCP HTTPRoute examples so each route explicitly targets its Gateway listener:

- `mcps` for the external MCP server examples
- `kubernetes-mcp` for the dedicated Kubernetes MCP server listener

The listener guide already documents this field. This PR updates only the related upstream MCP guide and tutorial examples; Helm, downstream RHCL, and A2A documentation are unchanged.

## Verification

- `git diff --check` (with CRLF-aware whitespace configuration)
- Checked all Markdown `HTTPRoute` examples; the only remaining omission is the intentionally out-of-scope A2A guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP server guides and tutorials with explicit Gateway listener sections in HTTPRoute examples.
  * Clarified routing configuration for external MCP and Kubernetes MCP servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->