### PR TITLE
refactor(routing): consolidate JSON-RPC error response builders

### DIFF
--- a/internal/routing/mcp_request.go
+++ b/internal/routing/mcp_request.go
@@ -267,50 +267,7 @@ type ElicitationInfo struct {
 	ElicitationID string
 }
 
-// SseJSONRPC constructs sse json-rpc event with custom body
-func SseJSONRPC(requestID any, writeBody func(b *strings.Builder)) string {
-	var b strings.Builder
-	b.WriteString("\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":")
-	idBytes, err := json.Marshal(requestID)
-	if err != nil {
-		b.WriteString("null")
-	} else {
-		b.Write(idBytes)
-	}
-	writeBody(&b)
-	b.WriteString("\n\n")
-	return b.String()
-}
 
-// BuildSSEToolError constructs sse error response for tool call
-func BuildSSEToolError(requestID any, message string) string {
-	return SseJSONRPC(requestID, func(b *strings.Builder) {
-		b.WriteString(",\"result\":{\"content\":[{\"type\":\"text\",\"text\":")
-		b.WriteString(jsonQuote(message))
-		b.WriteString("}],\"isError\":true}}")
-	})
-}
-
-// BuildJSONToolError constructs a plain JSON-RPC error response for 2026-07-28
-func BuildJSONToolError(requestID any, message string) string {
-	var b strings.Builder
-	b.WriteString("{\"jsonrpc\":\"2.0\",\"id\":")
-	idBytes, err := json.Marshal(requestID)
-	if err != nil {
-		b.WriteString("null")
-	} else {
-		b.Write(idBytes)
-	}
-	b.WriteString(",\"result\":{\"content\":[{\"type\":\"text\",\"text\":")
-	b.WriteString(jsonQuote(message))
-	b.WriteString("}],\"isError\":true}}")
-	return b.String()
-}
-
-func jsonQuote(s string) string {
-	b, _ := json.Marshal(s)
-	return string(b)
-}
 
 // ResourceAuthority extracts the authority segment (host) from a resource URI.
 // For malformed URIs, returns the URI unchanged.

--- a/internal/routing/response_errors.go
+++ b/internal/routing/response_errors.go
@@ -1,0 +1,90 @@
+package routing
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ── Tool-level errors ───────────────────────────────────────────────────
+// These build a JSON-RPC *result* with isError:true. The HTTP request was
+// valid and the gateway understood it, but the tool execution could not be
+// fulfilled (e.g. tool not found, token resolution failed).
+
+// BuildSSEToolExecutionError constructs an SSE JSON-RPC result indicating
+// tool execution failure for the 2025-11-05 (SSE/streamable-HTTP) protocol.
+func BuildSSEToolExecutionError(requestID any, message string) string {
+	return SseJSONRPC(requestID, func(b *strings.Builder) {
+		b.WriteString(",\"result\":{\"content\":[{\"type\":\"text\",\"text\":")
+		b.WriteString(jsonQuote(message))
+		b.WriteString("}],\"isError\":true}}")
+	})
+}
+
+// BuildJSONToolExecutionError constructs a plain JSON-RPC result indicating
+// tool execution failure for the 2026-07-28 (HTTP-only) protocol.
+func BuildJSONToolExecutionError(requestID any, message string) string {
+	var b strings.Builder
+	b.WriteString("{\"jsonrpc\":\"2.0\",\"id\":")
+	idBytes, err := json.Marshal(requestID)
+	if err != nil {
+		b.WriteString("null")
+	} else {
+		b.Write(idBytes)
+	}
+	b.WriteString(",\"result\":{\"content\":[{\"type\":\"text\",\"text\":")
+	b.WriteString(jsonQuote(message))
+	b.WriteString("}],\"isError\":true}}")
+	return b.String()
+}
+
+// ── Protocol-level rejections ───────────────────────────────────────────
+// These build a JSON-RPC *error* object. The request is rejected before it
+// reaches any upstream server (e.g. invalid method, unknown prompt).
+
+// BuildSSEProtocolRejection constructs an SSE JSON-RPC error response for
+// the 2025-11-05 (SSE/streamable-HTTP) protocol. code is the JSON-RPC
+// error code (e.g. -32602 for "Invalid params").
+func BuildSSEProtocolRejection(requestID any, code int, message string) string {
+	return SseJSONRPC(requestID, func(b *strings.Builder) {
+		fmt.Fprintf(b, ",\"error\":{\"code\":%d,\"message\":%s}}", code, jsonQuote(message))
+	})
+}
+
+// BuildJSONProtocolRejection constructs a plain JSON-RPC error response
+// for the 2026-07-28 (HTTP-only) protocol. code is the JSON-RPC error
+// code (e.g. -32602 for "Invalid params").
+func BuildJSONProtocolRejection(requestID any, code int, message string) string {
+	var b strings.Builder
+	b.WriteString("{\"jsonrpc\":\"2.0\",\"id\":")
+	idBytes, err := json.Marshal(requestID)
+	if err != nil {
+		b.WriteString("null")
+	} else {
+		b.Write(idBytes)
+	}
+	fmt.Fprintf(&b, ",\"error\":{\"code\":%d,\"message\":%s}}", code, jsonQuote(message))
+	return b.String()
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+// SseJSONRPC constructs sse json-rpc event with custom body
+func SseJSONRPC(requestID any, writeBody func(b *strings.Builder)) string {
+	var b strings.Builder
+	b.WriteString("\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":")
+	idBytes, err := json.Marshal(requestID)
+	if err != nil {
+		b.WriteString("null")
+	} else {
+		b.Write(idBytes)
+	}
+	writeBody(&b)
+	b.WriteString("\n\n")
+	return b.String()
+}
+
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/routing/router_202511.go
+++ b/internal/routing/router_202511.go
@@ -131,7 +131,7 @@ func (r *Router202511) routeToolCall(ctx context.Context, table RoutingTable, mc
 		return &Decision{
 			Error: &Error{
 				StatusCode: 200,
-				JSONRPCErr: BuildSSEToolError(mcpReq.ID, "MCP error -32602: Tool not found"),
+				JSONRPCErr: BuildSSEToolExecutionError(mcpReq.ID, "MCP error -32602: Tool not found"),
 			},
 			SetHeaders: map[string]string{
 				SessionHeader: mcpReq.GetSessionID(),
@@ -146,7 +146,7 @@ func (r *Router202511) routeToolCall(ctx context.Context, table RoutingTable, mc
 		return &Decision{
 			Error: &Error{
 				StatusCode: 200,
-				JSONRPCErr: BuildSSEToolError(mcpReq.ID, "MCP error -32602: Tool not found"),
+				JSONRPCErr: BuildSSEToolExecutionError(mcpReq.ID, "MCP error -32602: Tool not found"),
 			},
 			SetHeaders: map[string]string{
 				SessionHeader: mcpReq.GetSessionID(),
@@ -199,7 +199,7 @@ func (r *Router202511) routeToolCall(ctx context.Context, table RoutingTable, mc
 				return &Decision{
 					Error: &Error{
 						StatusCode: 200,
-						JSONRPCErr: BuildSSEToolError(mcpReq.ID, tokenErr.Error()),
+						JSONRPCErr: BuildSSEToolExecutionError(mcpReq.ID, tokenErr.Error()),
 					},
 					SetHeaders: map[string]string{
 						SessionHeader: mcpReq.GetSessionID(),
@@ -259,7 +259,7 @@ func (r *Router202511) routePromptGet(ctx context.Context, table RoutingTable, m
 		return &Decision{
 			Error: &Error{
 				StatusCode: 200,
-				JSONRPCErr: "\nevent: message\ndata: {\"error\":{\"code\":-32602,\"message\":\"Prompt not found\"},\"jsonrpc\":\"2.0\"}\n\n",
+				JSONRPCErr: BuildSSEProtocolRejection(mcpReq.ID, -32602, "Prompt not found"),
 			},
 			SetHeaders: map[string]string{
 				SessionHeader: mcpReq.GetSessionID(),
@@ -274,7 +274,7 @@ func (r *Router202511) routePromptGet(ctx context.Context, table RoutingTable, m
 		return &Decision{
 			Error: &Error{
 				StatusCode: 200,
-				JSONRPCErr: BuildSSEToolError(mcpReq.ID, "MCP error -32602: Prompt not found"),
+				JSONRPCErr: BuildSSEToolExecutionError(mcpReq.ID, "MCP error -32602: Prompt not found"),
 			},
 			SetHeaders: map[string]string{
 				SessionHeader: mcpReq.GetSessionID(),
@@ -340,7 +340,7 @@ func (r *Router202511) routeResourceRead(ctx context.Context, table RoutingTable
 		return &Decision{
 			Error: &Error{
 				StatusCode: 200,
-				JSONRPCErr: BuildSSEToolError(mcpReq.ID, "MCP error -32602: Resource not found"),
+				JSONRPCErr: BuildSSEToolExecutionError(mcpReq.ID, "MCP error -32602: Resource not found"),
 			},
 			SetHeaders: map[string]string{
 				SessionHeader: mcpReq.GetSessionID(),
@@ -355,7 +355,7 @@ func (r *Router202511) routeResourceRead(ctx context.Context, table RoutingTable
 		return &Decision{
 			Error: &Error{
 				StatusCode: 200,
-				JSONRPCErr: BuildSSEToolError(mcpReq.ID, "MCP error -32602: Resource not found"),
+				JSONRPCErr: BuildSSEToolExecutionError(mcpReq.ID, "MCP error -32602: Resource not found"),
 			},
 			SetHeaders: map[string]string{
 				SessionHeader: mcpReq.GetSessionID(),

--- a/internal/routing/router_202607.go
+++ b/internal/routing/router_202607.go
@@ -102,7 +102,7 @@ func (r *Router202607) routeToolCall(ctx context.Context, table RoutingTable, re
 		return &Decision{
 			Error: &Error{
 				StatusCode:  200,
-				JSONRPCErr:  BuildJSONToolError(req.RequestID, "MCP error -32602: Tool not found"),
+				JSONRPCErr:  BuildJSONToolExecutionError(req.RequestID, "MCP error -32602: Tool not found"),
 				ContentType: "application/json",
 			},
 		}
@@ -190,7 +190,7 @@ func (r *Router202607) routePromptGet(ctx context.Context, table RoutingTable, r
 		return &Decision{
 			Error: &Error{
 				StatusCode:  200,
-				JSONRPCErr:  BuildJSONToolError(req.RequestID, "MCP error -32602: Prompt not found"),
+				JSONRPCErr:  BuildJSONToolExecutionError(req.RequestID, "MCP error -32602: Prompt not found"),
 				ContentType: "application/json",
 			},
 		}
@@ -203,7 +203,7 @@ func (r *Router202607) routePromptGet(ctx context.Context, table RoutingTable, r
 		return &Decision{
 			Error: &Error{
 				StatusCode:  200,
-				JSONRPCErr:  BuildJSONToolError(req.RequestID, "MCP error -32602: Prompt not found"),
+				JSONRPCErr:  BuildJSONToolExecutionError(req.RequestID, "MCP error -32602: Prompt not found"),
 				ContentType: "application/json",
 			},
 		}
@@ -295,7 +295,7 @@ func (r *Router202607) validateAndRewriteBody(ctx context.Context, span trace.Sp
 		span.SetAttributes(attribute.String("error.type", "header_mismatch"))
 		return nil, &Error{
 			StatusCode:  200,
-			JSONRPCErr:  BuildJSONToolError(req.Parsed.ID, "MCP error -32602: HeaderMismatch: Mcp-Name header does not match body"),
+			JSONRPCErr:  BuildJSONToolExecutionError(req.Parsed.ID, "MCP error -32602: HeaderMismatch: Mcp-Name header does not match body"),
 			ContentType: "application/json",
 		}
 	}

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -2334,8 +2334,8 @@ func TestResolveUpstreamToken_SubExtractedAndStored(t *testing.T) {
 	require.Equal(t, validToken, entry.SessionID)
 }
 
-func TestBuildSSEToolError(t *testing.T) {
-	result := BuildSSEToolError("req-1", "something went wrong")
+func TestBuildSSEToolExecutionError(t *testing.T) {
+	result := BuildSSEToolExecutionError("req-1", "something went wrong")
 	var envelope struct {
 		JSONRPC string `json:"jsonrpc"`
 		ID      string `json:"id"`


### PR DESCRIPTION
This PR resolves #1467 by consolidating all JSON-RPC error response builders into a single, unified file (`internal/routing/response_errors.go`) and standardizing their nomenclature to clearly distinguish between tool-level execution failures and protocol-level rejections.

### Changes Made
*   **New File (`internal/routing/response_errors.go`):** 
    *   Created this new file to house all JSON-RPC error response builders, alongside their internal helper functions (`jsonQuote` and `SseJSONRPC`).
*   **Renamed Tool-Level Builders:** 
    *   `BuildSSEToolError` → `BuildSSEToolExecutionError`
    *   `BuildJSONToolError` → `BuildJSONToolExecutionError`
    *   *(These produce a `result` object with `isError:true` when execution fails but the request was structurally valid).*
*   **Added/Renamed Protocol-Level Builders:** 
    *   Extracted the protocol-level builders (which produce standard JSON-RPC `error` objects when a request is rejected before reaching the upstream) and standardized them as `BuildSSEProtocolRejection` and `BuildJSONProtocolRejection`.
*   **Refactored Call Sites:** 
    *   Updated all references across `mcp_request.go`, `router_202511.go`, and `router_202607.go` to use the new nomenclature.
    *   Replaced a legacy hardcoded SSE error string in `router_202511.go` with the new `BuildSSEProtocolRejection` method for consistency.

### Related Issues
Resolves [refactor: consolidate JSON-RPC error response builders into one file #1467](#1467)

### Checklist
- [x] Created `response_errors.go` and consolidated builders.
- [x] Renamed tool-level builders to clearly denote `ToolExecutionError`.
- [x] Renamed protocol-level builders to clearly denote `ProtocolRejection`.
- [x] Cleaned up `mcp_request.go` and removed moved functions.
- [x] Updated all references and tests in the `routing` package.
- [x] Code compiles and full test suite (`go test ./...`) passes.