### PR TITLE
fix: preserve digest image references in Helm chart

### DIFF
--- a/.github/workflows/helm-install-test.yaml
+++ b/.github/workflows/helm-install-test.yaml
@@ -32,6 +32,8 @@ jobs:
       - name: Install tools
         run: make tools
 
+      - name: Run Helm image rendering test
+        run: make test-helm-render
       - name: Run helm install test
         run: make test-helm-install
 

--- a/build/helm-test.mk
+++ b/build/helm-test.mk
@@ -3,3 +3,7 @@
 .PHONY: test-helm-install
 test-helm-install: kind helm kustomize yq ## Run helm install test against a clean Kind cluster
 	bash tests/helm/test-helm-install.sh
+
+.PHONY: test-helm-render
+test-helm-render: helm ## Validate Helm image reference rendering
+	bash tests/helm/test-image-rendering.sh

--- a/charts/mcp-gateway/templates/_helpers.tpl
+++ b/charts/mcp-gateway/templates/_helpers.tpl
@@ -73,7 +73,11 @@ Create the name of the controller service account to use
 Docker image name gateway
 */}}
 {{- define "mcp-gateway.image" -}}
+{{- if contains "@" .Values.image.repository -}}
+{{ .Values.image.repository }}
+{{- else -}}
 {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
 {{- end }}
 
 
@@ -81,5 +85,9 @@ Docker image name gateway
 Docker image name controller
 */}}
 {{- define "mcp-controller.image" -}}
+{{- if contains "@" .Values.imageController.repository -}}
+{{ .Values.imageController.repository }}
+{{- else -}}
 {{ .Values.imageController.repository }}:{{ .Values.imageController.tag | default .Chart.AppVersion }}
+{{- end -}}
 {{- end }}

--- a/tests/helm/test-image-rendering.sh
+++ b/tests/helm/test-image-rendering.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HELM="${HELM:-${ROOT_DIR}/bin/helm}"
+CHART_DIR="${ROOT_DIR}/charts/mcp-gateway"
+
+if [[ ! -x "$HELM" ]]; then
+    HELM="$(command -v helm)"
+fi
+
+render_image() {
+    "$HELM" template test-release "$CHART_DIR" \
+        --set controller.enabled=true \
+        --set mcpGatewayExtension.create=false \
+        --set-string imageController.repository="$1" \
+        --set-string imageController.tag="$2" \
+        | awk '$1 == "image:" { print $2; exit }'
+}
+
+digest_image="ghcr.io/kuadrant/mcp-controller@sha256:abc123"
+actual_digest_image="$(render_image "$digest_image" "")"
+[[ "$actual_digest_image" == "$digest_image" ]] || {
+    echo "digest image rendered as $actual_digest_image, want $digest_image" >&2
+    exit 1
+}
+
+tagged_image="ghcr.io/kuadrant/mcp-controller"
+actual_tagged_image="$(render_image "$tagged_image" "v0.9.0")"
+expected_tagged_image="${tagged_image}:v0.9.0"
+[[ "$actual_tagged_image" == "$expected_tagged_image" ]] || {
+    echo "tagged image rendered as $actual_tagged_image, want $expected_tagged_image" >&2
+    exit 1
+}
+
+echo "PASS: image references render correctly"


### PR DESCRIPTION
## What does this PR do?

Preserves digest-pinned controller and broker image references during Helm rendering instead of appending the chart AppVersion. The same conditional rendering keeps the existing tag and AppVersion fallback for ordinary image references.

Relates to #1463

## Why

`ImageSplitValue` intentionally keeps `repo@sha256:digest` in the repository field and leaves the tag empty. The chart helper previously rendered `repository:tag-or-AppVersion`, producing invalid references such as `repo@sha256:digest:0.9.0`.

The helpers now render repositories containing `@` unchanged. A focused Helm rendering test covers digest and tagged controller images, and CI runs it before the integration test.

## Verification

- `make test-helm-render`
- `bin/helm lint charts/mcp-gateway`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Helm charts now support container image references specified by digest, preserving the full digest-based reference.
  - Standard repository-and-tag image references continue to render with the configured tag.

- **Tests**
  - Added automated Helm rendering checks for digest-based and tagged image references.
  - Helm install validation now includes image rendering validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->