### PR TITLE
feat(scaling): validate 2026 stateless horizontal scaling without Redis

### DIFF
--- a/docs/design/session-mgmt.md
+++ b/docs/design/session-mgmt.md
@@ -2,7 +2,7 @@
 
 The MCP Protocol is stateful. Providing an MCP Gateway, requires us to think about how to manage long lived sessions between clients and backend MCP Severs. This document covers how the MCP Gateway manages sessions.
 
-
+> **Note:** The session management described in this document applies to the **2025-11-25** MCP protocol. The 2026-07-28 protocol is fully stateless — it does not use server-side sessions or require session mapping. Gateways fronting exclusively 2026 upstreams do not need shared state for horizontal scaling. See the [Scaling Guide](../guides/scaling.md) for details.
 ## Types of session
 
 There are three types of session managed within the MCP Gateway components to provide its capabilities:

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -1,10 +1,30 @@
 # Scaling the MCP Gateway
 
-This guide covers scaling the MCP Gateway horizontally by running multiple replicas with shared session state.
+This guide covers scaling the MCP Gateway horizontally. The scaling strategy depends on which MCP protocol versions your gateway serves.
 
-## Overview
+## Scaling 2026-Only Gateways (No Redis Required)
 
-By default, the MCP Gateway runs as a single replica with session mappings stored in memory. To handle increased traffic or improve availability, you can scale the gateway to multiple replicas. However, because the gateway router maintains stateful session mappings between clients and backend MCP servers, scaling requires an external session store so that any replica can serve any client request.
+The 2026-07-28 MCP protocol is fully stateless — it eliminates server-side sessions and session mapping entirely. If your gateway fronts **exclusively** 2026-protocol MCP servers, you can scale horizontally using standard round-robin load balancing without deploying Redis or any external session store.
+
+Simply scale the deployment:
+
+```bash
+kubectl scale deployment/mcp-gateway -n mcp-system --replicas=3
+```
+
+Verify all replicas are ready:
+
+```bash
+kubectl rollout status deployment/mcp-gateway -n mcp-system
+```
+
+No `sessionStore` configuration is needed. Requests can land on any replica because there is no session state to share.
+
+For more details on protocol versions, see [Multi-Protocol Support](./multi-protocol-support.md).
+
+## Scaling 2025 and Mixed-Protocol Gateways (Redis Required)
+
+When fronting 2025-11-25 protocol servers — or a mix of 2025 and 2026 servers — the gateway maintains stateful session mappings between clients and backend MCP servers. To scale beyond a single replica, these mappings must be shared via an external Redis-based datastore so that any replica can serve any client request.
 
 Key concepts:
 - **Session Mapping**: Each gateway session ID maps to one or more backend MCP server session IDs

--- a/tests/e2e/scaling_stateless_test.go
+++ b/tests/e2e/scaling_stateless_test.go
@@ -1,0 +1,183 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	statelessScalingExtName   = "stateless-scaling-ext"
+	statelessScalingNamespace = "mcp-stateless-scaling"
+	statelessScalingPrefix    = "scale_"
+	statelessScalingReplicas  = 2
+)
+
+// statelessScalingServerHost returns a hostname for the protocol-2026 listener.
+func statelessScalingServerHost(subdomain string) string {
+	return subdomain + ".protocol-2026." + e2eDomain
+}
+
+// tests prove that a 2026-only gateway can scale horizontally without Redis.
+// requests succeed across replicas because the protocol is stateless.
+var _ = Describe("Stateless Scaling", Ordered, func() {
+	var (
+		testResources []client.Object
+		ssExt         *MCPGatewayExtensionSetup
+		ssURL         = Protocol2026GatewayURL
+	)
+
+	BeforeAll(func() {
+		By("Creating stateless-scaling namespace")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   statelessScalingNamespace,
+				Labels: map[string]string{"e2e": "test"},
+			},
+		}
+		_ = k8sClient.Delete(ctx, ns)
+		Eventually(func(g Gomega) {
+			err := k8sClient.Create(ctx, ns)
+			g.Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+		}, TestTimeoutShort, TestRetryInterval).Should(Succeed())
+
+		By("Creating MCPGatewayExtension (no sessionStore — no Redis)")
+		ssExt = NewMCPGatewayExtensionSetup(k8sClient).
+			WithName(statelessScalingExtName).
+			InNamespace(statelessScalingNamespace).
+			TargetingGateway(GatewayName, GatewayNamespace).
+			WithSectionName(Protocol2026ListenerName).
+			WithPublicHost(Protocol2026PublicHost).
+			Build()
+		ssExt.Clean(ctx).Register(ctx)
+
+		By("Waiting for MCPGatewayExtension to become ready")
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPGatewayExtensionReady(ctx, k8sClient, statelessScalingExtName, statelessScalingNamespace)).To(Succeed())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+
+		By("Waiting for deployment to be ready")
+		Eventually(func(g Gomega) {
+			g.Expect(WaitForDeploymentReady(ctx, statelessScalingNamespace, "mcp-gateway")).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Registering a 2026-only stateless server")
+		reg := NewTestResources("ss-stateless", k8sClient).
+			InNamespace(statelessScalingNamespace).
+			WithBackendTarget("mcp-test-stateless-server", 9090).
+			WithBackendNamespace(TestServerNameSpace).
+			WithHostname(statelessScalingServerHost("scaling")).
+			WithPrefix(statelessScalingPrefix).
+			WithSectionName(Protocol2026ListenerName).
+			WithParentGateway(GatewayName, GatewayNamespace).
+			Build()
+		testResources = append(testResources, reg.GetObjects()...)
+		server := reg.Register(ctx)
+
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, server.Name, server.Namespace)).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("Waiting for tools to appear via a 2026 client")
+		c, err := NewStatelessClient(ctx, ssURL)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = c.Close() }()
+
+		Eventually(func(g Gomega) {
+			result, listErr := c.ListTools(ctx, nil)
+			g.Expect(listErr).NotTo(HaveOccurred())
+			g.Expect(result).NotTo(BeNil())
+			g.Expect(verifyMCPServerRegistrationToolsPresent(statelessScalingPrefix, result)).To(BeTrue(),
+				"tools with prefix %q should exist", statelessScalingPrefix)
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By(fmt.Sprintf("Scaling deployment to %d replicas", statelessScalingReplicas))
+		Expect(ScaleDeployment(ctx, statelessScalingNamespace, "mcp-gateway", statelessScalingReplicas)).To(Succeed())
+
+		By("Waiting for all replicas to be ready")
+		Eventually(func(g Gomega) {
+			g.Expect(WaitForDeploymentReady(ctx, statelessScalingNamespace, "mcp-gateway")).To(Succeed())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		By("Scaling back to 1 replica")
+		_ = ScaleDeployment(ctx, statelessScalingNamespace, "mcp-gateway", 1)
+
+		Eventually(func(g Gomega) {
+			g.Expect(WaitForDeploymentReady(ctx, statelessScalingNamespace, "mcp-gateway")).To(Succeed())
+		}, TestTimeoutMedium, TestRetryInterval).Should(Succeed())
+	})
+
+	JustAfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			DumpClusterState(ctx, statelessScalingNamespace, GatewayNamespace)
+		}
+	})
+
+	Context("2026-only requests across replicas", func() {
+		It("[Happy,StatelessScaling] tools/list succeeds consistently across replicas", func() {
+			for i := 0; i < 10; i++ {
+				c, err := NewStatelessClient(ctx, ssURL)
+				Expect(err).NotTo(HaveOccurred(), "request %d: connect failed", i)
+
+				result, err := c.ListTools(ctx, nil)
+				Expect(err).NotTo(HaveOccurred(), "request %d: tools/list failed", i)
+				Expect(result).NotTo(BeNil())
+				Expect(verifyMCPServerRegistrationToolsPresent(statelessScalingPrefix, result)).To(BeTrue(),
+					"request %d: tools with prefix %q should exist", i, statelessScalingPrefix)
+
+				_ = c.Close()
+			}
+		})
+
+		It("[Happy,StatelessScaling] tools/call succeeds consistently across replicas", func() {
+			toolName := statelessScalingPrefix + "echo"
+			for i := 0; i < 5; i++ {
+				c, err := NewStatelessClient(ctx, ssURL)
+				Expect(err).NotTo(HaveOccurred(), "request %d: connect failed", i)
+
+				result, err := c.CallTool(ctx, &mcp.CallToolParams{
+					Name:      toolName,
+					Arguments: map[string]any{"message": fmt.Sprintf("ping-%d", i)},
+				})
+				Expect(err).NotTo(HaveOccurred(), "request %d: tools/call failed", i)
+				Expect(result).NotTo(BeNil())
+				Expect(result.IsError).To(BeFalse(), "request %d: tool returned error", i)
+
+				_ = c.Close()
+			}
+		})
+
+		It("[Happy,StatelessScaling] no session errors in gateway logs", func() {
+			cmd := exec.CommandContext(ctx, "kubectl", "logs",
+				"deployment/mcp-gateway",
+				"-n", statelessScalingNamespace,
+				"--all-containers",
+				"--since=5m",
+			)
+			output, err := cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), "failed to fetch gateway logs")
+
+			logs := string(output)
+			for _, errMsg := range []string{
+				"session not found",
+				"session validation failed",
+				"failed to get remote session",
+			} {
+				Expect(strings.Contains(logs, errMsg)).To(BeFalse(),
+					"gateway logs should not contain %q, but found it in:\n%s", errMsg, logs)
+			}
+		})
+	})
+})


### PR DESCRIPTION
This PR resolves #1447 by documenting and explicitly testing that a Kuadrant MCP Gateway fronting only 2026-protocol servers can scale horizontally without a Redis dependency.

### Changes Made

**Documentation Updates:**
*   **`docs/guides/scaling.md`:** 
    *   Rewrote the introduction to clarify that scaling architecture now depends entirely on the upstream protocol version.
    *   Added a new **"Scaling 2026-Only Gateways (No Redis Required)"** section explaining the stateless nature of the 2026 protocol.
    *   Scoped the existing Redis requirements under a new **"Scaling 2025 and Mixed-Protocol Gateways (Redis Required)"** heading.
*   **`docs/design/session-mgmt.md`:** Added a blockquote callout at the top of the document clarifying that the complex session mapping logic described applies exclusively to the 2025-11-25 protocol, cross-referencing the updated scaling guide.

**New E2E Test (`tests/e2e/scaling_stateless_test.go`):**
Added a new isolated Ginkgo test suite configured with 2 replicas, a 2026-only backend server, and no `sessionStore` configuration. It verifies the following behavior:
1.  **Tool Listing:** 10 consecutive stateless `tools/list` connections succeed seamlessly across the load-balanced replicas.
2.  **Tool Calling:** 5 consecutive `tools/call` executions (using an echo tool) succeed with no session mapping failures.
3.  **Log Verification:** Scans the Gateway pod logs to guarantee no `session not found`, `session validation failed`, or `failed to get remote session` errors are emitted during the test run.

### Related Issues
Resolves [e2e + docs: 2026-only gateways scale horizontally without Redis #1447](#1447)

### Checklist
- [x] E2e test passes with 2+ replicas, no Redis, and 2026-only upstreams.
- [x] Scaling guide clearly states: Redis needed for 2025, not needed for 2026-only.
- [x] Mixed deployments (2025 + 2026 servers) documented as requiring Redis.
- [x] Session management design doc updated to cross-reference the 2026 stateless model.
- [x] Code compiles and `go test` passes.