### PR TITLE
fix: keep non-cacheable tools out of shared cache

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -451,14 +451,15 @@ func (m *mcpBrokerImpl) filteringMiddleware() mcp.Middleware {
 				}
 				isStateless := isStatelessProtocol(headers)
 
-				// filter by protocol version before user-specific fetches
-				toolsResult.Tools = m.toolsForProtocol(isStateless)
+				// load tools and fresh-fetch servers from one protocol-cache snapshot
+				var freshFetchServers []userSpecificServer
+				toolsResult.Tools, freshFetchServers = m.toolsAndFreshFetchServersForProtocol(isStateless)
 
 				var sessionID string
 				if s := req.GetSession(); s != nil {
 					sessionID = s.ID()
 				}
-				m.FetchUserSpecificTools(ctx, headers, toolsResult)
+				m.fetchUserSpecificTools(ctx, headers, toolsResult, freshFetchServers)
 
 				// collect cache metadata before FilterTools strips kuadrant/id
 				if isStateless {

--- a/internal/broker/protocol_filter.go
+++ b/internal/broker/protocol_filter.go
@@ -81,9 +81,44 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 	// per-user servers with no prefix serve unroutable tools; exclude them
 	excluded := m.privateScopeServersWithoutPrefix()
 
+	// precompute 2026 servers needing per-request fetching (cacheScope:"private"
+	// or ttlMs:0). Their tools remain out of the shared cache and are merged
+	// into each request after a fresh upstream fetch.
+	userSpecific := make(map[config.UpstreamMCPID]bool, len(m.userSpecificServers))
+	for _, s := range m.userSpecificServers {
+		userSpecific[s.id] = true
+	}
+	freshToolServers := make(map[config.UpstreamMCPID]struct{})
+	var freshFetchServers []userSpecificServer
+	for id, mgr := range m.mcpServers {
+		if userSpecific[id] {
+			continue
+		}
+		if _, isExcluded := excluded[id]; isExcluded {
+			continue
+		}
+		if !m.ServerSupportsVersion(id, protocol.Version2026) {
+			continue
+		}
+		meta := mgr.ToolsCacheMetadata()
+		cfg := mgr.Config()
+		srv := userSpecificServer{
+			id:     id,
+			name:   cfg.Name,
+			url:    cfg.URL,
+			prefix: cfg.Prefix,
+			caCert: cfg.CACert,
+		}
+		if m.handler2026.ShouldFetchFresh(srv, &meta) {
+			freshToolServers[id] = struct{}{}
+			freshFetchServers = append(freshFetchServers, srv)
+		}
+	}
+
 	// partition tools
 	allTools := m.gatewayServer.ListTools()
 	var statefulT, statelessT protocolCacheEntry[*mcp.Tool]
+	statelessT.freshFetchServers = freshFetchServers
 	statefulServersSeen := make(map[config.UpstreamMCPID]bool)
 	statelessServersSeen := make(map[config.UpstreamMCPID]bool)
 
@@ -120,43 +155,13 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 			}
 		}
 		if m.ServerSupportsVersion(serverID, protocol.Version2026) {
-			statelessT.items = append(statelessT.items, tool)
+			if _, fresh := freshToolServers[serverID]; !fresh {
+				statelessT.items = append(statelessT.items, tool)
+			}
 			if !statelessServersSeen[serverID] {
 				statelessServersSeen[serverID] = true
 				statelessT.serverIDs = append(statelessT.serverIDs, serverID)
 			}
-		}
-	}
-	// precompute 2026 servers needing per-request fetching (cacheScope:"private"
-	// or ttlMs:0) so FetchUserSpecificTools avoids iterating all servers per request.
-	// iterates all connected 2026 upstreams, not just those with cached tools —
-	// a fully-private upstream may contribute zero shared tools.
-	// CRD-declared userSpecificList servers are excluded (handled in startManagers).
-	crdUserSpecific := make(map[config.UpstreamMCPID]bool, len(m.userSpecificServers))
-	for _, s := range m.userSpecificServers {
-		crdUserSpecific[s.id] = true
-	}
-	for id, mgr := range m.mcpServers {
-		if crdUserSpecific[id] {
-			continue
-		}
-		if _, isExcluded := excluded[id]; isExcluded {
-			continue
-		}
-		if !m.ServerSupportsVersion(id, protocol.Version2026) {
-			continue
-		}
-		meta := mgr.ToolsCacheMetadata()
-		cfg := mgr.Config()
-		srv := userSpecificServer{
-			id:     id,
-			name:   cfg.Name,
-			url:    cfg.URL,
-			prefix: cfg.Prefix,
-			caCert: cfg.CACert,
-		}
-		if m.handler2026.ShouldFetchFresh(srv, &meta) {
-			statelessT.freshFetchServers = append(statelessT.freshFetchServers, srv)
 		}
 	}
 
@@ -202,7 +207,6 @@ func (m *mcpBrokerImpl) rebuildProtocolCaches() {
 	}
 	m.statefulPrompts.Store(&statefulP)
 	m.statelessPrompts.Store(&statelessP)
-
 	m.logger.Debug("rebuilt protocol caches",
 		"statefulTools", len(statefulT.items), "statelessTools", len(statelessT.items),
 		"statefulPrompts", len(statefulP.items), "statelessPrompts", len(statelessP.items))
@@ -227,21 +231,28 @@ func (m *mcpBrokerImpl) promptsForProtocol(isStateless bool) []*mcp.Prompt {
 	return nil
 }
 
+// toolsAndFreshFetchServersForProtocol loads one cache entry so the returned
+// tools and fresh-fetch servers describe the same routing-table snapshot.
+func (m *mcpBrokerImpl) toolsAndFreshFetchServersForProtocol(isStateless bool) ([]*mcp.Tool, []userSpecificServer) {
+	var cached *protocolCacheEntry[*mcp.Tool]
+	if isStateless {
+		cached = m.statelessTools.Load()
+	}
+	if cached == nil {
+		cached = m.statefulTools.Load()
+	}
+	if cached == nil {
+		return nil, nil
+	}
+
+	tools := make([]*mcp.Tool, len(cached.items))
+	copy(tools, cached.items)
+	return tools, cached.freshFetchServers
+}
+
 // toolsForProtocol returns the pre-cached tool set for the client's protocol version.
 // Returns a shallow copy to avoid mutation by downstream filters.
 func (m *mcpBrokerImpl) toolsForProtocol(isStateless bool) []*mcp.Tool {
-	if isStateless {
-		if cached := m.statelessTools.Load(); cached != nil {
-			tools := make([]*mcp.Tool, len(cached.items))
-			copy(tools, cached.items)
-			return tools
-		}
-	}
-
-	if cached := m.statefulTools.Load(); cached != nil {
-		tools := make([]*mcp.Tool, len(cached.items))
-		copy(tools, cached.items)
-		return tools
-	}
-	return nil
+	tools, _ := m.toolsAndFreshFetchServersForProtocol(isStateless)
+	return tools
 }

--- a/internal/broker/protocol_filter_private_scope_test.go
+++ b/internal/broker/protocol_filter_private_scope_test.go
@@ -34,36 +34,48 @@ func registerServer(t *testing.T, b *mcpBrokerImpl, id config.UpstreamMCPID, pre
 	})
 }
 
-func TestRebuildProtocolCaches_ExcludesPrivateScopeWithoutPrefix(t *testing.T) {
+func TestRebuildProtocolCaches_ExcludesNonCacheableTools(t *testing.T) {
 	tests := []struct {
-		name         string
-		prefix       string
-		meta         upstream.CacheMetadata
-		wantExcluded bool
+		name       string
+		prefix     string
+		meta       upstream.CacheMetadata
+		wantCached bool
+		wantFresh  bool
 	}{
 		{
-			name:         "private scope, no prefix -> excluded",
-			prefix:       "",
-			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate},
-			wantExcluded: true,
+			name:       "private scope, no prefix -> excluded as unroutable",
+			prefix:     "",
+			meta:       upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate},
+			wantCached: false,
+			wantFresh:  false,
 		},
 		{
-			name:         "private scope, with prefix -> included",
-			prefix:       "s1_",
-			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate},
-			wantExcluded: false,
+			name:       "private scope, with prefix -> fresh only",
+			prefix:     "s1_",
+			meta:       upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePrivate},
+			wantCached: false,
+			wantFresh:  true,
 		},
 		{
-			name:         "public scope, no prefix -> included",
-			prefix:       "",
-			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
-			wantExcluded: false,
+			name:       "zero TTL, with prefix -> fresh only",
+			prefix:     "s1_",
+			meta:       upstream.CacheMetadata{TTLMs: 0, CacheScope: upstream.CacheScopePublic},
+			wantCached: false,
+			wantFresh:  true,
 		},
 		{
-			name:         "userSpecificList, no prefix -> excluded",
-			prefix:       "",
-			meta:         upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePublic, UserSpecificList: true},
-			wantExcluded: true,
+			name:       "public scope, positive TTL -> cached",
+			prefix:     "",
+			meta:       upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePublic},
+			wantCached: true,
+			wantFresh:  false,
+		},
+		{
+			name:       "userSpecificList, no prefix -> excluded as unroutable",
+			prefix:     "",
+			meta:       upstream.CacheMetadata{TTLMs: 60000, CacheScope: upstream.CacheScopePublic, UserSpecificList: true},
+			wantCached: false,
+			wantFresh:  false,
 		},
 	}
 
@@ -79,19 +91,21 @@ func TestRebuildProtocolCaches_ExcludesPrivateScopeWithoutPrefix(t *testing.T) {
 			if cached == nil {
 				t.Fatal("statelessTools is nil")
 			}
-			got := len(cached.items)
-			if tt.wantExcluded && got != 0 {
-				t.Errorf("expected tools excluded from listing, got %d", got)
+			if got := len(cached.items); got != btoi(tt.wantCached) {
+				t.Errorf("cached tool count: got %d, want %d", got, btoi(tt.wantCached))
 			}
-			if !tt.wantExcluded && got != 1 {
-				t.Errorf("expected 1 tool included in listing, got %d", got)
-			}
-			// an excluded server must not be scheduled for per-request fetching
-			if tt.wantExcluded && len(cached.freshFetchServers) != 0 {
-				t.Errorf("expected excluded server absent from freshFetchServers, got %d", len(cached.freshFetchServers))
+			if got := len(cached.freshFetchServers); got != btoi(tt.wantFresh) {
+				t.Errorf("fresh-fetch server count: got %d, want %d", got, btoi(tt.wantFresh))
 			}
 		})
 	}
+}
+
+func btoi(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 // warnCounter counts warn records matching a specific message.

--- a/internal/broker/protocol_filter_test.go
+++ b/internal/broker/protocol_filter_test.go
@@ -259,6 +259,22 @@ func TestToolsForProtocol(t *testing.T) {
 		[]string{"tool1", "tool2"}, []string{"tool3"},
 	)
 }
+func TestToolsAndFreshFetchServersForProtocol_UsesOneSnapshot(t *testing.T) {
+	b := NewBroker(slog.Default(), WithDiscoveryToolsEnabled(false)).(*mcpBrokerImpl)
+	fresh := userSpecificServer{id: "fresh-server"}
+	b.statelessTools.Store(&protocolCacheEntry[*mcp.Tool]{
+		items:             []*mcp.Tool{{Name: "cached-tool"}},
+		freshFetchServers: []userSpecificServer{fresh},
+	})
+
+	tools, freshServers := b.toolsAndFreshFetchServersForProtocol(true)
+	if len(tools) != 1 || tools[0].Name != "cached-tool" {
+		t.Fatalf("got tools %#v, want cached-tool", tools)
+	}
+	if len(freshServers) != 1 || freshServers[0].id != fresh.id {
+		t.Fatalf("got fresh servers %#v, want %s", freshServers, fresh.id)
+	}
+}
 
 func TestRebuildProtocolCaches_Prompts(t *testing.T) {
 	t.Run("mixed servers with edge cases", func(t *testing.T) {

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -480,9 +480,7 @@ func (broker *mcpBrokerImpl) fetchStatefulUserTools(ctx context.Context, servers
 	}
 	_ = g.Wait()
 
-	for i := range allTools {
-		result.Tools = append(result.Tools, &allTools[i])
-	}
+	appendUniqueTools(result, allTools)
 }
 
 // fetchStatelessUserTools fetches tools from the given servers using stateless
@@ -510,8 +508,34 @@ func (broker *mcpBrokerImpl) fetchStatelessUserTools(ctx context.Context, server
 	}
 	_ = g.Wait()
 
-	for i := range allTools {
-		result.Tools = append(result.Tools, &allTools[i])
+	appendUniqueTools(result, allTools)
+}
+
+type toolIdentity struct {
+	serverID string
+	name     string
+}
+
+func identityForTool(tool *mcp.Tool) toolIdentity {
+	if tool == nil {
+		return toolIdentity{}
+	}
+	serverID, _ := tool.Meta["kuadrant/id"].(string)
+	return toolIdentity{serverID: serverID, name: tool.Name}
+}
+
+func appendUniqueTools(result *mcp.ListToolsResult, tools []mcp.Tool) {
+	seen := make(map[toolIdentity]struct{}, len(result.Tools)+len(tools))
+	for _, tool := range result.Tools {
+		seen[identityForTool(tool)] = struct{}{}
+	}
+	for i := range tools {
+		tool := &tools[i]
+		if _, exists := seen[identityForTool(tool)]; exists {
+			continue
+		}
+		seen[identityForTool(tool)] = struct{}{}
+		result.Tools = append(result.Tools, tool)
 	}
 }
 

--- a/internal/broker/user_specific_tools.go
+++ b/internal/broker/user_specific_tools.go
@@ -53,9 +53,18 @@ type cachedUserSession struct {
 // FetchUserSpecificTools fetches tools from servers that need per-request
 // fetching and merges them into the result before FilterTools runs.
 // Sources: CRD-declared userSpecificList (precomputed in startManagers) and
-// 2026 upstreams whose cache metadata indicates fresh fetching (evaluated here
-// at request time so newly-connected managers are picked up without a config change).
+// 2026 upstreams whose cache metadata indicates fresh fetching.
 func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers http.Header, result *mcp.ListToolsResult) {
+	var freshFetchServers []userSpecificServer
+	if isStatelessProtocol(headers) {
+		if cached := broker.statelessTools.Load(); cached != nil {
+			freshFetchServers = cached.freshFetchServers
+		}
+	}
+	broker.fetchUserSpecificTools(ctx, headers, result, freshFetchServers)
+}
+
+func (broker *mcpBrokerImpl) fetchUserSpecificTools(ctx context.Context, headers http.Header, result *mcp.ListToolsResult, freshFetchServers []userSpecificServer) {
 	clientVersion := protocol.Version2025
 	handler := broker.handler2025
 	if isStatelessProtocol(headers) {
@@ -77,14 +86,12 @@ func (broker *mcpBrokerImpl) FetchUserSpecificTools(ctx context.Context, headers
 		seen[srv.id] = true
 	}
 
-	// for 2026 clients, also include upstreams whose cache metadata indicates
-	// per-request fetching (precomputed in rebuildProtocolCaches)
+	// for 2026 clients, include the fresh-fetch servers from the same
+	// protocol-cache snapshot that supplied the initial tool list.
 	if clientVersion == protocol.Version2026 {
-		if cached := broker.statelessTools.Load(); cached != nil {
-			for _, srv := range cached.freshFetchServers {
-				if !seen[srv.id] {
-					matching = append(matching, srv)
-				}
+		for _, srv := range freshFetchServers {
+			if !seen[srv.id] {
+				matching = append(matching, srv)
 			}
 		}
 	}
@@ -480,7 +487,7 @@ func (broker *mcpBrokerImpl) fetchStatefulUserTools(ctx context.Context, servers
 	}
 	_ = g.Wait()
 
-	appendUniqueTools(result, allTools)
+	appendTools(result, allTools)
 }
 
 // fetchStatelessUserTools fetches tools from the given servers using stateless
@@ -508,34 +515,11 @@ func (broker *mcpBrokerImpl) fetchStatelessUserTools(ctx context.Context, server
 	}
 	_ = g.Wait()
 
-	appendUniqueTools(result, allTools)
+	appendTools(result, allTools)
 }
-
-type toolIdentity struct {
-	serverID string
-	name     string
-}
-
-func identityForTool(tool *mcp.Tool) toolIdentity {
-	if tool == nil {
-		return toolIdentity{}
-	}
-	serverID, _ := tool.Meta["kuadrant/id"].(string)
-	return toolIdentity{serverID: serverID, name: tool.Name}
-}
-
-func appendUniqueTools(result *mcp.ListToolsResult, tools []mcp.Tool) {
-	seen := make(map[toolIdentity]struct{}, len(result.Tools)+len(tools))
-	for _, tool := range result.Tools {
-		seen[identityForTool(tool)] = struct{}{}
-	}
+func appendTools(result *mcp.ListToolsResult, tools []mcp.Tool) {
 	for i := range tools {
-		tool := &tools[i]
-		if _, exists := seen[identityForTool(tool)]; exists {
-			continue
-		}
-		seen[identityForTool(tool)] = struct{}{}
-		result.Tools = append(result.Tools, tool)
+		result.Tools = append(result.Tools, &tools[i])
 	}
 }
 

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -649,42 +649,6 @@ func TestFetchUserSpecificTools_StatelessFetch(t *testing.T) {
 	// no session should be cached (stateless path)
 	assert.Equal(t, 0, poolSize(b), "stateless fetch should not cache sessions")
 }
-func TestFetchUserSpecificTools_DeduplicatesCachedAndFreshTools(t *testing.T) {
-	ts := newStatelessTestMCPServer(t)
-	defer ts.Close()
-
-	cache, _ := session.NewCache()
-	srv := userSpecificServer{
-		id: "ns/stateless-server", name: "stateless-server",
-		url: ts.URL, prefix: "sl_",
-	}
-	b := &mcpBrokerImpl{
-		userSpecificServers:      []userSpecificServer{srv},
-		logger:                   slog.Default(),
-		sessionCache:             cache,
-		userSpecificFetchTimeout: 10 * time.Second,
-	}
-	b.serverVersions.Store(srv.id, []string{"2026-07-28"})
-	withProtocolHandlers(b)
-
-	result := &mcp.ListToolsResult{
-		Tools: []*mcp.Tool{
-			{Name: "sl_tool", Meta: mcp.Meta{"kuadrant/id": string(srv.id)}},
-			{Name: "other_tool", Meta: mcp.Meta{"kuadrant/id": "other-server"}},
-		},
-	}
-	headers := http.Header{
-		"Mcp-Session-Id":       []string{"gw-session-1"},
-		"Mcp-Protocol-Version": []string{"2026-07-28"},
-		"Authorization":        []string{"Bearer user-token"},
-	}
-
-	b.FetchUserSpecificTools(context.Background(), headers, result)
-
-	require.Len(t, result.Tools, 2)
-	names := []string{result.Tools[0].Name, result.Tools[1].Name}
-	assert.ElementsMatch(t, []string{"other_tool", "sl_tool"}, names)
-}
 
 // registerActiveServer wires an upstream into b.mcpServers with the given
 // prefix, URL and tools cache metadata (so the exclusion predicate can read

--- a/internal/broker/user_specific_tools_test.go
+++ b/internal/broker/user_specific_tools_test.go
@@ -649,6 +649,42 @@ func TestFetchUserSpecificTools_StatelessFetch(t *testing.T) {
 	// no session should be cached (stateless path)
 	assert.Equal(t, 0, poolSize(b), "stateless fetch should not cache sessions")
 }
+func TestFetchUserSpecificTools_DeduplicatesCachedAndFreshTools(t *testing.T) {
+	ts := newStatelessTestMCPServer(t)
+	defer ts.Close()
+
+	cache, _ := session.NewCache()
+	srv := userSpecificServer{
+		id: "ns/stateless-server", name: "stateless-server",
+		url: ts.URL, prefix: "sl_",
+	}
+	b := &mcpBrokerImpl{
+		userSpecificServers:      []userSpecificServer{srv},
+		logger:                   slog.Default(),
+		sessionCache:             cache,
+		userSpecificFetchTimeout: 10 * time.Second,
+	}
+	b.serverVersions.Store(srv.id, []string{"2026-07-28"})
+	withProtocolHandlers(b)
+
+	result := &mcp.ListToolsResult{
+		Tools: []*mcp.Tool{
+			{Name: "sl_tool", Meta: mcp.Meta{"kuadrant/id": string(srv.id)}},
+			{Name: "other_tool", Meta: mcp.Meta{"kuadrant/id": "other-server"}},
+		},
+	}
+	headers := http.Header{
+		"Mcp-Session-Id":       []string{"gw-session-1"},
+		"Mcp-Protocol-Version": []string{"2026-07-28"},
+		"Authorization":        []string{"Bearer user-token"},
+	}
+
+	b.FetchUserSpecificTools(context.Background(), headers, result)
+
+	require.Len(t, result.Tools, 2)
+	names := []string{result.Tools[0].Name, result.Tools[1].Name}
+	assert.ElementsMatch(t, []string{"other_tool", "sl_tool"}, names)
+}
 
 // registerActiveServer wires an upstream into b.mcpServers with the given
 // prefix, URL and tools cache metadata (so the exclusion predicate can read


### PR DESCRIPTION
## Summary

- Keep 2026 tools with `cacheScope: private` or `ttlMs: 0` out of the shared broker tool cache.
- Continue fetching those tools fresh per request, as required for per-user data.
- Load the cached tool set and fresh-fetch server list from one cache snapshot so metadata transitions cannot combine stale cached tools with a fresh fetch.
- Preserve aggregate cache metadata and existing 2025 behavior.
- Add regression coverage for private scope, zero TTL, and cache-snapshot consistency.

Fixes #1488

## Why

The original failure was not that the broker needed to deduplicate two valid lists. Private and zero-TTL tools were incorrectly inserted into the shared cache even though they were already classified for fresh per-request fetching. A subsequent `tools/list` therefore started with a cached copy and appended a fresh copy.

The fix prevents those tools from entering the shared cache. Fresh fetching remains the source of truth for those servers.

## Scope

This PR addresses the tool-list caching issue only. Prompt and resource protocol behavior are intentionally unchanged.

## How to review

1. Review `rebuildProtocolCaches` in `internal/broker/protocol_filter.go` and confirm private/zero-TTL 2026 tools are excluded from `statelessTools` but their servers remain available for fresh fetching and cache metadata aggregation.
2. Review `toolsAndFreshFetchServersForProtocol` and the `tools/list` middleware path for the single-snapshot guarantee.
3. Review the regression tests in `protocol_filter_private_scope_test.go` and `protocol_filter_test.go`.

## Verification

- `go test ./internal/broker -run 'Test(RebuildProtocolCaches_ExcludesNonCacheableTools|ToolsAndFreshFetchServersForProtocol_UsesOneSnapshot)$' -count=1`
- `go test ./internal/broker/... -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool listings by checking servers requiring fresh data at request time.
  - Ensured tool listings use a consistent snapshot, reducing mismatches between available tools and server routing.
  - Restored expected handling for tools returned by multiple sources, preventing valid results from being inadvertently omitted.

- **Tests**
  - Added coverage for fresh-data handling, cache behavior, and consistent tool-list responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->