### PR TITLE
Remove the mcp manager connection recycling and use of subscription/listen

### DIFF
--- a/internal/broker/upstream/discover_capture.go
+++ b/internal/broker/upstream/discover_capture.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Kuadrant/mcp-gateway/internal/transport"
 )
@@ -15,19 +16,36 @@ import (
 // discoverCapture wraps an http.RoundTripper and intercepts the SDK's
 // server/discover response to capture the upstream's SupportedVersions.
 // the captured versions are read after Connect via Versions().
+//
+// harvest runs on EOF or Close of the response body. for SSE responses
+// the SDK may return from Connect before the body is closed, so
+// Versions blocks briefly on a ready channel to let harvest complete.
 type discoverCapture struct {
 	base      http.RoundTripper
 	mu        sync.Mutex
 	versions  []string
 	connected bool
+	// ready is closed by store() once versions have been harvested.
+	// allocated per-intercept in RoundTrip; nil when no discover
+	// request has been seen yet.
+	ready chan struct{}
 }
+
+const versionsWaitTimeout = 5 * time.Second
 
 func (d *discoverCapture) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Method != http.MethodPost || !isDiscoverRequest(req) {
 		return d.base.RoundTrip(req)
 	}
+	d.mu.Lock()
+	d.ready = make(chan struct{})
+	d.mu.Unlock()
+
 	resp, err := d.base.RoundTrip(req)
 	if err != nil || resp == nil || resp.Body == nil {
+		d.mu.Lock()
+		close(d.ready)
+		d.mu.Unlock()
 		return resp, err
 	}
 	resp.Body = &discoverTeeBody{
@@ -46,21 +64,58 @@ func (d *discoverCapture) SetConnected() {
 	d.mu.Unlock()
 }
 
-// Versions returns the captured SupportedVersions. returns an error if
-// called before Connect has completed.
+// Versions returns the captured SupportedVersions. blocks up to
+// versionsWaitTimeout for harvest to complete if a discover request
+// was intercepted. returns an error if called before Connect.
 func (d *discoverCapture) Versions() ([]string, error) {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	if !d.connected {
+		d.mu.Unlock()
 		return nil, fmt.Errorf("versions called before connect")
 	}
+	ch := d.ready
+	d.mu.Unlock()
+
+	if ch != nil {
+		select {
+		case <-ch:
+		case <-time.After(versionsWaitTimeout):
+		}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	return d.versions, nil
 }
 
 func (d *discoverCapture) store(versions []string) {
 	d.mu.Lock()
 	d.versions = versions
+	ch := d.ready
 	d.mu.Unlock()
+	if ch != nil {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+}
+
+// signalReady closes the ready channel without storing versions.
+// called when harvest completes but finds no versions (e.g. error
+// response from server/discover).
+func (d *discoverCapture) signalReady() {
+	d.mu.Lock()
+	ch := d.ready
+	d.mu.Unlock()
+	if ch != nil {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
 }
 
 // isDiscoverRequest is only used for the broker client. gateway client requests don't go through this client.
@@ -117,10 +172,13 @@ func (b *discoverTeeBody) harvest() {
 				return
 			}
 		}
+		b.capture.signalReady()
 		return
 	}
 	if versions := parseDiscoverVersions(b.buf.Bytes()); len(versions) > 0 {
 		b.capture.store(versions)
+	} else {
+		b.capture.signalReady()
 	}
 }
 

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -463,7 +463,7 @@ func (man *MCPManager) registerCallbacks() func() {
 }
 
 // manage should be the only entry point that triggers changes to tools
-// TODO this has become overly complex handling both prompts and tools independentantly and duplicating logic. Look to simplify and unify
+// TODO this has become overly complex handling both prompts and tools independently and duplicating logic. Look to simplify and unify
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.logger.DebugContext(ctx, "managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
 
@@ -783,7 +783,7 @@ func (man *MCPManager) adjustTickerFromTTL() {
 	if ttlInterval != man.tickerInterval {
 		man.logger.Info("adjusting poll interval from upstream TTL", "upstream", man.mcp.ID(), "ttlMs", meta.TTLMs, "interval", ttlInterval)
 		man.tickerInterval = ttlInterval
-		man.ticker.Reset(ttlInterval)
+		man.resetTicker(ttlInterval)
 	}
 }
 

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -463,6 +463,7 @@ func (man *MCPManager) registerCallbacks() func() {
 }
 
 // manage should be the only entry point that triggers changes to tools
+// TODO this has become overly complex handling both prompts and tools independentantly and duplicating logic. Look to simplify and unify
 func (man *MCPManager) manage(ctx context.Context, event eventType) {
 	man.logger.DebugContext(ctx, "managing connection", "upstream mcp server", man.mcp.ID(), "event type", event)
 
@@ -489,15 +490,6 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 
 	numberOfTools := len(man.tools)
 	numberOfPrompts := len(man.prompts)
-
-	// 2026 upstreams rely on subscriptions/listen for notifications. the SDK
-	// silently drops the listen stream when the upstream restarts without
-	// closing the session, so the broker never learns notifications stopped.
-	// force a fresh connection on each health tick to re-establish the stream.
-	if event == eventTypeTimer && man.mcp.UsesStatelessProtocol() {
-		man.logger.DebugContext(ctx, "recycling stateless connection", "upstream mcp server", man.mcp.ID())
-		_ = man.mcp.Disconnect()
-	}
 
 	man.logger.DebugContext(ctx, "attempting to connect", "upstream mcp server", man.mcp.ID())
 	if err := man.mcp.Connect(ctx, man.registerCallbacks()); err != nil {
@@ -611,6 +603,12 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 						}
 					}
 					man.logger.DebugContext(ctx, "internal tools", "upstream mcp server", man.mcp.ID(), "total", len(man.serverTools))
+
+					// adjust tick interval for 2026 upstreams based on upstream TTL hint.
+					// without notification handlers, polling is the only freshness mechanism.
+					if man.mcp.UsesStatelessProtocol() {
+						man.adjustTickerFromTTL()
+					}
 				}
 			}
 		}
@@ -770,6 +768,22 @@ func (man *MCPManager) resetTicker(d time.Duration) {
 	select {
 	case <-man.ticker.C:
 	default:
+	}
+}
+
+// adjustTickerFromTTL resets the ticker to match the upstream's tools/list TTLMs
+// hint. only applied for 2026 upstreams where polling replaces push notifications.
+// clamped to DefaultTickerInterval minimum to avoid hot-looping on low TTLs.
+func (man *MCPManager) adjustTickerFromTTL() {
+	meta := man.mcp.ToolsCacheMetadata()
+	if meta.TTLMs <= 0 {
+		return
+	}
+	ttlInterval := max(time.Duration(meta.TTLMs)*time.Millisecond, DefaultTickerInterval)
+	if ttlInterval != man.tickerInterval {
+		man.logger.Info("adjusting poll interval from upstream TTL", "upstream", man.mcp.ID(), "ttlMs", meta.TTLMs, "interval", ttlInterval)
+		man.tickerInterval = ttlInterval
+		man.ticker.Reset(ttlInterval)
 	}
 }
 

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -776,10 +776,12 @@ func (man *MCPManager) resetTicker(d time.Duration) {
 // clamped to DefaultTickerInterval minimum to avoid hot-looping on low TTLs.
 func (man *MCPManager) adjustTickerFromTTL() {
 	meta := man.mcp.ToolsCacheMetadata()
+	var ttlInterval time.Duration
 	if meta.TTLMs <= 0 {
-		return
+		ttlInterval = DefaultTickerInterval
+	} else {
+		ttlInterval = max(time.Duration(meta.TTLMs)*time.Millisecond, DefaultTickerInterval)
 	}
-	ttlInterval := max(time.Duration(meta.TTLMs)*time.Millisecond, DefaultTickerInterval)
 	if ttlInterval != man.tickerInterval {
 		man.logger.Info("adjusting poll interval from upstream TTL", "upstream", man.mcp.ID(), "ttlMs", meta.TTLMs, "interval", ttlInterval)
 		man.tickerInterval = ttlInterval

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -50,18 +50,22 @@ const (
 
 // ServerValidationStatus contains the validation results for an upstream MCP server
 type ServerValidationStatus struct {
-	ID                 string              `json:"id"`
-	Name               string              `json:"name"`
-	LastValidated      time.Time           `json:"lastValidated"`
-	Message            string              `json:"message"`
-	Ready              bool                `json:"ready"`
-	TotalTools         int                 `json:"totalTools"`
-	TotalPrompts       int                 `json:"totalPrompts"`
-	InvalidTools       int                 `json:"invalidTools"`
-	InvalidToolList    []InvalidToolInfo   `json:"invalidToolList,omitempty"`
-	InvalidPrompts     int                 `json:"invalidPrompts"`
-	InvalidPromptList  []InvalidPromptInfo `json:"invalidPromptList,omitempty"`
-	ProtocolValidation ProtocolValidation  `json:"protocolValidation"`
+	ID                   string              `json:"id"`
+	Name                 string              `json:"name"`
+	LastValidated        time.Time           `json:"lastValidated"`
+	Message              string              `json:"message"`
+	Ready                bool                `json:"ready"`
+	TotalTools           int                 `json:"totalTools"`
+	TotalPrompts         int                 `json:"totalPrompts"`
+	InvalidTools         int                 `json:"invalidTools"`
+	InvalidToolList      []InvalidToolInfo   `json:"invalidToolList,omitempty"`
+	InvalidPrompts       int                 `json:"invalidPrompts"`
+	InvalidPromptList    []InvalidPromptInfo `json:"invalidPromptList,omitempty"`
+	ProtocolValidation   ProtocolValidation  `json:"protocolValidation"`
+	SupportedVersions    []string            `json:"supportedVersions,omitempty"`
+	UsesStatelessProtocol bool               `json:"usesStatelessProtocol"`
+	TickerInterval       string              `json:"tickerInterval"`
+	ConsecutiveFailures  int                 `json:"consecutiveFailures"`
 }
 
 // ProtocolValidation reports the MCP protocol version negotiated with the upstream.
@@ -502,7 +506,7 @@ func (man *MCPManager) manage(ctx context.Context, event eventType) {
 		return
 	}
 	man.consecutiveFailures = 0
-	man.logger.Info("upstream negotiated", "upstream", man.mcp.ID(), "supported-versions", man.mcp.SupportedVersions())
+	man.logger.Info("upstream negotiated", "name", man.mcp.GetName(), "upstream", man.mcp.ID(), "supported-versions", man.mcp.SupportedVersions())
 	if man.onConnect != nil {
 		versions := slices.Sorted(slices.Values(man.mcp.SupportedVersions()))
 		if !slices.Equal(versions, man.lastVersions) {
@@ -708,6 +712,10 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	man.status.InvalidToolList = invalidTools
 	man.status.InvalidPrompts = len(invalidPrompts)
 	man.status.InvalidPromptList = invalidPrompts
+	man.status.SupportedVersions = man.mcp.SupportedVersions()
+	man.status.UsesStatelessProtocol = man.mcp.UsesStatelessProtocol()
+	man.status.TickerInterval = man.tickerInterval.String()
+	man.status.ConsecutiveFailures = man.consecutiveFailures
 	if err != nil {
 		man.status.Message = err.Error()
 		man.status.Ready = false
@@ -717,7 +725,6 @@ func (man *MCPManager) setStatus(err error, toolCount int, promptCount int, inva
 	man.status.TotalPrompts = promptCount
 	man.status.Ready = true
 	man.status.Message = fmt.Sprintf("server added successfully. Total tools added %d. Total prompts added %d", toolCount, promptCount)
-	// always report the version we expect; fill in the negotiated version once it is known
 	man.status.ProtocolValidation = ProtocolValidation{ExpectedVersion: expectedProtocolVersion}
 	if info := man.mcp.ProtocolInfo(); info != nil {
 		man.status.ProtocolValidation.IsValid = true

--- a/internal/broker/upstream/manager.go
+++ b/internal/broker/upstream/manager.go
@@ -50,22 +50,22 @@ const (
 
 // ServerValidationStatus contains the validation results for an upstream MCP server
 type ServerValidationStatus struct {
-	ID                   string              `json:"id"`
-	Name                 string              `json:"name"`
-	LastValidated        time.Time           `json:"lastValidated"`
-	Message              string              `json:"message"`
-	Ready                bool                `json:"ready"`
-	TotalTools           int                 `json:"totalTools"`
-	TotalPrompts         int                 `json:"totalPrompts"`
-	InvalidTools         int                 `json:"invalidTools"`
-	InvalidToolList      []InvalidToolInfo   `json:"invalidToolList,omitempty"`
-	InvalidPrompts       int                 `json:"invalidPrompts"`
-	InvalidPromptList    []InvalidPromptInfo `json:"invalidPromptList,omitempty"`
-	ProtocolValidation   ProtocolValidation  `json:"protocolValidation"`
-	SupportedVersions    []string            `json:"supportedVersions,omitempty"`
-	UsesStatelessProtocol bool               `json:"usesStatelessProtocol"`
-	TickerInterval       string              `json:"tickerInterval"`
-	ConsecutiveFailures  int                 `json:"consecutiveFailures"`
+	ID                    string              `json:"id"`
+	Name                  string              `json:"name"`
+	LastValidated         time.Time           `json:"lastValidated"`
+	Message               string              `json:"message"`
+	Ready                 bool                `json:"ready"`
+	TotalTools            int                 `json:"totalTools"`
+	TotalPrompts          int                 `json:"totalPrompts"`
+	InvalidTools          int                 `json:"invalidTools"`
+	InvalidToolList       []InvalidToolInfo   `json:"invalidToolList,omitempty"`
+	InvalidPrompts        int                 `json:"invalidPrompts"`
+	InvalidPromptList     []InvalidPromptInfo `json:"invalidPromptList,omitempty"`
+	ProtocolValidation    ProtocolValidation  `json:"protocolValidation"`
+	SupportedVersions     []string            `json:"supportedVersions,omitempty"`
+	UsesStatelessProtocol bool                `json:"usesStatelessProtocol"`
+	TickerInterval        string              `json:"tickerInterval"`
+	ConsecutiveFailures   int                 `json:"consecutiveFailures"`
 }
 
 // ProtocolValidation reports the MCP protocol version negotiated with the upstream.

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -49,6 +49,7 @@ type MockMCP struct {
 	hasResourcesCap     bool
 	connected           atomic.Bool
 	notificationHandler func(method string)
+	toolsCacheMeta      CacheMetadata
 }
 
 func (m *MockMCP) GetName() string {
@@ -188,7 +189,7 @@ func (m *MockMCP) SupportsVersion(v string) bool {
 	return false
 }
 
-func (m *MockMCP) ToolsCacheMetadata() CacheMetadata   { return CacheMetadata{} }
+func (m *MockMCP) ToolsCacheMetadata() CacheMetadata   { return m.toolsCacheMeta }
 func (m *MockMCP) PromptsCacheMetadata() CacheMetadata { return CacheMetadata{} }
 func (m *MockMCP) UsesStatelessProtocol() bool         { return m.protocolVersion >= "2026-07-28" }
 
@@ -1859,6 +1860,73 @@ func findGaugeValue(t *testing.T, rm metricdata.ResourceMetrics, name string, la
 	}
 	t.Fatalf("metric %s with labels %v not found", name, labels)
 	return 0
+}
+
+func TestMCPManager_adjustTickerFromTTL(t *testing.T) {
+	tests := []struct {
+		name             string
+		protocolVersion  string
+		ttlMs            int
+		wantInterval     time.Duration
+		wantAdjusted     bool
+	}{
+		{
+			name:            "2026 upstream with TTL above default",
+			protocolVersion: "2026-07-28",
+			ttlMs:           300000,
+			wantInterval:    5 * time.Minute,
+			wantAdjusted:    true,
+		},
+		{
+			name:            "2026 upstream with TTL below default is clamped",
+			protocolVersion: "2026-07-28",
+			ttlMs:           10000,
+			wantInterval:    DefaultTickerInterval,
+			wantAdjusted:    false,
+		},
+		{
+			name:            "2026 upstream with TTL zero is ignored",
+			protocolVersion: "2026-07-28",
+			ttlMs:           0,
+			wantInterval:    DefaultTickerInterval,
+			wantAdjusted:    false,
+		},
+		{
+			name:            "2026 upstream with negative TTL is ignored",
+			protocolVersion: "2026-07-28",
+			ttlMs:           -1,
+			wantInterval:    DefaultTickerInterval,
+			wantAdjusted:    false,
+		},
+		{
+			name:            "2026 upstream with TTL equal to default",
+			protocolVersion: "2026-07-28",
+			ttlMs:           int(DefaultTickerInterval / time.Millisecond),
+			wantInterval:    DefaultTickerInterval,
+			wantAdjusted:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+			mock := newMockMCP("test-server", "test_")
+			mock.protocolVersion = tt.protocolVersion
+			mock.toolsCacheMeta = CacheMetadata{TTLMs: tt.ttlMs}
+			mock.tools = []mcp.Tool{validTool("tool1")}
+			mock.hasToolsCap = false
+			gateway := newMockToolsAdderDeleter()
+			manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, InvalidToolPolicyFilterOut)
+			require.NoError(t, err)
+
+			manager.manage(context.Background(), eventTypeTimer)
+
+			assert.Equal(t, tt.wantInterval, manager.tickerInterval, "ticker interval")
+			if tt.wantAdjusted {
+				assert.NotEqual(t, DefaultTickerInterval, manager.tickerInterval, "should have adjusted from default")
+			}
+		})
+	}
 }
 
 func labelsMatch(attrs attribute.Set, want map[string]string) bool {

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1864,11 +1864,11 @@ func findGaugeValue(t *testing.T, rm metricdata.ResourceMetrics, name string, la
 
 func TestMCPManager_adjustTickerFromTTL(t *testing.T) {
 	tests := []struct {
-		name             string
-		protocolVersion  string
-		ttlMs            int
-		wantInterval     time.Duration
-		wantAdjusted     bool
+		name            string
+		protocolVersion string
+		ttlMs           int
+		wantInterval    time.Duration
+		wantAdjusted    bool
 	}{
 		{
 			name:            "2026 upstream with TTL above default",
@@ -1902,6 +1902,13 @@ func TestMCPManager_adjustTickerFromTTL(t *testing.T) {
 			name:            "2026 upstream with TTL equal to default",
 			protocolVersion: "2026-07-28",
 			ttlMs:           int(DefaultTickerInterval / time.Millisecond),
+			wantInterval:    DefaultTickerInterval,
+			wantAdjusted:    false,
+		},
+		{
+			name:            "2025 upstream TTL is ignored",
+			protocolVersion: "2025-11-25",
+			ttlMs:           300000,
 			wantInterval:    DefaultTickerInterval,
 			wantAdjusted:    false,
 		},

--- a/internal/broker/upstream/manager_test.go
+++ b/internal/broker/upstream/manager_test.go
@@ -1936,6 +1936,25 @@ func TestMCPManager_adjustTickerFromTTL(t *testing.T) {
 	}
 }
 
+func TestMCPManager_adjustTickerFromTTL_ResetOnZero(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mock := newMockMCP("test-server", "test_")
+	mock.protocolVersion = "2026-07-28"
+	mock.toolsCacheMeta = CacheMetadata{TTLMs: 300000}
+	mock.tools = []mcp.Tool{validTool("tool1")}
+	mock.hasToolsCap = false
+	gateway := newMockToolsAdderDeleter()
+	manager, err := NewUpstreamMCPManager(mock, gateway, nil, logger, 0, InvalidToolPolicyFilterOut)
+	require.NoError(t, err)
+
+	manager.manage(context.Background(), eventTypeTimer)
+	require.Equal(t, 5*time.Minute, manager.tickerInterval, "should adopt upstream TTL")
+
+	mock.toolsCacheMeta = CacheMetadata{TTLMs: 0}
+	manager.manage(context.Background(), eventTypeTimer)
+	assert.Equal(t, DefaultTickerInterval, manager.tickerInterval, "should fall back to default when TTL disappears")
+}
+
 func labelsMatch(attrs attribute.Set, want map[string]string) bool {
 	for k, v := range want {
 		val, ok := attrs.Value(attribute.Key(k))

--- a/internal/broker/upstream/mcp.go
+++ b/internal/broker/upstream/mcp.go
@@ -275,12 +275,11 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 			RootsV2:     &mcp.RootCapabilities{ListChanged: true}, //nolint:staticcheck // deliberate parity with mark3labs
 			Elicitation: &mcp.ElicitationCapabilities{},
 		},
-		// setting these handlers causes the SDK to open a subscriptions/listen
-		// stream for 2026 upstreams during Connect. the actual notification
-		// dispatch is handled by the receiving middleware below; these
-		// handlers exist only to enable the stream.
-		ToolListChangedHandler:   func(_ context.Context, _ *mcp.ToolListChangedRequest) {},
-		PromptListChangedHandler: func(_ context.Context, _ *mcp.PromptListChangedRequest) {},
+		// go-sdk <= v1.7.0 opens subscriptions/listen during Connect when these
+		// handlers are set. servers that return 404 for subscriptions/listen
+		// (e.g. GitHub MCP, FastMCP 4.x) cause Connect to fail fatally.
+		// re-add once go-sdk >= v1.8.0 is adopted (PR #1193 wraps the failure).
+		// without handlers the broker relies on TTL-based polling for freshness.
 	})
 	// wire the notification handler before the session exists so nothing
 	// arriving during or right after the handshake is missed
@@ -326,14 +325,12 @@ func (up *MCPServer) Connect(ctx context.Context, onConnection func()) error {
 	}
 	up.logger.Debug("upstream connected", "upstream", up.ID(), "negotiated-protocol", negotiated, "supported-versions", up.supportedVersions, "uses-stateless", up.UsesStatelessProtocol())
 
-	// 2026 upstreams receive notifications via the SDK's subscriptions/listen
-	// stream (opened automatically because ToolListChangedHandler is set).
-	// 2025 upstreams use the custom GET SSE notificationWatcher.
+	// 2025 upstreams use the custom GET SSE notificationWatcher for push
+	// notifications. 2026 upstreams rely on TTL-based polling; notification
+	// handlers are disabled until go-sdk >= v1.8.0 (see client options above).
 	if !up.UsesStatelessProtocol() {
 		up.logger.Debug("starting GET SSE notification watcher (2025 upstream)", "upstream", up.ID())
 		up.startNotificationWatcher(ctx, httpC, session)
-	} else {
-		up.logger.Debug("using subscriptions/listen for notifications (2026 upstream)", "upstream", up.ID())
 	}
 
 	// register notification and connection-lost handlers after session is

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -794,3 +794,4 @@ func TestCacheMetadata_ToolsAndPromptsIndependent(t *testing.T) {
 	require.Equal(t, 10000, pmeta.TTLMs)
 	require.Equal(t, "private", pmeta.CacheScope)
 }
+

--- a/internal/broker/upstream/mcp_test.go
+++ b/internal/broker/upstream/mcp_test.go
@@ -794,4 +794,3 @@ func TestCacheMetadata_ToolsAndPromptsIndependent(t *testing.T) {
 	require.Equal(t, 10000, pmeta.TTLMs)
 	require.Equal(t, "private", pmeta.CacheScope)
 }
-

--- a/tests/servers/server3/Dockerfile
+++ b/tests/servers/server3/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
-RUN pip install fastmcp>=2.12.2
+RUN pip install "fastmcp>=2.12.2,<3"
 COPY *.py /app
 
 # CMD ["fastmcp run server.py --host 0.0.0.0 --port 9090 --transport http"]


### PR DESCRIPTION
fixes #1484 

## What does this PR do?

There are several issues with the subscription listen implementation in the 1.7 version of the MCP client that forced us to use various work arounds. See the above issue for more details.

This pr removes the subscription/listen connection for 2026 servers handled by the brokers MCP manager component. 

The impact of this PR is that is  stops the need to recycle connections in the manager for 2026 backends,  and also removes the impact of connections being torn down on a 404 response from the MCP Backend. In order to keep an upto date tools and prompts list, this PR configures the tool and prompt refresh from a server based on the cache TTLMs sent back by the server and falling back to a default min of 60s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved reliability when connecting to newer upstream protocol versions.
  - Upstream tool information now refreshes according to the server-provided cache duration, with a safe default when unavailable.
  - Reduced unnecessary connection resets during routine health checks.
  - Improved protocol-version detection and status reporting during upstream discovery.
  - Improved reliability when retrieving upstream capabilities and tool information.

- **Maintenance**
  - Improved compatibility with supported FastMCP server versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->