### PR TITLE
fix: make standalone MCP Gateway Operator installation conditional

### DIFF
--- a/config/openshift/deploy_openshift.sh
+++ b/config/openshift/deploy_openshift.sh
@@ -10,6 +10,8 @@ INSTALL_RHCL="${INSTALL_RHCL:-false}"
 INSTALL_SERVICE_MESH="${INSTALL_SERVICE_MESH:-true}"
 USE_OCP_INGRESS="${USE_OCP_INGRESS:-true}"
 
+# Note: CATALOG_IMG, INSTALL_PRODUCTIZED_VERSION, and CHANNEL are only
+# applied if MCP Gateway controller is not bundled within RHCL Operator
 # If set to true then MCP Gateway from official Red Hat Catalog is installed
 # CATALOG_IMG env var is ignored, no custom CatalogSource is created
 INSTALL_PRODUCTIZED_VERSION="${INSTALL_PRODUCTIZED_VERSION:-false}"
@@ -49,8 +51,7 @@ else
   echo "Skipping Service Mesh installation (INSTALL_SERVICE_MESH=$INSTALL_SERVICE_MESH)..."
 fi
 
-# Install Connectivity Link Operator
-# typically not needed since RHCL Operator is listed as an OLM dependency of MCP Gateway Controller
+# Install Connectivity Link Operator from official Catalog
 if [ "$INSTALL_RHCL" = "true" ]; then
   echo "Installing Connectivity Link Operator..."
   oc apply -k "$SCRIPT_BASE_DIR/kustomize/connectivity-link/operator/base"
@@ -64,62 +65,74 @@ fi
 # Create gateway namespace
 oc create ns "$GATEWAY_NAMESPACE" --dry-run=client -o yaml | oc apply -f -
 
-# Install MCP Gateway Controller via OLM
-echo "Installing MCP Gateway Controller via OLM..."
+# Create MCP Gateway system namespace
 oc create ns "$MCP_GATEWAY_NAMESPACE" --dry-run=client -o yaml | oc apply -f -
 
-if [ "$INSTALL_PRODUCTIZED_VERSION" != "true" ]; then
-  if [ -n "${CATALOG_IMG:-}" ]; then
-    sed "s|image: .*|image: ${CATALOG_IMG}|" \
-      "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" | oc apply -n openshift-marketplace -f -
-  else
-    oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" -n openshift-marketplace
+# Check all CSVs/Deployments to see whether RELATED_IMAGE_MCP_GATEWAY is present.
+# If so, MCP Gateway controller is bundled within RHCL Operator, no need to install it separately via OLM
+GATEWAY_IMAGE_ENV='.spec.template.spec.containers[*].env[?(@.name=="RELATED_IMAGE_MCP_GATEWAY")].name'
+DEPLOYMENT_QUERY="{.items[*]${GATEWAY_IMAGE_ENV}}"
+CSV_QUERY="{.items[*].spec.install.spec.deployments[*]${GATEWAY_IMAGE_ENV}}"
+MCP_GATEWAY_MANAGED=$(oc get deployments,csv -A \
+  -o jsonpath="${DEPLOYMENT_QUERY}${CSV_QUERY}")
+if [ -n "$MCP_GATEWAY_MANAGED" ]; then
+  echo "Kuadrant/RHCL Operator manages MCP Gateway, skipping standalone OLM installation..."
+else
+  echo "Installing MCP Gateway Controller via OLM..."
+
+  if [ "$INSTALL_PRODUCTIZED_VERSION" != "true" ]; then
+    if [ -n "${CATALOG_IMG:-}" ]; then
+      sed "s|image: .*|image: ${CATALOG_IMG}|" \
+        "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" | oc apply -n openshift-marketplace -f -
+    else
+      oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/catalogsource.yaml" -n openshift-marketplace
+    fi
+
+    echo "Waiting for CatalogSource to be ready..."
+    retries=0
+    until oc get catalogsource mcp-gateway-catalog -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null | grep -q "READY"; do
+      retries=$((retries + 1))
+      if [ $retries -ge 60 ]; then
+        echo "Timed out waiting for CatalogSource to be ready"
+        exit 1
+      fi
+      sleep 5
+    done
   fi
 
-  echo "Waiting for CatalogSource to be ready..."
+  # Check if OperatorGroup already exists in namespace (only one allowed per namespace)
+  if oc get operatorgroup -n "$MCP_GATEWAY_NAMESPACE" -o name 2>/dev/null | grep -q .; then
+    echo "OperatorGroup already exists in $MCP_GATEWAY_NAMESPACE, skipping creation..."
+  else
+    oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/operatorgroup.yaml" -n "$MCP_GATEWAY_NAMESPACE"
+  fi
+
+  # patch subscription sourceNamespace for OpenShift
+  sed "s|sourceNamespace: .*|sourceNamespace: openshift-marketplace|" \
+    "$SCRIPT_BASE_DIR/../deploy/olm/subscription.yaml" > /tmp/mcp-subscription.yaml
+
+  # patch subscription channel for OpenShift
+  sed -i "s|channel: .*|channel: $CHANNEL|" /tmp/mcp-subscription.yaml
+
+  # patch subscription source for OpenShift
+  if [ "$INSTALL_PRODUCTIZED_VERSION" = "true" ]; then
+    sed -i "s|source: .*|source: redhat-operators|" /tmp/mcp-subscription.yaml
+  fi
+
+  oc apply -f /tmp/mcp-subscription.yaml -n "$MCP_GATEWAY_NAMESPACE"
+
+  echo "Waiting for controller CSV to succeed..."
   retries=0
-  until oc get catalogsource mcp-gateway-catalog -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null | grep -q "READY"; do
+  until oc get csv -n "$MCP_GATEWAY_NAMESPACE" -l "operators.coreos.com/mcp-gateway.$MCP_GATEWAY_NAMESPACE"="" -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Succeeded"; do
     retries=$((retries + 1))
     if [ $retries -ge 60 ]; then
-      echo "Timed out waiting for CatalogSource to be ready"
+      echo "Timed out waiting for controller CSV to succeed"
       exit 1
     fi
     sleep 5
   done
+  echo "MCP Gateway Controller installed via OLM"
 fi
-
-# Check if OperatorGroup already exists in namespace (only one allowed per namespace)
-if oc get operatorgroup -n "$MCP_GATEWAY_NAMESPACE" -o name 2>/dev/null | grep -q .; then
-  echo "OperatorGroup already exists in $MCP_GATEWAY_NAMESPACE, skipping creation..."
-else
-  oc apply -f "$SCRIPT_BASE_DIR/../deploy/olm/operatorgroup.yaml" -n "$MCP_GATEWAY_NAMESPACE"
-fi
-
-# patch subscription sourceNamespace for OpenShift
-sed "s|sourceNamespace: .*|sourceNamespace: openshift-marketplace|" \
-  "$SCRIPT_BASE_DIR/../deploy/olm/subscription.yaml" > /tmp/mcp-subscription.yaml
-
-# patch subscription channel for OpenShift
-sed -i "s|channel: .*|channel: $CHANNEL|" /tmp/mcp-subscription.yaml
-
-# patch subscription source for OpenShift
-if [ "$INSTALL_PRODUCTIZED_VERSION" = "true" ]; then
-  sed -i "s|source: .*|source: redhat-operators|" /tmp/mcp-subscription.yaml
-fi
-
-oc apply -f /tmp/mcp-subscription.yaml -n "$MCP_GATEWAY_NAMESPACE"
-
-echo "Waiting for controller CSV to succeed..."
-retries=0
-until oc get csv -n "$MCP_GATEWAY_NAMESPACE" -l "operators.coreos.com/mcp-gateway.$MCP_GATEWAY_NAMESPACE"="" -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Succeeded"; do
-  retries=$((retries + 1))
-  if [ $retries -ge 60 ]; then
-    echo "Timed out waiting for controller CSV to succeed"
-    exit 1
-  fi
-  sleep 5
-done
-echo "MCP Gateway Controller installed via OLM"
 
 echo "Waiting for Kuadrant CRD to be established..."
 until oc wait crd/kuadrants.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
@@ -136,6 +149,7 @@ fi
 echo "Waiting for MCP Gateway CRDs to be established..."
 until oc wait crd/mcpgatewayextensions.mcp.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
 until oc wait crd/mcpserverregistrations.mcp.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
+until oc wait crd/mcpvirtualservers.mcp.kuadrant.io --for condition=established &>/dev/null; do sleep 5; done
 
 # Install MCP Gateway Instance (Gateway, ReferenceGrant, MCPGatewayExtension)
 echo "Installing MCP Gateway Instance..."


### PR DESCRIPTION
## What does this PR do?

Standalone MCP Gateway Operator is not installed via OLM if MCP Gateway controller is already running due to Kuadrant/RHCL Operator being installed via OLM earlier (in a version that bundles MCP Gateway controller)

### Changes
There is a simple check for presence of RELATED_IMAGE_MCP_GATEWAY in csv and Deployment CRs - it there is at least one such CR, the script assumes that Kuadrant/RHCL Operator version that bundles MCP Gateway controller is installed on cluster and skips standalone MCP Gateway Operator installation.

## Pre-review checklist

Before requesting review from a maintainer, confirm you have read [CONTRIBUTING.md](../CONTRIBUTING.md) and:

- [x] Checked the CodeRabbit walkthrough for "Possibly related issues" and confirmed the PR uses `Fixes` or `Closes` syntax for any it addresses
- [x] Checked the CodeRabbit walkthrough for "Possibly related PRs" and confirmed this PR is not a duplicate
- [x] Read, understood, and addressed or dismissed (with a reason) all CodeRabbit comments
- [x] All CI checks pass, or failures have been investigated and explained below
- [x] Ran the `agent-skills:review` skill (from https://github.com/addyosmani/agent-skills) and addressed all valid recommendations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment now detects when the MCP Gateway Controller is already managed by the RHCL/Kuadrant Operator and skips installing a duplicate standalone instance.
  - Added a readiness check for the MCP VirtualServer custom resource definition to improve deployment reliability.

- **Deployment**
  - MCP Gateway installation continues through the catalog-based process when no bundled controller is detected.
  - Improved deployment handling for the MCP Gateway namespace and related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->