### PR TITLE
feat(controller): preserve user-applied metadata on broker HTTPRoute

### DIFF
--- a/internal/controller/broker_router.go
+++ b/internal/controller/broker_router.go
@@ -587,6 +587,8 @@ func (r *MCPGatewayExtensionReconciler) reconcileBrokerRouter(ctx context.Contex
 			}
 		} else if needsUpdate, reason := httpRouteNeedsUpdate(httpRoute, existingHTTPRoute); needsUpdate {
 			r.log.Info("updating gateway httproute", "namespace", mcpExt.Namespace, "reason", reason)
+			existingHTTPRoute.Labels = mergeMetadata(httpRoute.Labels, existingHTTPRoute.Labels)
+			existingHTTPRoute.Annotations = mergeMetadata(httpRoute.Annotations, existingHTTPRoute.Annotations)
 			existingHTTPRoute.Spec.ParentRefs = httpRoute.Spec.ParentRefs
 			existingHTTPRoute.Spec.Hostnames = httpRoute.Spec.Hostnames
 			existingHTTPRoute.Spec.Rules = httpRoute.Spec.Rules
@@ -878,8 +880,39 @@ func (r *MCPGatewayExtensionReconciler) buildGatewayHTTPRoute(mcpExt *mcpv1.MCPG
 	}
 }
 
+// metadataIsSubset returns true when every key in desired exists in existing
+// with the same value. Extra keys in existing (user-applied) are ignored.
+func metadataIsSubset(desired, existing map[string]string) bool {
+	for k, v := range desired {
+		if existing[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeMetadata returns a copy of existing with every key from desired
+// set (overwriting if already present). User-applied keys that are not
+// in desired are preserved.
+func mergeMetadata(desired, existing map[string]string) map[string]string {
+	merged := make(map[string]string, len(existing)+len(desired))
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range desired {
+		merged[k] = v
+	}
+	return merged
+}
+
 // httpRouteNeedsUpdate checks if the HTTPRoute needs to be updated
 func httpRouteNeedsUpdate(desired, existing *gatewayv1.HTTPRoute) (bool, string) {
+	if !metadataIsSubset(desired.Labels, existing.Labels) {
+		return true, fmt.Sprintf("labels changed: %v -> %v", existing.Labels, desired.Labels)
+	}
+	if !metadataIsSubset(desired.Annotations, existing.Annotations) {
+		return true, fmt.Sprintf("annotations changed: %v -> %v", existing.Annotations, desired.Annotations)
+	}
 	if !equality.Semantic.DeepEqual(desired.Spec.ParentRefs, existing.Spec.ParentRefs) {
 		return true, "parentRefs changed"
 	}
@@ -989,6 +1022,8 @@ func (r *MCPGatewayExtensionReconciler) reconcileTokensHTTPRoute(ctx context.Con
 
 	if needsUpdate, reason := httpRouteNeedsUpdate(desired, existing); needsUpdate {
 		r.log.Info("updating tokens httproute", "namespace", mcpExt.Namespace, "reason", reason)
+		existing.Labels = mergeMetadata(desired.Labels, existing.Labels)
+		existing.Annotations = mergeMetadata(desired.Annotations, existing.Annotations)
 		existing.Spec.ParentRefs = desired.Spec.ParentRefs
 		existing.Spec.Hostnames = desired.Spec.Hostnames
 		existing.Spec.Rules = desired.Spec.Rules

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -2038,6 +2038,48 @@ func TestHTTPRouteNeedsUpdate(t *testing.T) {
 			},
 			wantUpdate: true,
 		},
+		{
+			name: "user-added annotation does not trigger update",
+			modify: func(r *gatewayv1.HTTPRoute) {
+				r.Annotations = map[string]string{
+					"external-dns.alpha.kubernetes.io/controller": "none",
+					"custom.io/note": "user-applied",
+				}
+				// keep all controller labels intact
+				r.Labels = reconciler.buildGatewayHTTPRoute(mcpExt, publicHost).Labels
+			},
+			wantUpdate: false,
+		},
+		{
+			name: "user-added label does not trigger update",
+			modify: func(r *gatewayv1.HTTPRoute) {
+				r.Labels = map[string]string{
+					labelAppName:      brokerRouterName,
+					labelManagedBy:    labelManagedByValue,
+					"team":            "platform",
+				}
+			},
+			wantUpdate: false,
+		},
+		{
+			name: "controller label removed triggers update",
+			modify: func(r *gatewayv1.HTTPRoute) {
+				r.Labels = map[string]string{
+					"team": "platform", // only user label, controller labels missing
+				}
+			},
+			wantUpdate: true,
+		},
+		{
+			name: "controller label value changed triggers update",
+			modify: func(r *gatewayv1.HTTPRoute) {
+				r.Labels = map[string]string{
+					labelAppName:   "wrong-value",
+					labelManagedBy: labelManagedByValue,
+				}
+			},
+			wantUpdate: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2048,6 +2090,104 @@ func TestHTTPRouteNeedsUpdate(t *testing.T) {
 			needsUpdate, _ := httpRouteNeedsUpdate(desired, existing)
 			if needsUpdate != tt.wantUpdate {
 				t.Errorf("httpRouteNeedsUpdate() = %v, want %v", needsUpdate, tt.wantUpdate)
+			}
+		})
+	}
+}
+
+func TestMergeMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  map[string]string
+		existing map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "user annotations preserved",
+			desired:  map[string]string{labelAppName: brokerRouterName},
+			existing: map[string]string{"external-dns.alpha.kubernetes.io/controller": "none", labelAppName: "old"},
+			want:     map[string]string{labelAppName: brokerRouterName, "external-dns.alpha.kubernetes.io/controller": "none"},
+		},
+		{
+			name:     "nil existing",
+			desired:  map[string]string{"a": "1"},
+			existing: nil,
+			want:     map[string]string{"a": "1"},
+		},
+		{
+			name:     "nil desired",
+			desired:  nil,
+			existing: map[string]string{"user": "val"},
+			want:     map[string]string{"user": "val"},
+		},
+		{
+			name:     "both nil",
+			desired:  nil,
+			existing: nil,
+			want:     map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeMetadata(tt.desired, tt.existing)
+			if !equality.Semantic.DeepEqual(got, tt.want) {
+				t.Errorf("mergeMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetadataIsSubset(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  map[string]string
+		existing map[string]string
+		want     bool
+	}{
+		{
+			name:     "exact match",
+			desired:  map[string]string{"a": "1"},
+			existing: map[string]string{"a": "1"},
+			want:     true,
+		},
+		{
+			name:     "existing has extra keys",
+			desired:  map[string]string{"a": "1"},
+			existing: map[string]string{"a": "1", "b": "2"},
+			want:     true,
+		},
+		{
+			name:     "desired key missing from existing",
+			desired:  map[string]string{"a": "1", "b": "2"},
+			existing: map[string]string{"a": "1"},
+			want:     false,
+		},
+		{
+			name:     "value mismatch",
+			desired:  map[string]string{"a": "1"},
+			existing: map[string]string{"a": "wrong"},
+			want:     false,
+		},
+		{
+			name:     "nil desired is always subset",
+			desired:  nil,
+			existing: map[string]string{"a": "1"},
+			want:     true,
+		},
+		{
+			name:     "both nil",
+			desired:  nil,
+			existing: nil,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := metadataIsSubset(tt.desired, tt.existing)
+			if got != tt.want {
+				t.Errorf("metadataIsSubset() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -2054,9 +2054,9 @@ func TestHTTPRouteNeedsUpdate(t *testing.T) {
 			name: "user-added label does not trigger update",
 			modify: func(r *gatewayv1.HTTPRoute) {
 				r.Labels = map[string]string{
-					labelAppName:      brokerRouterName,
-					labelManagedBy:    labelManagedByValue,
-					"team":            "platform",
+					labelAppName:   brokerRouterName,
+					labelManagedBy: labelManagedByValue,
+					"team":         "platform",
 				}
 			},
 			wantUpdate: false,


### PR DESCRIPTION
This PR resolves #927 by updating the `HTTPRoute` reconciliation logic to natively support and preserve user-applied annotations and labels (such as `external-dns` opt-outs) without requiring users to disable controller route management.

Following the maintainer's architectural guidance, this avoids adding new CRD fields and leaking the API. Instead, it intelligently merges metadata during the controller's reconciliation loop.

### Changes Made

**Controller Logic (`internal/controller/broker_router.go`):**
*   **Drift Detection (`metadataIsSubset`):** Added a new helper function that ensures the controller only flags an update if its *own* required labels/annotations are missing or modified. It completely ignores extra user-applied keys, preventing spurious reconciliation loops.
*   **Safe Merging (`mergeMetadata`):** Added a helper function to merge `desired` and `existing` maps safely. 
*   **Reconciliation Flow:** Updated `httpRouteNeedsUpdate` to evaluate metadata drift alongside `Spec` changes. Modified both the primary gateway `HTTPRoute` and the tokens `HTTPRoute` reconciliation blocks to call `mergeMetadata`, ensuring user-applied metadata survives indefinitely while strictly enforcing the controller's required labels.

**Unit Tests (`internal/controller/deployment_test.go`):**
Added extensive test coverage for the new subset and merging logic:
*   `TestHTTPRouteNeedsUpdate`: Proved that user-added annotations (e.g., `external-dns.alpha.kubernetes.io/controller: none`) and custom labels do NOT trigger false drift. Proved that removing or altering a controller-owned label correctly triggers an update.
*   `TestMergeMetadata`: Validated map merging semantics, including nil-safety and overwrite precedence.
*   `TestMetadataIsSubset`: Validated subset comparison logic across 6 different map state permutations.

### Related Issues
Resolves [Controller-managed broker HTTPRoute has no way to set annotations (e.g. external-dns opt-out) #927](#927)

### Checklist
- [x] Controller preserves user-applied `Annotations` and `Labels` on managed HTTPRoutes.
- [x] Controller enforces and corrects its own required labels.
- [x] Implemented safe map merging without exposing the underlying `HTTPRoute` API to the Kuadrant CRDs.
- [x] Added unit tests for subset evaluation and map merging.
- [x] Code compiles and `go test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTPRoute updates now preserve user-applied labels and annotations.
  - Controller-managed metadata is reconciled without overwriting additional metadata.
  - Unnecessary updates are avoided when only user-added metadata differs.
  - Changes to controller-managed labels or annotations continue to trigger updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->