### PR TITLE
Harden controller deployment securityContext

### DIFF
--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -18,10 +18,17 @@ spec:
         {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
       containers:
         - name: mcp-controller
           image: {{ include "mcp-controller.image" . }}
           imagePullPolicy: {{ .Values.imageController.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           command:
             - ./mcp_controller
             - --log-level=0


### PR DESCRIPTION
## What

Add a `securityContext` to the mcp-gateway controller deployment:

- pod-level `runAsNonRoot: true`
- container-level `allowPrivilegeEscalation: false` and drop `ALL` capabilities

## Why

Other Kuadrant component controllers (e.g. dns-operator) already ship this hardening. Adding it here keeps the controllers consistent and lets the controller run under the OpenShift `restricted-v2` SCC without requesting extra privileges.

The chart is consumed downstream via the kuadrant-operator component-chart sync, so this is the correct source of truth for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
The idea itself came from reviewing the downstream consolidation work: https://github.com/rh-api-management/rhcl-operator-product-build/pull/659 
Thanks @Patryk-Stefanski 