### PR TITLE
ci: dispatch mcp-gateway chart sync

### DIFF
--- a/.github/workflows/dispatch-chart-sync.yaml
+++ b/.github/workflows/dispatch-chart-sync.yaml
@@ -1,0 +1,59 @@
+# Notifies the kuadrant-operator repo when this component's Helm chart changes.
+# Sends a repository_dispatch event containing the component name, source branch,
+# PR author/approver, and commit URL. The kuadrant-operator's sync-component-chart
+# workflow receives this event, syncs the updated chart, and creates a PR.
+
+name: Dispatch chart sync
+
+on:
+  push:
+    branches:
+      - main
+      - 'release-*'
+    paths:
+      - 'charts/mcp-gateway/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.KUADRANT_DEV_PAT }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          PR_JSON=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0] // empty')
+          if [ -n "$PR_JSON" ]; then
+            AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.html_url')
+            PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+            APPROVER=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --slurp \
+              | jq -r 'flatten | [.[] | select(.state == "APPROVED")] | sort_by(.submitted_at) | last | .user.login // empty')
+          else
+            AUTHOR="$ACTOR"
+            PR_URL=""
+            APPROVER=""
+          fi
+          {
+            echo "author=$AUTHOR"
+            echo "pr-url=$PR_URL"
+            echo "approver=${APPROVER:-}"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
+          repository: Kuadrant/kuadrant-operator
+          event-type: component-chart-sync
+          client-payload: >-
+            {
+              "component": "mcp-gateway",
+              "ref": "${{ github.ref_name }}",
+              "actor": "${{ steps.pr.outputs.author }}",
+              "commit-url": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}",
+              "pr-url": "${{ steps.pr.outputs.pr-url }}",
+              "pr-approver": "${{ steps.pr.outputs.approver }}"
+            }


### PR DESCRIPTION
## Summary
- add the chart-sync repository dispatch workflow for mcp-gateway
- trigger it for chart changes on `main` and `release-*` branches
- resolve PR metadata and notify `Kuadrant/kuadrant-operator`

## Issue
Closes #1468

## How to review
1. Inspect `.github/workflows/dispatch-chart-sync.yaml` against the dns-operator workflow.
2. Verify the branch and chart path filters.
3. Verify the `component-chart-sync` payload fields and `mcp-gateway` component value.

## Verification
- `go test ./...` — 20 packages passed, 10 packages had no tests (baseline checkout)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/dispatch-chart-sync.yaml`
- Ruby YAML parse passed

## Manual end-to-end verification
Requires the `KUADRANT_DEV_PAT` repository secret. Push a chart-only commit to `main` or a `release-*` branch, then verify this workflow dispatches `component-chart-sync` and that kuadrant-operator opens the chart-sync PR. The secret and downstream dispatch cannot be exercised from this local checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated chart synchronization notifications when gateway chart changes are pushed to the main or release branches.
  * Notifications include relevant commit, branch, pull request, author, and reviewer details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->