### PR TITLE
fix(controller): decouple config sync from extension readiness

### DIFF
--- a/internal/controller/mcpgatewayextension.go
+++ b/internal/controller/mcpgatewayextension.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	mcpv1 "github.com/Kuadrant/mcp-gateway/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -102,7 +101,7 @@ func (r *MCPGatewayExtensionValidator) FindValidMCPGatewayExtsForGateway(ctx con
 			// we have to exit here
 			return validExtensions, fmt.Errorf("failed to check if mcpgatewayextension is valid %w", err)
 		}
-		if has && meta.IsStatusConditionTrue(mg.Status.Conditions, mcpv1.ConditionTypeReady) {
+		if has {
 			validExtensions = append(validExtensions, &mg)
 		}
 	}


### PR DESCRIPTION
This PR resolves #1446 by fixing a fatal reconciliation deadlock in cross-namespace Kuadrant deployments.

### The Problem
Previously, a bad credential caused the broker to crash, turning the `MCPGatewayExtension` to `NotReady`. The `FindValidMCPGatewayExtsForGateway` function was explicitly filtering out cross-namespace extensions if they were not `Ready`. Because the extension was filtered out, `MCPServerRegistration` exited its reconciliation loop early and never reached `buildMCPServerConfig` to re-read the corrected Secret. This created a permanent deadlock.

### Changes Made
*   **Decoupled Config Sync from Readiness:** Modified `internal/controller/mcpgatewayextension.go` to remove the `mcpv1.ConditionTypeReady` requirement for cross-namespace extensions.
*   **Import Cleanup:** Removed the now-unused `"k8s.io/apimachinery/pkg/api/meta"` import.

### Why This Works
By removing the `Ready` gate, a bad credential will still accurately transition the extension to `NotReady`, but the reconciler will now successfully proceed to `buildMCPServerConfig`, sync the corrected Secret to the runtime config, and restart the broker—breaking the deadlock.

*Note: Existing security boundaries remain intact (ReferenceGrants are still strictly validated), and this change brings cross-namespace extensions to parity with same-namespace extensions, which already bypassed the `Ready` check.*

### Related Issues
Resolves [MCPServerRegistration never re-reads a corrected credentialRef Secret while its MCPGatewayExtension is NotReady #1446](#1446)

### Checklist
- [x] Configuration syncing is no longer blocked by extension readiness.
- [x] Cross-namespace `ReferenceGrant` validation remains fully enforced.
- [x] Code compiles and `go test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-namespace gateway extensions are now recognized as valid when an appropriate reference grant exists, even if their Ready status condition is not set to true.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->