### PR TITLE
e2e + docs(scaling): 2026-only gateways scale horizontally without Redis

### DIFF
--- a/docs/design/session-mgmt.md
+++ b/docs/design/session-mgmt.md
@@ -1,6 +1,8 @@
 # Session Management
 
-The MCP Protocol is stateful. Providing an MCP Gateway, requires us to think about how to manage long lived sessions between clients and backend MCP Severs. This document covers how the MCP Gateway manages sessions.
+The 2025-11-25 MCP protocol is stateful. Providing an MCP Gateway, requires us to think about how to manage long lived sessions between clients and backend MCP Severs. This document covers how the MCP Gateway manages sessions.
+
+> **Protocol scope:** This document describes the **2025-11-25** stateful session model — gateway session IDs, backend session mapping, lazy initialization, and the shared session store needed to scale it. The **2026-07-28** protocol is stateless: routing is header-based (`Mcp-Method`/`Mcp-Name`), there are no gateway or backend sessions and no session mapping, so a 2026-only gateway holds no cross-replica session state and scales without a shared store. See the [router-2026-07-28 design](./router-2026-07-28/router-2026-07-28-design.md) and the [scaling guide](../guides/scaling.md).
 
 
 ## Types of session

--- a/docs/design/session-mgmt.md
+++ b/docs/design/session-mgmt.md
@@ -1,8 +1,8 @@
 # Session Management
 
-The 2025-11-25 MCP protocol is stateful. Providing an MCP Gateway, requires us to think about how to manage long lived sessions between clients and backend MCP Severs. This document covers how the MCP Gateway manages sessions.
+The 2025-11-25 MCP protocol is stateful. Providing an MCP Gateway requires us to think about how to manage long-lived sessions between clients and backend MCP Servers. This document covers how the MCP Gateway manages sessions.
 
-> **Protocol scope:** This document describes the **2025-11-25** stateful session model — gateway session IDs, backend session mapping, lazy initialization, and the shared session store needed to scale it. The **2026-07-28** protocol is stateless: routing is header-based (`Mcp-Method`/`Mcp-Name`), there are no gateway or backend sessions and no session mapping, so a 2026-only gateway holds no cross-replica session state and scales without a shared store. See the [router-2026-07-28 design](./router-2026-07-28/router-2026-07-28-design.md) and the [scaling guide](../guides/scaling.md).
+> **Note:** This document describes the **2025-11-25** stateful session model — gateway session IDs, backend session mapping, lazy initialization, and the shared session store needed to scale it. The **2026-07-28** protocol is stateless: routing is header-based (`Mcp-Method`/`Mcp-Name`), there are no gateway or backend sessions and no session mapping, so a 2026-only gateway holds no cross-replica session state and scales without a shared store. See the [router-2026-07-28 design](./router-2026-07-28/router-2026-07-28-design.md) and the [scaling guide](../guides/scaling.md).
 
 
 ## Types of session

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -1,20 +1,37 @@
 # Scaling the MCP Gateway
 
-This guide covers scaling the MCP Gateway horizontally by running multiple replicas with shared session state.
+This guide covers scaling the MCP Gateway horizontally by running multiple replicas.
 
 ## Overview
 
-By default, the MCP Gateway runs as a single replica with session mappings stored in memory. To handle increased traffic or improve availability, you can scale the gateway to multiple replicas. However, because the gateway router maintains stateful session mappings between clients and backend MCP servers, scaling requires an external session store so that any replica can serve any client request.
+By default, the MCP Gateway runs as a single replica. To handle increased traffic or improve availability, you can scale the gateway to multiple replicas behind Envoy, which load-balances requests across them.
 
-Key concepts:
+Whether scaling requires an external session store depends on the MCP protocol version your clients and backends use:
+
+- **2026-07-28** traffic is stateless and header-based. Every request carries its own routing intent, so any replica can serve any request with no shared state. Scale directly, with no `sessionStore`.
+- **2025-11-25** traffic is stateful. The gateway router maintains in-memory session mappings between clients and backend MCP servers, so scaling requires an external Redis-based session store to make those mappings available to every replica.
+
+Key concepts for stateful (2025-11-25) traffic:
+
 - **Session Mapping**: Each gateway session ID maps to one or more backend MCP server session IDs
 - **Lazy Initialization**: Backend sessions are created on first `tools/call`, not at connection time
 - **Shared State**: An external Redis-based datastore makes session mappings accessible to all gateway replicas
 
+## Do I need Redis?
+
+Use this table to decide whether you need an external session store before scaling:
+
+| Gateway traffic | Redis (`sessionStore`) | How to scale |
+|-----------------|------------------------|--------------|
+| **2026-07-28 only** — all clients and backends use 2026-07-28 | Not required | Scale replicas directly; stateless header routing means any replica serves any request. See [Scaling a 2026-07-28-only gateway](#scaling-a-2026-07-28-only-gateway-no-redis). |
+| **2025-11-25 or mixed** — any 2025-11-25 client or backend | Required before scaling | Configure `sessionStore`, then scale. See [Scaling a 2025-11-25 or mixed gateway](#scaling-a-2025-11-25-or-mixed-gateway-redis-required). |
+
+> **Note:** Scaling a 2025-11-25 or mixed gateway to multiple replicas **without** Redis breaks sessions across replicas. Session mappings live in each replica's memory, so when a client's request lands on a replica other than the one that created its backend session, that session is lost. Always configure `sessionStore` before scaling a gateway that serves any 2025-11-25 traffic.
+
 ## Prerequisites
 
 - MCP Gateway installed and configured
-- A Redis-based datastore accessible from the gateway
+- For 2025-11-25 or mixed gateways: a Redis-based datastore accessible from the gateway
 
 The gateway connects using the Redis protocol and is compatible with any Redis-based datastore. For details on how to install and configure a datastore, see the documentation for your chosen implementation:
 
@@ -23,7 +40,27 @@ The gateway connects using the Redis protocol and is compatible with any Redis-b
 - [Dragonfly documentation](https://www.dragonflydb.io/docs)
 - [Valkey documentation](https://valkey.io/docs/)
 
-## Step 1: Deploy a Redis-based Datastore
+## Scaling a 2026-07-28-only gateway (no Redis)
+
+If all your clients and backends use the 2026-07-28 protocol, you do not need a session store. Confirm the MCPGatewayExtension has no `sessionStore` field, then scale the deployment directly:
+
+```bash
+kubectl scale deployment/mcp-gateway -n mcp-system --replicas=3
+```
+
+Verify all replicas are ready:
+
+```bash
+kubectl rollout status deployment/mcp-gateway -n mcp-system
+```
+
+Envoy load-balances requests across the replicas. The 2026-07-28 router keeps no server-side sessions and no session mappings — each request carries its own routing intent in the `Mcp-Method` and `Mcp-Name` headers, so any replica can serve any request. There is no cross-replica state to share, so no shared session store and no `CACHE_CONNECTION_STRING` are required.
+
+## Scaling a 2025-11-25 or mixed gateway (Redis required)
+
+If any of your clients or backends use the 2025-11-25 protocol, configure an external Redis-based session store before scaling. The following steps deploy a datastore, wire it into the MCPGatewayExtension as `sessionStore`, and scale the gateway.
+
+### Step 1: Deploy a Redis-based Datastore
 
 If you don't already have a Redis-based datastore available, deploy one in your cluster. Any Redis-compatible deployment will work. For example, to deploy Redis:
 
@@ -78,7 +115,7 @@ Wait for the datastore to be ready:
 kubectl rollout status deployment/redis -n your-namespace
 ```
 
-## Step 2: Create the Redis Credentials Secret
+### Step 2: Create the Redis Credentials Secret
 
 Create a secret containing the Redis connection URL. The secret must have the `mcp.kuadrant.io/secret: "true"` label — without it, the MCPGatewayExtension will fail validation.
 
@@ -106,7 +143,7 @@ redis://<user>:<password>@<host>:<port>/<db>
 
 For an instance without authentication in the same cluster, the host is typically `<service-name>.<namespace>.svc.cluster.local`.
 
-## Step 3: Configure the MCPGatewayExtension
+### Step 3: Configure the MCPGatewayExtension
 
 Add the `sessionStore` field to your MCPGatewayExtension to reference the Redis credentials secret:
 
@@ -118,7 +155,7 @@ spec:
 
 The operator will inject the Redis connection string as the `CACHE_CONNECTION_STRING` env var into the broker-router deployment.
 
-## Step 4: Scale the Gateway
+### Step 4: Scale the Gateway
 
 With the datastore configured, scale the gateway to multiple replicas:
 
@@ -132,7 +169,7 @@ Verify all replicas are ready:
 kubectl rollout status deployment/mcp-gateway -n mcp-system
 ```
 
-## Step 5: Verify Session Sharing
+### Step 5: Verify Session Sharing
 
 Confirm that the external store is active by checking the gateway logs. You should see `cache using external redis store` on startup:
 

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -52,7 +52,7 @@ Confirm the MCPGatewayExtension has no `sessionStore` field:
 kubectl get mcpgatewayextension mcp-gateway-extension -n mcp-system -o jsonpath='{.spec.sessionStore}'
 ```
 
-The output should be empty. If it returns a value, the gateway is configured for stateful 2025-11-25 traffic and requires Redis before scaling — follow [Scaling a 2025-11-25 or mixed gateway](#scaling-a-2025-11-25-or-mixed-gateway-redis-required) instead.
+The output should be empty. If it returns a value, Redis is already configured — the gateway is on the 2025-11-25 or mixed path, so follow [Scaling a 2025-11-25 or mixed gateway](#scaling-a-2025-11-25-or-mixed-gateway-redis-required) instead. This command only confirms whether a session store is configured; whether your traffic is 2026-07-28-only depends on the protocol versions your clients and backends negotiate, which you determine from the [Do I need Redis?](#do-i-need-redis) table above.
 
 ### Step 2: Scale the Deployment
 
@@ -69,6 +69,8 @@ kubectl rollout status deployment/mcp-gateway -n mcp-system
 ```
 
 Envoy load-balances requests across the replicas. There is no cross-replica state to share, so no shared session store and no `CACHE_CONNECTION_STRING` are required.
+
+> **Note:** A replica passing its readiness probe does not guarantee it has already connected to every configured backend — readiness reports true once any upstream is ready or while backend config is still syncing. Envoy adds a replica to its load-balancing pool as soon as it is ready, so immediately after scaling a new replica may briefly return errors for tools whose backend it has not yet loaded. Allow a short warm-up after `kubectl rollout status` completes, or confirm a replica serves the expected tools by checking the broker `/status` endpoint before sending production traffic.
 
 ## Scaling a 2025-11-25 or mixed gateway (Redis required)
 

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -42,7 +42,21 @@ The gateway connects using the Redis protocol and is compatible with any Redis-b
 
 ## Scaling a 2026-07-28-only gateway (no Redis)
 
-If all your clients and backends use the 2026-07-28 protocol, you do not need a session store. Confirm the MCPGatewayExtension has no `sessionStore` field, then scale the deployment directly:
+If all your clients and backends use the 2026-07-28 protocol, you do not need a session store. The 2026-07-28 router keeps no server-side sessions and no session mappings — each request carries its own routing intent in the `Mcp-Method` and `Mcp-Name` headers, so any replica can serve any request.
+
+### Step 1: Verify No Session Store Configured
+
+Confirm the MCPGatewayExtension has no `sessionStore` field:
+
+```bash
+kubectl get mcpgatewayextension mcp-gateway-extension -n mcp-system -o jsonpath='{.spec.sessionStore}'
+```
+
+The output should be empty. If it returns a value, the gateway is configured for stateful 2025-11-25 traffic and requires Redis before scaling — follow [Scaling a 2025-11-25 or mixed gateway](#scaling-a-2025-11-25-or-mixed-gateway-redis-required) instead.
+
+### Step 2: Scale the Deployment
+
+Scale the gateway to the desired number of replicas:
 
 ```bash
 kubectl scale deployment/mcp-gateway -n mcp-system --replicas=3
@@ -54,7 +68,7 @@ Verify all replicas are ready:
 kubectl rollout status deployment/mcp-gateway -n mcp-system
 ```
 
-Envoy load-balances requests across the replicas. The 2026-07-28 router keeps no server-side sessions and no session mappings — each request carries its own routing intent in the `Mcp-Method` and `Mcp-Name` headers, so any replica can serve any request. There is no cross-replica state to share, so no shared session store and no `CACHE_CONNECTION_STRING` are required.
+Envoy load-balances requests across the replicas. There is no cross-replica state to share, so no shared session store and no `CACHE_CONNECTION_STRING` are required.
 
 ## Scaling a 2025-11-25 or mixed gateway (Redis required)
 

--- a/tests/e2e/scaling_2026_test.go
+++ b/tests/e2e/scaling_2026_test.go
@@ -15,14 +15,11 @@ import (
 	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
 )
 
-// The 2026-07-28 router is stateless and header-based: every request carries
-// its own routing intent, so any replica serves any request without shared
-// session state. This spec proves a 2026-only gateway scales horizontally with
-// no Redis (sessionStore) by scaling the shared deployment to two replicas and
-// driving repeated stateless tools/call through Envoy, asserting every call
-// succeeds and no CACHE_CONNECTION_STRING is configured.
+// 2026-07-28 is stateless/header-based: any replica serves any request with no
+// shared session state. Proves horizontal scaling without Redis by driving repeated
+// tools/call across 2 replicas with no CACHE_CONNECTION_STRING configured.
 var _ = Describe("2026 horizontal scaling", func() {
-	It("[Full,Protocol2026] 2026-only traffic served across replicas without Redis", Serial, func() {
+	It("[Full,Protocol2026] 2026-07-28 traffic served across replicas without Redis", Serial, func() {
 		const iterations = 20
 		deploymentName := GatewayName
 
@@ -87,13 +84,8 @@ var _ = Describe("2026 horizontal scaling", func() {
 		})
 		Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, deploymentName, 2, gen)).To(Succeed())
 
-		// A replica passing its readiness probe does not mean it already serves
-		// scale2026_ tools: IsReady() reports ready when any upstream is ready
-		// (or while config is still syncing), and Envoy adds the pod to its LB
-		// pool the moment it is ready. A single successful poll could hit the
-		// warm replica while the other is still cold. Require several consecutive
-		// fresh-client successes (> 2x replicas) so round-robin exercises both
-		// replicas warm before the strict loop, which has no per-call retry.
+		// readiness doesn't guarantee tools are available; require consecutive fresh-client
+		// successes (> 2x replicas) so both replicas are warm before the strict loop
 		By("warming up: requiring consecutive fresh clients to see scale2026_ tools across replicas")
 		const warmStreak = 6
 		Eventually(func(g Gomega) {
@@ -110,22 +102,24 @@ var _ = Describe("2026 horizontal scaling", func() {
 
 		By(fmt.Sprintf("driving %d stateless tools/call across replicas — every call must succeed", iterations))
 		for i := range iterations {
-			name := fmt.Sprintf("scale-%d", i)
+			// closure so the client is closed even when an assertion fails mid-iteration
+			func() {
+				name := fmt.Sprintf("scale-%d", i)
 
-			c, err := NewStatelessClient(ctx, gatewayURL)
-			Expect(err).NotTo(HaveOccurred(), "iteration %d: connect", i)
+				c, err := NewStatelessClient(ctx, gatewayURL)
+				Expect(err).NotTo(HaveOccurred(), "iteration %d: connect", i)
+				defer func() { _ = c.Close() }()
 
-			result, err := c.CallTool(ctx, &mcp.CallToolParams{
-				Name:      "scale2026_hello_world",
-				Arguments: map[string]any{"name": name},
-			})
-			Expect(err).NotTo(HaveOccurred(), "iteration %d: tools/call", i)
-			Expect(result.Content).NotTo(BeEmpty(), "iteration %d: empty content", i)
-			text, ok := result.Content[0].(*mcp.TextContent)
-			Expect(ok).To(BeTrue(), "iteration %d: expected text content", i)
-			Expect(text.Text).To(ContainSubstring(fmt.Sprintf("Hello, %s!", name)), "iteration %d", i)
-
-			Expect(c.Close()).To(Succeed())
+				result, err := c.CallTool(ctx, &mcp.CallToolParams{
+					Name:      "scale2026_hello_world",
+					Arguments: map[string]any{"name": name},
+				})
+				Expect(err).NotTo(HaveOccurred(), "iteration %d: tools/call", i)
+				Expect(result.Content).NotTo(BeEmpty(), "iteration %d: empty content", i)
+				text, ok := result.Content[0].(*mcp.TextContent)
+				Expect(ok).To(BeTrue(), "iteration %d: expected text content", i)
+				Expect(text.Text).To(ContainSubstring(fmt.Sprintf("Hello, %s!", name)), "iteration %d", i)
+			}()
 		}
 	})
 })

--- a/tests/e2e/scaling_2026_test.go
+++ b/tests/e2e/scaling_2026_test.go
@@ -1,0 +1,131 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
+)
+
+// The 2026-07-28 router is stateless and header-based: every request carries
+// its own routing intent, so any replica serves any request without shared
+// session state. This spec proves a 2026-only gateway scales horizontally with
+// no Redis (sessionStore) by scaling the shared deployment to two replicas and
+// driving repeated stateless tools/call through Envoy, asserting every call
+// succeeds and no CACHE_CONNECTION_STRING is configured.
+var _ = Describe("2026 horizontal scaling", func() {
+	It("[Full,Protocol2026] 2026-only traffic served across replicas without Redis", Serial, func() {
+		const iterations = 20
+		deploymentName := GatewayName
+
+		testResources := []client.Object{}
+		deferCleanupResources(&testResources)
+
+		By("asserting the shared gateway has no session store configured")
+		ext := &mcpv1.MCPGatewayExtension{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: MCPExtensionName, Namespace: SystemNamespace}, ext)).To(Succeed())
+		Expect(ext.Spec.SessionStore).To(BeNil(), "test requires a 2026-only, Redis-free gateway")
+
+		By("asserting the broker-router deployment has no CACHE_CONNECTION_STRING env")
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: SystemNamespace}, dep)).To(Succeed())
+		Expect(dep.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+		var envNames []string
+		for _, e := range dep.Spec.Template.Spec.Containers[0].Env {
+			envNames = append(envNames, e.Name)
+		}
+		Expect(envNames).NotTo(ContainElement("CACHE_CONNECTION_STRING"),
+			"a 2026-only gateway must scale without a Redis session store")
+
+		By("registering a 2026-capable backend on the shared gateway")
+		registration := NewMCPServerResourcesWithDefaults("scale-2026", k8sClient).
+			WithBackendTarget("mcp-test-stateless-server", 9090).
+			WithPrefix("scale2026_").
+			Build()
+		testResources = append(testResources, registration.GetObjects()...)
+		registeredServer := registration.Register(ctx)
+
+		Eventually(func(g Gomega) {
+			g.Expect(VerifyMCPServerRegistrationReady(ctx, k8sClient, registeredServer.Name, registeredServer.Namespace)).To(BeNil())
+		}, TestTimeoutLong, TestRetryInterval).To(Succeed())
+
+		By("confirming a stateless client negotiates 2026-07-28 and sees scale2026_ tools")
+		Eventually(func(g Gomega) {
+			c, err := NewStatelessClient(ctx, gatewayURL)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = c.Close() }()
+
+			init := c.InitializeResult()
+			g.Expect(init).NotTo(BeNil())
+			g.Expect(init.ProtocolVersion).To(Equal("2026-07-28"),
+				"gateway with a 2026-capable backend must negotiate 2026-07-28")
+
+			result, err := c.ListTools(ctx, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(verifyMCPServerRegistrationToolsPresent("scale2026_", result)).To(BeTrue())
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By("scaling the gateway to 2 replicas")
+		gen, err := GetDeploymentGeneration(ctx, SystemNamespace, deploymentName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ScaleDeployment(ctx, SystemNamespace, deploymentName, 2)).To(Succeed())
+		// register scale-down now that the spec is at 2, so cleanup runs on any later failure
+		DeferCleanup(func() {
+			By("scaling the gateway back to 1 replica")
+			downGen, dErr := GetDeploymentGeneration(ctx, SystemNamespace, deploymentName)
+			Expect(dErr).NotTo(HaveOccurred())
+			Expect(ScaleDeployment(ctx, SystemNamespace, deploymentName, 1)).To(Succeed())
+			Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, deploymentName, 1, downGen)).To(Succeed())
+		})
+		Expect(WaitForDeploymentReplicas(ctx, SystemNamespace, deploymentName, 2, gen)).To(Succeed())
+
+		// A replica passing its readiness probe does not mean it already serves
+		// scale2026_ tools: IsReady() reports ready when any upstream is ready
+		// (or while config is still syncing), and Envoy adds the pod to its LB
+		// pool the moment it is ready. A single successful poll could hit the
+		// warm replica while the other is still cold. Require several consecutive
+		// fresh-client successes (> 2x replicas) so round-robin exercises both
+		// replicas warm before the strict loop, which has no per-call retry.
+		By("warming up: requiring consecutive fresh clients to see scale2026_ tools across replicas")
+		const warmStreak = 6
+		Eventually(func(g Gomega) {
+			for range warmStreak {
+				c, err := NewStatelessClient(ctx, gatewayURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				result, err := c.ListTools(ctx, nil)
+				_ = c.Close()
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(verifyMCPServerRegistrationToolsPresent("scale2026_", result)).To(BeTrue(),
+					"every replica must serve scale2026_ tools before the strict loop")
+			}
+		}, TestTimeoutLong, TestRetryInterval).Should(Succeed())
+
+		By(fmt.Sprintf("driving %d stateless tools/call across replicas — every call must succeed", iterations))
+		for i := range iterations {
+			name := fmt.Sprintf("scale-%d", i)
+
+			c, err := NewStatelessClient(ctx, gatewayURL)
+			Expect(err).NotTo(HaveOccurred(), "iteration %d: connect", i)
+
+			result, err := c.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "scale2026_hello_world",
+				Arguments: map[string]any{"name": name},
+			})
+			Expect(err).NotTo(HaveOccurred(), "iteration %d: tools/call", i)
+			Expect(result.Content).NotTo(BeEmpty(), "iteration %d: empty content", i)
+			text, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue(), "iteration %d: expected text content", i)
+			Expect(text.Text).To(ContainSubstring(fmt.Sprintf("Hello, %s!", name)), "iteration %d", i)
+
+			Expect(c.Close()).To(Succeed())
+		}
+	})
+})

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -481,9 +481,9 @@ When a server advertises `cacheScope: "private"` and is registered with no prefi
 
 - A 2026 client lists prompts (prefixed with `sl_`), then calls `prompts/get` on `sl_greeting`. The prompt response contains the expected greeting.
 
-### [Full,Protocol2026] 2026-only traffic served across replicas without Redis
+### [Full,Protocol2026] 2026-07-28 traffic served across replicas without Redis
 
-- The shared gateway has no `sessionStore` configured and its broker-router deployment has no `CACHE_CONNECTION_STRING` env var. A 2026-capable backend is registered (prefix `scale2026_`) and a stateless client confirms the gateway negotiates `2026-07-28`. The deployment is scaled to 2 replicas; once both are ready, 20 fresh stateless clients each call `scale2026_hello_world` through Envoy, which load-balances across the replicas. Every call succeeds with the expected content, proving the stateless 2026 router serves any request from any replica with no shared session state. On cleanup the deployment is scaled back to 1 replica and the registration removed. Serial, `[Full]` (nightly) tier.
+- The shared gateway has no `sessionStore` configured and its broker-router deployment has no `CACHE_CONNECTION_STRING` env var. A 2026-capable backend is registered (prefix `scale2026_`) and a stateless client confirms the gateway negotiates `2026-07-28`. The deployment is scaled to 2 replicas; once both are ready, 20 fresh stateless clients each call `scale2026_hello_world` through Envoy, which load-balances across the replicas. Every call succeeds with the expected content, proving the stateless 2026 router serves any request from any replica with no shared session state. The backend fixture is dual-protocol, but every client negotiates 2026-07-28, so no stateful session is created — this validates that 2026-07-28 traffic scales without Redis, not that the backend refuses 2025. On cleanup the deployment is scaled back to 1 replica and the registration removed. Serial, `[Full]` (nightly) tier.
 
 ## Version-aware server/discover
 

--- a/tests/e2e/test_cases.md
+++ b/tests/e2e/test_cases.md
@@ -481,6 +481,10 @@ When a server advertises `cacheScope: "private"` and is registered with no prefi
 
 - A 2026 client lists prompts (prefixed with `sl_`), then calls `prompts/get` on `sl_greeting`. The prompt response contains the expected greeting.
 
+### [Full,Protocol2026] 2026-only traffic served across replicas without Redis
+
+- The shared gateway has no `sessionStore` configured and its broker-router deployment has no `CACHE_CONNECTION_STRING` env var. A 2026-capable backend is registered (prefix `scale2026_`) and a stateless client confirms the gateway negotiates `2026-07-28`. The deployment is scaled to 2 replicas; once both are ready, 20 fresh stateless clients each call `scale2026_hello_world` through Envoy, which load-balances across the replicas. Every call succeeds with the expected content, proving the stateless 2026 router serves any request from any replica with no shared session state. On cleanup the deployment is scaled back to 1 replica and the registration removed. Serial, `[Full]` (nightly) tier.
+
 ## Version-aware server/discover
 
 ### [Happy,DualProtocol] 2025-only gateway negotiates 2025 with SDK client


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Kuadrant/mcp-gateway/issues/1447

## Changes

### Documentation

- **`docs/guides/scaling.md`**: Splits scaling guidance by protocol version with two paths:
  - 2026-07-28 only: scale directly, no `sessionStore` required (stateless header routing)
  - 2025-11-25 or mixed: configure Redis `sessionStore` before scaling (stateful session mappings)
- **`docs/design/session-mgmt.md`**: Adds note that this design doc describes 2025-11-25 stateful sessions; 2026-07-28 is stateless with no gateway sessions or session mapping

### Test Coverage

- **`tests/e2e/scaling_2026_test.go`**: New `[Full,Protocol2026]` Serial spec that:
  - Asserts gateway has no `sessionStore` and no `CACHE_CONNECTION_STRING` env var
  - Registers a 2026-capable backend (prefix `scale2026_`)
  - Scales deployment to 2 replicas
  - Drives 20 stateless `tools/call` requests through Envoy load balancer
  - Proves every request succeeds across replicas with no shared session state
  - Includes warm-up phase ensuring both replicas serve tools before strict loop
- **`tests/e2e/test_cases.md`**: Documents the new test case


## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that the 2026-07-28 protocol is stateless and does not require gateway sessions or Redis.
  - Updated scaling guidance for 2026-07-28-only traffic, 2025-11-25 traffic, and mixed deployments.
  - Added guidance on protocol-specific routing, session requirements, scaling decisions, and readiness verification.

- **Tests**
  - Added end-to-end coverage confirming 2026-07-28 traffic scales across multiple gateway replicas without Redis.
  - Documented the new multi-replica, stateless protocol test scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->