### PR TITLE
perf(router): skip prefix-free 2026 request bodies

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -139,6 +139,41 @@ func (config *MCPServersConfig) GetGuardrails() (api.Checker, *api.Config) {
 	return config.guardrailsChecker, config.GlobalGuardrails
 }
 
+// RoutingSnapshot returns a consistent, request-scoped copy of the routing
+// fields that can change during a configuration reload.
+func (config *MCPServersConfig) RoutingSnapshot() *MCPServersConfig {
+	if config == nil {
+		return nil
+	}
+
+	config.lock.RLock()
+	defer config.lock.RUnlock()
+
+	servers := make([]*MCPServer, len(config.Servers))
+	for i, server := range config.Servers {
+		if server == nil {
+			continue
+		}
+		serverCopy := *server
+		serverCopy.GuardrailsConfigIDs = slices.Clone(server.GuardrailsConfigIDs)
+		servers[i] = &serverCopy
+	}
+
+	var globalGuardrails *api.Config
+	if config.GlobalGuardrails != nil {
+		globalCopy := *config.GlobalGuardrails
+		globalCopy.ConfigIDs = slices.Clone(config.GlobalGuardrails.ConfigIDs)
+		globalGuardrails = &globalCopy
+	}
+
+	return &MCPServersConfig{
+		Servers:                    servers,
+		MCPGatewayExternalHostname: config.MCPGatewayExternalHostname,
+		GlobalGuardrails:           globalGuardrails,
+		guardrailsChecker:          config.guardrailsChecker,
+	}
+}
+
 // ServerByName returns the MCPServer with the given name, or nil if not found.
 func (config *MCPServersConfig) ServerByName(name string) *MCPServer {
 	config.lock.RLock()

--- a/internal/mcp-router/ext_proc_adapter.go
+++ b/internal/mcp-router/ext_proc_adapter.go
@@ -60,8 +60,7 @@ func (s *ExtProcServer) requestBodyLimit() int {
 	return limit
 }
 
-func (s *ExtProcServer) canSkip2026RequestBody() bool {
-	cfg := s.RoutingConfig.Load()
+func canSkip2026RequestBody(cfg *config.MCPServersConfig) bool {
 	if cfg == nil {
 		return false
 	}
@@ -134,7 +133,8 @@ func headerDecisionToResponse(d *routing.Decision, fallbackAuthority, verifiedSu
 	}
 	setHeaders := append(headers.Build(), decisionHeaders(d)...)
 	removeHeaders := append([]string(nil), routing.InternalOnlyHeaders...)
-	for _, header := range d.UnsetHeaders {
+	reservedHeaders := []string{routing.SessionHeader, "mcp-init-host", routing.RoutingKey}
+	for _, header := range append(reservedHeaders, d.UnsetHeaders...) {
 		found := false
 		for _, existing := range removeHeaders {
 			if header == existing {
@@ -342,20 +342,31 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 			if strings.HasSuffix(requestPath, protocol.PathSuffixStateful) {
 				effectiveVersion = protocol.Version2025
 			}
+			var routingConfig *config.MCPServersConfig
 			if method == http.MethodPost && !endOfStream && mcpMethodHeader != "" &&
-				effectiveVersion == protocol.Version2026 && s.Router202607 != nil && s.canSkip2026RequestBody() {
+				effectiveVersion == protocol.Version2026 && s.Router202607 != nil {
+				routingConfig = s.RoutingConfig.Load().RoutingSnapshot()
+			}
+			if canSkip2026RequestBody(routingConfig) {
 				rawHeaders := headerMapToMap(localRequestHeaders.Headers)
 				verifiedSub, _ := internaljwt.ExtractSubClaim(rawHeaders[routing.AuthorizationHeader])
 				routingReq := &routing.Request{
 					MCPMethod:       mcpMethodHeader,
 					MCPName:         mcpNameHeader,
 					ProtocolVersion: effectiveVersion,
-					Authority:       s.RoutingConfig.Load().MCPGatewayExternalHostname,
+					Authority:       routingConfig.MCPGatewayExternalHostname,
 					Path:            requestPath,
 					RequestID:       requestID,
 					RawHeaders:      rawHeaders,
 				}
-				decision := s.Router202607.RouteRequest(ctx, routingReq)
+				var decision *routing.Decision
+				if snapshotRouter, ok := s.Router202607.(interface {
+					RouteRequestWithConfig(context.Context, *routing.Request, *config.MCPServersConfig) *routing.Decision
+				}); ok {
+					decision = snapshotRouter.RouteRequestWithConfig(ctx, routingReq, routingConfig)
+				} else {
+					decision = s.Router202607.RouteRequest(ctx, routingReq)
+				}
 				if decision.Error == nil {
 					mcpRequest = &routing.MCPRequest{
 						Method:     mcpMethodHeader,
@@ -364,7 +375,7 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 						ServerName: decision.SetHeaders[routing.MCPServerNameHeader],
 					}
 				}
-				responses := headerDecisionToResponse(decision, s.RoutingConfig.Load().MCPGatewayExternalHostname, verifiedSub)
+				responses := headerDecisionToResponse(decision, routingConfig.MCPGatewayExternalHostname, verifiedSub)
 				for _, response := range responses {
 					s.Logger.DebugContext(ctx, "sending header-only routing instructions to envoy", "response", response)
 					if err := stream.Send(response); err != nil {

--- a/internal/mcp-router/ext_proc_adapter.go
+++ b/internal/mcp-router/ext_proc_adapter.go
@@ -60,6 +60,24 @@ func (s *ExtProcServer) requestBodyLimit() int {
 	return limit
 }
 
+func (s *ExtProcServer) canSkip2026RequestBody() bool {
+	cfg := s.RoutingConfig.Load()
+	if cfg == nil {
+		return false
+	}
+
+	_, globalGuardrails := cfg.GetGuardrails()
+	if globalGuardrails != nil && len(globalGuardrails.ConfigIDs) > 0 {
+		return false
+	}
+	for _, server := range cfg.ListServers() {
+		if server.Prefix != "" || len(server.GuardrailsConfigIDs) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // HandleRequestHeaders sets the gateway authority and extracts the verified sub claim.
 func (s *ExtProcServer) HandleRequestHeaders(ctx context.Context, headers *extProcV3.HttpHeaders) ([]*extProcV3.ProcessingResponse, error) {
 	s.Logger.DebugContext(ctx, "Request Handler: HandleRequestHeaders called")
@@ -100,6 +118,46 @@ func decisionToResponse(d *routing.Decision) []*extProcV3.ProcessingResponse {
 		rb.WithRequestBodyHeadersResponse(headers)
 	}
 	return rb.Build()
+}
+
+func headerDecisionToResponse(d *routing.Decision, fallbackAuthority, verifiedSub string) []*extProcV3.ProcessingResponse {
+	if d.Error != nil {
+		return decisionToResponse(d)
+	}
+
+	headers := NewHeaders()
+	if d.Authority == "" {
+		headers.WithAuthority(fallbackAuthority)
+	}
+	if verifiedSub != "" {
+		headers.WithVerifiedSub(verifiedSub)
+	}
+	setHeaders := append(headers.Build(), decisionHeaders(d)...)
+	removeHeaders := append([]string(nil), routing.InternalOnlyHeaders...)
+	for _, header := range d.UnsetHeaders {
+		found := false
+		for _, existing := range removeHeaders {
+			if header == existing {
+				found = true
+				break
+			}
+		}
+		if !found {
+			removeHeaders = append(removeHeaders, header)
+		}
+	}
+	responses := NewResponse().WithRequestHeadersResponse(setHeaders, removeHeaders...).Build()
+	if len(responses) > 0 {
+		responses[0].ModeOverride = &extprochttp.ProcessingMode{
+			RequestHeaderMode:   extprochttp.ProcessingMode_SEND,
+			ResponseHeaderMode:  extprochttp.ProcessingMode_SEND,
+			RequestBodyMode:     extprochttp.ProcessingMode_NONE,
+			ResponseBodyMode:    extprochttp.ProcessingMode_NONE,
+			RequestTrailerMode:  extprochttp.ProcessingMode_SKIP,
+			ResponseTrailerMode: extprochttp.ProcessingMode_SKIP,
+		}
+	}
+	return responses
 }
 
 // decisionHeaders merges Authority and Path from the decision into the
@@ -271,6 +329,44 @@ func (s *ExtProcServer) Process(stream extProcV3.ExternalProcessor_ProcessServer
 				s.Logger.DebugContext(ctx, "[ext_proc] Process: A2A request headers", "request id", requestID, "path", requestPath, "method", method)
 				resp := responseBuilder.WithRequestHeadersResponse(a2aHeaders.Build(), a2aInternalHeaders...).Build()
 				for _, response := range resp {
+					if err := stream.Send(response); err != nil {
+						s.Logger.ErrorContext(ctx, "error sending response", "error", err)
+						recordError(span, err, 500)
+						return err
+					}
+				}
+				continue
+			}
+
+			effectiveVersion := protocolVersion
+			if strings.HasSuffix(requestPath, protocol.PathSuffixStateful) {
+				effectiveVersion = protocol.Version2025
+			}
+			if method == http.MethodPost && !endOfStream && mcpMethodHeader != "" &&
+				effectiveVersion == protocol.Version2026 && s.Router202607 != nil && s.canSkip2026RequestBody() {
+				rawHeaders := headerMapToMap(localRequestHeaders.Headers)
+				verifiedSub, _ := internaljwt.ExtractSubClaim(rawHeaders[routing.AuthorizationHeader])
+				routingReq := &routing.Request{
+					MCPMethod:       mcpMethodHeader,
+					MCPName:         mcpNameHeader,
+					ProtocolVersion: effectiveVersion,
+					Authority:       s.RoutingConfig.Load().MCPGatewayExternalHostname,
+					Path:            requestPath,
+					RequestID:       requestID,
+					RawHeaders:      rawHeaders,
+				}
+				decision := s.Router202607.RouteRequest(ctx, routingReq)
+				if decision.Error == nil {
+					mcpRequest = &routing.MCPRequest{
+						Method:     mcpMethodHeader,
+						Params:     map[string]any{"name": mcpNameHeader},
+						Headers:    rawHeaders,
+						ServerName: decision.SetHeaders[routing.MCPServerNameHeader],
+					}
+				}
+				responses := headerDecisionToResponse(decision, s.RoutingConfig.Load().MCPGatewayExternalHostname, verifiedSub)
+				for _, response := range responses {
+					s.Logger.DebugContext(ctx, "sending header-only routing instructions to envoy", "response", response)
 					if err := stream.Send(response); err != nil {
 						s.Logger.ErrorContext(ctx, "error sending response", "error", err)
 						recordError(span, err, 500)

--- a/internal/mcp-router/ext_proc_adapter_test.go
+++ b/internal/mcp-router/ext_proc_adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -13,9 +14,12 @@ import (
 	"testing"
 
 	"github.com/Kuadrant/mcp-gateway/internal/config"
+	guardrailsapi "github.com/Kuadrant/mcp-gateway/internal/guardrails/api"
+	"github.com/Kuadrant/mcp-gateway/internal/protocol"
 	"github.com/Kuadrant/mcp-gateway/internal/routing"
 	"github.com/Kuadrant/mcp-gateway/internal/session"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprochttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extProcV3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/require"
@@ -136,6 +140,98 @@ func TestProcess_HappyPath(t *testing.T) {
 	err := srv.Process(mock)
 	require.NoError(t, err)
 	mock.verifyAllResponsesConsumed()
+}
+
+func TestProcess_202607SkipsPrefixFreeRequestBody(t *testing.T) {
+	srv := newTestServer(t)
+	srv.Router202607 = &fixedDecisionRouter{decision: &routing.Decision{
+		Authority: "backend.example.test",
+		Path:      "/mcp",
+		SetHeaders: map[string]string{
+			routing.MethodHeader:        routing.MethodToolCall,
+			routing.MCPServerNameHeader: "backend",
+			routing.ToolHeader:          "echo",
+			"mcp-name":                  "echo",
+		},
+		UnsetHeaders: routing.InternalOnlyHeaders,
+	}}
+	srv.ResponseHandler2026 = &stubResponseHandler{}
+	srv.RoutingConfig.Store(&config.MCPServersConfig{
+		MCPGatewayExternalHostname: "gateway.example.test",
+		Servers: []*config.MCPServer{{
+			Name:     "backend",
+			Hostname: "backend.example.test",
+		}},
+	})
+
+	mode := &extprochttp.ProcessingMode{
+		RequestHeaderMode:   extprochttp.ProcessingMode_SEND,
+		ResponseHeaderMode:  extprochttp.ProcessingMode_SEND,
+		RequestBodyMode:     extprochttp.ProcessingMode_NONE,
+		ResponseBodyMode:    extprochttp.ProcessingMode_NONE,
+		RequestTrailerMode:  extprochttp.ProcessingMode_SKIP,
+		ResponseTrailerMode: extprochttp.ProcessingMode_SKIP,
+	}
+	mock := makeMockProcessServer(t, []mockProcessServerMessageAndErr{
+		{
+			msg: &extProcV3.ProcessingRequest{
+				Request: &extProcV3.ProcessingRequest_RequestHeaders{
+					RequestHeaders: &extProcV3.HttpHeaders{Headers: &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+						{Key: ":method", RawValue: []byte(http.MethodPost)},
+						{Key: ":path", RawValue: []byte("/mcp/stateless")},
+						{Key: "content-type", RawValue: []byte("application/json")},
+						{Key: "mcp-protocol-version", RawValue: []byte(protocol.Version2026)},
+						{Key: "mcp-method", RawValue: []byte(routing.MethodToolCall)},
+						{Key: "mcp-name", RawValue: []byte("echo")},
+					}}},
+				},
+			},
+			resp: []*extProcV3.ProcessingResponse{{
+				ModeOverride: mode,
+				Response: &extProcV3.ProcessingResponse_RequestHeaders{
+					RequestHeaders: &extProcV3.HeadersResponse{Response: &extProcV3.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &extProcV3.HeaderMutation{
+							SetHeaders: []*corev3.HeaderValueOption{
+								{Header: &corev3.HeaderValue{Key: ":authority", RawValue: []byte("backend.example.test")}},
+								{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/mcp")}},
+								{Header: &corev3.HeaderValue{Key: routing.MethodHeader, RawValue: []byte(routing.MethodToolCall)}},
+								{Header: &corev3.HeaderValue{Key: routing.MCPServerNameHeader, RawValue: []byte("backend")}},
+								{Header: &corev3.HeaderValue{Key: routing.ToolHeader, RawValue: []byte("echo")}},
+								{Header: &corev3.HeaderValue{Key: "mcp-name", RawValue: []byte("echo")}},
+							},
+							RemoveHeaders: routing.InternalOnlyHeaders,
+						},
+					}},
+				},
+			}},
+		},
+		responseHeadersStep(),
+	})
+
+	require.NoError(t, srv.Process(mock))
+	mock.verifyAllResponsesConsumed()
+}
+
+func TestCanSkip2026RequestBody(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *config.MCPServersConfig
+		want   bool
+	}{
+		{name: "prefix-free", config: &config.MCPServersConfig{Servers: []*config.MCPServer{{Name: "one"}}}, want: true},
+		{name: "server prefix", config: &config.MCPServersConfig{Servers: []*config.MCPServer{{Name: "one", Prefix: "one__"}}}},
+		{name: "server guardrails", config: &config.MCPServersConfig{Servers: []*config.MCPServer{{Name: "one", GuardrailsConfigIDs: []string{"rail"}}}}},
+		{name: "global guardrails", config: &config.MCPServersConfig{GlobalGuardrails: &guardrailsapi.Config{ConfigIDs: []string{"rail"}}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &ExtProcServer{}
+			srv.RoutingConfig.Store(tt.config)
+			require.Equal(t, tt.want, srv.canSkip2026RequestBody())
+		})
+	}
 }
 
 func TestProcess_EmptyBody(t *testing.T) {
@@ -538,6 +634,7 @@ func (m *mockProcessServer) Send(actualResp *extProcV3.ProcessingResponse) error
 	require.Less(m.t, m.responseCursor, len(step.resp), "no more expected responses left in the mock stream")
 	expectedResponse := step.resp[m.responseCursor]
 	require.NotNil(m.t, expectedResponse)
+	require.Equal(m.t, expectedResponse.ModeOverride, actualResp.ModeOverride)
 
 	switch v := expectedResponse.Response.(type) {
 	case *extProcV3.ProcessingResponse_RequestHeaders:
@@ -694,6 +791,12 @@ type stubRouter struct{}
 
 func (s *stubRouter) RouteRequest(_ context.Context, _ *routing.Request) *routing.Decision {
 	return &routing.Decision{}
+}
+
+type fixedDecisionRouter struct{ decision *routing.Decision }
+
+func (s *fixedDecisionRouter) RouteRequest(_ context.Context, _ *routing.Request) *routing.Decision {
+	return s.decision
 }
 
 // stubErrorRouter is a Router that always returns an error decision with the given status code.

--- a/internal/mcp-router/ext_proc_adapter_test.go
+++ b/internal/mcp-router/ext_proc_adapter_test.go
@@ -144,7 +144,20 @@ func TestProcess_HappyPath(t *testing.T) {
 
 func TestProcess_202607SkipsPrefixFreeRequestBody(t *testing.T) {
 	srv := newTestServer(t)
-	srv.Router202607 = &fixedDecisionRouter{decision: &routing.Decision{
+	initialConfig := &config.MCPServersConfig{
+		MCPGatewayExternalHostname: "gateway.example.test",
+		Servers: []*config.MCPServer{{
+			Name:     "backend",
+			Hostname: "backend.example.test",
+		}},
+	}
+	reloadedConfig := &config.MCPServersConfig{
+		MCPGatewayExternalHostname: "reloaded.example.test",
+		GlobalGuardrails:           &guardrailsapi.Config{ConfigIDs: []string{"rail"}},
+	}
+	srv.RoutingConfig.Store(initialConfig)
+	var routingSnapshot *config.MCPServersConfig
+	srv.Router202607 = &snapshotDecisionRouter{decision: &routing.Decision{
 		Authority: "backend.example.test",
 		Path:      "/mcp",
 		SetHeaders: map[string]string{
@@ -154,15 +167,11 @@ func TestProcess_202607SkipsPrefixFreeRequestBody(t *testing.T) {
 			"mcp-name":                  "echo",
 		},
 		UnsetHeaders: routing.InternalOnlyHeaders,
+	}, onRoute: func(cfg *config.MCPServersConfig) {
+		routingSnapshot = cfg
+		srv.RoutingConfig.Store(reloadedConfig)
 	}}
 	srv.ResponseHandler2026 = &stubResponseHandler{}
-	srv.RoutingConfig.Store(&config.MCPServersConfig{
-		MCPGatewayExternalHostname: "gateway.example.test",
-		Servers: []*config.MCPServer{{
-			Name:     "backend",
-			Hostname: "backend.example.test",
-		}},
-	})
 
 	mode := &extprochttp.ProcessingMode{
 		RequestHeaderMode:   extprochttp.ProcessingMode_SEND,
@@ -183,6 +192,9 @@ func TestProcess_202607SkipsPrefixFreeRequestBody(t *testing.T) {
 						{Key: "mcp-protocol-version", RawValue: []byte(protocol.Version2026)},
 						{Key: "mcp-method", RawValue: []byte(routing.MethodToolCall)},
 						{Key: "mcp-name", RawValue: []byte("echo")},
+						{Key: routing.SessionHeader, RawValue: []byte("client-session")},
+						{Key: "mcp-init-host", RawValue: []byte("client.example.test")},
+						{Key: routing.RoutingKey, RawValue: []byte("client-key")},
 					}}},
 				},
 			},
@@ -200,7 +212,8 @@ func TestProcess_202607SkipsPrefixFreeRequestBody(t *testing.T) {
 								{Header: &corev3.HeaderValue{Key: routing.ToolHeader, RawValue: []byte("echo")}},
 								{Header: &corev3.HeaderValue{Key: "mcp-name", RawValue: []byte("echo")}},
 							},
-							RemoveHeaders: routing.InternalOnlyHeaders,
+							RemoveHeaders: append(append([]string(nil), routing.InternalOnlyHeaders...),
+								routing.SessionHeader, "mcp-init-host", routing.RoutingKey),
 						},
 					}},
 				},
@@ -211,6 +224,11 @@ func TestProcess_202607SkipsPrefixFreeRequestBody(t *testing.T) {
 
 	require.NoError(t, srv.Process(mock))
 	mock.verifyAllResponsesConsumed()
+	require.NotSame(t, initialConfig, routingSnapshot)
+	require.Equal(t, "gateway.example.test", routingSnapshot.MCPGatewayExternalHostname)
+	_, snapshotGuardrails := routingSnapshot.GetGuardrails()
+	require.Nil(t, snapshotGuardrails)
+	require.Same(t, reloadedConfig, srv.RoutingConfig.Load())
 }
 
 func TestCanSkip2026RequestBody(t *testing.T) {
@@ -229,7 +247,7 @@ func TestCanSkip2026RequestBody(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := &ExtProcServer{}
 			srv.RoutingConfig.Store(tt.config)
-			require.Equal(t, tt.want, srv.canSkip2026RequestBody())
+			require.Equal(t, tt.want, canSkip2026RequestBody(srv.RoutingConfig.Load()))
 		})
 	}
 }
@@ -796,6 +814,20 @@ func (s *stubRouter) RouteRequest(_ context.Context, _ *routing.Request) *routin
 type fixedDecisionRouter struct{ decision *routing.Decision }
 
 func (s *fixedDecisionRouter) RouteRequest(_ context.Context, _ *routing.Request) *routing.Decision {
+	return s.decision
+}
+
+type snapshotDecisionRouter struct {
+	decision *routing.Decision
+	onRoute  func(*config.MCPServersConfig)
+}
+
+func (s *snapshotDecisionRouter) RouteRequest(_ context.Context, _ *routing.Request) *routing.Decision {
+	return &routing.Decision{Error: &routing.Error{StatusCode: 500, Message: "snapshot route not used"}}
+}
+
+func (s *snapshotDecisionRouter) RouteRequestWithConfig(_ context.Context, _ *routing.Request, cfg *config.MCPServersConfig) *routing.Decision {
+	s.onRoute(cfg)
 	return s.decision
 }
 

--- a/internal/routing/router_202607.go
+++ b/internal/routing/router_202607.go
@@ -25,6 +25,11 @@ var _ Router = &Router202607{}
 
 // RouteRequest routes header-based mcp request to backend or broker
 func (r *Router202607) RouteRequest(ctx context.Context, req *Request) *Decision {
+	return r.RouteRequestWithConfig(ctx, req, r.RoutingConfig.Load())
+}
+
+// RouteRequestWithConfig routes a request against one configuration snapshot.
+func (r *Router202607) RouteRequestWithConfig(ctx context.Context, req *Request, routingConfig *config.MCPServersConfig) *Decision {
 	table := r.Table()
 
 	ctx, span := tracer().Start(ctx, "mcp-router.route-decision",
@@ -36,7 +41,7 @@ func (r *Router202607) RouteRequest(ctx context.Context, req *Request) *Decision
 	)
 	defer span.End()
 
-	if expected := r.RoutingConfig.Load().MCPGatewayExternalHostname; expected != "" && req.Authority != "" && req.Authority != expected {
+	if expected := routingConfig.MCPGatewayExternalHostname; expected != "" && req.Authority != "" && req.Authority != expected {
 		r.Logger.ErrorContext(ctx, "authority mismatch", "expected", expected, "got", req.Authority)
 		span.SetStatus(codes.Error, "authority mismatch")
 		span.SetAttributes(attribute.String("error.type", "authority_mismatch"))
@@ -46,7 +51,7 @@ func (r *Router202607) RouteRequest(ctx context.Context, req *Request) *Decision
 	switch req.MCPMethod {
 	case MethodToolCall:
 		span.SetAttributes(attribute.String("mcp.route", "tool-call"))
-		return r.routeToolCall(ctx, table, req)
+		return r.routeToolCall(ctx, table, req, routingConfig)
 	case MethodPromptGet:
 		span.SetAttributes(attribute.String("mcp.route", "prompt-get"))
 		return r.routePromptGet(ctx, table, req)
@@ -56,7 +61,7 @@ func (r *Router202607) RouteRequest(ctx context.Context, req *Request) *Decision
 	}
 }
 
-func (r *Router202607) routeToolCall(ctx context.Context, table RoutingTable, req *Request) *Decision {
+func (r *Router202607) routeToolCall(ctx context.Context, table RoutingTable, req *Request, routingConfig *config.MCPServersConfig) *Decision {
 	toolName := req.MCPName
 
 	ctx, span := tracer().Start(ctx, "mcp-router.tool-call",
@@ -143,7 +148,7 @@ func (r *Router202607) routeToolCall(ctx context.Context, table RoutingTable, re
 		return &Decision{Error: routerErr}
 	}
 
-	gc := newGuardrailsCheck(r.RoutingConfig.Load(), route.GuardrailsConfigIDs, r.Logger)
+	gc := newGuardrailsCheck(routingConfig, route.GuardrailsConfigIDs, r.Logger)
 	modified, blocked := gc.checkToolCall(ctx, req.Parsed, upstreamToolName)
 	if blocked != nil {
 		return blocked


### PR DESCRIPTION
## What does this PR do?

Fixes #1496

Routes eligible MCP 2026-07-28 requests during the request-header phase and overrides Envoy's per-request processing mode so request bodies are not buffered when no prefix rewriting or guardrail inspection is required.

- sets request body processing to `NONE` for prefix-free, guardrail-free 2026 routes
- preserves buffered processing for prefixed servers and global or per-server guardrails
- preserves internal-only header stripping, authority/path mutations, and response audit context
- adds focused regression coverage for the fast path and each fallback condition

## Testing

- `go vet ./internal/mcp-router`
- `go test -race ./internal/mcp-router`
- `go test ./internal/...`

## Pre-review checklist

- [ ] Checked CodeRabbit's related issues and PRs after its review completes
- [ ] Addressed or dismissed CodeRabbit comments after its review completes
- [ ] Confirmed CI passes after the workflows complete
- [ ] Ran the requested external review skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved routing for eligible MCP 2026 POST requests by evaluating headers without waiting for request bodies.
  * Preserved fallback routing and verified subject information in header-only responses.
  * Continued full request-body processing for stateful or specially configured routes.

* **Bug Fixes**
  * Removed reserved internal headers from generated routing responses, including session, initialization, and router-specific headers.
  * Ensured routing decisions consistently use the configuration active when a request begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->