### PR TITLE
docs: describe managed broker-router NetworkPolicy

### DIFF
--- a/docs/guides/olm-install.md
+++ b/docs/guides/olm-install.md
@@ -93,8 +93,20 @@ kubectl get deployment mcp-gateway-controller -n mcp-system
 
 Installing the operator deploys the controller only. To deploy the MCP Gateway data plane
 (broker-router), create an `MCPGatewayExtension` that targets your Gateway. The controller
-reconciles it and creates the broker-router `Deployment`, `Service`, `HTTPRoute`, and the
-`EnvoyFilter` on the Gateway.
+reconciles it and creates the broker-router `Deployment`, `Service`, `HTTPRoute`, an
+`EnvoyFilter` on the Gateway, and a `NetworkPolicy` named `mcp-gateway`.
+
+The controller automatically creates and manages this `NetworkPolicy` in the
+`MCPGatewayExtension` namespace, which can differ from the target Gateway namespace. The policy
+allows ingress on ports `8080` (broker HTTP/MCP) and `50051` (router gRPC ext_proc) only from the
+target Gateway namespace.
+It allows metrics on port `9090` from any source, denies other broker-router ingress by default,
+and allows all egress. The controller selects the target Gateway namespace by matching the
+`kubernetes.io/metadata.name` namespace label to `spec.targetRef.namespace`; when that field is
+omitted, it uses the `MCPGatewayExtension` namespace.
+
+For details about `MCPGatewayExtension` fields, see the
+[MCPGatewayExtension API Reference](../reference/mcpgatewayextension.md).
 
 This example keeps the `MCPGatewayExtension` and target `Gateway` in `mcp-system`, so it does not
 require a `ReferenceGrant`. If the target Gateway is in another namespace, set


### PR DESCRIPTION
## Summary

Document the broker-router NetworkPolicy created by the controller and explain how the target Gateway namespace is selected.

## Relationship

- Stacked on #1283
- Follow-up to merged #1429
- Implements the documentation follow-up requested in
  #1429#issuecomment-5524484010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OLM installation guide to document the `mcp-gateway` NetworkPolicy created by the controller.
  * Added details about ingress, metrics, egress, and default-deny behavior.
  * Clarified how the target Gateway namespace is determined.
  * Added a link to the `MCPGatewayExtension` API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->