### PR TITLE
fix: handle missing Istio EnvoyFilter CRD

### DIFF
--- a/api/v1/mcpgatewayextension_types.go
+++ b/api/v1/mcpgatewayextension_types.go
@@ -35,6 +35,8 @@ const (
 	ConditionReasonRefGrantRequired = "ReferenceGrantRequired"
 	// ConditionReasonDeploymentNotReady is the reason when the broker-router deployment is not ready
 	ConditionReasonDeploymentNotReady = "DeploymentNotReady"
+	// ConditionReasonIstioUnavailable is the reason when the Istio EnvoyFilter CRD is unavailable
+	ConditionReasonIstioUnavailable = "IstioEnvoyFilterUnavailable"
 
 	// ConditionReasonSecretNotFound is the reason when the trusted headers secret is missing
 	ConditionReasonSecretNotFound = "SecretNotFound"

--- a/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
+++ b/bundle/manifests/mcp-gateway.clusterserviceversion.yaml
@@ -63,6 +63,14 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
                 - apps
               resources:
                 - deployments

--- a/charts/mcp-gateway/templates/rbac.yaml
+++ b/charts/mcp-gateway/templates/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ This package contains the main of the mcp controller
 package main
 
 import (
+	"context"
 	"flag"
 	"log/slog"
 	"os"
@@ -29,6 +30,7 @@ import (
 	goenv "github.com/caitlinelfring/go-env-default"
 	istionetv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -47,6 +49,7 @@ import (
 )
 
 func init() {
+	runtime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
 	runtime.Must(mcpv1.AddToScheme(scheme.Scheme))
 	runtime.Must(mcpv1alpha1.AddToScheme(scheme.Scheme))
 	runtime.Must(gatewayv1.Install(scheme.Scheme))
@@ -73,7 +76,8 @@ func main() {
 
 	ctrl.SetLogger(logr.FromSlogHandler(slogger.Handler()))
 	slogger.Info("Controller starting (health: :8081, metrics: :8082)...")
-	ctx := ctrl.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme.Scheme,
 		Metrics:                metricsserver.Options{BindAddress: ":8082"},
@@ -133,6 +137,7 @@ func main() {
 		MCPExtFinderValidator: mcpExtFinderValidator,
 		BrokerRouterImage:     brokerRouterImage,
 		BrokerRouterLogLevel:  brokerRouterLogLevel,
+		Shutdown:              cancel,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		panic("unable to start manager : " + err.Error())
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestControllerSchemeIncludesCustomResourceDefinitions(t *testing.T) {
+	if _, _, err := scheme.Scheme.ObjectKinds(&apiextensionsv1.CustomResourceDefinition{}); err != nil {
+		t.Fatalf("controller scheme cannot encode CustomResourceDefinition: %v", err)
+	}
+}

--- a/config/mcp-gateway/components/controller/rbac-controller.yaml
+++ b/config/mcp-gateway/components/controller/rbac-controller.yaml
@@ -30,6 +30,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/internal/controller/istio_discovery.go
+++ b/internal/controller/istio_discovery.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
+)
+
+const envoyFilterGroupVersion = "networking.istio.io/v1alpha3"
+
+const envoyFilterCRDName = "envoyfilters.networking.istio.io"
+
+type apiResourceDiscovery interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+func (r *MCPGatewayExtensionReconciler) refreshEnvoyFilterAvailability() error {
+	if r.envoyFilterDiscovery == nil {
+		return nil
+	}
+	available, err := envoyFilterAvailable(r.envoyFilterDiscovery)
+	if err != nil {
+		return err
+	}
+	r.envoyFilterUnavailable.Store(!available)
+	return nil
+}
+
+func (r *MCPGatewayExtensionReconciler) reconcileUnavailableEnvoyFilter(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension) (ctrl.Result, error) {
+	if !r.envoyFilterUnavailable.Load() {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.updateStatus(ctx, mcpExt, metav1.ConditionFalse, mcpv1.ConditionReasonIstioUnavailable,
+		"waiting for the Istio EnvoyFilter CRD to be installed"); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MCPGatewayExtensionReconciler) handleEnvoyFilterCRDAvailable() {
+	r.envoyFilterUnavailable.Store(false)
+	if !r.restartOnEnvoyFilterAvailable {
+		return
+	}
+
+	r.restartOnEnvoyFilterAvailable = false
+	if r.log != nil {
+		r.log.Info("Istio EnvoyFilter CRD available; restarting controller to register typed watch")
+	}
+	if r.Shutdown != nil {
+		r.Shutdown()
+	}
+}
+
+func (r *MCPGatewayExtensionReconciler) handleEnvoyFilterCRDDeleted() {
+	r.envoyFilterUnavailable.Store(true)
+}
+
+func (r *MCPGatewayExtensionReconciler) shouldRestartForEnvoyFilterCRD() bool {
+	return r.restartOnEnvoyFilterAvailable && r.envoyFilterUnavailable.Load()
+}
+
+func envoyFilterCRDEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	if crd == nil || crd.Name != envoyFilterCRDName {
+		return false
+	}
+	for i := range crd.Status.Conditions {
+		condition := &crd.Status.Conditions[i]
+		if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *MCPGatewayExtensionReconciler) enqueueRequestsForEnvoyFilterCRD(
+	ctx context.Context,
+	queue workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	extensions := &mcpv1.MCPGatewayExtensionList{}
+	if err := r.List(ctx, extensions); err != nil {
+		if r.log != nil {
+			r.log.Error("failed to list mcpgatewayextensions after EnvoyFilter CRD change", "error", err)
+		}
+		return
+	}
+	for i := range extensions.Items {
+		queue.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&extensions.Items[i])})
+	}
+}
+
+func envoyFilterAvailable(discovery apiResourceDiscovery) (bool, error) {
+	resources, err := discovery.ServerResourcesForGroupVersion(envoyFilterGroupVersion)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to discover Istio EnvoyFilter resource: %w", err)
+	}
+
+	for i := range resources.APIResources {
+		if resources.APIResources[i].Name == "envoyfilters" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/controller/istio_discovery_test.go
+++ b/internal/controller/istio_discovery_test.go
@@ -1,0 +1,211 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
+)
+
+type stubAPIResourceDiscovery struct {
+	resources *metav1.APIResourceList
+	err       error
+}
+
+func (s stubAPIResourceDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	return s.resources, s.err
+}
+
+type mutableAPIResourceDiscovery struct {
+	resources *metav1.APIResourceList
+	err       error
+}
+
+func (s *mutableAPIResourceDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	return s.resources, s.err
+}
+
+func TestRefreshEnvoyFilterAvailability(t *testing.T) {
+	discovery := &mutableAPIResourceDiscovery{
+		err: apierrors.NewNotFound(schema.GroupResource{Group: "networking.istio.io", Resource: "envoyfilters"}, ""),
+	}
+	reconciler := &MCPGatewayExtensionReconciler{
+		envoyFilterDiscovery: discovery,
+	}
+	reconciler.envoyFilterUnavailable.Store(true)
+
+	require.NoError(t, reconciler.refreshEnvoyFilterAvailability())
+	require.True(t, reconciler.envoyFilterUnavailable.Load())
+
+	discovery.err = nil
+	discovery.resources = &metav1.APIResourceList{
+		APIResources: []metav1.APIResource{{Name: "envoyfilters", Kind: "EnvoyFilter"}},
+	}
+	require.NoError(t, reconciler.refreshEnvoyFilterAvailability())
+	require.False(t, reconciler.envoyFilterUnavailable.Load())
+}
+
+func TestReconcileUnavailableEnvoyFilter(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1.AddToScheme(scheme))
+	extension := &mcpv1.MCPGatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{Name: "extension", Namespace: "default"},
+	}
+	k8sClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(extension).
+		WithObjects(extension).
+		Build()
+	reconciler := &MCPGatewayExtensionReconciler{
+		Client: k8sClient,
+		log:    slog.Default(),
+	}
+	reconciler.envoyFilterUnavailable.Store(true)
+
+	result, err := reconciler.reconcileUnavailableEnvoyFilter(context.Background(), extension)
+
+	require.NoError(t, err)
+	require.Zero(t, result.RequeueAfter)
+	current := &mcpv1.MCPGatewayExtension{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKeyFromObject(extension), current))
+	condition := meta.FindStatusCondition(current.Status.Conditions, mcpv1.ConditionTypeReady)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, mcpv1.ConditionReasonIstioUnavailable, condition.Reason)
+}
+
+func TestReconcileActiveStopsBeforeValidationWhenEnvoyFilterUnavailable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1.AddToScheme(scheme))
+	extension := &mcpv1.MCPGatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{Name: "extension", Namespace: "default"},
+	}
+	k8sClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(extension).
+		WithObjects(extension).
+		Build()
+	reconciler := &MCPGatewayExtensionReconciler{
+		Client: k8sClient,
+		log:    slog.Default(),
+	}
+	reconciler.envoyFilterUnavailable.Store(true)
+
+	_, err := reconciler.reconcileActive(context.Background(), extension)
+
+	require.NoError(t, err)
+	current := &mcpv1.MCPGatewayExtension{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKeyFromObject(extension), current))
+	condition := meta.FindStatusCondition(current.Status.Conditions, mcpv1.ConditionTypeReady)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, mcpv1.ConditionReasonIstioUnavailable, condition.Reason)
+}
+
+func TestEnvoyFilterAvailable(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources *metav1.APIResourceList
+		err       error
+		want      bool
+		wantErr   error
+	}{
+		{
+			name: "resource exists",
+			resources: &metav1.APIResourceList{
+				APIResources: []metav1.APIResource{{Name: "envoyfilters", Kind: "EnvoyFilter"}},
+			},
+			want: true,
+		},
+		{
+			name: "resource is absent",
+			resources: &metav1.APIResourceList{
+				APIResources: []metav1.APIResource{{Name: "virtualservices", Kind: "VirtualService"}},
+			},
+			want: false,
+		},
+		{
+			name: "api group is absent",
+			err:  apierrors.NewNotFound(schema.GroupResource{Group: "networking.istio.io", Resource: "envoyfilters"}, ""),
+			want: false,
+		},
+		{
+			name:    "discovery fails",
+			err:     errors.New("discovery unavailable"),
+			wantErr: errors.New("failed to discover Istio EnvoyFilter resource: discovery unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := envoyFilterAvailable(stubAPIResourceDiscovery{resources: tt.resources, err: tt.err})
+			if tt.wantErr != nil {
+				require.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+func TestHandleEnvoyFilterCRDAvailableRestartsController(t *testing.T) {
+	restarted := false
+	reconciler := &MCPGatewayExtensionReconciler{
+		restartOnEnvoyFilterAvailable: true,
+		Shutdown: func() {
+			restarted = true
+		},
+	}
+	reconciler.envoyFilterUnavailable.Store(true)
+
+	reconciler.handleEnvoyFilterCRDAvailable()
+
+	require.True(t, restarted)
+	require.False(t, reconciler.envoyFilterUnavailable.Load())
+}
+
+func TestHandleEnvoyFilterCRDAvailableDoesNotRestartAfterStartup(t *testing.T) {
+	restarted := false
+	reconciler := &MCPGatewayExtensionReconciler{
+		Shutdown: func() {
+			restarted = true
+		},
+	}
+	reconciler.envoyFilterUnavailable.Store(true)
+
+	reconciler.handleEnvoyFilterCRDAvailable()
+
+	require.False(t, restarted)
+	require.False(t, reconciler.envoyFilterUnavailable.Load())
+}
+
+func TestHandleEnvoyFilterCRDDeletedMarksUnavailable(t *testing.T) {
+	reconciler := &MCPGatewayExtensionReconciler{}
+
+	reconciler.handleEnvoyFilterCRDDeleted()
+
+	require.True(t, reconciler.envoyFilterUnavailable.Load())
+}
+
+func TestEnvoyFilterCRDEstablished(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: envoyFilterCRDName},
+	}
+	require.False(t, envoyFilterCRDEstablished(crd))
+
+	crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+		Type:   apiextensionsv1.Established,
+		Status: apiextensionsv1.ConditionTrue,
+	}}
+	require.True(t, envoyFilterCRDEstablished(crd))
+}

--- a/internal/controller/mcpgatewayextension_controller.go
+++ b/internal/controller/mcpgatewayextension_controller.go
@@ -6,23 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"sync/atomic"
 	"time"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
 	"github.com/Kuadrant/mcp-gateway/internal/config"
@@ -32,6 +17,27 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -118,12 +124,17 @@ type MCPGatewayExtensionReconciler struct {
 	BrokerRouterImage     string
 	// BrokerRouterLogLevel, when non-empty, is passed to the broker-router
 	// as --log-level (sourced from the BROKER_ROUTER_LOG_LEVEL env var)
-	BrokerRouterLogLevel string
+	BrokerRouterLogLevel          string
+	Shutdown                      func()
+	envoyFilterUnavailable        atomic.Bool
+	envoyFilterDiscovery          apiResourceDiscovery
+	restartOnEnvoyFilterAvailable bool
 }
 
 // +kubebuilder:rbac:groups=mcp.kuadrant.io,resources=mcpgatewayextensions,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=mcp.kuadrant.io,resources=mcpgatewayextensions/status,verbs=get;update
 // +kubebuilder:rbac:groups=mcp.kuadrant.io,resources=mcpgatewayextensions/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/status,verbs=get;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=list;watch
@@ -168,8 +179,10 @@ func (r *MCPGatewayExtensionReconciler) handleDeletion(ctx context.Context, mcpE
 		// don't fail deletion for status cleanup errors
 	}
 
-	if err := r.deleteEnvoyFilter(ctx, mcpExt); err != nil {
-		return ctrl.Result{}, err
+	if !r.envoyFilterUnavailable.Load() {
+		if err := r.deleteEnvoyFilter(ctx, mcpExt); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err := r.ConfigWriterDeleter.WriteEmptyConfig(ctx, config.NamespaceName(mcpExt.Namespace)); err != nil {
@@ -190,6 +203,9 @@ func (r *MCPGatewayExtensionReconciler) ensureFinalizer(ctx context.Context, mcp
 }
 
 func (r *MCPGatewayExtensionReconciler) reconcileActive(ctx context.Context, mcpExt *mcpv1.MCPGatewayExtension) (ctrl.Result, error) {
+	if r.envoyFilterUnavailable.Load() {
+		return r.reconcileUnavailableEnvoyFilter(ctx, mcpExt)
+	}
 	// check for namespace conflict first - only one MCPGatewayExtension per namespace
 	if err := r.checkNamespaceConflict(ctx, mcpExt); err != nil {
 		var valErr *validationError
@@ -902,17 +918,17 @@ func envoyFilterNameAndNamespace(mcpExt *mcpv1.MCPGatewayExtension) (name, names
 }
 
 func (r *MCPGatewayExtensionReconciler) enqueueMCPGatewayExtForEnvoyFilter(_ context.Context, obj client.Object) []reconcile.Request {
-	envoyFilter, ok := obj.(*istionetv1alpha3.EnvoyFilter)
-	if !ok || envoyFilter.Labels == nil {
+	if obj == nil || obj.GetLabels() == nil {
 		return nil
 	}
 
-	if envoyFilter.Labels[labelManagedBy] != labelManagedByValue {
+	labels := obj.GetLabels()
+	if labels[labelManagedBy] != labelManagedByValue {
 		return nil
 	}
 
-	extName := envoyFilter.Labels[labelExtensionName]
-	extNamespace := envoyFilter.Labels[labelExtensionNamespace]
+	extName := labels[labelExtensionName]
+	extNamespace := labels[labelExtensionNamespace]
 	if extName == "" || extNamespace == "" {
 		return nil
 	}
@@ -959,7 +975,7 @@ func (r *MCPGatewayExtensionReconciler) reconcileGuardrails(ctx context.Context,
 	return r.ConfigWriterDeleter.WriteGlobalGuardrails(ctx, guardrailsConfig, ns)
 }
 
-// SetupWithManager sets up the controller with the Manager.
+// SetupWithManager sets up the controller.
 func (r *MCPGatewayExtensionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	r.log = slog.New(logr.ToSlogHandler(mgr.GetLogger()))
 	if err := setupIndexExtensionToGateway(ctx, mgr.GetFieldIndexer()); err != nil {
@@ -970,10 +986,25 @@ func (r *MCPGatewayExtensionReconciler) SetupWithManager(ctx context.Context, mg
 		return fmt.Errorf("failed to setup manager %w", err)
 	}
 
+	istioDiscovery, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes discovery client: %w", err)
+	}
+	r.envoyFilterDiscovery = istioDiscovery
+	if err := r.refreshEnvoyFilterAvailability(); err != nil {
+		return err
+	}
+	if r.envoyFilterUnavailable.Load() {
+		if r.Shutdown == nil {
+			return fmt.Errorf("controller shutdown callback is required when the EnvoyFilter CRD is unavailable")
+		}
+		r.restartOnEnvoyFilterAvailable = true
+		r.log.Warn("Istio EnvoyFilter CRD not found; skipping EnvoyFilter watch and reconciliation")
+	}
+
 	// enqueue mcpgateway extensions when the gateway changes
 	// enqueue when reference grants change
-	// enqueue when envoy filter changes (cross-namespace, so we use Watches instead of Owns)
-	return ctrl.NewControllerManagedBy(mgr).
+	controller := ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1.MCPGatewayExtension{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
@@ -981,8 +1012,54 @@ func (r *MCPGatewayExtensionReconciler) SetupWithManager(ctx context.Context, mg
 		Owns(&gatewayv1.HTTPRoute{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Watches(&gatewayv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(r.enqueueMCPGatewayExtForGateway)).
-		Watches(&gatewayv1beta1.ReferenceGrant{}, handler.EnqueueRequestsFromMapFunc(r.enqueueMCPGatewayExtForReferenceGrant)).
-		Watches(&istionetv1alpha3.EnvoyFilter{}, handler.EnqueueRequestsFromMapFunc(r.enqueueMCPGatewayExtForEnvoyFilter)).
+		Watches(&gatewayv1beta1.ReferenceGrant{}, handler.EnqueueRequestsFromMapFunc(r.enqueueMCPGatewayExtForReferenceGrant))
+
+	crdHandler := handler.TypedFuncs[*apiextensionsv1.CustomResourceDefinition, reconcile.Request]{
+		CreateFunc: func(ctx context.Context, e event.TypedCreateEvent[*apiextensionsv1.CustomResourceDefinition], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if !envoyFilterCRDEstablished(e.Object) {
+				return
+			}
+			if r.shouldRestartForEnvoyFilterCRD() {
+				r.handleEnvoyFilterCRDAvailable()
+				return
+			}
+			r.handleEnvoyFilterCRDAvailable()
+			r.enqueueRequestsForEnvoyFilterCRD(ctx, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.TypedUpdateEvent[*apiextensionsv1.CustomResourceDefinition], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if envoyFilterCRDEstablished(e.ObjectOld) || !envoyFilterCRDEstablished(e.ObjectNew) {
+				return
+			}
+			if r.shouldRestartForEnvoyFilterCRD() {
+				r.handleEnvoyFilterCRDAvailable()
+				return
+			}
+			r.handleEnvoyFilterCRDAvailable()
+			r.enqueueRequestsForEnvoyFilterCRD(ctx, q)
+		},
+		DeleteFunc: func(ctx context.Context, _ event.TypedDeleteEvent[*apiextensionsv1.CustomResourceDefinition], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			r.handleEnvoyFilterCRDDeleted()
+			r.enqueueRequestsForEnvoyFilterCRD(ctx, q)
+		},
+	}
+	crdPredicate := predicate.TypedFuncs[*apiextensionsv1.CustomResourceDefinition]{
+		CreateFunc: func(e event.TypedCreateEvent[*apiextensionsv1.CustomResourceDefinition]) bool {
+			return e.Object.Name == envoyFilterCRDName
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*apiextensionsv1.CustomResourceDefinition]) bool {
+			return e.ObjectOld.Name == envoyFilterCRDName || e.ObjectNew.Name == envoyFilterCRDName
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*apiextensionsv1.CustomResourceDefinition]) bool {
+			return e.Object.Name == envoyFilterCRDName
+		},
+	}
+	controller = controller.WatchesRawSource(source.TypedKind(mgr.GetCache(), &apiextensionsv1.CustomResourceDefinition{}, crdHandler, crdPredicate))
+
+	if !r.envoyFilterUnavailable.Load() {
+		// enqueue when envoy filter changes (cross-namespace, so we use Watches instead of Owns)
+		controller = controller.Watches(&istionetv1alpha3.EnvoyFilter{}, handler.EnqueueRequestsFromMapFunc(r.enqueueMCPGatewayExtForEnvoyFilter))
+	}
+	return controller.
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.enqueueMCPGatewayExtForSecret)).
 		Named("mcpgatewayextension").
 		Complete(r)


### PR DESCRIPTION
Closes #1465

## Summary
- discover the Istio `EnvoyFilter` API resource before registering the typed watch
- register a safe `CustomResourceDefinition` lifecycle watch even when Istio is absent
- report `Ready=False` and stop MCPGatewayExtension reconciliation before creating Deployments, Services, HTTPRoutes, or EnvoyFilters when the CRD is unavailable
- when the CRD is missing at startup, cancel the manager after it becomes Established so the Kubernetes-managed controller restarts and registers the typed EnvoyFilter watch safely
- when an already-initialized CRD is deleted, keep the controller running, report `Ready=False`, and avoid normal dependent-resource updates until the CRD returns
- resume reconciliation when the CRD is recreated; no periodic discovery polling or custom dynamic EnvoyFilter watcher remains
- add CRD scheme registration, generated RBAC permissions, bundle RBAC metadata, discovery tests, and controller wiring tests

## Review guide
Review `internal/controller/istio_discovery.go` first, then the early availability guard and CRD lifecycle watch in `internal/controller/mcpgatewayextension_controller.go`, followed by `cmd/main.go`, generated RBAC manifests, and the bundle permission update.

## Verification
- `go test ./...` — 21 packages passed, 9 packages had no tests
- `make test-controller-integration` — 45/45 specs passed
- `make check` — CRDs, bundle manifests, and RBAC rules synchronized
- all shell blocks in the local Kind verification guide pass `bash -n`

The local Kind procedure is available in the untracked `kind-istio-envoyfilter-verification.md` file and is intentionally not part of the commit. It verifies startup with a missing CRD, safe restart when the CRD first appears, live EnvoyFilter events, and unchanged Deployment, Service, and HTTPRoute desired state while the CRD is unavailable.