### PR TITLE
fix: harden mcp-gateway chart resources

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -48,8 +48,8 @@ type MCPServerRegistration struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec defines the desired state of MCPServerRegistration.
-	// +optional
-	Spec MCPServerRegistrationSpec `json:"spec,omitempty"`
+	// +required
+	Spec MCPServerRegistrationSpec `json:"spec,omitzero"`
 
 	// status defines the observed state of MCPServerRegistration.
 	// +optional
@@ -246,8 +246,8 @@ type MCPVirtualServer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec defines the desired state of MCPVirtualServer.
-	// +optional
-	Spec MCPVirtualServerSpec `json:"spec,omitempty"`
+	// +required
+	Spec MCPVirtualServerSpec `json:"spec,omitzero"`
 
 	// status defines the observed state of MCPVirtualServer.
 	// +optional

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -49,8 +49,8 @@ type MCPServerRegistration struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec defines the desired state of MCPServerRegistration.
-	// +optional
-	Spec MCPServerRegistrationSpec `json:"spec,omitempty"`
+	// +required
+	Spec MCPServerRegistrationSpec `json:"spec,omitzero"`
 
 	// status defines the observed state of MCPServerRegistration.
 	// +optional
@@ -249,8 +249,8 @@ type MCPVirtualServer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec defines the desired state of MCPVirtualServer.
-	// +optional
-	Spec MCPVirtualServerSpec `json:"spec,omitempty"`
+	// +required
+	Spec MCPVirtualServerSpec `json:"spec,omitzero"`
 
 	// status defines the observed state of MCPVirtualServer.
 	// +optional

--- a/build/helm-test.mk
+++ b/build/helm-test.mk
@@ -5,5 +5,6 @@ test-helm-install: kind helm kustomize yq ## Run helm install test against a cle
 	bash tests/helm/test-helm-install.sh
 
 .PHONY: test-helm-render
-test-helm-render: helm ## Validate Helm image reference rendering
+test-helm-render: helm yq ## Validate Helm chart and CRD rendering
 	bash tests/helm/test-image-rendering.sh
+	bash tests/helm/test-chart-rendering.sh

--- a/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -294,6 +294,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -580,6 +582,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/bundle/manifests/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/bundle/manifests/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -144,6 +144,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -280,6 +282,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -294,6 +294,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -580,6 +582,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -144,6 +144,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -280,6 +282,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -20,6 +20,8 @@ spec:
       serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -18,8 +18,18 @@ spec:
         {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mcp-controller
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           image: {{ include "mcp-controller.image" . }}
           imagePullPolicy: {{ .Values.imageController.pullPolicy }}
           command:

--- a/charts/mcp-gateway/templates/mcpgatewayextension.yaml
+++ b/charts/mcp-gateway/templates/mcpgatewayextension.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if .Values.gateway.publicHost }}
   publicHost: {{ .Values.gateway.publicHost | quote }}
   {{- end }}
-  privateHost: {{ printf "%s-%s.%s.svc.cluster.local:%v" .Values.gateway.name .Values.gateway.gatewayClassName .Values.gateway.namespace .Values.gateway.port | quote }}
+  {{- with .Values.mcpGatewayExtension.privateHost }}
+  privateHost: {{ . | quote }}
+  {{- end }}
   {{- if .Values.broker.pollInterval }}
   backendPingIntervalSeconds: {{ .Values.broker.pollInterval }}
   {{- end }}

--- a/charts/mcp-gateway/templates/referencegrant.yaml
+++ b/charts/mcp-gateway/templates/referencegrant.yaml
@@ -1,9 +1,11 @@
 {{- if and .Values.mcpGatewayExtension.create .Values.mcpGatewayExtension.gatewayRef.namespace }}
 {{- if ne .Values.mcpGatewayExtension.gatewayRef.namespace .Release.Namespace }}
+{{- $grantKey := printf "%s/%s/%s" .Release.Name .Release.Namespace .Values.mcpGatewayExtension.gatewayRef.name }}
+{{- $grantHash := $grantKey | sha256sum | trunc 16 }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: allow-{{ .Values.mcpGatewayExtension.gatewayRef.name }}
+  name: {{ printf "allow-%s-%s" .Release.Namespace $grantHash }}
   namespace: {{ .Values.mcpGatewayExtension.gatewayRef.namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
@@ -15,5 +17,6 @@ spec:
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway
+      name: {{ .Values.mcpGatewayExtension.gatewayRef.name }}
 {{- end }}
 {{- end }}

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -83,6 +83,8 @@ mcpGatewayExtension:
     namespace: gateway-system
     # Name of the listener on the Gateway to target (required)
     sectionName: mcp
+  # Optional override for the controller-discovered internal Gateway host
+  privateHost: ""
   
   # advanced configuration fields
   

--- a/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -294,6 +294,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -580,6 +582,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/config/crd/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/config/crd/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -144,6 +144,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -280,6 +282,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/tests/helm/test-chart-rendering.sh
+++ b/tests/helm/test-chart-rendering.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HELM="${HELM:-${ROOT_DIR}/bin/helm}"
+YQ="${YQ:-${ROOT_DIR}/bin/yq}"
+CHART_DIR="${ROOT_DIR}/charts/mcp-gateway"
+CRD_DIR="${ROOT_DIR}/config/crd"
+CHART_CRD_DIR="${CHART_DIR}/crds"
+
+if [[ ! -x "$HELM" ]]; then
+    HELM="$(command -v helm)"
+fi
+if [[ ! -x "$YQ" ]]; then
+    YQ="$(command -v yq)"
+fi
+
+render() {
+    "$HELM" template "$1" "$CHART_DIR" "${@:2}"
+}
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local message="$3"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "FAIL: $message: got '$actual', want '$expected'" >&2
+        exit 1
+    fi
+}
+
+assert_crd_spec_required() {
+    local crd_dir="$1"
+    local crd="$2"
+    local version="$3"
+    local required
+    required=$("$YQ" eval \
+        ".spec.versions[] | select(.name == \"$version\") | (.schema.openAPIV3Schema.required // []) | contains([\"spec\"])" \
+        "$crd_dir/$crd")
+    assert_eq "$required" "true" "$crd_dir/$crd $version requires spec"
+}
+
+for crd_dir in "$CRD_DIR" "$CHART_CRD_DIR"; do
+    for crd in \
+        mcp.kuadrant.io_mcpserverregistrations.yaml \
+        mcp.kuadrant.io_mcpvirtualservers.yaml; do
+        assert_crd_spec_required "$crd_dir" "$crd" v1
+        assert_crd_spec_required "$crd_dir" "$crd" v1alpha1
+    done
+done
+
+rendered=$(render test-release \
+    --namespace source-one \
+    --set controller.enabled=true \
+    --set gateway.create=false \
+    --set mcpGatewayExtension.gatewayRef.name=shared-gateway \
+    --set mcpGatewayExtension.gatewayRef.namespace=shared-system \
+    --set mcpGatewayExtension.gatewayRef.sectionName=mcp)
+
+private_host=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "MCPGatewayExtension") | .spec.privateHost // ""' -)
+assert_eq "$private_host" "" "privateHost is omitted by default"
+
+deployment_security=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.securityContext.runAsNonRoot' -)
+assert_eq "$deployment_security" "true" "controller runs as non-root"
+
+seccomp_profile=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' -)
+assert_eq "$seccomp_profile" "RuntimeDefault" "controller uses the runtime seccomp profile"
+
+container_security=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation' -)
+assert_eq "$container_security" "false" "controller disallows privilege escalation"
+
+root_filesystem=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' -)
+assert_eq "$root_filesystem" "true" "controller uses a read-only root filesystem"
+
+capabilities=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.capabilities.drop[0]' -)
+assert_eq "$capabilities" "ALL" "controller drops all capabilities"
+
+grant_name=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "ReferenceGrant") | .metadata.name' -)
+[[ "$grant_name" == allow-source-one-* ]] || {
+    echo "FAIL: ReferenceGrant name does not include the source namespace: $grant_name" >&2
+    exit 1
+}
+[[ ${#grant_name} -le 253 ]] || {
+    echo "FAIL: ReferenceGrant name exceeds 253 characters: $grant_name" >&2
+    exit 1
+}
+[[ "$grant_name" != *[.-] ]] || {
+    echo "FAIL: ReferenceGrant name ends with an invalid separator: $grant_name" >&2
+    exit 1
+}
+
+grant_target=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "ReferenceGrant") | .spec.to[0].name' -)
+assert_eq "$grant_target" "shared-gateway" "ReferenceGrant targets only the configured Gateway"
+
+explicit_private_host=$(render test-release \
+    --set controller.enabled=false \
+    --set-string mcpGatewayExtension.privateHost=https://custom-gateway:443 \
+    | "$YQ" eval 'select(.kind == "MCPGatewayExtension") | .spec.privateHost' -)
+assert_eq "$explicit_private_host" "https://custom-gateway:443" "explicit privateHost override is preserved"
+
+echo "PASS: chart and CRD rendering checks passed"

--- a/tests/helm/test-chart-rendering.sh
+++ b/tests/helm/test-chart-rendering.sh
@@ -62,6 +62,12 @@ assert_eq "$private_host" "" "privateHost is omitted by default"
 
 deployment_security=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.securityContext.runAsNonRoot' -)
 assert_eq "$deployment_security" "true" "controller runs as non-root"
+run_as_user=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.securityContext.runAsUser' -)
+assert_eq "$run_as_user" "65532" "controller runs as the image user"
+
+run_as_group=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.securityContext.runAsGroup' -)
+assert_eq "$run_as_group" "65532" "controller runs as the image group"
+
 
 seccomp_profile=$(printf '%s\n' "$rendered" | "$YQ" eval 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' -)
 assert_eq "$seccomp_profile" "RuntimeDefault" "controller uses the runtime seccomp profile"


### PR DESCRIPTION
## What does this PR do?

Relates to #1463. This draft addresses the medium-or-higher priority findings from the CodeRabbit review of the MCP Gateway Helm chart.

## Why these changes were made

### Require CRD root `spec`

The root `spec` fields for `MCPServerRegistration` and `MCPVirtualServer` were previously optional. That allowed incomplete resources with no configuration to pass schema validation, even though each resource has required values inside `spec`:

- `MCPServerRegistration.spec.targetRef` is required because it identifies the HTTPRoute/backend MCP server.
- `MCPVirtualServer.spec.tools` is required and must contain at least one tool.
- `MCPServerRegistration` conditionally requires `spec.prefix` when `spec.userSpecificList` is enabled.

Requiring the parent `spec` ensures Kubernetes evaluates those nested requirements and rejects invalid resources before they reach the controller. It does not make every field inside `spec` mandatory; optional fields and defaults remain unchanged. The v1 and v1alpha1 schemas now behave consistently, and the generated CRDs shipped through config, Helm, and the OLM bundle are synchronized.

### Stop deriving an incorrect `privateHost`

The chart previously derived `privateHost` from `.Values.gateway`, even when `mcpGatewayExtension.gatewayRef` targeted a different Gateway or namespace. That could make broker hairpin traffic use the wrong service. The chart now omits `privateHost` by default so the controller derives it from the actual referenced Gateway; an explicit `mcpGatewayExtension.privateHost` override remains available.

### Scope cross-namespace `ReferenceGrant` resources

The old grant name could collide for releases from different source namespaces, and the grant authorized references to every Gateway in the target namespace. Grant names now include the source namespace and a bounded hash, while `spec.to[].name` is restricted to the configured Gateway.

## Intentionally out of scope

- Controller Deployment security hardening is intentionally left to [#1469](https://github.com/Kuadrant/mcp-gateway/pull/1469) to avoid overlapping changes between the two PRs.
- The low-priority `/status` curl error-handling finding remains unchanged.
- The digest image rendering finding is already addressed by [#1477](https://github.com/Kuadrant/mcp-gateway/pull/1477).

## Verification

- `make test-unit`
- `make lint-go`
- `make test-helm-render`
- `make test-helm-install`
- `make check-crd-sync`
- `make check-bundle-crd-sync`
- Changed-file spelling checks

Commits are GPG-signed and include DCO sign-offs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Helm configuration to override the internal gateway host.
  * Helm-generated access grants now use more unique, reliable names and explicitly target the configured gateway.

* **Security**
  * Controller workloads now run as a non-root user with a read-only filesystem, restricted privileges, a default seccomp profile, and no Linux capabilities.

* **Validation**
  * Resource definitions now require the `spec` field for MCP server registrations and virtual servers across supported API versions.
  * Added automated checks for chart rendering, security settings, resource validation, and host overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->